### PR TITLE
feat(persistence): V9 schema with agent + skill session fields (W1B)

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
@@ -25,7 +25,7 @@ import ManifoldInference
 public enum ModelContainerFactory {
     /// The current schema version.
     public static var currentSchema: any VersionedSchema.Type {
-        ManifoldSchemaV8.self
+        ManifoldSchemaV9.self
     }
 
     /// Returns an on-disk `ModelContainer` configured with the current schema.

--- a/Sources/ManifoldPersistenceSwiftData/Schema/Agent.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/Agent.swift
@@ -1,0 +1,4 @@
+/// Public alias for the current SwiftData agent model.
+///
+/// Introduced in SchemaV9 as part of the multi-agent / skills foundation.
+public typealias Agent = ManifoldSchemaV9.Agent

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ChatMessage.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ChatMessage.swift
@@ -1,7 +1,6 @@
 /// Public alias for the current SwiftData chat message model.
 ///
-/// Points to ``ManifoldSchemaV7/ChatMessage``, which adds `kindRaw` and
-/// `citationsJSON` columns over the V4 baseline. Older schema versions
-/// (V4–V6) still reference ``ManifoldSchemaV4/ChatMessage`` directly in
-/// their `models` lists so their checksums remain stable.
-public typealias ChatMessage = ManifoldSchemaV7.ChatMessage
+/// SchemaV9 adds `agentID: UUID?` for multi-agent attribution. Intentionally
+/// not a `@Relationship` so deleting an agent doesn't cascade-delete its
+/// authored history (see the field doc in ``ManifoldSchemaV9/ChatMessage``).
+public typealias ChatMessage = ManifoldSchemaV9.ChatMessage

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession.swift
@@ -1,6 +1,6 @@
 /// Public alias for the current SwiftData chat session model.
 ///
-/// SchemaV8 (#1301) adds `isPinned: Bool` and `pinnedAt: Date?` columns. The
-/// alias points at the V8 model so existing call sites keep compiling while
-/// gaining the new pinning fields.
-public typealias ChatSession = ManifoldSchemaV8.ChatSession
+/// SchemaV9 adds `activeAgentID: UUID?`, `activeSkillName: String?`, and a
+/// cascade `agents: [Agent]` relationship for the multi-agent / skills
+/// foundation. Lightweight migration; all new fields default to nil/empty.
+public typealias ChatSession = ManifoldSchemaV9.ChatSession

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldMigrationPlan.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldMigrationPlan.swift
@@ -9,6 +9,7 @@ public enum ManifoldMigrationPlan: SchemaMigrationPlan {
             ManifoldSchemaV6.self,
             ManifoldSchemaV7.self,
             ManifoldSchemaV8.self,
+            ManifoldSchemaV9.self,
         ]
     }
 
@@ -22,6 +23,10 @@ public enum ManifoldMigrationPlan: SchemaMigrationPlan {
             .lightweight(fromVersion: ManifoldSchemaV6.self, toVersion: ManifoldSchemaV7.self),
             // V8 adds isPinned (default false) and pinnedAt (default nil) to ChatSession.
             .lightweight(fromVersion: ManifoldSchemaV7.self, toVersion: ManifoldSchemaV8.self),
+            // V9 adds activeAgentID, activeSkillName, agents (cascade) to ChatSession,
+            // agentID to ChatMessage, and a new Agent @Model. All new fields default
+            // to nil/empty so no data motion is required.
+            .lightweight(fromVersion: ManifoldSchemaV8.self, toVersion: ManifoldSchemaV9.self),
         ]
     }
 }

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV9.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV9.swift
@@ -1,0 +1,304 @@
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+@preconcurrency import SwiftData
+
+/// ManifoldKit SwiftData schema version 9.
+///
+/// Adds agent identity + skill scope fields used by the Wave 1B foundation of
+/// the multi-agent / skill plan:
+///
+/// - ``ChatSession/activeAgentID`` — UUID of the agent currently authoring
+///   the session's next turn; nil when no multi-agent registry is in play.
+/// - ``ChatSession/activeSkillName`` — sticky scope name while a skill is
+///   active. Cleared when the skill's invocation completes.
+/// - ``ChatSession/agents`` — per-session cascade relationship of ``Agent``
+///   rows. Agents die with their session.
+/// - ``ChatMessage/agentID`` — identity of the agent that authored a
+///   message. **Intentionally NOT a `@Relationship`** — see the field doc.
+/// - New ``Agent`` `@Model`.
+///
+/// V9 redefines `ChatSession` and `ChatMessage` in-namespace so SwiftData
+/// picks up the new columns. The migration is lightweight: every new field
+/// has a nil/empty default, no existing column changes, no data motion.
+///
+/// All other model types (sampler preset, API endpoint, benchmark cache,
+/// RAG document, usage record) are carried forward unchanged.
+public enum ManifoldSchemaV9: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(9, 0, 0)
+
+    public static var models: [any PersistentModel.Type] {
+        [
+            ChatMessage.self,
+            ChatSession.self,
+            Agent.self,
+            ManifoldSchemaV4.SamplerPreset.self,
+            ManifoldSchemaV4.APIEndpoint.self,
+            ManifoldSchemaV4.ModelBenchmarkCache.self,
+            ManifoldSchemaV5.RagDocument.self,
+            ManifoldSchemaV6.TurnUsageRecordModel.self,
+        ]
+    }
+
+    // MARK: - ChatSession (V9 — adds activeAgentID, activeSkillName, agents)
+
+    @Model
+    public final class ChatSession {
+        public var id: UUID
+        public var title: String
+        public var createdAt: Date
+        public var updatedAt: Date
+
+        /// Per-session system prompt.
+        public var systemPrompt: String
+
+        /// The UUID of the selected ModelInfo for this session.
+        public var selectedModelID: UUID?
+
+        /// The UUID of the selected APIEndpoint for this session.
+        public var selectedEndpointID: UUID?
+
+        // Per-session generation overrides (nil = use global default)
+        public var temperature: Float?
+        public var topP: Float?
+        public var repeatPenalty: Float?
+
+        /// Stored as PromptTemplate.rawValue; nil means auto-detect or global default.
+        public var promptTemplateRawValue: String?
+
+        /// User override for context window size; nil uses model default.
+        public var contextSizeOverride: Int?
+
+        /// Comma-separated UUID strings of pinned messages in this session.
+        public var pinnedMessageIDsRaw: String?
+
+        /// True if this session is pinned to the top of the session list.
+        public var isPinned: Bool = false
+
+        /// Timestamp recorded when ``isPinned`` flipped to `true`.
+        public var pinnedAt: Date?
+
+        /// Non-optional sort key used by the persistence adapter to express
+        /// pinned-first ordering in a single SortDescriptor. Maintained by
+        /// the adapter; callers should not write directly.
+        public var pinnedSortKey: Date = Date.distantPast
+
+        /// UUID of the agent currently authoring this session's next turn.
+        /// Nil when the session has no multi-agent registry. The executor
+        /// re-derives the active system prompt per turn from this ID.
+        public var activeAgentID: UUID?
+
+        /// Sticky scope name while a skill is mid-invocation. Cleared when
+        /// the skill returns. While non-nil the advertised tool list is
+        /// intersected with the skill's `allowed-tools`.
+        public var activeSkillName: String?
+
+        /// Per-session agent registry. Cascade delete is correct here:
+        /// agents only have meaning inside their owning session.
+        @Relationship(deleteRule: .cascade) public var agents: [Agent] = []
+
+        public init(title: String = "New Chat") {
+            self.id = UUID()
+            self.title = title
+            self.createdAt = Date()
+            self.updatedAt = Date()
+            self.systemPrompt = ""
+            self.isPinned = false
+        }
+
+        /// The set of pinned message IDs for this session.
+        public var pinnedMessageIDs: Set<UUID> {
+            get {
+                guard let raw = pinnedMessageIDsRaw else { return [] }
+                return Set(raw.split(separator: ",").compactMap { UUID(uuidString: String($0)) })
+            }
+            set {
+                pinnedMessageIDsRaw = newValue.isEmpty ? nil : newValue.map(\.uuidString).joined(separator: ",")
+            }
+        }
+
+        /// Convenience to get/set the prompt template as a `PromptTemplate` enum.
+        public var promptTemplate: PromptTemplate? {
+            get {
+                guard let raw = promptTemplateRawValue else { return nil }
+                return PromptTemplate(rawValue: raw)
+            }
+            set {
+                promptTemplateRawValue = newValue?.rawValue
+            }
+        }
+    }
+
+    // MARK: - ChatMessage (V9 — adds agentID)
+
+    @Model
+    public final class ChatMessage {
+        public var id: UUID
+        public var role: MessageRole
+        public var timestamp: Date
+        public var sessionID: UUID
+
+        /// Plain-text cache of the message content.
+        public var content: String
+
+        /// JSON-encoded `[MessagePart]` array. This is the source of truth for
+        /// structured content.
+        public var contentPartsJSON: String
+
+        /// Tokens used in the prompt for this response (cloud API backends only).
+        public var promptTokens: Int?
+        /// Tokens generated in this response (cloud API backends only).
+        public var completionTokens: Int?
+
+        /// Raw storage for ``MessageKind``. Defaults to "chat" so rows written
+        /// before SchemaV7 decode as ``MessageKind/chat``.
+        public var kindRaw: String = "chat"
+
+        /// JSON-encoded ``[Citation]`` array. `nil` when the turn was not RAG-augmented.
+        public var citationsJSON: String?
+
+        /// Identity of the agent that authored this message, when the session has a
+        /// multi-agent registry. Intentionally NOT a `@Relationship` — agents can be
+        /// deleted independently of their authored history, and the UI falls back to
+        /// role-based rendering when an `agentID` no longer resolves to an `Agent`
+        /// in the session. A `@Relationship` here would cascade-delete authored
+        /// messages on agent removal, which destroys conversation audit trail.
+        public var agentID: UUID?
+
+        public init(
+            role: MessageRole,
+            content: String,
+            sessionID: UUID
+        ) {
+            self.id = UUID()
+            self.role = role
+            self.timestamp = Date()
+            self.sessionID = sessionID
+            self.content = content
+            self.contentPartsJSON = Self.encode([.text(content)])
+            self.kindRaw = "chat"
+        }
+
+        /// Creates a message from structured content parts.
+        public init(
+            role: MessageRole,
+            contentParts: [MessagePart],
+            sessionID: UUID
+        ) {
+            self.id = UUID()
+            self.role = role
+            self.timestamp = Date()
+            self.sessionID = sessionID
+            self.contentPartsJSON = Self.encode(contentParts)
+            self.content = contentParts.compactMap(\.textContent).joined()
+            self.kindRaw = "chat"
+        }
+
+        // MARK: - Content Parts
+
+        public var contentParts: [MessagePart] {
+            get { Self.decode(contentPartsJSON) }
+            set {
+                contentPartsJSON = Self.encode(newValue)
+                content = newValue.compactMap(\.textContent).joined()
+            }
+        }
+
+        // MARK: - Kind (MessageKind)
+
+        public var kind: MessageKind {
+            get { MessageKind(rawStorage: kindRaw) ?? .chat }
+            set { kindRaw = newValue.rawStorage }
+        }
+
+        // MARK: - Citations
+
+        public var citations: [Citation]? {
+            get {
+                guard let data = citationsJSON?.data(using: .utf8) else { return nil }
+                do {
+                    return try JSONDecoder().decode([Citation].self, from: data)
+                } catch {
+                    Log.persistence.warning("Failed to decode citationsJSON: \(error)")
+                    return nil
+                }
+            }
+            set {
+                guard let v = newValue, !v.isEmpty else { citationsJSON = nil; return }
+                do {
+                    let data = try JSONEncoder().encode(v)
+                    citationsJSON = String(data: data, encoding: .utf8)
+                } catch {
+                    Log.persistence.warning("Failed to encode citations: \(error)")
+                    citationsJSON = nil
+                }
+            }
+        }
+
+        // MARK: - JSON Helpers
+
+        static func encode(_ parts: [MessagePart]) -> String {
+            do {
+                let data = try JSONEncoder().encode(parts)
+                if let json = String(data: data, encoding: .utf8) {
+                    return json
+                }
+                Log.persistence.warning("Failed to convert encoded MessagePart data to UTF-8 string")
+            } catch {
+                Log.persistence.error("Failed to encode MessagePart array: \(error)")
+            }
+            return "[]"
+        }
+
+        static func decode(_ json: String) -> [MessagePart] {
+            guard let data = json.data(using: .utf8) else {
+                Log.persistence.warning("contentPartsJSON is not valid UTF-8")
+                return json.isEmpty ? [] : [.text(json)]
+            }
+            do {
+                return try JSONDecoder().decode([MessagePart].self, from: data)
+            } catch {
+                Log.persistence.warning("Failed to decode contentPartsJSON, falling back to text: \(error)")
+                return json.isEmpty ? [] : [.text(json)]
+            }
+        }
+    }
+
+    // MARK: - Agent (V9 — new model)
+
+    /// A per-session agent identity with its own system prompt and tool scope.
+    ///
+    /// Lives inside its owning ``ChatSession`` via a cascade relationship.
+    /// The executor re-derives the active system prompt per turn from the
+    /// session's `activeAgentID`; prior assistant messages keep their
+    /// `agentID` attribution for audit purposes.
+    @Model
+    public final class Agent {
+        @Attribute(.unique) public var id: UUID
+        public var name: String
+        public var systemPrompt: String
+
+        /// User-facing description. SwiftData reserves the unadorned `description`
+        /// identifier on `@Model` types, so we expose it under a renamed column.
+        public var descriptionText: String
+
+        /// Optional intersection scope for tools. When non-nil, the executor
+        /// restricts the advertised tool list to names in this set while this
+        /// agent is active.
+        public var allowedToolNames: [String]?
+
+        public init(
+            id: UUID = UUID(),
+            name: String,
+            systemPrompt: String,
+            descriptionText: String,
+            allowedToolNames: [String]? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.systemPrompt = systemPrompt
+            self.descriptionText = descriptionText
+            self.allowedToolNames = allowedToolNames
+        }
+    }
+}

--- a/Tests/ManifoldPersistenceSwiftDataTests/SchemaMigrationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SchemaMigrationTests.swift
@@ -43,10 +43,12 @@ final class SchemaMigrationTests: XCTestCase {
     }
 
     func test_publicTypealiases_matchCurrentSchemaModelTypes() {
-        // ChatMessage points to ManifoldSchemaV7.ChatMessage (kindRaw/citationsJSON).
-        XCTAssertEqual(ObjectIdentifier(ChatMessage.self), ObjectIdentifier(ManifoldSchemaV7.ChatMessage.self))
-        // ChatSession is redefined at V8 to carry isPinned/pinnedAt (#1301).
-        XCTAssertEqual(ObjectIdentifier(ChatSession.self), ObjectIdentifier(ManifoldSchemaV8.ChatSession.self))
+        // ChatMessage is redefined at V9 to carry agentID.
+        XCTAssertEqual(ObjectIdentifier(ChatMessage.self), ObjectIdentifier(ManifoldSchemaV9.ChatMessage.self))
+        // ChatSession is redefined at V9 to carry activeAgentID / activeSkillName / agents.
+        XCTAssertEqual(ObjectIdentifier(ChatSession.self), ObjectIdentifier(ManifoldSchemaV9.ChatSession.self))
+        // Agent is introduced at V9.
+        XCTAssertEqual(ObjectIdentifier(Agent.self), ObjectIdentifier(ManifoldSchemaV9.Agent.self))
         // Other model types remain at V4.
         XCTAssertEqual(ObjectIdentifier(SamplerPreset.self), ObjectIdentifier(ManifoldSchemaV4.SamplerPreset.self))
         XCTAssertEqual(ObjectIdentifier(APIEndpoint.self), ObjectIdentifier(ManifoldSchemaV4.APIEndpoint.self))
@@ -76,8 +78,8 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertNotNil(container)
     }
 
-    func test_containerFactory_currentSchema_isV8() {
-        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(ManifoldSchemaV8.self))
+    func test_containerFactory_currentSchema_isV9() {
+        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(ManifoldSchemaV9.self))
     }
 
     func test_containerFactory_reopensPersistedStore() throws {
@@ -200,13 +202,94 @@ final class SchemaMigrationTests: XCTestCase {
                      "pinnedAt must default to nil for rows written under V7")
     }
 
+    // MARK: - V8 -> V9 migration (agents + skills foundation)
+
+    /// Boots a store at V8, writes a session and a message, then re-opens it
+    /// through the full migration plan. The migrated rows must surface with
+    /// nil/empty defaults on every new V9 field: `activeAgentID == nil`,
+    /// `activeSkillName == nil`, `agents.isEmpty`, and `agentID == nil` on
+    /// the message. No data motion; lightweight migration.
+    ///
+    /// Sabotage-evidence: removing the `activeAgentID` / `activeSkillName` /
+    /// `agents` declarations from ``ManifoldSchemaV9/ChatSession`` causes
+    /// compilation failure here (M1). Changing the default of `agentID` on
+    /// ``ManifoldSchemaV9/ChatMessage`` to non-nil produces a failing
+    /// XCTAssertNil (M2). Replacing the V8→V9 stage with a no-op `[]` halts
+    /// `makeContainer` with a schema-mismatch error before the asserts run
+    /// (M3).
+    func test_migrationPlan_v8SessionMigratesToV9WithNilAgentDefaults() throws {
+        let storeDirectory = try makeStoreDirectory(named: "ManifoldSchemaV8ToV9")
+        let storeURL = storeDirectory.appendingPathComponent("Manifold.sqlite")
+        let sessionID: UUID
+        let messageID: UUID
+
+        do {
+            let config = ModelConfiguration(url: storeURL)
+            let container = try ModelContainer(
+                for: Schema(versionedSchema: ManifoldSchemaV8.self),
+                configurations: [config]
+            )
+            let context = ModelContext(container)
+
+            // V8 owns ChatSession in its own namespace, but ChatMessage at V8
+            // is still ManifoldSchemaV7.ChatMessage (V8 didn't redefine it).
+            let session = ManifoldSchemaV8.ChatSession(title: "Legacy V8 session")
+            session.systemPrompt = "carry forward"
+            session.isPinned = true
+            session.pinnedAt = Date(timeIntervalSince1970: 1_700_000_000)
+            context.insert(session)
+
+            let message = ManifoldSchemaV7.ChatMessage(
+                role: .assistant,
+                content: "pre-V9 history",
+                sessionID: session.id
+            )
+            context.insert(message)
+
+            try context.save()
+            sessionID = session.id
+            messageID = message.id
+        }
+
+        let migratedContainer = try ModelContainerFactory.makeContainer(
+            configurations: [ModelConfiguration(url: storeURL)]
+        )
+        let migratedContext = ModelContext(migratedContainer)
+
+        let fetchedSessions = try migratedContext.fetch(FetchDescriptor<ChatSession>(
+            predicate: #Predicate { $0.id == sessionID }
+        ))
+        XCTAssertEqual(fetchedSessions.count, 1)
+        let migratedSession = try XCTUnwrap(fetchedSessions.first)
+        XCTAssertEqual(migratedSession.title, "Legacy V8 session")
+        XCTAssertEqual(migratedSession.systemPrompt, "carry forward")
+        XCTAssertTrue(migratedSession.isPinned,
+                      "Existing V8 pin state must survive the V8→V9 migration")
+        XCTAssertNil(migratedSession.activeAgentID,
+                     "V9 lightweight migration must default activeAgentID to nil for rows written under V8")
+        XCTAssertNil(migratedSession.activeSkillName,
+                     "V9 lightweight migration must default activeSkillName to nil for rows written under V8")
+        XCTAssertTrue(migratedSession.agents.isEmpty,
+                      "V9 lightweight migration must default agents to an empty array for rows written under V8")
+
+        let fetchedMessages = try migratedContext.fetch(FetchDescriptor<ChatMessage>(
+            predicate: #Predicate { $0.id == messageID }
+        ))
+        XCTAssertEqual(fetchedMessages.count, 1)
+        let migratedMessage = try XCTUnwrap(fetchedMessages.first)
+        XCTAssertEqual(migratedMessage.content, "pre-V9 history")
+        XCTAssertNil(migratedMessage.agentID,
+                     "V9 lightweight migration must default ChatMessage.agentID to nil for rows written under V8")
+    }
+
     func test_schemaOwnedModelAndPublicAlias_areInterchangeable() throws {
         let container = try ModelContainerFactory.makeInMemoryContainer()
         let context = ModelContext(container)
 
-        // Use the V7 class (the current schema's ChatMessage type) so the
-        // SwiftData schema validator finds all required columns (kindRaw etc.).
-        let nestedMessage = ManifoldSchemaV7.ChatMessage(role: .user, content: "alias check", sessionID: UUID())
+        // Use the V9 class (the current schema's ChatMessage type) so the
+        // SwiftData schema validator finds all required columns (kindRaw,
+        // agentID, etc.).
+        let nestedMessage = ManifoldSchemaV9.ChatMessage(role: .user, content: "alias check", sessionID: UUID())
         context.insert(nestedMessage)
         try context.save()
         let nestedMessageID = nestedMessage.id


### PR DESCRIPTION
## Summary

Wave 1B of the multi-wave plan in `~/.claude/plans/put-an-implementation-plan-reactive-penguin.md`. SwiftData V9 schema adding agent identity + skill scope fields. Independent of W1A.

- `ChatSession`: `activeAgentID: UUID?`, `activeSkillName: String?`, `agents: [Agent]` (cascade delete).
- `ChatMessage`: `agentID: UUID?` — intentionally NOT a `@Relationship` (see code comment for why).
- New `Agent` `@Model` with `id`, `name`, `systemPrompt`, `descriptionText`, `allowedToolNames`.
- Lightweight V8 → V9 migration; all new fields default to nil/empty so existing data flows through untouched.

## Test plan

- [x] `swift build --disable-default-traits` clean
- [x] `SchemaMigrationTests` — typealias identity bumped (incl. new `Agent`), `currentSchema` bumped to V9, NEW fixture-based V8→V9 round-trip asserts nil/empty defaults on every new field
- [x] Sabotage-evidence on the new migration test (defaulting `activeAgentID` to a fresh UUID caused the expected XCTAssertNil failure)
- [x] 19 schema-migration tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>