### PR TITLE
docs: first-launch backend selection in QUICKSTART

### DIFF
--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -25,7 +25,7 @@ The smallest possible CLI. No model files to manage, no network calls, no API ke
 **`Package.swift`:**
 
 ```swift
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
@@ -102,7 +102,7 @@ This is the section that closes the "I'm on macOS 15 and want to evaluate Manifo
 **`Package.swift`:**
 
 ```swift
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(
@@ -310,7 +310,7 @@ For any HTTP-speaking provider — Ollama at `localhost:11434`, OpenAI, Anthropi
 **`Package.swift`:**
 
 ```swift
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ A one-page tutorial for getting from "empty SwiftUI project" to "working chat UI
 
 ## Prerequisites
 
-- Xcode 16+ on macOS, or Swift 6.2+ toolchain (`swift-tools-version: 6.2` is required for `.macOS(.v26)` / `.iOS(.v26)` platform entries).
+- Xcode 16+ on macOS, or Swift 6.1+ toolchain. ManifoldKit's own `Package.swift` declares `// swift-tools-version: 6.1` and platforms `.iOS(.v18)` / `.macOS(.v15)`; consumer packages should match (or go higher) to avoid SwiftPM version-resolution churn.
 - A SwiftUI app target on iOS 18+ / macOS 15+ (Apple Foundation Models require iOS 26+ / macOS 26+).
 - Familiarity with SwiftUI's `App` protocol and `@State`. No prior knowledge of MLX, llama.cpp, MCP, or any specific backend is assumed.
 
@@ -67,9 +67,159 @@ struct MyChatApp: App {
 }
 ```
 
-Run the app. On macOS or iOS 26+, the Apple Foundation Models backend is available immediately; for other backends, see [Customizing backends](#customizing-backends).
+Run the app. `quickStart()` will compile, launch, and render a usable composer — but the chat will be inert until a backend is selected. See [First-launch backend selection](#first-launch-backend-selection) for the next step.
 
 > **Session bootstrap.** `quickStart()` auto-creates an initial empty `ChatSessionRecord` and activates it on first launch when the persistent store has no sessions yet, so `ChatView`'s composer is enabled the moment the view appears. On subsequent launches the most-recent existing session is selected. Hosts that need finer control over the initial session (custom title, system prompt, restoring from a deep link) can drop down to `ManifoldBootstrap.build(...)` directly and call `result.bootstrap.persistence.insertSession(_:)` before constructing the view model — `quickStart()` only auto-creates when the store is *empty*, so seeding one session first opts out cleanly. The full session-management surface (list sidebar, create/delete/rename) lives on `SessionManagerViewModel` — see [`Example/Advanced`](../Example/Advanced) for the worked example.
+
+## First-launch backend selection
+
+`quickStart()` registers every compiled-in backend with the inference service, but **it does not pick one for you**. The composer is enabled (a session exists), but no model is loaded — `ChatViewModel.isModelLoaded` is `false`, the composer placeholder reads "No model loaded", and the empty-state surfaces a "Select Model" button that flips the `showModelManagement` binding (see [`showModelManagement` binding](#showmodelmanagement-binding) below — by itself the binding doesn't present anything).
+
+This section shows the three documented paths to get a model loaded on first launch.
+
+### What "available immediately" actually means
+
+On macOS 26 / iOS 26, the Apple Foundation Models backend is *registered* by `DefaultBackends.register(with:)` — but it is **not auto-selected by `quickStart()`**. `ChatViewModel` needs two extra inputs before Foundation Models appears in `availableModels`:
+
+1. A provider closure that reports availability — `foundationModelProvider = { FoundationBackend.isAvailable }`.
+2. An explicit `loadFoundationModelIfAvailable()` call (or `autoSelectFirstRunModel()`, which is gated on a first-launch `UserDefaults` flag).
+
+Without those, `availableModels` won't contain the Foundation entry and `ChatView`'s welcome state will read "Welcome — Download a model to get started" even though the OS ships with one. (Tracked as A2-F1 in the iter-1 walkthrough.)
+
+### Seeding Foundation Models
+
+Add this to the `Hello World` example so the moment `result` is non-nil, you also probe Foundation availability and dispatch a load. The probe is OS-gated; the rest of `quickStart()`'s flow runs unchanged on older OSes.
+
+```swift,no-build
+import SwiftUI
+import SwiftData
+import ManifoldKit
+import ManifoldUI
+#if canImport(ManifoldFoundation)
+import ManifoldFoundation
+#endif
+
+@main
+struct MyChatApp: App {
+    @State private var result: QuickStartResult?
+    @State private var showModelManagement = false
+
+    var body: some Scene {
+        WindowGroup {
+            if let result {
+                ChatView(showModelManagement: $showModelManagement)
+                    .environment(result.viewModel)
+                    .modelContainer(result.bootstrap.modelContainer)
+                    .task {
+                        #if canImport(ManifoldFoundation)
+                        if #available(macOS 26, iOS 26, *) {
+                            result.viewModel.foundationModelProvider = { FoundationBackend.isAvailable }
+                            result.viewModel.loadFoundationModelIfAvailable()
+                        }
+                        #endif
+                    }
+            } else {
+                ProgressView().task {
+                    result = try? await ManifoldKit.quickStart()
+                }
+            }
+        }
+    }
+}
+```
+
+`loadFoundationModelIfAvailable()` is a no-op when the provider returns `false` or when no Foundation entry exists in `availableModels`, so it's safe to call unconditionally on supported OSes.
+
+### Seeding an Ollama endpoint
+
+For cloud / LAN backends (Ollama, OpenAI Chat Completions, OpenAI Responses, Anthropic Claude), the host inserts an `APIEndpointRecord` into the endpoint store *before* the view appears. `quickStart()` exposes the store on `result.bootstrap.endpointStore`; `ChatViewModel.refreshAvailableEndpointsFromStore()` is wired up automatically and will pick up the new endpoint.
+
+```swift,no-build
+import SwiftUI
+import ManifoldKit
+import ManifoldUI
+import ManifoldInference
+
+@main
+struct MyChatApp: App {
+    @State private var result: QuickStartResult?
+    @State private var showModelManagement = false
+
+    var body: some Scene {
+        WindowGroup {
+            if let result {
+                ChatView(showModelManagement: $showModelManagement)
+                    .environment(result.viewModel)
+                    .modelContainer(result.bootstrap.modelContainer)
+            } else {
+                ProgressView().task {
+                    do {
+                        let r = try await ManifoldKit.quickStart()
+                        let existing = try await r.bootstrap.endpointStore.fetchEndpoints()
+                        if existing.isEmpty {
+                            // Seed a default Ollama endpoint pointing at localhost:11434.
+                            // `defaultBaseURL` / `defaultModelName` come from `APIProvider`.
+                            let ollama = APIEndpointRecord(
+                                name: "Local Ollama",
+                                provider: .ollama,
+                                modelName: "llama3.2:3b"  // any model you've `ollama pull`-ed
+                            )
+                            try await r.bootstrap.endpointStore.insertEndpoint(ollama)
+                            r.viewModel.setAvailableEndpoints([ollama])
+                        }
+                        result = r
+                    } catch {
+                        // Show ContentUnavailableView, log, etc.
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+The user can then pick "Local Ollama" from the model sidebar without ever opening a settings sheet. Cloud SaaS providers (OpenAI, Anthropic) follow the same pattern but additionally need an API key written to the keychain under `keychainAccount`; the `ManifoldUIModelManagement` `APIConfigurationView` handles that wiring, or you can write the key yourself before inserting the record.
+
+### `showModelManagement` binding
+
+`ChatView(showModelManagement: $flag)` accepts a `Binding<Bool>` but **does not present any sheet itself** — `ChatView` only *writes* `true` to the binding when the user taps an empty-state "Select Model" / "Browse" button. The host attaches a `.sheet(isPresented:)` modifier to whatever model-management surface they want.
+
+The canonical surface is `ModelManagementSheet` from the **`ManifoldUIModelManagement`** product (a non-default, opt-in module — add `.product(name: "ManifoldUIModelManagement", package: "ManifoldKit")` to your target's dependencies). It needs a `ModelManagementViewModel` in the SwiftUI environment; construct it with `.live()` for production:
+
+```swift,no-build
+import SwiftUI
+import ManifoldKit
+import ManifoldUI
+import ManifoldUIModelManagement
+
+@main
+struct MyChatApp: App {
+    @State private var result: QuickStartResult?
+    @State private var showModelManagement = false
+    @State private var managementVM = ModelManagementViewModel.live()
+
+    var body: some Scene {
+        WindowGroup {
+            if let result {
+                ChatView(showModelManagement: $showModelManagement)
+                    .environment(result.viewModel)
+                    .environment(managementVM)
+                    .modelContainer(result.bootstrap.modelContainer)
+                    .sheet(isPresented: $showModelManagement) {
+                        ModelManagementSheet(modelRegistry: result.viewModel.modelRegistry)
+                            .environment(managementVM)
+                    }
+            } else {
+                ProgressView().task {
+                    result = try? await ManifoldKit.quickStart()
+                }
+            }
+        }
+    }
+}
+```
+
+If you don't want the full model-management UI (e.g. cloud-only apps that seed an endpoint at launch as shown above), leave the `.sheet` modifier off and the binding will simply toggle a value nothing observes. The `Select Model` / `Browse` buttons then become harmless no-ops; consider hiding the empty-state hint with a custom empty-state view (see `ChatView.init(showModelManagement:emptyState:apiConfiguration:)`).
 
 ## Customizing backends
 


### PR DESCRIPTION
## Summary

Closes the 3/3-concordant iter-1 finding **O1-iter1-C1**: SwiftUI walkthrough agents — on both FoundationBackend (macOS 26) and Ollama paths — reached an empty-state "No model loaded / connect a cloud API in settings" with no docs-visible next step after running `quickStart()`.

Adds a new top-level **"First-launch backend selection"** section to `docs/QUICKSTART.md` that:

- Clarifies that `quickStart()` *registers* compiled-in backends but does **not** auto-select one — Foundation Models on macOS 26 is "available" but `availableModels` won't include it until the host wires `foundationModelProvider` and calls `loadFoundationModelIfAvailable()`. Verified against `Sources/ManifoldKit/QuickStart.swift` and `Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift`.
- Gives worked examples for **(1)** Foundation Models probe + load, **(2)** programmatic Ollama `APIEndpointRecord` seeding via `result.bootstrap.endpointStore.insertEndpoint(_:)` + `viewModel.setAvailableEndpoints(_:)`, and **(3)** the host-attached `.sheet(isPresented: $showModelManagement)` pattern with `ModelManagementSheet(modelRegistry:)` and `ModelManagementViewModel.live()` from `ManifoldUIModelManagement`.
- Explicitly states that the `ChatView(showModelManagement:)` binding does not present any built-in sheet — `ChatView` only writes `true` to it.

Also fixes papercut **O1-iter1-3b** from run-3 entry 6: `// swift-tools-version` in `docs/QUICKSTART.md` prose and the three `Package.swift` snippets in `docs/QUICKSTART-CLI.md` were `6.2`; root `Package.swift` declares `6.1`. Aligned both docs to `6.1`.

All new code blocks are tagged `swift,no-build` (they are partial `@main` App scaffolds, not self-contained programs). The pre-existing Hello World snippet (the only compile-tested block in QUICKSTART.md) is unchanged; `scripts/extract-snippets.sh` still emits the same `quickstart-003.swift` from line 39.

Iter-1 SUMMARY: `scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter1/02-swiftui-chat/SUMMARY.md`

## Friction entries addressed

- **O1-iter1-C1** (3/3 blocker) — empty-state with no docs-visible path forward
- **O1-iter1-3b** (papercut) — `swift-tools-version` mismatch between QUICKSTART docs and root Package.swift

Related iter-1 findings this section also softens (not "closes" — these are API/UX gaps a doc PR can't fix, but the new section at least tells the reader they exist and how to work around them):

- **A2-F1** — `quickStart()` doesn't auto-select Foundation Models (documented workaround)
- **A2-F5** — "Browse Models" empty-state button bound to dead handler by default (documented wiring)
- **A2-iter2-F4** — `QuickStartResult` / `bootstrap` shape undocumented (now shows `bootstrap.endpointStore`, `bootstrap.modelContainer`, `viewModel.modelRegistry`)

## Test plan

- [x] `scripts/extract-snippets.sh` — extracts only the pre-existing `swift` blocks; my three new `swift,no-build` blocks correctly route to `.skip`
- [ ] CI snippet compile gate passes (no compile-eligible blocks changed)
- [ ] Reviewer skim: section length (~145 lines new prose+code) under the 200-line budget