### PR TITLE
docs(quickstart-cli): bundle three papercut fixes (F19, F20, F22)

### DIFF
--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -14,6 +14,8 @@ A one-page tutorial for getting from "empty terminal" to "streaming tokens" with
 
 Each section below is a complete, compile-tested example: a full `Package.swift` plus a full `main.swift`, ready to copy-paste into an empty directory and `swift run`.
 
+> **Evaluating against a local checkout?** Swap the `.package(url:from:)` line in each section for `.package(name: "ManifoldKit", path: "/path/to/ManifoldKit")`. The `name:` argument is required — SwiftPM derives package identity from the last path component of `.package(path:)`, which breaks under non-default checkout paths (e.g. worktrees, custom directory names).
+
 ---
 
 ## 1. Foundation Models (macOS 26)
@@ -259,13 +261,25 @@ Some models — Qwen3, DeepSeek-R1, and similar — emit "thinking" content (rea
 If you need to support reasoning models, either render thinking content distinctly:
 
 ```swift,no-build
+// Track whether we're currently inside a thinking block so the "[thinking] "
+// prefix is emitted once per block (not once per token). Without this, every
+// thinking token gets its own prefix: "[thinking] Okay[thinking] ,[thinking]  the…".
+var inThinking = false
 for try await event in stream.events {
     switch event {
     case .token(let text):
+        if inThinking {
+            FileHandle.standardError.write(Data("\n".utf8))
+            inThinking = false
+        }
         print(text, terminator: "")
     case .thinkingToken(let text):
-        // Render in a dim color, hide behind a fold, or skip entirely.
-        FileHandle.standardError.write(Data("[thinking] \(text)".utf8))
+        if !inThinking {
+            // Render in a dim color, hide behind a fold, or skip entirely.
+            FileHandle.standardError.write(Data("[thinking] ".utf8))
+            inThinking = true
+        }
+        FileHandle.standardError.write(Data(text.utf8))
     default:
         break
     }
@@ -348,7 +362,7 @@ struct ChatCLICloud {
             name: "Local Ollama",
             provider: .ollama,
             baseURL: "http://localhost:11434",
-            modelName: "llama3.2"
+            modelName: "llama3.2" // swap for an entry from `ollama list`
         )
 
         try await inference.loadCloudBackend(from: endpoint)


### PR DESCRIPTION
## Summary

Three small `docs/QUICKSTART-CLI.md` fixes surfaced by iteration 4 of the DX walkthrough — bundled into one tiny PR.

- **F22**: top-of-file callout for developers using `.package(name:path:)` against a local MK checkout. CLAUDE.md flags the explicit `name:` requirement; readers shouldn't have to know that.
- **F20**: fix a visual bug in *my* own ([#1401](https://github.com/roryford/ManifoldKit/pull/1401)) "Reasoning models" snippet — it emitted `[thinking] ` per token rather than per block. Track an `inThinking` flag and emit on transitions.
- **F19**: add a `// swap for an entry from \`ollama list\`` comment to §3's `modelName: "llama3.2"` placeholder.

## Walkthrough report

Iter-4 synthesis: `scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter4/01-chat-cli/SUMMARY.md` (also pending check-in via #1405).

3/3 walkthrough agents reached working CLIs first try; these are all papercuts that remained after the structural docs work was done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)