### PR TITLE
docs(quickstart-cli): recommend Llama-3 default, add multi-turn + thinking-token sections

### DIFF
--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -1,6 +1,7 @@
 name: README Snippets
 
-# Compiles every `swift`-fenced code block in README.md and docs/QUICKSTART.md
+# Compiles every `swift`-fenced code block in README.md, docs/QUICKSTART.md,
+# and docs/QUICKSTART-CLI.md
 # against the current ManifoldKit package. Catches snippet drift the moment a
 # `feat:` PR renames a public type or removes an initializer that the docs
 # still copy-paste.
@@ -25,6 +26,7 @@ on:
       #   - The scripts the gate runs.
       - "README.md"
       - "docs/QUICKSTART.md"
+      - "docs/QUICKSTART-CLI.md"
       - "Sources/ManifoldKit/**"
       - "Sources/ManifoldUI/**"
       - "Sources/ManifoldInference/QuickStart*.swift"
@@ -39,6 +41,7 @@ on:
     paths:
       - "README.md"
       - "docs/QUICKSTART.md"
+      - "docs/QUICKSTART-CLI.md"
       - "Sources/ManifoldKit/**"
       - "Sources/ManifoldUI/**"
       - "Sources/ManifoldInference/QuickStart*.swift"

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -89,11 +89,13 @@ Both `InferenceService.loadModel(...)` and `InferenceService.generate(...)` are 
 
 This is the section that closes the "I'm on macOS 15 and want to evaluate ManifoldKit" gap. The Llama backend loads GGUF files via llama.cpp + Metal and runs on every supported platform.
 
-**Get a model first.** Drop any GGUF file into `~/Documents/Models/`. Good starter picks (small, fast, instruction-tuned):
+**Get a model first.** Drop any GGUF file into `~/Documents/Models/`. Good starter picks:
 
-- [`Qwen3-0.6B-Q4_K_M.gguf`](https://huggingface.co/Qwen/Qwen3-0.6B-GGUF) — ~400 MB, decent quality, fastest cold-start
-- [`Llama-3.2-3B-Instruct-Q4_K_M.gguf`](https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF) — ~2 GB, better quality
+- [`Llama-3.2-3B-Instruct-Q4_K_M.gguf`](https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF) — ~2 GB, instruction-tuned, no reasoning tokens — **the snippet below works with this model unchanged**
+- [`Qwen3-0.6B-Q4_K_M.gguf`](https://huggingface.co/Qwen/Qwen3-0.6B-GGUF) — ~400 MB, fast, but emits `.thinkingToken` events before its final answer — see ["Reasoning models" below](#reasoning-models-thinking-tokens) before using
 - Any other GGUF you've downloaded via HuggingFace, Ollama, or LM Studio
+
+> **Known issue with Llama-3 family multi-turn**: tracked at [#1398](https://github.com/roryford/ManifoldKit/issues/1398) — long multi-turn conversations may produce ChatML control-token leakage and hallucinated turns. Single-turn use is unaffected.
 
 **`Package.swift`:**
 
@@ -138,7 +140,7 @@ struct ChatCLILlama {
     static func main() async throws {
         // 1. Locate the GGUF on disk. Adjust to taste — or read it from argv.
         let modelURL = URL(fileURLWithPath: NSString(
-            string: "~/Documents/Models/Qwen3-0.6B-Q4_K_M.gguf"
+            string: "~/Documents/Models/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
         ).expandingTildeInPath)
 
         guard FileManager.default.fileExists(atPath: modelURL.path) else {
@@ -186,7 +188,7 @@ struct ChatCLILlama {
             temperature: 0.7,
             topP: 0.95,
             repeatPenalty: 1.1,
-            maxOutputTokens: 64
+            maxOutputTokens: 256
         )
 
         for try await event in stream.events {
@@ -222,6 +224,66 @@ ManifoldKit has two `loadModel(from:)` shapes at different layers:
 - **`BackendProtocol.loadModel(from: URL, plan:)`** — the backend-protocol contract that custom backends implement. You'd only call this if you were building a brand-new backend.
 
 The README's "Custom Backends" section documents the URL form because it's the protocol shape backend authors satisfy. Consumers call the `ModelInfo` form, and `ModelInfo(ggufURL:)` wraps the URL.
+
+### Multi-turn conversations
+
+`generate(messages:)` takes `[(role, content)]` and is stateless — the host owns the conversation history. Append the user's prompt before each call and the model's reply after each call:
+
+```swift,no-build
+var history: [(String, String)] = []
+
+while let prompt = readLine() {
+    history.append(("user", prompt))
+
+    var reply = ""
+    let stream = try inference.generate(messages: history, maxOutputTokens: 256)
+    for try await event in stream.events {
+        if case .token(let text) = event {
+            print(text, terminator: "")
+            fflush(stdout)
+            reply += text
+        }
+    }
+    print("")
+
+    history.append(("assistant", reply))
+}
+```
+
+Canonical role strings are `"user"`, `"assistant"`, and `"system"`. The `systemPrompt:` parameter on `generate(...)` is a convenience for the common case of one system message — when you pass it, ManifoldKit prepends a synthetic `("system", systemPrompt)` to the message array.
+
+### Reasoning models (thinking tokens)
+
+Some models — Qwen3, DeepSeek-R1, and similar — emit "thinking" content (reasoning steps) before their final answer. ManifoldKit surfaces these as a separate `GenerationEvent.thinkingToken(String)` case so the host can hide or render them as the UX demands. The §2 snippet above only handles `.token`, which means thinking output is silently dropped — that's fine for an instruct model but produces zero visible output for a reasoning model if its thinking block exhausts your `maxOutputTokens` budget.
+
+If you need to support reasoning models, either render thinking content distinctly:
+
+```swift,no-build
+for try await event in stream.events {
+    switch event {
+    case .token(let text):
+        print(text, terminator: "")
+    case .thinkingToken(let text):
+        // Render in a dim color, hide behind a fold, or skip entirely.
+        FileHandle.standardError.write(Data("[thinking] \(text)".utf8))
+    default:
+        break
+    }
+    fflush(stdout)
+}
+```
+
+…or use `maxThinkingTokens:` on `generate(...)` to cap how long the model can "think" before being forced to emit a final answer:
+
+```swift,no-build
+let stream = try inference.generate(
+    messages: history,
+    maxOutputTokens: 512,
+    maxThinkingTokens: 128
+)
+```
+
+If you're not sure whether your GGUF is a reasoning model, the simplest test is to run the §2 snippet against it: if you see no visible output, swap in the multi-handler `switch` shape above.
 
 ---
 


### PR DESCRIPTION
## Summary

Patches `docs/QUICKSTART-CLI.md` for three findings surfaced by the iteration-3 DX walkthrough:

- **F13** — §2's recommended starter model (Qwen3-0.6B) is a reasoning model that emits `.thinkingToken` events. The §2 snippet only handles `.token`, so following the doc verbatim produced zero visible output. Reorder model picks to lead with **Llama-3.2-3B** (no thinking tokens, snippet works unchanged). Add an explicit "Reasoning models" subsection showing the multi-event `switch` pattern and the `maxThinkingTokens:` knob.
- **F16** — §2 didn't show how to thread conversation history across turns. Add a "Multi-turn conversations" subsection with the canonical `("user", ...)` / `("assistant", ...)` pattern and the role-string canon.
- Bump §2's `maxOutputTokens: 64` to `256` so a real reply fits.

Also adds a callout pointing at #1398 (Llama-3 multi-turn ChatML leakage) so users are warned about that known issue before they hit it.

## Verification

- `bash scripts/check-readme.sh` — passes locally (no-build blocks land under "Multi-turn conversations" / "Reasoning models" subsections, neither of which is in the contract-heading list)
- New snippets are `swift,no-build`-tagged fragments (reference undefined `inference`, `history`, `stream`) — not part of the compile gate. The existing `quickstart-cli-002` snippet only changed a string (model URL) and integer (maxOutputTokens) — should still compile.

## Walkthrough report

Full iteration-3 synthesis: `scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-postfix-v2/01-chat-cli/SUMMARY.md`

## What's NOT in this PR

- **#1398** (Llama-3 multi-turn ChatML leakage) — real bug, separate fix
- **#1399** (llama.cpp log spam) — needs API-surface decision, separate work
- **F12** (default-trait mlx-swift resolution failure) — needs investigation to confirm whether it's a real cold-build issue or methodology artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)