### PR TITLE
feat(runtime): HookRegistry actor + preToolUse/preCompact events (W1C)

### DIFF
--- a/Sources/ManifoldRuntime/Services/Hooks/HookEvent.swift
+++ b/Sources/ManifoldRuntime/Services/Hooks/HookEvent.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Synchronous hook events distinct from the observational `ConversationEvent`
+/// surface. These fire at decision points in the turn loop where a host may
+/// mutate or block the operation.
+public enum HookEvent: String, Sendable, Equatable, CaseIterable {
+    /// Fires before a tool call dispatches. Hooks may sanitize the
+    /// arguments (via `HookOutput.updatedInput`) or block the call entirely
+    /// (via `HookOutput.block`). Sanitize-only contract — see `HookOutput` docs.
+    case preToolUse
+
+    /// Fires before history compression runs. Hooks may inspect or transform
+    /// the compression-bound context. Cannot block compression (it always
+    /// proceeds with whatever the hook chain produces).
+    case preCompact
+}

--- a/Sources/ManifoldRuntime/Services/Hooks/HookInput.swift
+++ b/Sources/ManifoldRuntime/Services/Hooks/HookInput.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Immutable input passed to every hook handler. Tool-specific fields are
+/// only meaningful for `.preToolUse`; `.preCompact` ignores them.
+public struct HookInput: Sendable {
+    public let event: HookEvent
+    public let sessionID: UUID
+    public let toolName: String?
+    /// Raw JSON string of the tool call's arguments — the same shape the
+    /// model emitted. Hooks may sanitize this via `HookOutput.updatedInput`
+    /// but must observe the sanitize-only contract on `HookOutput`.
+    public let toolArguments: String?
+
+    public init(
+        event: HookEvent,
+        sessionID: UUID,
+        toolName: String? = nil,
+        toolArguments: String? = nil
+    ) {
+        self.event = event
+        self.sessionID = sessionID
+        self.toolName = toolName
+        self.toolArguments = toolArguments
+    }
+}

--- a/Sources/ManifoldRuntime/Services/Hooks/HookOutput.swift
+++ b/Sources/ManifoldRuntime/Services/Hooks/HookOutput.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Result a hook may return. The contract is **sanitize-only, not redirect**:
+/// `updatedInput` may narrow or scrub the tool input (e.g. constrain a path
+/// to a sandbox dir) but must reference the same logical target as the
+/// original. To redirect or refuse, use `block: true` instead — wholesale
+/// rewriting tool arguments produces incoherent transcripts because the
+/// model's prior assistant message still references the original target.
+public struct HookOutput: Sendable, Equatable {
+    /// If non-nil, replaces the tool call's `arguments` JSON string before
+    /// dispatch. Subject to the sanitize-only invariant above. Only honoured
+    /// for `.preToolUse`.
+    public let updatedInput: String?
+
+    /// If true, the operation is cancelled — for `.preToolUse`, the tool
+    /// call returns a typed denial without dispatching.
+    public let block: Bool
+
+    /// Optional message attached to the cancellation (when `block == true`).
+    public let denyReason: String?
+
+    public init(
+        updatedInput: String? = nil,
+        block: Bool = false,
+        denyReason: String? = nil
+    ) {
+        self.updatedInput = updatedInput
+        self.block = block
+        self.denyReason = denyReason
+    }
+
+    /// Sentinel for "hook did nothing". Equivalent to a hook that wasn't
+    /// registered at all.
+    public static let passthrough = HookOutput()
+}

--- a/Sources/ManifoldRuntime/Services/Hooks/HookRegistry.swift
+++ b/Sources/ManifoldRuntime/Services/Hooks/HookRegistry.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Synchronous hook dispatch surface. Distinct from the existing
+/// `GenerationHook` observability protocol: handlers here may mutate
+/// (sanitize) tool inputs or block dispatch entirely.
+///
+/// W2C will wire callsites:
+///   - `.preToolUse` before `dispatchResult()` in `GenerationToolDispatchLoop`.
+///   - `.preCompact` at the `CompressionPolicy.compress` invocation in
+///     `ConversationTurnExecutor.runGenerationTurn` (~line 957).
+/// This file is intentionally callsite-free — it ships the actor + value
+/// types so the wiring PR is a localized diff.
+public actor HookRegistry {
+    public typealias Handler = @Sendable (HookInput) async -> HookOutput
+
+    private var handlers: [HookEvent: [Handler]] = [:]
+    private let clock: any Clock<Duration>
+    private let timeout: Duration
+
+    /// Injectable clock for deterministic timeout tests. Defaults to
+    /// `ContinuousClock()` for production use.
+    public init(
+        clock: any Clock<Duration> = ContinuousClock(),
+        timeout: Duration = .seconds(5)
+    ) {
+        self.clock = clock
+        self.timeout = timeout
+    }
+
+    public func register(_ event: HookEvent, handler: @escaping Handler) {
+        handlers[event, default: []].append(handler)
+    }
+
+    /// Runs every registered handler for `input.event` in registration order.
+    /// If any handler returns `block: true`, the chain short-circuits and
+    /// that output is returned. `updatedInput` from earlier handlers is
+    /// threaded into later handlers' inputs (so a sanitizer can chain). A
+    /// handler that exceeds `timeout` is cancelled and treated as
+    /// passthrough — a slow hook must never deadlock the turn loop.
+    public func run(_ input: HookInput) async -> HookOutput {
+        let chain = handlers[input.event] ?? []
+        guard !chain.isEmpty else { return .passthrough }
+
+        var current = input
+        var lastOutput: HookOutput = .passthrough
+
+        for handler in chain {
+            let result = await runWithTimeout(handler: handler, input: current)
+            if result.block {
+                return result
+            }
+            if let updated = result.updatedInput {
+                // Thread the sanitized input into the next handler so a
+                // chain of sanitizers can layer narrowing transforms.
+                current = HookInput(
+                    event: current.event,
+                    sessionID: current.sessionID,
+                    toolName: current.toolName,
+                    toolArguments: updated
+                )
+                lastOutput = result
+            } else if result != .passthrough {
+                lastOutput = result
+            }
+        }
+        return lastOutput
+    }
+
+    /// Distinguishes "handler finished" from "timeout fired" so a handler
+    /// returning *after* cancellation can't be mistaken for a real result.
+    private enum RaceWinner: Sendable {
+        case handler(HookOutput)
+        case timeout
+    }
+
+    private func runWithTimeout(
+        handler: @escaping Handler,
+        input: HookInput
+    ) async -> HookOutput {
+        // Race: handler vs. clock timeout. Whichever finishes first wins;
+        // the loser is cancelled. The clock is injectable so tests don't
+        // burn wall-clock time. We tag results with their source so a
+        // late-returning handler (e.g. one that swallows cancellation) is
+        // discarded if the timeout already won.
+        let timeout = self.timeout
+        let clock = self.clock
+        return await withTaskGroup(of: RaceWinner?.self) { group in
+            group.addTask { @Sendable in
+                let output = await handler(input)
+                return .handler(output)
+            }
+            group.addTask { @Sendable in
+                do {
+                    try await clock.sleep(for: timeout)
+                    return .timeout
+                } catch {
+                    // Sleep was cancelled — handler won the race.
+                    return nil
+                }
+            }
+            // First non-nil result is the race winner. Cancel siblings.
+            for await winner in group {
+                guard let winner else { continue }
+                group.cancelAll()
+                switch winner {
+                case .handler(let output):
+                    return output
+                case .timeout:
+                    // Treat slow hook as no-op rather than failing the turn.
+                    return .passthrough
+                }
+            }
+            return .passthrough
+        }
+    }
+}

--- a/Tests/ManifoldRuntimeTests/HookRegistryTests.swift
+++ b/Tests/ManifoldRuntimeTests/HookRegistryTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import ManifoldRuntime
+
+/// Tests for the synchronous hook dispatch surface. Timeout test uses a
+/// `TestClock` fake so the suite never burns wall-clock time on a hung
+/// handler (per `feedback_task_yield_fragility`).
+final class HookRegistryTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Thread-safe counter for asserting handler invocation order and skips.
+    private actor Counter {
+        private(set) var values: [String] = []
+        func append(_ value: String) { values.append(value) }
+        func snapshot() -> [String] { values }
+    }
+
+    /// Minimal fake clock that suspends `sleep(for:)` calls until the test
+    /// explicitly advances time. We don't need a real virtual-time
+    /// scheduler — we just need a `sleep` that never returns on its own,
+    /// plus a way to release it. The test uses cancellation as the release
+    /// mechanism (the registry races against this clock and cancels the
+    /// timeout task when the handler-side decides the chain is done).
+    ///
+    /// For the timeout-fires test, we use a clock whose `sleep` returns
+    /// immediately so the timeout always wins the race deterministically.
+    private struct ImmediateClock: Clock {
+        struct Instant: InstantProtocol {
+            let rawValue: Int = 0
+            func advanced(by duration: Duration) -> Instant { self }
+            func duration(to other: Instant) -> Duration { .zero }
+            static func < (lhs: Instant, rhs: Instant) -> Bool { false }
+            static func == (lhs: Instant, rhs: Instant) -> Bool { true }
+        }
+        var now: Instant { Instant() }
+        var minimumResolution: Duration { .zero }
+        func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+            // Yield once to honour cooperative cancellation but return
+            // immediately. The injected timeout fires "now" deterministically.
+            await Task.yield()
+        }
+    }
+
+    // MARK: - Tests
+
+    func test_run_emptyRegistry_returnsPassthrough() async {
+        let registry = HookRegistry()
+        let input = HookInput(event: .preToolUse, sessionID: UUID())
+
+        let output = await registry.run(input)
+
+        XCTAssertEqual(output, .passthrough)
+        // Sabotage-evidence: M1 changing `guard !chain.isEmpty else { return .passthrough }`
+        // to `return HookOutput(block: true)` flips this from passthrough → blocked.
+        // M2 returning `lastOutput` unconditionally after iterating zero handlers
+        // would still pass (lastOutput defaults to passthrough), so M1 is the
+        // load-bearing mutation. M3 removing the empty-guard early-return would
+        // still pass for the same reason — the guard is a fast path, not a
+        // correctness boundary. M1 is the only sabotage that fails this test.
+    }
+
+    func test_run_orderedDispatch_threadsUpdatedInput() async {
+        let registry = HookRegistry()
+        let observed = Counter()
+        let sessionID = UUID()
+
+        await registry.register(.preToolUse) { input in
+            await observed.append("first:\(input.toolArguments ?? "nil")")
+            return HookOutput(updatedInput: "{\"sanitized\": true}")
+        }
+        await registry.register(.preToolUse) { input in
+            await observed.append("second:\(input.toolArguments ?? "nil")")
+            return .passthrough
+        }
+
+        let input = HookInput(
+            event: .preToolUse,
+            sessionID: sessionID,
+            toolName: "read_file",
+            toolArguments: "{\"path\": \"./foo\"}"
+        )
+        _ = await registry.run(input)
+
+        let trace = await observed.snapshot()
+        XCTAssertEqual(trace, [
+            "first:{\"path\": \"./foo\"}",
+            "second:{\"sanitized\": true}",
+        ])
+        // Sabotage-evidence: M1 dropping the `current = HookInput(...)` rebind
+        // (so the second handler sees the original args) flips the second
+        // trace entry back to `./foo` and fails. M2 reversing the for-loop
+        // order swaps the trace. M3 short-circuiting on the first non-nil
+        // updatedInput would skip the second handler entirely and fail.
+    }
+
+    func test_run_blockShortCircuits() async {
+        let registry = HookRegistry()
+        let counter = Counter()
+
+        await registry.register(.preToolUse) { _ in
+            await counter.append("first")
+            return .passthrough
+        }
+        await registry.register(.preToolUse) { _ in
+            await counter.append("second")
+            return HookOutput(block: true, denyReason: "test denial")
+        }
+        await registry.register(.preToolUse) { _ in
+            await counter.append("third")
+            return .passthrough
+        }
+
+        let output = await registry.run(HookInput(event: .preToolUse, sessionID: UUID()))
+
+        XCTAssertTrue(output.block)
+        XCTAssertEqual(output.denyReason, "test denial")
+        let trace = await counter.snapshot()
+        XCTAssertEqual(trace, ["first", "second"])
+        // Sabotage-evidence: M1 removing the `if result.block { return result }`
+        // short-circuit lets the third handler run; trace becomes
+        // ["first", "second", "third"] and fails. M2 returning .passthrough
+        // instead of `result` after detecting block keeps the trace correct
+        // but fails the `output.block` assertion. M3 swapping the order of
+        // block-check and updatedInput-thread can't be triggered here (the
+        // blocking handler returns no updatedInput).
+    }
+
+    func test_run_timeoutHandler_treatedAsPassthrough() async {
+        // Use ImmediateClock so the timeout task wins the race instantly.
+        // The handler honours cancellation (throws on `try await Task.sleep`)
+        // so the registry sees a timeout-source result and the handler's
+        // would-be `block: true` return value is dropped. We assert the
+        // chain continues to the next handler and the final output is NOT
+        // blocked — i.e. the slow hook was treated as a no-op.
+        let registry = HookRegistry(
+            clock: ImmediateClock(),
+            timeout: .milliseconds(1)
+        )
+        let counter = Counter()
+
+        await registry.register(.preToolUse) { _ in
+            await counter.append("entered")
+            // The Handler signature is non-throwing, so we honour
+            // cancellation by checking after the sleep. A handler that
+            // *would* have returned block:true must not be allowed to
+            // leak that decision after the timeout fired — the registry
+            // tags the race winner and discards the late handler result.
+            do {
+                try await Task.sleep(for: .seconds(3600))
+            } catch {
+                await counter.append("cancelled")
+                return HookOutput(block: true) // late result; should be discarded
+            }
+            await counter.append("returned")
+            return HookOutput(block: true)
+        }
+        await registry.register(.preToolUse) { _ in
+            await counter.append("next")
+            return .passthrough
+        }
+
+        let output = await registry.run(HookInput(event: .preToolUse, sessionID: UUID()))
+
+        let trace = await counter.snapshot()
+        XCTAssertTrue(trace.contains("entered"), "trace=\(trace)")
+        XCTAssertTrue(trace.contains("cancelled"), "trace=\(trace)")
+        XCTAssertFalse(trace.contains("returned"), "trace=\(trace)")
+        XCTAssertTrue(trace.contains("next"), "trace=\(trace)")
+        XCTAssertFalse(output.block, "trace=\(trace) output=\(output)")
+        // Sabotage-evidence: M1 removing the timeout task from the
+        // TaskGroup race lets the slow handler block on the real clock
+        // until XCTest's default 60s timeout kills the test. M2 treating
+        // timeout as block:true (i.e. returning `.handler(HookOutput(block:true))`
+        // for the timeout branch) would fail `XCTAssertFalse(output.block)`.
+        // M3 returning the late handler result instead of the timeout's
+        // passthrough (e.g. by removing the RaceWinner tagging) would let
+        // a cancellation-swallowing handler still block the call.
+    }
+}


### PR DESCRIPTION
## Summary

Wave 1C of the multi-wave plan in `~/.claude/plans/put-an-implementation-plan-reactive-penguin.md`. Synchronous hook mechanism — value types + actor only; callsite wiring deferred to W2C.

- `HookEvent` enum: `preToolUse`, `preCompact`.
- `HookRegistry` actor with injectable `Clock` for deterministic timeout tests.
- `HookOutput` ships a **sanitize-only** contract (documented inline): hooks may narrow inputs (path → sandbox) but not redirect (foo.txt → bar.txt). Wholesale rewrites produce incoherent transcripts.
- Race-winner tagging (`.handler` vs `.timeout`) prevents a slow handler that swallows cancellation from delivering a stale `block:true` after the timeout fires.
- Independent of W1A (SessionToolSource) and W1B (V9 schema). Callsite wiring is W2C's job (`preToolUse` before `dispatchResult` in `GenerationToolDispatchLoop`; `preCompact` at `CompressionPolicy.compress` in `ConversationTurnExecutor.runGenerationTurn` ~line 957).

## Test plan

- [x] `swift build --disable-default-traits` clean
- [x] 4 new tests under `HookRegistryTests`: empty-registry passthrough, ordered dispatch + input threading, block short-circuit, timeout-as-passthrough (ImmediateClock fake).
- [x] No wall-clock sleeps — all timing via injected Clock.
- [x] Sabotage-evidence verified on every test (empty-registry guard, input-threading rebind, block short-circuit, RaceWinner tagging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>