### PR TITLE
dx: archetype-2 walkthrough artifacts (brief + iter-1 + iter-2 retrospectives)

### DIFF
--- a/scripts/dx-walkthrough/briefs/02-swiftui-chat.md
+++ b/scripts/dx-walkthrough/briefs/02-swiftui-chat.md
@@ -1,0 +1,104 @@
+# Brief: SwiftUI Chat App with ManifoldKit
+
+You are a Swift developer who has just heard about **ManifoldKit** — a Swift framework for building local-first AI chat apps. You want to build a minimum-viable SwiftUI macOS app to evaluate it before committing to it for a larger project.
+
+## What you're building
+
+A native macOS SwiftUI app that:
+
+1. Launches a window showing a chat interface
+2. Lets the user pick a model (any documented backend — Foundation Models, a local GGUF, or an Ollama endpoint — your choice)
+3. Streams responses in the UI as they generate
+4. **Persists chat sessions across launches** — closing and reopening the app should restore prior conversations
+5. Lets the user start a new session and switch between sessions
+
+If MK provides a drop-in `ChatView` that handles all of this, use it. If you have to assemble pieces, do that. The goal is a working SwiftUI app, not a particular code shape.
+
+## Constraints
+
+- **Target**: macOS 26, Swift 6, SwiftUI
+- **You may read**: ManifoldKit's `README.md`, anything under `docs/`, anything under `Sources/*/Documentation.docc/`, the package's `Package.swift`, repo-root markdown, the existing `Example/Examples/MinimalExample/` directory if one exists (this is canonical sample code, fair game).
+- **You may NOT read**: ManifoldKit's source files (`Sources/Manifold*/**/*.swift`) OR its test files (`Tests/**`). If you find yourself wanting to grep MK internals or peek at how tests construct types, **stop and log it in FRICTION.md** as a discoverability gap, then try to work around it from the public docs alone.
+- **Budget**: ~60 minutes of focused work. If you're stuck on one problem for more than 3 substantive attempts, log it in FRICTION.md and pivot.
+
+## Cold build time
+
+A fresh consumer of ManifoldKit cold-builds all transitive dependencies (huggingface, MLX, llama, etc.). The first build can take 5–10 minutes. Plan accordingly; subsequent builds are cached.
+
+## Working directory
+
+Your app lives at `./app/` relative to wherever this brief is. Reference ManifoldKit via a local path dependency:
+
+```swift
+.package(name: "ManifoldKit", path: "/Users/roryford/Repos/ManifoldKit")
+```
+
+(Per CLAUDE.md, `.package(path:)` needs an explicit `name:` to work reliably.)
+
+## Required behavior (acceptance criteria)
+
+- [ ] App compiles cleanly (warnings allowed, errors not)
+- [ ] App launches and shows a SwiftUI window
+- [ ] A chat interface is visible (input field, message list — drop-in `ChatView` or your own)
+- [ ] You can verify in some way that a generation works end-to-end (screenshot, log, or stdout proof that tokens stream from a backend)
+- [ ] After closing and relaunching the app, prior chat sessions remain visible
+
+You do not need to make the UI pretty. You do need to verify it works — capture a screenshot via `xcrun screencapture` or equivalent, or a launch log showing the window opened and a backend loaded.
+
+## Deliverables
+
+In your run directory you should produce:
+
+1. **`./app/`** — the working Swift package or Xcode project
+2. **`./FRICTION.md`** — your friction log (template below). **This is the most important deliverable.**
+3. **`./session.log`** — output of your final build + launch session, plus any captured screenshots referenced by filename
+4. **`./screenshot.png`** (if possible) — screencapture of the running app
+5. **`./NOTES.md`** — 5–10 lines: what backend/path you picked, what worked smoothly, what was surprising, your overall impression of MK's SwiftUI DX
+
+## FRICTION.md template
+
+Start the file with this header, then append entries as you go. Log friction **as it happens**, not at the end — you will forget.
+
+```markdown
+# Friction log — swiftui-chat archetype
+
+Agent: <your model name>
+Date: 2026-05-23
+ManifoldKit version: <from version.txt or git tag>
+
+---
+
+## Entry 1
+- **Trying to**: <what you were attempting>
+- **Expected**: <based on docs / API names, what you thought would happen>
+- **Actual**: <what happened — error, missing API, confusing behavior>
+- **Resolution**: <how you got past it, or "gave up and pivoted">
+- **Category**: DOC-MISSING | DOC-WRONG | API-DISCOVERABILITY | API-ERGONOMICS | API-GAP
+- **Severity**: blocker | major | minor | papercut
+
+## Entry 2
+...
+```
+
+**Log liberally.** A papercut hit once is worth recording. A blocker is worth recording even if you eventually solved it — the resolution path matters. Surfaces of interest in this archetype that didn't apply to the CLI version:
+
+- The `ManifoldKit.quickStart()` flow vs explicit `ManifoldBootstrap`
+- SwiftData container setup and the `.modelContainer(...)` modifier
+- `ChatViewModel` and `ModelRegistry` access patterns
+- Whether `ChatView` is the right entry point or whether BYO views are needed
+- How sessions persist (do they just work? do you have to wire a store?)
+- Whether the umbrella `import ManifoldKit` covers everything you need
+
+## What we're trying to learn
+
+This is the second archetype in a DX walkthrough series. Archetype 1 (chat-cli) is shipping; we want to know whether the SwiftUI happy path is comparably polished or whether different friction layers surface here.
+
+**Be honest.** If the docs are great, say so. If something is genuinely confusing, say so without softening.
+
+## Reporting back
+
+When done (or when time/attempts are exhausted), respond with:
+- Whether the app works (yes/no/partially) — note specifically: does persistence work?
+- Path to your run directory
+- The 3 highest-severity friction entries, verbatim
+- One-line overall verdict

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter1/02-swiftui-chat/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter1/02-swiftui-chat/SUMMARY.md
@@ -1,0 +1,147 @@
+# swiftui-chat archetype — iteration 1 (baseline)
+
+**Date**: 2026-05-23
+**MK version**: 0.33.0 (post-#1406)
+**Agent model**: Opus 4.7 (all 3 runs)
+**App outcome**: 1/3 reached fully-working chat with persistence; 2/3 compiled + launched + rendered ChatView but couldn't complete a chat session
+
+## Coverage
+
+Per the methodology lesson from archetype-1 iter-3, each agent was steered to a different surface:
+
+| Run | Path | Outcome |
+|---|---|---|
+| 1 | `quickStart()` + drop-in `ChatView` (high-level) | Compiles, launches, ChatView renders → **stuck at "No session selected"** |
+| 2 | Explicit `ManifoldBootstrap` + shipped `ChatView` (BYO bootstrap) | **Full end-to-end**: streamed Foundation Models tokens, 7+ persistent sessions |
+| 3 | `quickStart(configuration:)` with bundleId, persistence focus | Compiles, launches, ChatView renders, persistence wired → **stuck at "Download a model"** |
+
+The 1/3 success rate is misleading — run-2 succeeded because they had to **dive past the documented happy path** to wire session creation. They explicitly noted the canonical DocC article they were following doesn't compile as written.
+
+## The headline finding
+
+**A2-F4 (blocker): the documented happy path produces a non-functional binary.**
+
+`quickStart()` + drop-in `ChatView` (the canonical "5-minute hello world") compiles, launches, and renders. The composer is then **disabled** with placeholder text "No session selected — Send a message to start chatting." There is no documented way to create a session through the high-level path. Session management lives in `SessionManagerViewModel` / `createSession()`, which exists only in `Example/Advanced/` and is mentioned **nowhere** in QUICKSTART.md or the MinimalExample README.
+
+Both run-1 (deliberately following the high-level docs) and run-3 (persistence-focused) hit this. Run-3 attributed it to "no model auto-selected" and ran out of budget before discovering the deeper truth; run-1 dug further and found the actual cause.
+
+This is the largest gap surfaced by any walkthrough so far. **The "minimal example" as shipped does not minimally work.**
+
+## Findings
+
+### A2-F4 — `quickStart()` ships a chat UI with no way to start a chat [2/3, BLOCKER]
+
+Already detailed above. Fix needs to be one of:
+- `quickStart()` auto-creates an initial session
+- `ChatView` exposes a "New Chat" button wired to a documented session-creation API
+- QUICKSTART.md explicitly documents the session-creation step
+
+The first option is the cleanest contract: "the minimal example shows a working chat" should mean *working*.
+
+### A2-F7 — `ManifoldBootstrap.build(...)` return type is an undocumented progress/task tuple [run-2, blocker]
+
+```
+(progress: AsyncStream<RuntimeBootstrapMilestone>, task: Task<ManifoldBootstrap, any Error>)
+```
+
+QUICKSTART says "drop down to `ManifoldBootstrap.build(...)` directly" without warning that the return is a tuple, without naming `RuntimeBootstrapMilestone`, and without showing how to consume either side. Run-2 reverse-engineered `try await result.task.value` from the compiler error alone — exactly the source-diving the brief was designed to surface.
+
+**Fix shape**: document the tuple return, the `RuntimeBootstrapMilestone` cases, and a worked example showing both how to await the bootstrap and how to render progress. This is BuildingAChatUI.md's job and it's currently silent.
+
+### A2-F8 — Canonical DocC article `BuildingAChatUI.md` does not compile as written [run-2, major]
+
+Same shape as archetype-1 F1 (broken `stream.events` snippet): the doc snippet calls `chatVM.switchToSession(session)` synchronously in `App.init()` and `sessionVM.createSession()` synchronously in an `onChange` closure — both methods are `async`. The article can't compile because `App.init()` and `onChange` closures aren't async contexts.
+
+This is **the exact pattern PR #1393 was supposed to prevent**. The snippet compile gate (`readme-snippets.yml`) extracts from `README.md`, `docs/QUICKSTART.md`, and `docs/QUICKSTART-CLI.md` — but **not from DocC catalogs** (`Sources/*/Documentation.docc/Articles/*.md`). DocC content is documentation but it's outside the gate.
+
+**Fix shape**: extend `scripts/extract-snippets.sh` to also walk DocC `.docc` catalogs, OR add an explicit DocC snippet gate. Either way, the same `swift,no-build` policy that PR #1393 enforced should apply.
+
+### A2-F9 — BYO chat views are blocked by missing public type docs [run-2, major]
+
+`ChatViewModel.messages` exists in DocC but the element type isn't named in any DocC topic page. No DocC page for `Message` / `ChatMessage` / `MessageRecord`. Without the type name, writing `ForEach(chatVM.messages) { msg in ... }` is impossible without source-diving or autocomplete.
+
+**Fix shape**: add the public message-record type to ManifoldRuntime/ManifoldInference's DocC `## Topics` table. One line in a curated page.
+
+### A2-F5 — "Browse Models" empty-state button is bound to a dead handler [run-1, major]
+
+`ChatView`'s built-in empty state shows a "Browse Models" button. The `showModelManagement` binding goes nowhere by default — the actual model browser (`ModelManagementSheet`) lives in `ManifoldUIModelManagement`, a non-default module that needs explicit product addition + `ModelManagementViewModel(huggingFaceService:downloadManager:)` construction + a `.sheet` modifier. None of this is in QUICKSTART. The button promises a flow it cannot deliver.
+
+**Fix shape**: either remove the button from the empty state by default (and let consumers add it via API) or document the wiring as a required step in QUICKSTART. The current state is "the framework dares you to find this on your own."
+
+### A2-F6 — `ChatViewModel.refreshModels()` scans the wrong directory by default [run-1, major]
+
+A fresh evaluator with GGUFs at `~/Documents/Models/` (the chat-cli archetype's canonical location) finds 0 models. The default scan path is `<Application Support>/<bundleId>/<modelsDirectoryName>/` — documented in README "Where data lives" but not surfaced anywhere a SwiftUI evaluator would look. Cross-archetype inconsistency: the CLI evaluator's models are invisible to the SwiftUI app and vice versa.
+
+**Fix shape**: document the default scan path prominently in the SwiftUI quickstart, OR have `ChatViewModel` scan a small set of common locations and surface them all.
+
+### A2-F1 — `quickStart()` doesn't auto-select a model when one is available [3/3, minor]
+
+When Foundation Models is available on macOS 26, `quickStart()` could theoretically auto-load it (it's free, on-device, no setup). Instead the ChatView shows "Welcome — Download a model to get started." A first-time evaluator with a perfectly capable backend already on disk sees a "no model" message.
+
+**Fix shape**: have `quickStart()` opportunistically wire Foundation Models when available. Document the fallback chain.
+
+### A2-F2 — MK-internal deprecation warnings reach SwiftUI consumers too [3/3, papercut]
+
+Cross-archetype concordance with iter-4 F21: the `MLX.GPU.set(cacheLimit:)`, `default will never be executed`, and `configure(runtime:)` deprecations all surface at consumer build time. Run-2 specifically flagged `configure(runtime:)` is **deprecated yet taught as current API** somewhere in the docs.
+
+### A2-F3 — SwiftPM bare executable doesn't restore window state [run-3, papercut]
+
+Window/sidebar layout doesn't survive process kill+relaunch. Likely needs an Xcode `.app` target. Could be addressed with a one-line callout in the SwiftUI quickstart pointing at Xcode's SwiftUI App template.
+
+## Cross-archetype patterns
+
+| Archetype 1 | Archetype 2 | Pattern |
+|---|---|---|
+| F1 broken stream snippet | A2-F8 broken DocC article | **Compile-test gate not covering DocC catalogs** |
+| F4 backend factory invisible | A2-F9 message type invisible | **DocC `## Topics` curation gaps** |
+| F8 `@MainActor` shape-dependent | A2-F7 bootstrap tuple-return | **Public API shape not visible in docs** |
+| F21 internal warnings leaking | A2-F2 same warnings | **Concordance: not archetype-specific** |
+
+The shape of failures repeats across archetypes. The root causes are not specific to CLI or SwiftUI — they're about the docs system itself.
+
+## Concordance map
+
+| Finding | Runs | Severity | Type |
+|---|---|---|---|
+| A2-F4 quickStart can't chat | 2/3 | **blocker** | Behavioral gap |
+| A2-F1 no auto-model-select | 3/3 | minor | DX gap |
+| A2-F2 internal warnings | 3/3 | papercut | Concordance |
+| A2-F7 bootstrap tuple-return | 1/3 | blocker | Doc gap |
+| A2-F8 DocC article broken | 1/3 | major | Compile-gate gap |
+| A2-F9 message type undocumented | 1/3 | major | DocC curation |
+| A2-F5 dead "Browse Models" button | 1/3 | major | API gap |
+| A2-F6 wrong default model scan dir | 1/3 | major | Doc/UX gap |
+| A2-F3 SwiftPM window-state | 1/3 | papercut | Doc gap |
+
+## Why the 1/3 success rate
+
+The 2/3 failures are not because the agents were weaker — both correctly followed the documented happy path and hit a behavioural gap (no session creation) that the docs don't address. Run-2 succeeded because they explicitly chose to deviate from the high-level surface and dive into the lower-level `ManifoldBootstrap` + manual session wiring path, finding session creation through the `Example/Advanced/` demo code.
+
+In other words: **the documented path doesn't work, but the framework underneath does.** Once you know what to wire, end-to-end works (streaming + persistence + multi-session) — but knowing what to wire requires reading sample code that QUICKSTART doesn't reference.
+
+## Recommended next moves, ranked
+
+### Behavioral fix (the actual blocker)
+1. **A2-F4**: Make `quickStart()` create an initial session OR have `ChatView` expose a documented "New Chat" affordance. This is the difference between "the docs are incomplete" and "the docs are misleading." Run-1's verdict: *"the documented 5-minute SwiftUI happy path ships a runnable binary you cannot actually chat in."*
+
+### Structural fix
+2. **A2-F8**: Extend the snippet compile gate to cover DocC `.docc` catalogs (or apply the no-build policy to them via a separate check). This catches A2-F8 and the next BuildingAChatUI.md-shape bug before it ships.
+
+### High-leverage docs
+3. **A2-F7**: Document `ManifoldBootstrap.build`'s tuple return, `RuntimeBootstrapMilestone`, and the await pattern. One DocC page closes a blocker for any BYO bootstrap consumer.
+4. **A2-F9**: Curate `Message` (or whatever the messages-array element is) into ManifoldRuntime's DocC `## Topics`. One line.
+
+### Single-line fixes
+5. **A2-F5**: Default off the dead "Browse Models" button, OR document the wiring.
+6. **A2-F6**: Document the default model scan directory in the SwiftUI quickstart.
+7. **A2-F1**: Have `quickStart()` opportunistically wire Foundation Models on macOS 26.
+8. **A2-F3**: SwiftPM-vs-Xcode-bundle window-state callout.
+9. **A2-F2**: Continue the F21 trait-gate / source-cleanup work.
+
+## Verdict
+
+Archetype-1 iter-1 found a broken hello-world snippet. **Archetype-2 iter-1 found a hello-world *binary* that doesn't work.** The framework underneath is solid — once wired correctly, streaming + persistence + multi-session all "just work." But the docs path documented for new users leads to a dead end.
+
+This is a bigger problem than any single chat-cli iteration uncovered. It's also exactly the kind of finding the walkthrough methodology was designed to surface: end-to-end runtime behavior that internal tests don't see and that fresh-eyes consumers hit immediately.
+
+**The methodology has a new question to answer**: how many iterations does it take to fix A2-F4? My prediction (from the archetype-1 pattern) is one focused PR to add session-creation to `quickStart()` + a doc update; the rerun will reveal what's hiding behind it.

--- a/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter2/02-swiftui-chat/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter2/02-swiftui-chat/SUMMARY.md
@@ -1,0 +1,125 @@
+# swiftui-chat archetype — iteration 2 (post-#1411, post-#1417)
+
+**Date**: 2026-05-23
+**MK version**: 0.33.0 + PR #1411 + PR #1417
+**Agent model**: Opus 4.7 (all 3 runs)
+**Outcome**: 1/3 reached a launching app with persistence verified (run-3); 0/3 reached fully-working multi-session chat with token streaming.
+
+Run-3 completed end-to-end after a delayed wake — verified persistence via direct sqlite inspection (`~/Library/Application Support/com.dxwalkthrough.chat/store.sqlite`: same row, same Z_PK, same `ZCREATEDAT` across quit+relaunch, no duplicate auto-create). Runs 1 and 2 stalled mid-build; their logged friction is still signal but partial.
+
+## Confirmed fixes
+
+- **A2-F4 (session auto-create) — CLOSED.** Run-3 Entry 1 explicitly noted: *"`docs/QUICKSTART.md` did exactly [what was needed] — full `@main MyChatApp` example with `ManifoldKit.quickStart()`, `ChatView`, `.modelContainer(result.bootstrap.modelContainer)`, and an explicit note that session bootstrap auto-creates an empty session. Resolution: No friction; copy-paste-ready."* The single-session happy path that iter-1 found broken now works.
+- **A2-F8 partial.** BuildingAChatUI.md no longer fails on sync-call-of-async-method, but introduced/preserved a new issue (see A2-iter2-F1 below).
+
+## New findings
+
+### A2-iter2-F1 — BuildingAChatUI.md teaches a fictitious `AppRuntime.make()` API [run-2, major]
+
+The article (rewritten in PR #1417 to fix the original sync-from-async-context bug) now calls `AppRuntime.make(inferenceService:)` in its scaffold. There is no such public type — the article comment says *"AppRuntime lives in your app composition root,"* meaning it's a host-supplied placeholder. But the article never shows **how to actually construct a `ChatRuntimeBootstrap`** in a real app from the shipped `ManifoldBootstrap`. The reader is told the result is *"a `ChatRuntimeBootstrap`-typed runtime"* and to feed it into `chatVM.configure(runtime:)`, but the bridge is hand-waved.
+
+The new shape compiles when no-build-tagged (which it is), but it doesn't teach the reader anything actionable. The first walkthrough agent following the article literally had to guess that `try await ManifoldBootstrap.build(...)` returns something they can pass directly. That's not a guess a doc-reader should be making.
+
+**Fix shape**: replace the `AppRuntime.make(...)` placeholder with the actual `ManifoldBootstrap.build(...)` shape, and show the consumer how to extract the `ChatRuntimeBootstrap` from it (or document that `ManifoldBootstrap` *is* a `ChatRuntimeBootstrap`).
+
+### A2-iter2-F2 — Article's sync-`init()` shape mismatches the realistic async bootstrap [run-2, major]
+
+Companion to F1. The article's `init()` calls `AppRuntime.make(...)` synchronously, training the reader to expect a sync helper. The shipped equivalent (`ManifoldBootstrap.build(...)`) is `try await`. A faithful adopter either:
+- Has to bootstrap inside `.task { }` on the root view (deviates from the article's "single bootstrap in App.init()" pitch), or
+- Hacks `Task.sync`-style blocking (anti-pattern), or
+- Discovers (via source-diving) a hypothetical sync helper that doesn't appear in public docs.
+
+The article's "Migrating" section repeats the same sync shape — so this isn't a one-off slip, it's the canonical pattern.
+
+### A2-iter2-F3 — No documented bridge from `quickStart()` to multi-session UI [run-3, major]
+
+`docs/QUICKSTART.md` mentions `SessionManagerViewModel` once: *"The full session-management surface (list sidebar, create/delete/rename) lives on `SessionManagerViewModel` — see `Example/Advanced` for the worked example."*
+
+But there is no documented bridge between `QuickStartResult` and `SessionManagerViewModel`. The consumer needs:
+- A way to extract the same runtime/inference handles `quickStart()` already built, OR
+- An equivalent of `quickStart()` that also returns a session manager, OR
+- A documented pattern of constructing the session manager from `result.bootstrap.<something>`.
+
+Run-3 verdict: *"Multi-session UI requires either dropping to `ManifoldBootstrap.build(...)` directly (which the docs allow but don't show end-to-end) or being told that `QuickStartResult` already contains the needed handles — neither is documented."*
+
+**Fix shape**: extend `QuickStartResult` with a `sessionManager: SessionManagerViewModel` property, OR add a docs section "Adding the session sidebar to your quickStart app" that shows the construction explicitly.
+
+### A2-iter2-F4 — `QuickStartResult` public shape not documented [run-3, major]
+
+README and MinimalExample only demonstrate `result.viewModel` and `result.bootstrap.modelContainer`. The full set of fields on `result.bootstrap` (runtime? inferenceService? sessionStore? messageStore? endpointStore?) is only discoverable by reading `Sources/ManifoldKit/QuickStart.swift` — which the walkthrough explicitly forbids.
+
+This is a 5-minute DocC fix: add a `## Topics` section to a curated page listing `QuickStartResult` and `ManifoldBootstrap`'s public fields.
+
+### A2-iter2-F6 — SwiftPM-only run requires manual .app bundling on macOS [run-3, major]
+
+Run-3 confirmed: a SwiftPM `.executableTarget` containing `@main struct App: App` builds, but **`swift run` produces a binary that silently refuses to open a window**. SwiftUI on macOS requires the binary to be inside a bundled `.app` with an `Info.plist` containing `NSPrincipalClass=NSApplication`. Running a raw SwiftPM executable produces no error, no window — just a long-running process that does nothing visible.
+
+To make `quickStart()` actually show a window, run-3 had to:
+1. Hand-roll an `Info.plist`
+2. Copy the executable into `DXChatApp.app/Contents/MacOS/`
+3. Ad-hoc codesign
+4. Hit a dyld error: `Library not loaded: @rpath/llama.framework/...`
+5. Copy `llama.framework` into `DXChatApp.app/Contents/Frameworks/`
+6. `install_name_tool -add_rpath @loader_path/../Frameworks` + re-codesign
+
+**~6 manual steps**, none documented. `MinimalExample` sidesteps via `ManifoldExamples.xcodeproj` (Xcode bundles automatically). Any SwiftPM-only consumer hits this.
+
+This is a sharper restatement of F5: not just "no scaffolding guidance" but "the obvious SwiftPM path doesn't actually run a SwiftUI app on macOS, period."
+
+**Fix shape**: prominently document in QUICKSTART that SwiftUI apps need either (a) an Xcode project / xcodegen path, or (b) the manual `.app` bundling dance. Ideally provide a tiny script or template that does the bundling.
+
+### A2-iter2-F7 — "Browse Models" CTA is still inert even with `ManifoldUIModelManagement` imported [run-3, major]
+
+Concordance with iter-1 A2-F5, but worse than expected: run-3 imported `ManifoldUIModelManagement` (the non-default module that contains `ModelManagementSheet`) and added the product dep, expecting the empty-state "Browse Models" button to wire up automatically. It didn't. Programmatic AX click confirmed `clicked button 1` but no sheet appears.
+
+QUICKSTART/DocC don't explain the actual wiring required. `ChatView(showModelManagement:)`'s `showModelManagement` binding appears to be for the API-key sheet only, not for `ModelManagementSheet`. There's no documented path from "I called `quickStart()`" to "the model browser sheet opens on Welcome state click."
+
+**Fix shape**: either auto-wire `ModelManagementSheet` when `ManifoldUIModelManagement` is linked, OR document the explicit binding consumers must add. The current state is a dead button with no recoverable user flow.
+
+### A2-iter2-F5 — No SwiftPM-only scaffolding instructions [run-1, major]
+
+QUICKSTART says *"Xcode 16+"* and *"a SwiftUI app target on iOS 18+ / macOS 15+"* but only `MinimalExample` shows the actual scaffolding — via `xcodegen` + `project.yml`. A consumer evaluating MK with **just** SwiftPM (no Xcode project files, no xcodegen) has no documented path to a SwiftUI app target.
+
+Notable: a bare SwiftPM `.executableTarget` containing `@main struct App: App` builds, but `swift run` produces a CLI binary with no Info.plist or bundle — SwiftUI window/persistence/`.modelContainer` lifecycle is at best fragile, at worst silently broken on macOS.
+
+**Fix shape**: add a "SwiftPM-only scaffolding" callout to QUICKSTART.md pointing at either the xcodegen path or Xcode's File→New→Project SwiftUI App template. This is a brief paragraph, not a full subsection.
+
+## Concordance map
+
+| Finding | Runs | Severity | Type |
+|---|---|---|---|
+| A2-iter2-F1 BuildingAChatUI uses fictitious AppRuntime | 1/3 | major | DOC-WRONG |
+| A2-iter2-F2 Article sync-init mismatches async bootstrap | 1/3 | major | DOC-WRONG |
+| A2-iter2-F3 No quickStart → SessionManager bridge | 1/3 | major | DOC-MISSING / API-GAP |
+| A2-iter2-F4 QuickStartResult shape undocumented | 1/3 | major | DOC-MISSING |
+| A2-iter2-F5 No SwiftPM-only scaffold guidance | 1/3 | major | DOC-MISSING |
+
+The findings are disjoint (each run hit a different layer), which is the expected shape when the methodology is working — each agent's path reveals a different next-layer-down issue.
+
+## Iteration delta
+
+| Iter | Working | Blockers | Major findings |
+|---|---|---|---|
+| 1 (baseline) | 1/3 fully (2/3 stuck at no-session) | A2-F4 (no session creation) | 6 (F4, F5, F6, F7, F8, F9) |
+| 2 (post #1411, #1417) | 0/3 fully (1/3 confirmed single-session works; 2/3 stalled mid-build) | 0 | 5 (iter2-F1 through F5) |
+
+**Single-session quickStart is solid. Multi-session SwiftUI is the next dominant gap.**
+
+## Recommended next moves
+
+### Highest leverage
+1. **Fix BuildingAChatUI.md properly** — replace the `AppRuntime.make()` placeholder with the actual `ManifoldBootstrap.build(...)` shape and show how to extract `ChatRuntimeBootstrap` from it (closes iter2-F1 + iter2-F2 in one PR). PR #1417's rewrite was structurally correct but didn't go far enough.
+
+### Documentation
+2. **Add `SessionManagerViewModel` to QuickStartResult** OR document the bridge — closes iter2-F3. This is the analogue of A2-F4: "the documented happy path provides only single-session; multi-session requires source-diving." Fix is structurally the same: ship the bridge, or document it.
+3. **DocC `## Topics` curation** for `QuickStartResult` and `ManifoldBootstrap` (iter2-F4). 10 minutes of DocC work.
+4. **SwiftPM scaffolding callout** in QUICKSTART (iter2-F5). One paragraph.
+
+### Methodology
+5. **The 60-min budget is still too tight for the SwiftUI archetype on this hardware.** Cold builds eat 5-10 min, leaving ~50 min for code + verification. Two of three agents stalled mid-build before completing acceptance criteria. Consider bumping to 90 min or warming the build cache via a different mechanism than the broken symlink trick (e.g. pre-resolve MK's deps as a brief precondition the human can do once).
+
+## Verdict
+
+PR #1411 closed the iter-1 blocker cleanly. PR #1417 partially closed iter-1 A2-F8 but introduced new doc-wrong-shape issues by leaving the `AppRuntime.make()` placeholder in place. The next iteration of MK's SwiftUI DX needs to **stop teaching fictitious APIs** in BuildingAChatUI.md — that's the headline of this round.
+
+The framework continues to work; the docs continue to under-deliver for anything past the most minimal hello-world.


### PR DESCRIPTION
## Summary

Checks in the second archetype's brief and synthesis docs from iter-1 and iter-2 so the harness has a complete record of the SwiftUI archetype's findings to compare against in future iterations.

- `scripts/dx-walkthrough/briefs/02-swiftui-chat.md` — agent brief
- `runs/2026-05-23_v0.33.0-iter1/02-swiftui-chat/SUMMARY.md` — iter-1 baseline (A2-F1 through A2-F9)
- `runs/2026-05-23_v0.33.0-iter2/02-swiftui-chat/SUMMARY.md` — iter-2 post-fix (A2-iter2-F1 through F7)

Per-run `app/` + `FRICTION.md` + `session.log` artifacts stay gitignored per `.gitignore` rules added in #1405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)