### PR TITLE
refactor: pin ContractTestSupport split with audit test (#1409 superseded)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -494,6 +494,15 @@ let package = Package(
         // so that fuzz-chat (an executable) can depend on ManifoldTestSupport
         // without pulling in XCTest, which is only available inside an xctest
         // host process and causes a dyld crash at runtime otherwise.
+        //
+        // DO NOT merge this back into ManifoldTestSupport. PR #1409 attempted
+        // that with a `#if canImport(XCTest)` file-level gate; the gate
+        // evaluated true on CI runners where the XCTest *headers* are
+        // available but the *runtime* dylib is not on the search path outside
+        // an xctest host. Result: `dyld[...]: Library not loaded:
+        // @rpath/libXCTestSwiftSupport.dylib` at fuzz-chat startup.
+        // `ContractTestSupportSplitAuditTest` (ManifoldCoreTests) enforces
+        // this split at the manifest + source-tree level.
         .target(
             name: "ManifoldContractTestSupport",
             dependencies: [

--- a/Tests/ManifoldCoreTests/ContractTestSupportSplitAuditTest.swift
+++ b/Tests/ManifoldCoreTests/ContractTestSupportSplitAuditTest.swift
@@ -1,0 +1,128 @@
+import XCTest
+
+/// Guards against regression of PR #1409: `ManifoldTestSupport` must NOT
+/// transitively pull in XCTest, and the XCTest-dependent contract mixins
+/// must stay in a dedicated `ManifoldContractTestSupport` target.
+///
+/// ## Why this matters
+///
+/// PR #1409 attempted to consolidate the two targets by collapsing
+/// `Sources/ManifoldContractTestSupport/*.swift` into
+/// `Sources/ManifoldTestSupport/Contracts/` under a file-level
+/// `#if canImport(XCTest)` gate. On the developer's local Mac this looked
+/// safe — `otool -L fuzz-chat` showed no XCTest references because Swift
+/// strips unused symbols at link time when the host compiler can resolve
+/// XCTest. On the CI runner, however, `canImport(XCTest)` evaluates true
+/// while the XCTest framework is not on the runtime library search path
+/// outside of an xctest host process. The result was a dyld crash at the
+/// first invocation of `swift run fuzz-chat ...`:
+///
+///     dyld[4010]: Library not loaded: @rpath/libXCTestSwiftSupport.dylib
+///       Referenced from: .../fuzz-chat
+///
+/// The fix is structural: XCTest-tainted code lives in its own target so
+/// non-test executables (`fuzz-chat` today, anything else tomorrow) can
+/// depend on `ManifoldTestSupport` without inheriting an XCTest link
+/// dependency they cannot satisfy at runtime.
+///
+/// ## What this test enforces
+///
+/// 1. `Sources/ManifoldContractTestSupport/` exists and contains at least
+///    one `*Contract.swift` file. (Sentinel against an "accidental" merge
+///    that deletes the directory.)
+/// 2. `Sources/ManifoldTestSupport/` contains no file with a top-level
+///    `import XCTest`. (Sentinel against re-introducing the
+///    `#if canImport(XCTest)` pattern that masked the crash.)
+/// 3. `Package.swift` declares both `ManifoldTestSupport` and
+///    `ManifoldContractTestSupport` as separate `.target(...)` entries.
+///
+/// ## Fixing a violation
+///
+/// Do not merge the two targets. If you need a helper that some tests
+/// share but executables also need, put it in `ManifoldTestSupport`
+/// (XCTest-free). If it must use `XCTAssert*` / `XCTestCase`, put it in
+/// `ManifoldContractTestSupport`.
+final class ContractTestSupportSplitAuditTest: XCTestCase {
+
+    func test_manifoldContractTestSupport_directoryExists() throws {
+        let repoRoot = try Self.repoRoot()
+        let contractDir = repoRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("ManifoldContractTestSupport")
+
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+            atPath: contractDir.path,
+            isDirectory: &isDir
+        )
+        XCTAssertTrue(exists && isDir.boolValue,
+                      "Sources/ManifoldContractTestSupport/ must exist as a directory. See PR #1409 retrospective in this file's doc comment.")
+
+        let contents = try FileManager.default.contentsOfDirectory(atPath: contractDir.path)
+        let contractFiles = contents.filter { $0.hasSuffix("Contract.swift") }
+        XCTAssertFalse(contractFiles.isEmpty,
+                       "Sources/ManifoldContractTestSupport/ must contain at least one *Contract.swift file.")
+    }
+
+    func test_manifoldTestSupport_doesNotImportXCTest() throws {
+        let repoRoot = try Self.repoRoot()
+        let supportDir = repoRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("ManifoldTestSupport")
+
+        let enumerator = FileManager.default.enumerator(atPath: supportDir.path)
+        var offenders: [String] = []
+        while let relative = enumerator?.nextObject() as? String {
+            guard relative.hasSuffix(".swift") else { continue }
+            let url = supportDir.appendingPathComponent(relative)
+            let text = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+            // Match a top-level `import XCTest` line — also catches the
+            // `#if canImport(XCTest)\nimport XCTest` shape that PR #1409
+            // introduced.
+            for line in text.split(separator: "\n") {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed == "import XCTest" {
+                    offenders.append(relative)
+                    break
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            offenders.isEmpty,
+            """
+            ManifoldTestSupport must stay XCTest-free so non-test executables
+            (e.g. fuzz-chat) can depend on it without a runtime dyld crash.
+            Move the offending file(s) to Sources/ManifoldContractTestSupport/.
+            Offenders: \(offenders)
+            """
+        )
+    }
+
+    func test_packageManifest_declaresBothTargets() throws {
+        let repoRoot = try Self.repoRoot()
+        let packageURL = repoRoot.appendingPathComponent("Package.swift")
+        let manifest = try String(contentsOf: packageURL, encoding: .utf8)
+
+        XCTAssertTrue(
+            manifest.contains("name: \"ManifoldTestSupport\""),
+            "Package.swift must declare a target named ManifoldTestSupport."
+        )
+        XCTAssertTrue(
+            manifest.contains("name: \"ManifoldContractTestSupport\""),
+            "Package.swift must declare a target named ManifoldContractTestSupport. See PR #1409 retrospective in this file's doc comment."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func repoRoot() throws -> URL {
+        // This test file lives at Tests/ManifoldCoreTests/<this>.swift.
+        // Walk up two directories to reach the package root.
+        let thisFile = URL(fileURLWithPath: #filePath)
+        return thisFile
+            .deletingLastPathComponent()  // ManifoldCoreTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // repo root
+    }
+}


### PR DESCRIPTION
## Background

PR #1409 proposed merging `ManifoldContractTestSupport` into `ManifoldTestSupport` using a file-level `#if canImport(XCTest)` gate. On the CI runner this caused a `dyld` crash when `fuzz-chat` started up:

```
dyld[4010]: Library not loaded: @rpath/libXCTestSwiftSupport.dylib
  Referenced from: .../fuzz-chat
```

`canImport(XCTest)` evaluates true on the CI runner — the Xcode toolchain's XCTest headers satisfy the compile-time check — but the XCTest runtime dylib is not on the library search path outside an xctest host process. Local `otool -L fuzz-chat` validation missed this because the local toolchain resolves the dylib at run-time too.

`main` was never touched by #1409 (the PR remained OPEN), so no source revert is needed. This PR supersedes #1409 by pinning the two-target split so the regression class can't slip back in silently.

## Option chosen — Option A (keep the existing split)

The task brief offered two options:

- **Option A** — keep `ManifoldContractTestSupport` and `ManifoldTestSupport` as separate targets (status quo on `main`).
- **Option B** — rename to `ManifoldTestSupportXCTest` for clarity.

Option A: the existing names are accurate (`ContractTestSupport` is the protocol-contract mixin target) and a rename would churn 6 test files' imports plus the manifest for no functional gain.

## Changes

- **`Package.swift`** — expand the `ManifoldContractTestSupport` target comment with the #1409 retrospective and a pointer to the new audit test. Documents the `canImport(XCTest)` footgun so the next maintainer doesn't repeat it.
- **`Tests/ManifoldCoreTests/ContractTestSupportSplitAuditTest.swift`** — three XCTest cases that fail if:
  1. `Sources/ManifoldContractTestSupport/` is removed or emptied.
  2. Any file under `Sources/ManifoldTestSupport/` adds a top-level `import XCTest` (catches the `#if canImport(XCTest)` shape #1409 used — the inner `import XCTest` line still matches).
  3. The `ManifoldContractTestSupport` target declaration disappears from `Package.swift`.

The audit test was sabotage-verified: dropping a 3-line `_Sabotage.swift` with `#if canImport(XCTest)` / `import XCTest` / `#endif` into `Sources/ManifoldTestSupport/` makes the suite fail with the exact expected message.

## Verification

- `swift run --disable-default-traits fuzz-chat --backend mock --iterations 5 --seed 1 --corpus-subset smoke --quiet` — **passes** (the failing-on-CI command from the brief, run locally on this branch).
- `swift test --disable-default-traits --filter ContractTestSupportSplitAuditTest` — **3/3 pass**.
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — **passes** (the trait-combo sweep).
- `scripts/test.sh --profile local` — **deferred to CI**. Another local session held the SwiftPM lock on `.build` for this worktree throughout the verification window; my test.sh queued behind it and never got the lock. CI runs the full `--disable-default-traits` two-invocation shape and will catch any regression. The diff is one comment block + one new test file (no production code, no behavior change), so the risk surface is limited to the new test compiling — which it did under `swift test --filter ContractTestSupportSplitAuditTest`.

## Supersedes

Closes #1409 (superseded). Comment posted on #1409 with this PR link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)