### PR TITLE
refactor: merge ManifoldContractTestSupport into ManifoldTestSupport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -510,19 +510,11 @@ let package = Package(
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
-        // XCTest-dependent protocol contract mixins, kept in a separate target
-        // so that fuzz-chat (an executable) can depend on ManifoldTestSupport
-        // without pulling in XCTest, which is only available inside an xctest
-        // host process and causes a dyld crash at runtime otherwise.
-        .target(
-            name: "ManifoldContractTestSupport",
-            dependencies: [
-                "ManifoldTestSupport",
-                "ManifoldInference",
-                "ManifoldRuntime",
-            ],
-            path: "Sources/ManifoldContractTestSupport"
-        ),
+        // Note: contract-test mixins live under `Sources/ManifoldTestSupport/Contracts/`
+        // and are wrapped in `#if canImport(XCTest)` so executable targets (e.g.
+        // `fuzz-chat`) that depend on `ManifoldTestSupport` don't drag XCTest into
+        // their link graph — XCTest is only available inside an xctest host
+        // process and causes a dyld crash at runtime otherwise.
         .testTarget(
             name: "ManifoldCoreTests",
             dependencies: [
@@ -542,7 +534,6 @@ let package = Package(
                 "ManifoldRuntime",
                 "ManifoldInference",
                 "ManifoldTestSupport",
-                "ManifoldContractTestSupport",
             ]
         ),
         // ManifoldPersistenceSwiftData-only tests: SwiftData @Model schema,
@@ -566,7 +557,6 @@ let package = Package(
             dependencies: [
                 "ManifoldTestSupport",
                 "ManifoldInference",
-                "ManifoldContractTestSupport",
             ]
         ),
         .testTarget(

--- a/Sources/ManifoldTestSupport/Contracts/BenchmarkCacheContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/BenchmarkCacheContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldRuntime
 import ManifoldInference
@@ -137,3 +138,4 @@ extension BenchmarkCacheContract where Self: XCTestCase {
         _ = upper  // suppress unused-variable warning
     }
 }
+#endif

--- a/Sources/ManifoldTestSupport/Contracts/EmbeddingBackendContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/EmbeddingBackendContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldInference
 
@@ -156,3 +157,4 @@ extension EmbeddingBackendContract where Self: XCTestCase {
         }
     }
 }
+#endif

--- a/Sources/ManifoldTestSupport/Contracts/EndpointStoreContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/EndpointStoreContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldRuntime
 import ManifoldInference
@@ -163,3 +164,4 @@ extension EndpointStoreContract where Self: XCTestCase {
         }
     }
 }
+#endif

--- a/Sources/ManifoldTestSupport/Contracts/InferenceBackendContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/InferenceBackendContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldInference
 import ManifoldTestSupport
@@ -216,3 +217,4 @@ extension InferenceBackendContract where Self: XCTestCase {
         )
     }
 }
+#endif

--- a/Sources/ManifoldTestSupport/Contracts/MessageStoreContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/MessageStoreContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldRuntime
 import ManifoldInference
@@ -252,3 +253,4 @@ extension MessageStoreContract where Self: XCTestCase {
                        file: file, line: line)
     }
 }
+#endif

--- a/Sources/ManifoldTestSupport/Contracts/SamplerPresetStoreContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/SamplerPresetStoreContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldRuntime
 import ManifoldInference
@@ -151,3 +152,4 @@ extension SamplerPresetStoreContract where Self: XCTestCase {
         XCTAssertEqual(fetchedIDs, insertedIDs, file: file, line: line)
     }
 }
+#endif

--- a/Sources/ManifoldTestSupport/Contracts/SessionStoreContract.swift
+++ b/Sources/ManifoldTestSupport/Contracts/SessionStoreContract.swift
@@ -1,3 +1,4 @@
+#if canImport(XCTest)
 import XCTest
 import ManifoldRuntime
 import ManifoldInference
@@ -223,3 +224,4 @@ extension SessionStoreContract where Self: XCTestCase {
         XCTAssertTrue(pastEnd.isEmpty, file: file, line: line)
     }
 }
+#endif

--- a/Tests/ManifoldRuntimeTests/BenchmarkCacheContractAdopterTests.swift
+++ b/Tests/ManifoldRuntimeTests/BenchmarkCacheContractAdopterTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import ManifoldRuntime
 import ManifoldInference
 import ManifoldTestSupport
-import ManifoldContractTestSupport
 
 // MARK: - InMemoryBenchmarkCache (test double for contract adoption)
 

--- a/Tests/ManifoldRuntimeTests/EndpointStoreContractAdopterTests.swift
+++ b/Tests/ManifoldRuntimeTests/EndpointStoreContractAdopterTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import ManifoldRuntime
 import ManifoldInference
 import ManifoldTestSupport
-import ManifoldContractTestSupport
 
 // MARK: - InMemoryEndpointStore (test double for contract adoption)
 

--- a/Tests/ManifoldRuntimeTests/MessageStoreContractAdopterTests.swift
+++ b/Tests/ManifoldRuntimeTests/MessageStoreContractAdopterTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import ManifoldRuntime
 import ManifoldInference
 import ManifoldTestSupport
-import ManifoldContractTestSupport
 
 // MARK: - InMemoryMessageStore (test double for contract adoption)
 

--- a/Tests/ManifoldRuntimeTests/SamplerPresetStoreContractAdopterTests.swift
+++ b/Tests/ManifoldRuntimeTests/SamplerPresetStoreContractAdopterTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import ManifoldRuntime
 import ManifoldInference
 import ManifoldTestSupport
-import ManifoldContractTestSupport
 
 // MARK: - InMemorySamplerPresetStore (test double for contract adoption)
 

--- a/Tests/ManifoldRuntimeTests/SessionStoreContractAdopterTests.swift
+++ b/Tests/ManifoldRuntimeTests/SessionStoreContractAdopterTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import ManifoldRuntime
 import ManifoldInference
 import ManifoldTestSupport
-import ManifoldContractTestSupport
 
 // MARK: - InMemorySessionStore (test double for contract adoption)
 

--- a/Tests/ManifoldTestSupportTests/MockInferenceBackendContractTests.swift
+++ b/Tests/ManifoldTestSupportTests/MockInferenceBackendContractTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import ManifoldInference
 @testable import ManifoldTestSupport
-import ManifoldContractTestSupport
 
 // MARK: - MockInferenceBackendContractTests
 


### PR DESCRIPTION
## Why

`ManifoldContractTestSupport` existed solely to keep `import XCTest` out of the `fuzz-chat` executable's compile graph. A file-level `#if canImport(XCTest)` gate on the seven contract-mixin files achieves the same outcome with one fewer SwiftPM target.

## Migration

Replace `import ManifoldContractTestSupport` with `import ManifoldTestSupport` in test files. The contract-mixin protocols (`MessageStoreContract`, `SessionStoreContract`, `EndpointStoreContract`, `SamplerPresetStoreContract`, `BenchmarkCacheContract`, `InferenceBackendContract`, `EmbeddingBackendContract`) are unchanged and now live under `Sources/ManifoldTestSupport/Contracts/`. Each file is wrapped top-to-bottom in `#if canImport(XCTest) ... #endif`, so when an executable target compiles `ManifoldTestSupport` against the host SDK (no xctest), the contract bodies drop out.

## Verification

- `swift build --product fuzz-chat --disable-default-traits` — clean build; XCTest link state matches `main` baseline (no regression).
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — succeeds.
- `scripts/test.sh --profile local` — 4432 XCTest + 83 Swift Testing, 0 failures, 57 expected `XCTSkip`s.

## Test plan

- [ ] CI green on `main` PR
- [ ] No external consumers should be affected — `ManifoldContractTestSupport` was a test-helper target only

🤖 Generated with [Claude Code](https://claude.com/claude-code)