### PR TITLE
dx: check in DX walkthrough harness (run.sh, compare.sh, briefs, retrospectives)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ xcuserdata/
 !.claude/settings.json
 tmp/
 .worktrees/
+# DX walkthrough per-run artefacts — large + ephemeral. Keep only the
+# synthesized SUMMARY.md / ROOT_CAUSES.md at the iteration root (those
+# live one level up from run-*/ and are tracked explicitly).
+scripts/dx-walkthrough/runs/*/*/run-*/
 # Security audit artefacts — must never be committed; contain detailed
 # vulnerability maps with file paths and line numbers.
 SECURITY_REMEDIATION_PLAN*.md

--- a/scripts/dx-walkthrough/README.md
+++ b/scripts/dx-walkthrough/README.md
@@ -1,0 +1,107 @@
+# DX Walkthrough Harness
+
+A repeatable, forced-blindness DX regression check. Three parallel agents
+play "fresh Swift developer", each follow an archetype brief (e.g.
+`01-chat-cli.md`) without reading ManifoldKit's source or tests, and log
+friction as they go. Their friction logs are synthesized into a
+per-iteration `SUMMARY.md` and diffed against prior iterations to track
+which DX papercuts get fixed, which persist, and which new ones surface.
+
+## Running it
+
+```sh
+scripts/dx-walkthrough/run.sh 01-chat-cli iter5
+```
+
+This scaffolds `runs/<date>_v<version>_<label>/<archetype>/run-{1,2,3}/`
+and prints three self-contained dispatch prompts. Hand each to the Agent
+tool with `subagent_type=claude`, `isolation=worktree`,
+`run_in_background=true`. They run in parallel.
+
+When the three agents report back, write `SUMMARY.md` (and optionally
+`ROOT_CAUSES.md`) directly under the iteration's archetype directory.
+Use prior iterations' SUMMARY.md as the format reference — see
+`runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md` for the canonical
+shape.
+
+## Comparing iterations
+
+```sh
+scripts/dx-walkthrough/compare.sh \
+  runs/2026-05-23_v0.33.0/01-chat-cli \
+  runs/2026-05-23_v0.33.0-iter4/01-chat-cli
+```
+
+Heuristic markdown diff. Groups findings into Disappeared (likely
+fixed), Persisted (still open), New (regression or next-layer
+discovery). Fingerprints by the first sentence of each entry's "Trying
+to:" line — false positives are possible when entries get rephrased.
+
+## The forced-blindness rule (do not relax)
+
+Agents may read `README.md`, `docs/`, `Sources/*/Documentation.docc/`,
+`Package.swift`, and repo-root markdown. They may **not** read
+`Sources/Manifold*/**/*.swift` or `Tests/**`. The whole point of the
+exercise is to measure whether the public-facing surface is sufficient
+for a new developer; letting agents grep internals turns the test into
+"can a competent reverse-engineer ship in 30 min", which is a different
+question.
+
+If an agent gets stuck and wants to peek at sources, they should log it
+in `FRICTION.md` as a discoverability gap and pivot — that signal is the
+deliverable.
+
+## Methodology: vary the surface across runs
+
+A regression-style rerun where all three agents pick the same backend
+collapses three data points into one. Steer each run at a different
+public path (e.g. Foundation in run-1, local Llama GGUF in run-2, cloud
+or Ollama in run-3, or different reasoning vs. non-reasoning models).
+Backend variation is signal — uniformity is noise.
+
+This lesson was learned the hard way between iter-2 and iter-3; iter-4
+was the first iteration where the dispatch deliberately spread runs
+across surfaces, and it surfaced multiple findings that homogeneous
+runs missed.
+
+## Recommended cadence
+
+- **Quarterly** as a baseline DX regression check
+- **Pre-release** before any minor-version bump
+- **Post-major-refactor** any time a module boundary moves or a
+  public-facing type changes shape
+
+A single archetype rerun is ~30 minutes of agent time and ~5 minutes of
+human synthesis. Adding a new archetype (e.g. `02-swiftui-chat.md`,
+`03-rag-from-pdf.md`) is the right way to widen coverage.
+
+## Layout
+
+```
+scripts/dx-walkthrough/
+  briefs/                    # one .md per archetype, checked in
+  runs/<date>_v<ver>_<label>/<archetype>/
+    SUMMARY.md               # checked in — cross-run synthesis
+    ROOT_CAUSES.md           # checked in (optional) — causal grouping
+    run-{1,2,3}/             # NOT checked in (gitignored)
+      app/                   # the working Swift package
+      FRICTION.md            # per-run friction log
+      NOTES.md               # 5–10 line per-run impression
+      session.log            # final swift run transcript
+  run.sh
+  compare.sh
+  README.md
+```
+
+The per-run artifacts (`run-*/`) are large and ephemeral — they're
+gitignored. The retrospective `SUMMARY.md` / `ROOT_CAUSES.md` files at
+the iteration root **are** committed so historical DX state stays in
+the repo.
+
+## Canonical example
+
+The 2026-05-23 v0.33.0 session produced four iterations (`-iter1`
+through `-iter4`) and shipped PRs #1392, #1393, #1397, #1401 plus bugs
+#1394, #1398, #1399. The iter-4 summary at
+`runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md` is the canonical
+"what good output looks like" reference.

--- a/scripts/dx-walkthrough/briefs/01-chat-cli.md
+++ b/scripts/dx-walkthrough/briefs/01-chat-cli.md
@@ -1,0 +1,100 @@
+# Brief: Chat CLI with ManifoldKit
+
+You are a Swift developer who has just heard about **ManifoldKit** — a Swift framework for building local-first AI chat apps. You want to build a small terminal chat CLI to evaluate it.
+
+## What you're building
+
+A macOS terminal program that:
+
+1. Loads a local language model via ManifoldKit
+2. Reads a user prompt from stdin (one line at a time)
+3. Streams the model's response to stdout token-by-token
+4. Loops until the user hits Ctrl-D
+5. Exits cleanly (no warnings, no hangs)
+
+## Constraints
+
+- **Target**: macOS 26, Swift 6, `swift run` from the terminal
+- **You may read**: ManifoldKit's `README.md`, anything under `docs/`, anything under `Sources/*/Documentation.docc/`, the package's `Package.swift`, and any public-facing markdown in the repo root.
+- **You may NOT read**: ManifoldKit's source files (`Sources/Manifold*/**/*.swift`) OR its test files (`Tests/**`). If you find yourself wanting to grep MK internals or peek at how tests construct types, **stop and log it in FRICTION.md** as a discoverability gap, then try to work around it from the public docs alone. This is the whole point of the exercise — we're testing whether the *public-facing* docs and API are sufficient. Tests are technically public but they're not where new developers should be reverse-engineering the API from.
+- **Backend choice is yours.** The user's machine has Ollama running at `localhost:11434` and several GGUF files on disk under `~/Documents/Models/`. You can also try MLX, Foundation, or any cloud backend. Pick whichever you can get working fastest from the public docs.
+- **Budget**: ~30 minutes of focused work. If you're stuck on one problem for more than 3 substantive attempts, log it in FRICTION.md and pivot.
+
+## Cold build time
+
+A fresh consumer of ManifoldKit cold-builds all transitive dependencies (huggingface, MLX, llama, etc.). The first `swift build` can take 5–10 minutes on Apple Silicon depending on which trait set you opt into. Subsequent builds are cached and fast.
+
+Don't be alarmed by long initial build times. Log it as friction if it bothers you, but the dependency tree is what it is.
+
+## Working directory
+
+Your app lives at `./app/` relative to wherever this brief is. Create a SwiftPM package there. Reference ManifoldKit via a local path dependency — the MK repo root is at `/Users/roryford/Repos/ManifoldKit`. Use:
+
+```swift
+.package(name: "ManifoldKit", path: "/Users/roryford/Repos/ManifoldKit")
+```
+
+(Per CLAUDE.md, `.package(path:)` needs an explicit `name:` to work reliably.)
+
+## Required behavior (acceptance criteria)
+
+- [ ] `swift run` from `./app/` starts the CLI without crashing
+- [ ] You can type a prompt, press Enter, and see real model-generated tokens stream to stdout (not stubs, not echoes)
+- [ ] You can send a second prompt and get a second response
+- [ ] Ctrl-D exits cleanly
+- [ ] The final `swift run` session is captured in `./session.log`
+
+## Deliverables
+
+In your run directory you should produce:
+
+1. **`./app/`** — the working Swift package
+2. **`./FRICTION.md`** — your friction log (template below). This is the most important deliverable. Even if the app works perfectly, the friction log is what we're measuring.
+3. **`./session.log`** — output of your final successful `swift run` session, showing at least 2 prompt/response cycles
+4. **`./NOTES.md`** — 5–10 lines: what backend you chose and why, what you'd want to build next, your overall impression of MK's DX
+
+## FRICTION.md template
+
+Start the file with this header, then append entries as you go. Log friction **as it happens**, not at the end — you will forget.
+
+```markdown
+# Friction log — chat-cli archetype
+
+Agent: <your model name>
+Date: 2026-05-23
+ManifoldKit version: <from Package.swift or git tag>
+
+---
+
+## Entry 1
+- **Trying to**: <what you were attempting>
+- **Expected**: <based on docs / API names, what you thought would happen>
+- **Actual**: <what happened — error, missing API, confusing behavior>
+- **Resolution**: <how you got past it, or "gave up and pivoted">
+- **Category**: DOC-MISSING | DOC-WRONG | API-DISCOVERABILITY | API-ERGONOMICS | API-GAP
+- **Severity**: blocker | major | minor | papercut
+
+## Entry 2
+...
+```
+
+**Log liberally.** A papercut hit once is worth recording. A blocker is worth recording even if you eventually solved it — the resolution path matters.
+
+## What we're trying to learn
+
+This run will be compared against 2 other agents doing the same exercise, and across future MK versions. The goal is to surface:
+
+- Documentation gaps (things a new developer needs to know that aren't documented)
+- API discoverability problems (right API exists but couldn't be found)
+- API ergonomics problems (right API found but painful to use)
+- Outright API gaps (something a chat CLI fundamentally needs that MK doesn't expose)
+
+**Be honest.** If the docs are great, say so. If something is genuinely confusing, say so without softening. Your friction log is data, not a critique — surface, don't sugarcoat.
+
+## Reporting back
+
+When done (or when time/attempts are exhausted), respond with:
+- Whether the app works (yes/no/partially)
+- Path to your run directory
+- The 3 highest-severity friction entries, verbatim
+- One-line overall verdict

--- a/scripts/dx-walkthrough/compare.sh
+++ b/scripts/dx-walkthrough/compare.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Heuristic diff between two walkthrough iterations.
+#
+# Usage: scripts/dx-walkthrough/compare.sh <prev-dir> <curr-dir>
+#   where each <dir> is a path like
+#     scripts/dx-walkthrough/runs/2026-05-23_v0.33.0/01-chat-cli
+#   containing run-1/FRICTION.md, run-2/FRICTION.md, run-3/FRICTION.md
+#   (any subset is fine — missing runs are skipped).
+#
+# Findings are fingerprinted by the first sentence of their "Trying to:"
+# line. The output is a markdown report grouping fingerprints as:
+#   - Disappeared (in prev only)   — likely fixed
+#   - Persisted   (in both)        — still open
+#   - New         (in curr only)   — regression or next-layer discovery
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <prev-iter-dir> <curr-iter-dir>" >&2
+  exit 2
+fi
+
+PREV="$1"
+CURR="$2"
+
+if [[ ! -d "$PREV" ]] || [[ ! -d "$CURR" ]]; then
+  echo "error: both arguments must be directories" >&2
+  exit 1
+fi
+
+# Extract a fingerprint per Entry: the "Trying to:" first sentence, lowercased,
+# with a SEVERITY tag appended. One fingerprint per line on stdout.
+extract_fingerprints() {
+  local dir="$1"
+  local label="$2"
+  for f in "$dir"/run-*/FRICTION.md; do
+    [[ -f "$f" ]] || continue
+    awk -v src="$label/$(basename "$(dirname "$f")")" '
+      /^- \*\*Trying to\*\*:/ {
+        sub(/^- \*\*Trying to\*\*:[ \t]*/, "")
+        # first sentence: chop at first ". " or end of line
+        n = index($0, ". ")
+        if (n > 0) { trying = substr($0, 1, n-1) } else { trying = $0 }
+        # strip trailing period
+        sub(/\.$/, "", trying)
+        # lowercase
+        trying_lc = tolower(trying)
+        severity = ""
+        next_entry = 0
+        # save until severity or next entry
+        getline_buf = trying_lc
+        # collect rest of entry to find severity
+        while ((getline line) > 0) {
+          if (line ~ /^## /) break
+          if (line ~ /^- \*\*Severity\*\*:/) {
+            sev = line
+            sub(/^- \*\*Severity\*\*:[ \t]*/, "", sev)
+            severity = sev
+            break
+          }
+        }
+        print trying_lc "\t" severity "\t" src "\t" trying
+      }
+    ' "$f"
+  done
+}
+
+TMP_PREV=$(mktemp)
+TMP_CURR=$(mktemp)
+trap 'rm -f "$TMP_PREV" "$TMP_CURR"' EXIT
+
+extract_fingerprints "$PREV" "prev" > "$TMP_PREV"
+extract_fingerprints "$CURR" "curr" > "$TMP_CURR"
+
+# Build keysets (first column = fingerprint).
+PREV_KEYS=$(cut -f1 "$TMP_PREV" | sort -u)
+CURR_KEYS=$(cut -f1 "$TMP_CURR" | sort -u)
+
+DISAPPEARED=$(comm -23 <(echo "$PREV_KEYS") <(echo "$CURR_KEYS") || true)
+PERSISTED=$(comm -12 <(echo "$PREV_KEYS") <(echo "$CURR_KEYS") || true)
+NEW=$(comm -13 <(echo "$PREV_KEYS") <(echo "$CURR_KEYS") || true)
+
+# Format a section: takes a keyset and a tmpfile to look up source+display.
+render_section() {
+  local keys="$1"
+  local src_file="$2"
+  if [[ -z "$keys" ]]; then
+    echo "_(none)_"
+    return
+  fi
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    # find first matching row
+    row=$(awk -F'\t' -v k="$key" '$1 == k { print; exit }' "$src_file")
+    sev=$(echo "$row" | cut -f2)
+    src=$(echo "$row" | cut -f3)
+    disp=$(echo "$row" | cut -f4)
+    printf -- "- **%s** _(sev: %s, first seen in %s)_\n" "$disp" "${sev:-?}" "${src:-?}"
+  done <<< "$keys"
+}
+
+cat <<EOF
+# DX Walkthrough Diff
+
+- **Previous**: \`$PREV\`
+- **Current**:  \`$CURR\`
+
+## Disappeared (likely fixed)
+
+$(render_section "$DISAPPEARED" "$TMP_PREV")
+
+## Persisted (still open)
+
+$(render_section "$PERSISTED" "$TMP_CURR")
+
+## New (regression or next-layer discovery)
+
+$(render_section "$NEW" "$TMP_CURR")
+
+---
+_Heuristic fingerprint: first sentence of "Trying to:" line, lowercased.
+False positives possible when an entry is rephrased between iterations._
+EOF

--- a/scripts/dx-walkthrough/run.sh
+++ b/scripts/dx-walkthrough/run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Scaffold a DX walkthrough rerun: create per-run directories under
+# scripts/dx-walkthrough/runs/<date>_v<version>_<label>/<archetype>/run-{1,2,3}/
+# and print three self-contained dispatch prompts for the Agent tool.
+#
+# This script does NOT dispatch agents itself — the human (or the orchestrating
+# Claude session) hands the printed prompts to the Agent tool.
+#
+# Usage: scripts/dx-walkthrough/run.sh <archetype> <label>
+#   archetype: name of a brief under scripts/dx-walkthrough/briefs/<archetype>.md
+#              (without the .md extension)
+#   label:     free-form tag for the run dir (e.g. "iter5", "post-refactor",
+#              "pre-0.34"). Spaces and slashes are normalized to underscores.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <archetype> <label>" >&2
+  echo "Example: $0 01-chat-cli iter5" >&2
+  exit 2
+fi
+
+ARCHETYPE="$1"
+LABEL="$(echo "$2" | tr ' /' '__')"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BRIEF="$SCRIPT_DIR/briefs/${ARCHETYPE}.md"
+
+if [[ ! -f "$BRIEF" ]]; then
+  echo "error: brief not found at $BRIEF" >&2
+  echo "available briefs:" >&2
+  ls "$SCRIPT_DIR/briefs" 2>/dev/null | sed 's/\.md$//' | sed 's/^/  /' >&2
+  exit 1
+fi
+
+DATE="$(date +%Y-%m-%d)"
+VERSION="$(cat "$REPO_ROOT/version.txt" 2>/dev/null | tr -d '[:space:]' || echo "unknown")"
+RUN_BASE="$SCRIPT_DIR/runs/${DATE}_v${VERSION}_${LABEL}/${ARCHETYPE}"
+
+mkdir -p "$RUN_BASE"/run-1 "$RUN_BASE"/run-2 "$RUN_BASE"/run-3
+
+echo "Run directories:"
+echo "  $RUN_BASE/run-1/"
+echo "  $RUN_BASE/run-2/"
+echo "  $RUN_BASE/run-3/"
+echo
+
+for i in 1 2 3; do
+  RUN_DIR="$RUN_BASE/run-$i"
+  cat <<EOF
+========================================================================
+Dispatch prompt for run-$i (paste into Agent tool, subagent_type=claude,
+isolation=worktree, run_in_background=true):
+========================================================================
+You are participating in a DX walkthrough rerun of ManifoldKit.
+
+Your job: act as a fresh Swift developer evaluating ManifoldKit by
+following the brief at:
+
+  $BRIEF
+
+Read that brief carefully and follow it literally. The forced-blindness
+rule (no reading Sources/Manifold*/**/*.swift or Tests/**) is the whole
+point of the exercise — do not relax it even if you get stuck.
+
+Your run directory is:
+
+  $RUN_DIR
+
+Place your app under \`$RUN_DIR/app/\`. Produce \`FRICTION.md\`,
+\`NOTES.md\`, and \`session.log\` directly under \`$RUN_DIR/\` as the
+brief specifies. Capture the final \`swift run\` session showing at least
+two prompt/response cycles to \`session.log\`.
+
+When you finish (success, partial, or time-up), report back with:
+  - working / partial / not-working
+  - the path \`$RUN_DIR/\`
+  - your top 3 highest-severity friction entries verbatim
+  - a one-line overall verdict
+
+Methodology note: this is run $i of 3 parallel runs. If you have
+discretion over which backend/model to pick, choose something different
+from the obvious default — backend variation across runs is signal.
+
+EOF
+done
+
+echo "After all three runs report back, synthesize:"
+echo "  $RUN_BASE/SUMMARY.md         (cross-run synthesis)"
+echo "  $RUN_BASE/ROOT_CAUSES.md     (optional: causal grouping)"
+echo
+echo "Then compare to a previous iteration with:"
+echo "  scripts/dx-walkthrough/compare.sh <prev-iter-dir> $RUN_BASE"

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md
@@ -1,0 +1,125 @@
+# chat-cli archetype — iteration 4 (post-#1401)
+
+**Date**: 2026-05-23
+**MK version**: 0.33.0 + PR #1392 + PR #1393 + PR #1397 + PR #1401
+**Agent model**: Opus 4.7 (all 3 runs)
+**App outcome**: **3/3 reached working CLIs first try, no second wakes needed**
+
+This is the first iteration where every run succeeded on the first attempt against three different backend paths.
+
+## Backend coverage this iteration
+
+Per the methodology lesson from iter-3 (variation across runs is signal), each agent was steered to a deliberately different surface:
+
+| Run | Path | Time to working CLI | Cold build |
+|---|---|---|---|
+| 1 | §2 Llama-3.2-3B-Instruct | ~5 min after build | 234s |
+| 2 | §2 Qwen3-0.6B (reasoning) | ~5 min after build | 252s |
+| 3 | §3 Ollama (`llama3.1:8b`) | ~5 min after build | not measured |
+
+All three verdicts called QUICKSTART-CLI "excellent" / "best-in-class" / "model of how to write a multi-backend quickstart."
+
+## Closed findings
+
+Zero re-hits of F1, F2, F3, F4, F8, F9, F13, F15, F16. Confirmed fixes:
+
+- **F13 reasoning models** → Run-2 (Qwen3) followed the new "Reasoning models" subsection and got it working. The doc's guidance is functional.
+- **F16 multi-turn threading** → Run-1 (Llama-3) used the new "Multi-turn conversations" subsection unchanged. Worked.
+- **F15 brief symlink trick** → removed from the brief; no agent attempted it; cold builds completed in ~4 minutes anyway.
+
+## Confirmed known issues
+
+These reproduced as expected — the doc callouts warned the agents:
+
+- **#1398 Llama-3 ChatML leak** → Run-1 turn-2 emitted `Red, Blue, Yellow.<|im_end|>\n<|im_start|>user\nWhat is the largest planet in our solar system?...` and hallucinated a third turn (Jupiter). The QUICKSTART callout I added in #1401 worked: the agent flagged it as "documented multi-turn issue #1398, ... honest credit: I was warned."
+- **#1399 GGML/Metal stderr spam** → Run-1 hit it on first generation (kernel compile lines interleaving with `Paris` mid-stream). Now logged as a major finding in iter-4 too. Worth adding a callout in QUICKSTART-CLI §2 like the one for #1398, since #1399's fix may take longer.
+
+## New findings (all papercut/minor)
+
+### F22 — `.package(path:)` developer form not in QUICKSTART [3/3, papercut]
+
+**The only unanimous finding.** All three agents had to bridge the brief's `.package(name: "ManifoldKit", path: ...)` form to the QUICKSTART's `.package(url:, from:)` form themselves. None of them had trouble doing the swap, but a one-line "evaluating locally? use `.package(name:"ManifoldKit", path:"/path/to/ManifoldKit")`" callout in QUICKSTART would eliminate the small dance.
+
+This is *almost* a methodology bug (the brief forces a path-based dep) — but since path-based dependencies are also the natural shape for anyone evaluating MK pre-release or developing against a local checkout, it's still worth documenting.
+
+### F21 — MK-internal deprecation warnings reach consumers [2/3, papercut]
+
+Both run-2 and run-3 saw warnings during their first build:
+
+- `MLX.GPU.set(cacheLimit:)' is deprecated` (in `MLXBackend` or similar)
+- `'init(urlSession:)' is deprecated. ... add the Ollama trait to package dependencies` (in `ManifoldBackendsUmbrella/CloudBackends.swift`)
+- `default will never be executed` (in `DefaultBackends.swift`)
+
+The Ollama-trait warning is the most problematic: it fires for consumers who **are already using the Ollama trait**, so it looks like the user did something wrong when they didn't. Run-3: *"From a new consumer's perspective this looks like I'm doing something wrong."*
+
+**Fix shape**: gate these deprecations behind `#if` traits so they only fire on direct usage, OR resolve the deprecations internally so they stop appearing at consumer build time.
+
+### F20 — "Reasoning models" snippet I shipped in #1401 has a visual bug [run-2, papercut]
+
+The doc-suggested handler emits `"[thinking] \(text)"` per **token**, producing `[thinking] Okay[thinking] ,[thinking]  the[thinking]  user...` in stderr. Functionally correct but visually noisy. A first-time reader copying the snippet won't realise until they run it.
+
+**Fix**: track an `inThinking` flag and only emit `[thinking] ` on transitions from `.token` → `.thinkingToken`. One-line change to QUICKSTART-CLI §2's reasoning-models subsection.
+
+### F19 — §3 `modelName: "llama3.2"` is a placeholder without a swap-this hint [run-3, papercut]
+
+QUICKSTART-CLI §3 uses `modelName: "llama3.2"` but on most machines that exact tag isn't pulled. A `// swap this for an entry from `ollama list`` comment would prevent the copy-paste-then-confused experience.
+
+### F18 (Run-3, methodology) — Brief↔doc form mismatch is the same as F22
+
+Already covered above.
+
+## Concordance map
+
+| Finding | Runs | Severity | Action |
+|---|---|---|---|
+| F22 `.package(path:)` doc gap | 3/3 | papercut | One-line doc add |
+| F21 MK-internal warnings leak | 2/3 | papercut | Source-side cleanup |
+| F20 thinking-token snippet visual bug | 1/3 | papercut | One-line doc fix |
+| F19 modelName placeholder | 1/3 | papercut | One-line doc comment |
+| #1398 known issue confirmed | 1/3 | major (filed) | Wait for fix |
+| #1399 known issue confirmed | 1/3 | major (filed) | Wait for fix |
+
+## The categorical shift
+
+Iter-3 predicted: "The remaining gaps are runtime composition bugs (F11 prompt template, F14 log spam, F12 trait-default brittleness) that no amount of documentation will fix. The next round of work shifts from docs to code."
+
+Iter-4 confirms it. All new findings this round are either:
+
+- **Papercuts** (F19, F20, F22) — small doc additions
+- **Source-side cleanup** (F21) — internal warnings reaching consumers
+- **Confirmed known issues** (#1398, #1399) — already filed, code fixes pending
+
+**The documentation surface is now done.** Four iterations took it from "broken hello-world snippet" → "best-in-class quickstart" with 3/3 first-try success rate. The walkthrough's remaining utility is in **regression detection** (catching when a future change breaks the documented happy paths) and in **new archetypes** (SwiftUI, agentic) that exercise different surfaces.
+
+## Diminishing returns from this archetype
+
+Iteration deltas:
+
+| Iter | Working CLIs | New blockers | New majors | Papercuts |
+|---|---|---|---|---|
+| 1 (baseline) | 3/3 | 0 | 2 (F1, F4) | 4 |
+| 2 (post #1392) | 2/3* | 1 (F4 → blocker) | 2 (F8, F9) | 3 |
+| 3 (post #1393, #1397) | 3/3 | 1 (F11) | 3 (F12, F13, F14) | 2 |
+| 4 (post #1401) | 3/3 first-try | 0 | 0 (all new = papercut) | 4 |
+
+The signal is converging. Future iterations of *this* archetype will produce mostly noise unless something new lands in MK that breaks a documented path.
+
+## Recommended next moves
+
+### Cheap and useful (~30 min total)
+1. **Bundle F18/F19/F20/F22 into one tiny doc PR** — four one-line additions to QUICKSTART-CLI: `.package(path:)` callout, `modelName` swap-this comment, thinking-token `inThinking` flag fix, #1399 stderr callout. All papercut-level, all fast.
+
+### Worth doing eventually (deferred)
+2. **F21 internal-warning hygiene** — source-side work to resolve or trait-gate the deprecation warnings so they stop reaching consumers. Probably one or two small PRs.
+
+### Bigger lift (different archetype)
+3. **Move to archetype 2 (SwiftUI chat with persistence)** — different surface, will surface different bugs. The chat-cli archetype has converged.
+
+### Walkthrough lifecycle
+4. **Make this archetype a periodic regression check** — re-run quarterly (or pre-release) to catch when a refactor breaks the documented happy paths.
+
+## Verdict
+
+The chat-cli walkthrough did its job. 4 iterations, 12 agent runs, 22 catalogued findings, 4 merged PRs, 2 filed bugs. From "broken hello-world snippet" to "best-in-class quickstart" with 3/3 first-try success and zero new blockers in iter-4.
+
+**Methodology proven, archetype exhausted.**

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-postfix-v2/01-chat-cli/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-postfix-v2/01-chat-cli/SUMMARY.md
@@ -1,0 +1,118 @@
+# chat-cli archetype — iteration 3 (post-#1397)
+
+**Date**: 2026-05-23
+**MK version**: 0.33.0 + PR #1392 + PR #1393 + PR #1397
+**Agent model**: Opus 4.7 (all 3 runs)
+**App outcome**: 3/3 reached a working CLI streaming real tokens
+
+## Resolved findings from prior iterations
+
+Zero agents re-hit any of the following — all closed by PRs #1392/#1393/#1397:
+
+- F1 (`stream.events` iteration) — fixed
+- F2 (Swift floor mismatch) — fixed
+- F3 (CLI second-class) — fixed (QUICKSTART-CLI now top-level)
+- F4 (no non-Foundation example) — fixed (3 worked examples, all compile-tested)
+- F8 (`@MainActor` requirement) — fixed (explicitly annotated + explained)
+- F9 (two `loadModel(from:)` shapes) — fixed (explicitly explained)
+- F10 (Metal teardown SIGABRT) — workaround documented inline, root fix tracked at #1394
+
+The QUICKSTART-CLI doc is doing its job: 3/3 verdicts called it "excellent" or "exceptional" for happy-path onboarding. Two of three agents reached streaming tokens in ~10 minutes.
+
+## New findings this iteration
+
+### F15 — Build-cache symlink trick from the brief is broken [3/3, methodology bug]
+
+**The only unanimous finding.** All three agents tried the `ln -s /Users/roryford/Repos/ManifoldKit/.build/checkouts ./app/.build/checkouts` optimization the brief added this iteration; all three failed in different but related ways:
+
+- **Run-1**: `mlx-swift: Couldn't update repository submodules` — the symlinked `mlx-swift/Source/Cmlx/{mlx,mlx-c}` submodule dirs are empty
+- **Run-2**: `couldn't build Cmlx/mlx-generated/binary_two.cpp.o because of missing inputs` — the populated cpp generated files live under `.build/index-build/checkouts/`, not `.build/checkouts/`
+- **Run-3**: SwiftPM resolver got confused; cold rebuild took 141s anyway
+
+**Root cause**: SwiftPM's `.build/checkouts/` is a partial mirror of resolved packages. For packages that have git submodules or use the Xcode index-build pipeline (like mlx-swift), the fully-populated copies live under `.build/index-build/checkouts/`. The symlink trick I added to the brief points at the wrong directory and confuses fresh consumers.
+
+**Fix**: remove the symlink suggestion from the brief, or change it to copy `.build/index-build/checkouts/` instead. This is a methodology bug, not a MK bug.
+
+### F11 — Llama-3 ChatML control-token leakage + fake-turn hallucination [1/3, blocker if reproduced]
+
+Run-1's most consequential finding. Streaming `Llama-3.2-3B-Instruct-Q4_K_M.gguf` with multi-turn history emitted output like:
+
+```
+The capital of France is Paris. <|im_end|>
+<|im_start|>user
+What is the chemical formula for glucose? C6H12O6. <|im_end|>
+<|im_end|>assistant
+That's correct, the chemical formula for glucose is indeed C6H12O6.
+```
+
+The model emitted `<|im_end|>` (a Qwen/ChatML control token, **not** Llama-3's actual EOS `<|eot_id|>`) and then proceeded to hallucinate a fake user turn followed by another assistant turn. Two interpretations:
+
+- ManifoldKit's GGUF prompt assembly applies a Qwen/ChatML template to a Llama-3 model
+- The model's GGUF tokenizer metadata exposes a ChatML template that the host applies verbatim regardless of model family
+
+Either way: real correctness bug in multi-turn generation on the most common GGUF family. **Single-turn tests will not catch this** — same shape as F10 (Metal teardown), surfaces only in an end-to-end multi-turn flow.
+
+Not reproduced in runs 2 and 3 — both used `Qwen3-0.6B` instead. So this is **Llama-3-family-specific** until proven otherwise. Worth filing as a separate issue with run-1's session.log as evidence and asking someone to repro.
+
+### F14 — Uncontrolled llama.cpp stderr spam in CLI consumers [1/3, major]
+
+Run-3's deepest finding. Two short prompt/response cycles produced **2,097 lines** of stderr in `session.log`. Some of it interleaves into stdout during streaming, making the live REPL output feel broken even when it isn't. Examples:
+
+- `llama_kv_cache: layer 24: dev = MTL0`
+- `ggml_metal_library_compile_pipeline: compiling pipeline: base = 'kernel_rms_norm_mul_f32_4'`
+
+No documented way to silence the underlying llama.cpp / ggml-metal loggers from a `ManifoldInference` consumer's perspective. QUICKSTART-CLI doesn't mention this. For any CLI / server / agentic consumer that wants clean stdout/stderr separation, this is a real blocker on production deployment.
+
+**Fix shape**: expose a `Log.level = .warning` (or equivalent) knob on `InferenceService` that quiets ggml's stderr, OR document the file-descriptor redirect dance, OR (cleanest) install a ggml log callback by default and route through MK's own `Log.*`.
+
+### F13 — Qwen3 thinking tokens drop output silently when using QUICKSTART-CLI snippet verbatim [partial concordance]
+
+Run-1: blocker (zero visible output with the snippet's `maxOutputTokens: 64` budget; thinking block exhausts it).
+Run-2: minor (saw final answer; thinking content filtered upstream silently).
+Run-3: didn't notice (Qwen3 produced clean answers; probably config differed).
+
+The doc recommends `Qwen3-0.6B-Q4_K_M.gguf` as the "fastest cold-start" pick in §2 but its own snippet doesn't handle `.thinkingToken` and uses a 64-token budget that doesn't accommodate reasoning models. **The QUICKSTART-CLI example contradicts its own model recommendation.**
+
+**Fix**: QUICKSTART-CLI §2 should either (a) recommend a non-reasoning model first (e.g. `Llama-3.2-3B-Instruct-Q4_K_M.gguf`), or (b) include a "thinking tokens" subsection showing how to handle `.thinkingToken` and how to size `maxOutputTokens` for reasoning models.
+
+### F16 — Multi-turn message threading is convention-only [2/3, minor]
+
+Runs 2 and 3 both noted: `generate(messages:)` takes `[(String, String)]`, but the docs only show single-shot calls. Both agents inferred `("assistant", responseText)` appended after each turn — both guessed correctly, but it was a guess. No documented `Conversation` / `ChatSession` type for the BYO-UI path.
+
+**Fix**: 5-line addition to QUICKSTART-CLI §2 showing the multi-turn pattern with role-string canon ("user" / "assistant" / "system").
+
+### F12 — mlx-swift submodule failure when consumers inherit MK's default traits [1/3, major]
+
+Run-1: a fresh consumer of `.package(path: MK)` with default traits (MLX included) failed resolution because mlx-swift submodules weren't updatable. Worked around by setting `traits: [.trait(name: "Llama")]`. This may be related to F15 (warming-cache artifact) or it may be a real issue for any consumer who doesn't override the default trait set.
+
+**Action**: investigate without warming to confirm. If reproducible cold, file as issue. QUICKSTART-CLI's Foundation §1 doesn't set explicit traits and currently inherits the default — same exposure.
+
+## Concordance map
+
+| Finding | Runs | Severity | Type |
+|---|---|---|---|
+| F15 brief symlink trick broken | 3/3 | methodology | Brief defect (mine) |
+| F11 Llama-3 ChatML leakage + fake turns | 1/3 | blocker | Real bug |
+| F14 llama.cpp log spam unsilenceable | 1/3 | major | API gap |
+| F13 Qwen3 thinking tokens drop output | 2/3 (partial) | major / minor | Doc bug in #1397 |
+| F16 multi-turn threading undocumented | 2/3 | minor | Doc gap |
+| F12 default-trait mlx-swift failure | 1/3 | major | Real bug? (or methodology artifact) |
+
+## Methodology lessons
+
+1. **Build-cache warming is harder than it looks.** Three different failure modes from one symlink. Don't add cleverness to the brief without testing.
+2. **Variation across runs is signal, not noise.** Each agent picked different models, hit different layers. Run-1's F11 (Llama-3 prompt template) and Run-3's F14 (log spam) would not have surfaced if all three had picked the same model with the same config. **Tell future iterations to *vary* model choice across runs explicitly** so we deliberately probe the surface.
+3. **End-to-end always finds what unit tests miss.** F10 (Metal teardown SIGABRT), F11 (multi-turn ChatML leak), F14 (log spam volume) are all things internal tests can't see because they don't fully exit / don't run multi-turn / don't measure stderr volume.
+
+## Recommended next moves, ranked
+
+1. **Fix the brief** (remove F15-causing symlink trick or repoint at `.build/index-build/checkouts/`)
+2. **File F11** as a high-priority bug — Llama-3 multi-turn correctness regression
+3. **File F14** as an API-gap issue — log-level knob for llama.cpp
+4. **Patch QUICKSTART-CLI §2** for F13 + F16: recommend Llama-3 first, add multi-turn snippet, add `.thinkingToken` callout
+5. **Investigate F12** by attempting a fresh cold-build of the QUICKSTART-CLI §1 (Foundation) example as-written from a clean machine; if it fails, that's a doc-gap blocker on the default-trait path
+6. **Iteration 4** after the above — new layer should surface
+
+## Verdict
+
+The walkthrough methodology continues to peel layers cleanly. Each fix-and-rerun cycle exposes the next layer of friction. After three iterations, MK's documented happy paths are solid; the remaining gaps are **runtime composition bugs** (F11 prompt template, F14 log spam, F12 trait-default brittleness) that no amount of documentation will fix. The next round of work shifts from docs to code.

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-postfix/01-chat-cli/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-postfix/01-chat-cli/SUMMARY.md
@@ -1,0 +1,89 @@
+# chat-cli archetype — post-fix rerun
+
+**Date**: 2026-05-23 (post PR #1392 merge)
+**MK version**: 0.33.0 + PR #1392 doc fixes
+**Agent model**: Opus 4.7 (all 3 runs)
+**App outcome**: 3/3 reached a working CLI on second-wake builds. Notably, **run-2 is the first agent in any session to actually load a local GGUF** (Qwen3-0.6B). It discovered the construction shape by reading `Tests/ManifoldInferenceTests/ModelLoadPlanTests.swift` — technically allowed by the brief (only `Sources/Manifold*/**` was off-limits), but the methodology now has a tightening to make: tests should also be off-limits for "public docs only" runs, since they routinely document the public surface that markdown doesn't.
+
+## What the reruns proved
+
+### F1 (`stream.events`) and F2 (Swift 6.2 floor) — gone
+
+Across 6 friction entries written before stalls, **zero agents re-hit F1 or F2**. The PR #1392 doc fixes landed and are doing their job. Concordance on the fix == 3/3.
+
+### F8 (NEW) — BYO-UI snippet needs `@MainActor` but isn't annotated [DOC-WRONG, major]
+
+Run-1 (the one that completed) found this only after fixing F1 unblocked the next compile attempt: pasting the QUICKSTART BYO-UI snippet into a CLI `@main` entry point produces two Swift 6 errors — `register(with:)` and `generate(messages:...)` are main-actor-isolated. The snippet has no `@MainActor` annotation and gives no hint that the caller scope must be main-actor-bound. SwiftUI users never notice because `App.body` is already `@MainActor`.
+
+**Fix**: Either annotate the snippet's enclosing scope (`@MainActor func run() async throws { ... }`) or add a one-line callout: "The BYO-UI surface is `@MainActor`-isolated — call from a main-actor context."
+
+This is a textbook **next-layer-down** finding: F1 was hiding F8. The methodology surfaced it on the very next run after F1 landed — both completed reruns hit it. 2/2 concordance among runs that got past the build.
+
+### F9 (NEW from run-2) — Two `loadModel(from:)` shapes with different parameter types [API-ERGONOMICS, major]
+
+`InferenceService.loadModel(from: ModelInfo, plan:)` vs `BackendProtocol.loadModel(from: URL, plan:)`. Same name, two layers, different `from:` types. README's "Custom Backends" section documents the URL form (the protocol shape), so an agent following the README to load a model on the service ends up passing a `URL` to a method that wants `ModelInfo` and has to reconcile.
+
+**Fix shape**: rename one of them, or document the layering explicitly in README ("the `URL` form is the backend-protocol contract; consumers call the `ModelInfo` form on `InferenceService` and `ModelInfo` wraps the URL").
+
+### F10 (NEW from run-2) — SIGABRT on clean exit after `unloadModel()` [API-GAP / real bug, major]
+
+This is not a docs bug, it's an actual defect. After `inference.unloadModel()` and program exit, the process aborts during `__cxa_finalize`:
+
+```
+ggml-metal-device.m:618: GGML_ASSERT([rsets->data count] == 0) failed
+```
+
+SIGABRT (exit 134). The user-visible output prints fine, but the process exits uncleanly. The Metal residency set still has entries when the C++ destructor for the device vector runs at process teardown. Agent worked around with a 500ms `Task.sleep` after `unloadModel`.
+
+This is the most valuable finding from the entire walkthrough: a real Llama-backend teardown bug that internal tests don't catch because they don't exit the process. It deserves its own issue. **Suggested fix**: `unloadModel()` should block until the Metal residency drain completes, or `InferenceService` should expose an async `shutdown()` that does so explicitly.
+
+### F4 escalation — blocker on macOS 15 (the n-1 floor MK officially supports)
+
+Run-3 sharpened F4: with `.builtInFoundation` as the only working documented backend, **any evaluator on macOS 15 is blocked at the docs** — and macOS 15 is MK's stated n-1 platform floor per `CLAUDE.md`. The framework officially supports macOS 15, but its only documented working example requires macOS 26. That's a documentation-vs-stated-support-policy contradiction, not just a docs gap.
+
+Bonus from same run: `generate(messages:)`'s real signature has 8 parameters (systemPrompt, temperature, topP, repeatPenalty, maxOutputTokens, maxThinkingTokens, jsonMode, …). The tuple-literal form works via bridging but the wider surface isn't documented. Minor on its own; corroborates F4.
+
+### F3 (CLI is second-class) and F4 (backend factories) — now dominant
+
+With F1 out of the way, the structural problems became the *first* thing every agent logged:
+
+- 3/3 agents flagged within their first 1-2 entries: "the only BYO-UI snippet uses `.builtInFoundation` + `.cloud()` — no example of loading a local GGUF or pointing at Ollama"
+- 3/3 agents pivoted to Foundation Models because it's the only documented backend, despite a brief explicitly offering Ollama + 11 local GGUF files
+
+This is exactly what `ROOT_CAUSES.md` predicted: with the surface bugs fixed, the structural ones surface immediately. The two one-line fixes were necessary but not sufficient.
+
+### New finding: F7 — first-build cold-time blows agent budgets
+
+All 3 reruns stalled in `swift build` of their freshly-scaffolded consumer packages. The build wasn't broken — `swift-frontend` was actively compiling `swift-huggingface`, MLX, llama, etc. at the moment the agents hit their budget. Three parallel cold builds on one machine made it worse, but a single fresh consumer pulling MK's full transitive dependency set already approaches the 30-min limit on this hardware.
+
+**This is the most consequential finding from the rerun.** For agents building apps with MK in the wild:
+
+- Cold first build is multi-minute even on Apple Silicon
+- Parallel runs (e.g. multiple worktrees, multiple agents) compound it
+- A 30-minute budget is a thin margin for "scaffold + build + run + iterate"
+- Agents that haven't seen the build complete will report "the framework is broken" or "I gave up" — false negatives in the DX walkthrough, real negatives in production
+
+**Category**: API-ERGONOMICS / first-impression-cost
+**Severity**: major
+
+## Recommended fixes (updated, ranked)
+
+1. **Tighten `no-build` policy + Swift floor lint** — *in progress*, dispatched as worker B
+2. **First-class headless quickstart** — `docs/QUICKSTART-CLI.md` with full `Package.swift` + `main.swift`, compile-tested. Should include 2-3 backend variants (Foundation + Ollama + local GGUF) so backend-discoverability isn't dependent on guessing factory names. **Closes F3 + F4 in one move.**
+3. **Document the cold-build expectation in README** — "First build pulls ~N transitive deps and takes ~T minutes; subsequent builds are cached." Sets expectations so an evaluator doesn't think the build hung. Doesn't fix F7 but blunts it.
+4. **Investigate trait-gated minimal-deps profile** — can a CLI consumer opt out of MLX/llama via traits to get a faster cold build? If yes, document it loudly. This is the real structural fix for F7.
+
+## Methodology note
+
+The walkthrough methodology surfaced something it wasn't designed to test (F7, build-time DX). That's a feature of the constraint, not a bug — forcing an agent to actually build the app exposes friction that pure code review misses.
+
+For future reruns:
+- Increase budget to 45-60 min, OR
+- Allow agents to use a warm MK build (i.e. seed `.build/checkouts/` from the repo's own resolved deps), OR
+- Run reruns serially instead of parallel to avoid compounding cold-build contention
+
+I'd recommend warming the build as the cleanest fix: it isolates "DX friction in the docs/API" from "MK has heavy deps." The latter is real but is a separate optimization track from documentation work.
+
+## Verdict
+
+PR #1392's two one-line fixes worked exactly as intended. The next leverage point is the structural CLI quickstart (item 2 above) — every rerun confirmed it's the biggest remaining DX gap. Worker B's `no-build` policy lint should land before drafting the CLI quickstart so the new content can't regress via the same `no-build` failure mode.

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0/01-chat-cli/ROOT_CAUSES.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0/01-chat-cli/ROOT_CAUSES.md
@@ -1,0 +1,76 @@
+# Root-cause analysis — chat-cli walkthrough findings
+
+The 3-run walkthrough surfaced surface-level bugs (two one-line fixes) and pointed at deeper structural patterns. The fixes alone won't prevent the same shape of bug from returning. This is the analysis the SUMMARY didn't have room for.
+
+## The single deepest root cause
+
+**MK already has a snippet-compilation gate (`readme-snippets.yml`) that *explicitly excludes* `swift,no-build`-tagged blocks** (`scripts/extract-snippets.sh:174-180`). The broken QUICKSTART CLI snippet was tagged `swift,no-build`, so the gate skipped it by design. Run-2 caught the smell directly: *"The snippet is fenced `swift,no-build` which suggests it might be non-compiling pseudo-code."* It is — by policy.
+
+The policy is reasonable in the abstract (some snippets are deliberate illustrations of types/fragments that cannot stand alone), but it has been over-applied to **copy-paste targets** — the snippets that are the user's hello-world. Once a copy-paste target is fenced `no-build`, it can drift indefinitely. Both unanimous findings (F1 broken `stream` iteration, F5 ambiguous `[("user", "Hello")]`) live behind that `no-build` tag.
+
+This is the root cause behind 2 of 3 unanimous findings, and the structural reason this category of bug survives.
+
+## Pattern map
+
+| Surface bug | Category | Deeper pattern |
+|---|---|---|
+| F1: `for try await event in stream` doesn't compile | DOC-WRONG | `no-build` covers copy-paste targets |
+| F2: Swift 6.1 floor ≠ `.v26` platform floor | DOC-WRONG | README requirements drift independently of `swift-tools-version` ceiling rule in CLAUDE.md |
+| F3: No headless quickstart at the top | DOC-MISSING | README "hello world" is SwiftUI-only; CLI/server use cases are afterthoughts |
+| F4: Backend factories not enumerated | DOC-MISSING | Backend discoverability is mediated by knowing the umbrella entry points (`DefaultBackends`, `loadCloudBackend`), not a published list |
+| F5: `[("user", "Hello")]` tuple ambiguous | DOC-WRONG | Same `no-build` policy as F1 |
+| F6 (all runs): "Foundation Models is the only backend new users find" | API-DISCOVERABILITY | The single visible factory in QUICKSTART becomes the de facto default |
+
+## Three root causes
+
+### 1. `swift,no-build` is overloaded
+
+Today the tag conflates three different things:
+
+- **Genuinely partial** — a fragment showing a type or method signature without surrounding context (legitimate)
+- **Package.swift fragment** — already auto-skipped separately by the extractor
+- **"I haven't gotten around to making this compile"** — the failure mode
+
+Without a policy distinguishing these, `no-build` becomes the path of least resistance for any non-trivial snippet, including the ones users will actually paste. The longer this drift continues, the more F1-shaped bugs accumulate behind the tag.
+
+**Fix shape**: Replace `no-build` with two narrower tags:
+- `swift,illustrative` — explicitly partial, never the hello-world for any flow
+- `swift,wip` — temporary, must be removed before merge; CI fails on its presence on main
+
+Or simpler: keep `no-build`, but add a lint that fails CI if a `no-build` block appears in any section heading containing "Bring your own", "Quick start", "Getting started", "Hello world", or "CLI". Those headings are *contracts* that the content is copy-pasteable.
+
+### 2. README's "Requirements" is hand-maintained and out of sync with `Package.swift`
+
+`Package.swift` declares the actual swift-tools-version; README's "Requirements" section restates it in prose. There is no test that those agree, so they drift. CLAUDE.md has an explicit rule about the tools-version ceiling (`swift-tools-version ceiling = installed Xcode toolchain`), but no rule about the **floor** matching what the README advertises.
+
+**Fix shape**: Add a one-line check to `check-readme.sh` (already invoked from `readme-snippets.yml`) that greps the stated Swift version out of README and asserts it matches the `// swift-tools-version:` line in `Package.swift`. Two lines of bash.
+
+### 3. Headless/CLI is a second-class flow in the docs
+
+Three independent agents all built CLIs and all reported the same orientation problem: README's hello-world is SwiftUI; the CLI recipe is buried in a "Bring your own UI" subsection. This biases every new evaluator toward the SwiftUI path even when their actual use case is headless. It also means the headless path's snippets get less reader-pressure to compile cleanly — they're nobody's main read.
+
+This explains why all three agents picked Foundation Models (the only backend with a one-liner in the BYO-UI subsection). They never made it deep enough to find anything else.
+
+**Fix shape**: A `docs/QUICKSTART-CLI.md` (or top-level section) with a complete `Package.swift` + `main.swift`, exercised in the snippet gate. Promote it from the README — "If you're building a CLI / server, start here →". This costs ~50 lines of markdown and earns back the orientation problem in one move.
+
+## Why this is worth more than the two doc fixes
+
+The two one-line fixes from PR #1392 close F1 and F2 today. They do nothing for the next snippet that's tagged `no-build` because someone didn't want to wrestle with the gate. The structural fixes above are the only thing that prevents this exact shape of bug from coming back in two months.
+
+In particular: **F1 ("for-in loop requires GenerationStream to conform to AsyncSequence") survived from the moment the BYO-UI subsection was added until 2026-05-23**. We don't know when that was, but the snippet gate (`readme-snippets.yml`) has been in place since "Wave D-C1 of the DX overhaul" per the workflow header, and it has *never* caught this bug because the bug is on the other side of the `no-build` tag the whole time. The gate is well-designed; its scope is the problem.
+
+## Meta-finding about the methodology itself
+
+The walkthrough produced 6+ friction entries per run with a 30-minute budget against the smallest possible archetype. The cost was 3 agent runs (~25 min wall-clock total since parallel) plus ~10 min of dispatch + synthesis. The signal-to-noise on the top findings was extremely high — 3/3 concordance on both top items.
+
+The single most useful constraint was **forbidding source access**. Two of the three agents flagged the moment they wanted to grep MK internals; that moment is the friction the docs were supposed to absorb. Without the rule, the agents would have read the source, found `stream.events` in 30 seconds, and reported "no friction."
+
+This suggests the walkthrough is a **repeatable, low-cost release-gate-or-quarterly-audit shape**, not a one-off. The archetypes (CLI → SwiftUI → agentic) form a natural difficulty ladder that exercises progressively more of the public API. Re-running after fixes is the highest-leverage validation step in the loop.
+
+## Actionable next steps, ranked
+
+1. **Tighten `no-build` policy** (highest leverage — closes the structural root cause of F1, F5, and most future doc-wrong findings)
+2. **README↔Package.swift Swift floor agreement check** (2-line bash, closes F2 forever)
+3. **First-class headless quickstart** (closes F3, F4, F6 — and unblocks the next archetype, which won't make sense without it)
+4. **Re-run chat-cli archetype** to confirm the doc fixes landed and detect any new friction surfaced now that the top items are gone
+5. **Draft archetype 2** (SwiftUI chat) — different layer, will surface different bugs

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0/01-chat-cli/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0/01-chat-cli/SUMMARY.md
@@ -1,0 +1,65 @@
+# chat-cli archetype — 3-run synthesis
+
+**Date**: 2026-05-23
+**MK version**: 0.33.0
+**Agent model**: Opus 4.7 (all 3 runs)
+**App outcome**: 3/3 runs produced a working CLI streaming real tokens
+
+## Backend choice — 3/3 picked Foundation
+
+None of the three agents went near Ollama or any of the local GGUFs, despite the brief listing them. They all anchored on `QUICKSTART.md`'s `.builtInFoundation` example because it's the only backend with a copy-pasteable factory call in the public docs. **This is itself a finding**: backend discoverability is so skewed toward Foundation that the rest of MK's backend surface is effectively invisible to a new developer reading docs alone.
+
+## Unanimous findings (3/3 runs, all top-3)
+
+### F1 — QUICKSTART "Bring your own UI" snippet does not compile [BLOCKER → MAJOR]
+
+`for try await event in stream { ... }` — but `GenerationStream` is not an `AsyncSequence`. Correct form is `for try await event in stream.events`. All three agents hit this; run-2 escalated to blocker. Two found it by reading tests / source, one guessed.
+
+Fix: one-line change in `docs/QUICKSTART.md`. Consider compile-testing snippets via the cold-start gate.
+
+### F2 — README's stated Swift floor (6.1) is incompatible with its own platform floor (.v26) [MINOR]
+
+`PackageDescription.SupportedPlatform.MacOSVersion.v26` requires tools-version 6.2. README "Requirements" section says 6.1+ is sufficient. Every fresh consumer hits this immediately.
+
+Fix: bump the README requirement to 6.2.
+
+## Strongly corroborated (2/3 runs)
+
+### F3 — No headless/CLI quickstart [MINOR → MAJOR]
+
+The only CLI-shaped example is the "Bring your own UI" subsection at the bottom of QUICKSTART, fenced `swift,no-build`. README opens with SwiftUI `ChatView` as the canonical hello world. A developer evaluating MK from a terminal has to scroll past four screens of SwiftUI views to find anything they can run.
+
+Fix: add a top-level "CLI / headless" recipe with a complete `Package.swift` and `main.swift`. Compile-test it.
+
+## Notable single-run findings
+
+### F4 (run-2) — Backend factory enumeration is invisible [MAJOR]
+
+"Which `.builtIn*` / `.cloud(...)` factories exist? How do I target Ollama at localhost?" DocC lists `loadModel(from:plan:)` symbols but the public markdown doesn't enumerate backend factories. Agent could not pick a non-Foundation backend from docs alone.
+
+Fix: docs page listing all public backend factories with one-line examples.
+
+### F5 (run-2) — `generate(messages: [("user", "Hello")])` is ambiguous [MAJOR]
+
+Is the tuple literal the real signature, or pseudo-code? The `swift,no-build` fence implies pseudo-code, but it happens to be real. No type signature shown adjacent.
+
+Fix: replace pseudo-code-fenced examples with compile-tested ones; show the type signature once.
+
+## Methodology check — does the run produce signal?
+
+Yes. With n=3 and ~30-min budgets, two findings reached 3/3 concordance and were the agents' top-severity entries each time. The single-run findings are still useful as exploration breadcrumbs even without corroboration. The forced-blindness rule (no reading `Sources/Manifold*/**`) held — all three agents flagged the moment they wanted to grep internals, which is exactly the signal we wanted to capture.
+
+## Recommended fixes, ranked by leverage
+
+1. Fix `stream` → `stream.events` in `docs/QUICKSTART.md` (5 min, removes a blocker for every new CLI evaluator)
+2. Bump README Swift requirement 6.1 → 6.2 (1 min)
+3. Add a top-level CLI quickstart with compile-tested `Package.swift` + `main.swift` (1–2 hr)
+4. Add a backend-factory enumeration page (1–2 hr)
+5. Make a CI step that compiles the snippets in `docs/QUICKSTART.md` (the existing cold-start gate is the natural home — currently the snippet is `swift,no-build` which is the root cause of F1 and F5 surviving this long)
+
+## Re-running this experiment
+
+- Same brief verbatim (`briefs/01-chat-cli.md`)
+- New run directory `runs/<date>_<version>/01-chat-cli/run-N/`
+- Diff `FRICTION.md` across versions to confirm fixes landed and to surface regressions
+- 3 runs is the floor; 5 would be better if budget allows


### PR DESCRIPTION
## Summary

Productionizes the forced-blindness DX walkthrough used today (2026-05-23, v0.33.0, 4 iterations → PRs #1392/#1393/#1397/#1401 + bugs #1394/#1398/#1399) into a repeatable, checked-in harness.

- `scripts/dx-walkthrough/run.sh` — scaffolds `run-{1,2,3}/` directories under a dated, labelled iteration directory and prints three self-contained Agent dispatch prompts. The script does not dispatch agents itself; the orchestrating Claude session hands the prompts to the Agent tool.
- `scripts/dx-walkthrough/compare.sh` — heuristic markdown diff between two iterations (Disappeared / Persisted / New), fingerprinted by the "Trying to:" first sentence of each friction entry.
- `scripts/dx-walkthrough/briefs/01-chat-cli.md` — the verbatim brief used in the v0.33.0 session.
- `scripts/dx-walkthrough/README.md` — operator doc: how to run, the forced-blindness rule and why it matters, the "vary surface across runs" methodology lesson, recommended cadence (quarterly + pre-release + post-major-refactor).
- Per-iteration retrospectives (`SUMMARY.md` for all 4 iters, `ROOT_CAUSES.md` for iter-1) committed as canonical examples of what the harness produces.
- `.gitignore` ignores `scripts/dx-walkthrough/runs/*/*/run-*/` so large/ephemeral per-run artefacts (the generated `app/`, `session.log`, `FRICTION.md`, `NOTES.md`) stay local while the synthesized iteration-root retrospectives stay in the repo.

Canonical showcase: [`scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md`](../blob/tools/dx-walkthrough-harness/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md).

No release impact (`tools:` prefix, no `feat:`/`fix:`).

## Test plan

- [x] `bash scripts/dx-walkthrough/run.sh 01-chat-cli "verify"` creates three run dirs and prints three valid dispatch prompts
- [x] `bash scripts/dx-walkthrough/run.sh 99-nonexistent x` fails with a clear error listing available briefs
- [x] `bash scripts/dx-walkthrough/compare.sh runs/2026-05-23_v0.33.0/01-chat-cli runs/2026-05-23_v0.33.0-iter4/01-chat-cli` produces a readable markdown diff (Disappeared / Persisted / New)
- [x] `git status` clean after staging: only intentional files

🤖 Generated with [Claude Code](https://claude.com/claude-code)