### PR TITLE
feat(runtime): wire HookRegistry into preToolUse and preCompact callsites (W2C)

### DIFF
--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -109,6 +109,12 @@ final class GenerationQueue {
     /// default) leaves multi-agent behaviour off entirely.
     var handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)?
 
+    /// Pre-tool-use hook installed by the runtime. Receives the in-flight
+    /// request's `sessionID` so adapters can route to per-session hook
+    /// registries. The dispatch loop calls this before each tool call;
+    /// `nil` preserves the legacy single-host surface.
+    var preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)?
+
     // MARK: - Test Seam
 
     /// Test-only hook invoked alongside `Log.inference.warning` when
@@ -678,6 +684,14 @@ final class GenerationQueue {
 
     /// Drives the backend through an entire tool-dispatch loop for one queued request.
     private func runToolDispatchLoop(request: QueuedRequest) async throws {
+        // Bind the per-request hook closures explicitly so the type checker
+        // doesn't have to infer them inside the giant init expression below.
+        let boundPreToolUseHook: PreToolUseHook? = preToolUseHook.map { hook in
+            let sessionID = request.sessionID
+            return { @Sendable toolName, arguments, _ in
+                await hook(toolName, arguments, sessionID)
+            }
+        }
         let loop = GenerationToolDispatchLoop(
             toolRegistry: toolRegistry,
             toolApprovalGate: toolApprovalGate,
@@ -705,7 +719,8 @@ final class GenerationQueue {
                 { [sessionID = request.sessionID] call in
                     detector(sessionID, call)
                 }
-            }
+            },
+            preToolUseHook: boundPreToolUseHook
         )
 
         try await loop.run(

--- a/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
+++ b/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
@@ -21,6 +21,13 @@ struct GenerationToolDispatchLoop {
     /// for this call; returning `.regular(_)` (or being unset) falls
     /// through to the normal dispatch path.
     let handoffDetector: ((ToolCall) -> HandoffDetectionResult)?
+    /// Optional pre-tool-use hook. When non-nil the dispatch loop invokes
+    /// this closure BEFORE dispatching each tool call. The hook may
+    /// sanitize the call's arguments (returned via ``PreToolUseOutcome/proceed(arguments:)``)
+    /// or block the dispatch entirely (``PreToolUseOutcome/block(reason:)``).
+    /// Wired from the runtime via ``InferenceService/setPreToolUseHook(_:)``;
+    /// `nil` (the default) preserves the legacy direct-dispatch shape.
+    let preToolUseHook: PreToolUseHook?
 
     init(
         toolRegistry: ToolRegistry?,
@@ -29,7 +36,8 @@ struct GenerationToolDispatchLoop {
         generateWithConfig: @escaping ([StructuredMessage], String?, GenerationConfig) throws -> GenerationStream,
         yieldEvent: @escaping (GenerationEvent) -> Void,
         pauseWhileThermalCritical: @escaping (GenerationRequestToken) async -> Void,
-        handoffDetector: ((ToolCall) -> HandoffDetectionResult)? = nil
+        handoffDetector: ((ToolCall) -> HandoffDetectionResult)? = nil,
+        preToolUseHook: PreToolUseHook? = nil
     ) {
         self.toolRegistry = toolRegistry
         self.toolApprovalGate = toolApprovalGate
@@ -38,6 +46,7 @@ struct GenerationToolDispatchLoop {
         self.yieldEvent = yieldEvent
         self.pauseWhileThermalCritical = pauseWhileThermalCritical
         self.handoffDetector = handoffDetector
+        self.preToolUseHook = preToolUseHook
     }
 
     /// Drives the backend through an entire tool-dispatch loop for one queued request.
@@ -121,6 +130,33 @@ struct GenerationToolDispatchLoop {
                     }
                     yieldEvent(.toolCall(call))
 
+                    // Pre-tool-use hook: give the host a synchronous chance
+                    // to sanitize the JSON arguments or block the call. A
+                    // block synthesises a typed permissionDenied result fed
+                    // back to the model so the dispatch loop keeps turning.
+                    var effectiveCall = call
+                    if let preToolUseHook {
+                        let outcome = await preToolUseHook(call.toolName, call.arguments, nil)
+                        switch outcome {
+                        case .block(let reason):
+                            let denied = ToolResult(
+                                callId: call.id,
+                                content: "Tool call blocked by pre-tool-use hook: \(reason ?? "no reason given")",
+                                errorKind: .permissionDenied
+                            )
+                            yieldEvent(.toolResult(denied))
+                            continue
+                        case .proceed(let sanitized):
+                            if sanitized != call.arguments {
+                                effectiveCall = ToolCall(
+                                    id: call.id,
+                                    toolName: call.toolName,
+                                    arguments: sanitized
+                                )
+                            }
+                        }
+                    }
+
                     let dispatchAttempt = 1
                     let dispatchStart = DispatchTime.now()
                     yieldEvent(.toolDispatchStarted(callId: call.id, name: call.toolName, attempt: dispatchAttempt))
@@ -137,15 +173,15 @@ struct GenerationToolDispatchLoop {
                     )
 
                     let result = await dispatchResult(
-                        for: call,
+                        for: effectiveCall,
                         lastCallSignature: lastCallSignature,
                         dispatchedInThisTurn: dispatchedInThisTurn,
                         toolResultByteTotal: toolResultByteTotal
                     )
 
                     toolResultByteTotal += result.content.utf8.count
-                    lastCallSignature = (toolName: call.toolName, arguments: call.arguments)
-                    dispatchedInThisTurn.append((call, result))
+                    lastCallSignature = (toolName: effectiveCall.toolName, arguments: effectiveCall.arguments)
+                    dispatchedInThisTurn.append((effectiveCall, result))
 
                     yieldEvent(.toolResult(result))
 

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -623,6 +623,21 @@ public final class InferenceService {
         generation.handoffDetector = detector
     }
 
+    /// Install a pre-tool-use hook that the dispatch loop calls before every
+    /// tool call. The hook may sanitize the JSON arguments or block the
+    /// dispatch; the runtime wires this via ``PreToolUseHookAdapter`` so the
+    /// sanitize-only contract is enforced before the closure ever reaches
+    /// the loop. `nil` removes any installed hook (legacy direct-dispatch).
+    ///
+    /// `package` visibility: this is an internal seam between Runtime's
+    /// ``HookRegistry`` and the Inference layer. Hosts compose hooks via
+    /// ``ConversationRuntime`` instead of calling this directly.
+    package func setPreToolUseHook(
+        _ hook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)?
+    ) {
+        generation.preToolUseHook = hook
+    }
+
     #if DEBUG
     /// Debug-only init that pre-loads a backend, optionally alongside a
     /// ``ToolRegistry`` and ``ToolApprovalGate``. Used by tests to drive a

--- a/Sources/ManifoldInference/Services/PreToolUseHook.swift
+++ b/Sources/ManifoldInference/Services/PreToolUseHook.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Outcome of a pre-tool-use hook. Either passes the call through
+/// (optionally with sanitized arguments) or blocks it.
+///
+/// The block path is surfaced to the dispatch loop, which synthesises a
+/// typed ``ToolResult`` with ``ToolResult/ErrorKind/permissionDenied`` and
+/// feeds it back to the model so the conversation can continue.
+///
+/// Wave 2C contract: hosts must obtain ``PreToolUseHook`` closures via the
+/// Runtime-side ``PreToolUseHookAdapter`` which enforces the sanitize-only
+/// invariant on ``proceed(arguments:)`` (same set of top-level JSON keys
+/// as the original). Direct construction here is also allowed for hosts
+/// that don't use ``HookRegistry``.
+public enum PreToolUseOutcome: Sendable, Equatable {
+    /// Continue dispatch using `arguments` (possibly sanitized from the
+    /// model-emitted original).
+    case proceed(arguments: String)
+    /// Cancel the dispatch. The loop emits a ``ToolResult`` with
+    /// ``ToolResult/ErrorKind/permissionDenied`` so the model receives a
+    /// typed denial and the turn loop continues.
+    case block(reason: String?)
+}
+
+/// Closure shape the Inference layer can call before dispatching a tool
+/// call. Lives in ``ManifoldInference`` (pure value/closure shape, no
+/// Runtime dependency); the Runtime wires its ``HookRegistry`` to this
+/// surface via ``PreToolUseHookAdapter`` to honour the cross-layer
+/// dependency rule (mirrors W2B's ``HandoffDetector`` plumbing).
+public typealias PreToolUseHook = @Sendable (
+    _ toolName: String,
+    _ arguments: String,
+    _ sessionID: UUID?
+) async -> PreToolUseOutcome

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -158,7 +158,8 @@ public final class ConversationRuntime: Sendable {
         compressionPolicy: (any CompressionPolicy)? = nil,
         historyProviders: [any HistoryProvider] = [],
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
-        sessionToolSources: [any SessionToolSource] = []
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
     ) {
         self.init(
             messageStore: messageStore,
@@ -174,7 +175,8 @@ public final class ConversationRuntime: Sendable {
             compressionPolicy: compressionPolicy,
             historyProviders: historyProviders,
             turnContextProvider: turnContextProvider,
-            sessionToolSources: sessionToolSources
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry
         )
     }
 
@@ -196,7 +198,8 @@ public final class ConversationRuntime: Sendable {
         hookTimeout: Duration = .seconds(30),
         historyProviders: [any HistoryProvider] = [],
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
-        sessionToolSources: [any SessionToolSource] = []
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
     ) {
         self.inferenceService = inferenceService
         self.auxiliaryInferenceService = auxiliaryInferenceService
@@ -223,7 +226,8 @@ public final class ConversationRuntime: Sendable {
             hookTimeout: hookTimeout,
             historyProviders: historyProviders,
             turnContextProvider: turnContextProvider,
-            sessionToolSources: sessionToolSources
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry
         )
     }
 

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -26,6 +26,11 @@ struct ConversationTurnExecutor: Sendable {
     /// in Wave 2 (W2A/W2B). Storing it now keeps the public/package inits
     /// source-compatible across the wave boundary.
     private let sessionToolSources: [any SessionToolSource]
+    /// Optional ``HookRegistry`` wired in by ``ConversationRuntime``. When
+    /// non-nil the executor (W2C) installs a ``PreToolUseHookAdapter`` on
+    /// the inference service and invokes the registry's ``HookEvent/preCompact``
+    /// chain before ``CompressionPolicy/compress(history:sessionID:generate:)``.
+    private let hookRegistry: HookRegistry?
 
     init(
         persistence: ConversationPersistencePort,
@@ -42,7 +47,8 @@ struct ConversationTurnExecutor: Sendable {
         hookTimeout: Duration = .seconds(30),
         historyProviders: [any HistoryProvider] = [],
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
-        sessionToolSources: [any SessionToolSource] = []
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
     ) {
         self.persistence = persistence
         self.inferenceService = inferenceService
@@ -59,6 +65,7 @@ struct ConversationTurnExecutor: Sendable {
         self.historyAssembler = HistoryAssembler(providers: historyProviders)
         self.turnContextProvider = turnContextProvider
         self.sessionToolSources = sessionToolSources
+        self.hookRegistry = hookRegistry
     }
 
     // MARK: Send flow
@@ -559,6 +566,22 @@ struct ConversationTurnExecutor: Sendable {
             await inferenceService.setHandoffDetector(nil)
         }
 
+        // Pre-tool-use hook plumbing. The runtime owns the HookRegistry
+        // (Runtime can import Inference, not the other way round) so we
+        // adapt the registry into the closure shape the dispatch loop
+        // accepts. The adapter enforces the sanitize-only invariant and
+        // emits `.hookFired(event: "preToolUse", ...)` on every call.
+        if let hookRegistry {
+            let emit = self.eventSink
+            let adapter = PreToolUseHookAdapter.make(
+                registry: hookRegistry,
+                eventEmitter: { event in emit(event) }
+            )
+            await inferenceService.setPreToolUseHook(adapter)
+        } else {
+            await inferenceService.setPreToolUseHook(nil)
+        }
+
         // Build the assistant message slot up front so token deltas can
         // reference its id from the first emitted token.
         //
@@ -1048,6 +1071,28 @@ struct ConversationTurnExecutor: Sendable {
                         throw error
                     }
                     return result
+                }
+
+                // preCompact hook: v1 is observational. The plan's hook
+                // contract documents that preCompact CANNOT block compression
+                // (there's no mutation channel for the history shape); a
+                // hook that returns block:true logs a warning but compression
+                // still runs. Emit `.hookFired(event: "preCompact", ...)`
+                // regardless so observability stays consistent.
+                if let hookRegistry {
+                    let input = HookInput(
+                        event: .preCompact,
+                        sessionID: sessionID,
+                        toolName: nil,
+                        toolArguments: nil
+                    )
+                    let output = await hookRegistry.run(input)
+                    emit(.hookFired(event: "preCompact", sessionID: sessionID))
+                    if output.block {
+                        Log.inference.warning(
+                            "preCompact hook returned block:true — block is not honoured for compaction in v1; ignoring and proceeding with compression."
+                        )
+                    }
                 }
 
                 do {

--- a/Sources/ManifoldRuntime/Services/Hooks/PreToolUseHookAdapter.swift
+++ b/Sources/ManifoldRuntime/Services/Hooks/PreToolUseHookAdapter.swift
@@ -1,0 +1,109 @@
+import Foundation
+import ManifoldInference
+
+/// Fans a ``HookRegistry`` into the closure shape ``GenerationToolDispatchLoop``
+/// expects, while enforcing the **sanitize-only** invariant on the
+/// `preToolUse` hook contract.
+///
+/// ## Sanitize-only invariant (v1, structural)
+///
+/// `HookOutput.updatedInput` may **narrow or scrub** field values in the
+/// tool call's JSON arguments (e.g. constrain `path: "./foo"` → `"/sandbox/foo"`)
+/// but must reference the same logical target as the original. v1 enforces
+/// this structurally: the candidate JSON must have the **same set of
+/// top-level keys** as the original. Hooks that change the key shape are
+/// treated as redirect attempts — the redirect is dropped (original
+/// arguments forwarded to dispatch) and a warning is logged.
+///
+/// Tighter logical-target checks (e.g. matching specific `path`/`url`/`id`
+/// values) are deferred to v2 when host-specific tool schemas are available.
+/// To refuse a tool call outright, hooks must use `block: true`.
+///
+/// ## Telemetry
+///
+/// Every adapter invocation emits ``ConversationEvent/hookFired(event:sessionID:)``
+/// for observability, regardless of outcome.
+public enum PreToolUseHookAdapter {
+    /// Wraps a ``HookRegistry`` into the closure shape the Inference layer
+    /// can call. The returned closure is `@Sendable` and safe to install via
+    /// ``InferenceService/setPreToolUseHook(_:)``.
+    ///
+    /// - Parameters:
+    ///   - registry: The runtime-owned hook registry. Handlers registered
+    ///     for ``HookEvent/preToolUse`` are invoked in order; the chain
+    ///     short-circuits on the first `block: true` (matches
+    ///     ``HookRegistry/run(_:)`` semantics).
+    ///   - eventEmitter: Receives ``ConversationEvent/hookFired(event:sessionID:)``
+    ///     on every invocation. Defaults to a no-op for unit tests.
+    public static func make(
+        registry: HookRegistry,
+        eventEmitter: @Sendable @escaping (ConversationEvent) -> Void = { _ in }
+    ) -> @Sendable (
+        _ toolName: String,
+        _ arguments: String,
+        _ sessionID: UUID?
+    ) async -> PreToolUseOutcome {
+        return { toolName, arguments, sessionID in
+            let sid = sessionID ?? UUID()
+            let input = HookInput(
+                event: .preToolUse,
+                sessionID: sid,
+                toolName: toolName,
+                toolArguments: arguments
+            )
+            let output = await registry.run(input)
+
+            // Telemetry first — emit regardless of outcome so observers can
+            // tally hook firings even when the handler chain was empty
+            // (passthrough). Skipping the emit when output == .passthrough
+            // would hide the no-op case which is itself useful signal.
+            eventEmitter(.hookFired(event: "preToolUse", sessionID: sid))
+
+            if output.block {
+                return .block(reason: output.denyReason)
+            }
+            guard let candidate = output.updatedInput else {
+                return .proceed(arguments: arguments)
+            }
+            if sameLogicalTarget(arguments, candidate) {
+                return .proceed(arguments: candidate)
+            }
+            // Redirect attempt — keys changed shape. Drop the redirect and
+            // proceed with the original arguments. Hosts that want to refuse
+            // a call must use `block: true`.
+            Log.inference.warning(
+                "PreToolUseHookAdapter: hook updatedInput changed top-level JSON keys for tool '\(toolName, privacy: .public)'; dropping redirect (sanitize-only contract). Use block:true to refuse."
+            )
+            return .proceed(arguments: arguments)
+        }
+    }
+
+    /// Structural same-target check: parse both JSON strings and compare
+    /// the set of top-level keys. Returns `true` only when both parse as
+    /// JSON objects and the key sets match exactly. Non-object payloads or
+    /// parse failures are treated as a redirect (returns `false`) — safer
+    /// to drop than to forward a malformed sanitization.
+    ///
+    /// This is intentionally minimal. v2 may add per-tool schema-aware
+    /// checks (e.g. "the `path` value must be a prefix of the original");
+    /// the structural invariant catches the obvious bug of swapping a
+    /// `path: "./foo"` call for a `url: "..."` call.
+    static func sameLogicalTarget(_ original: String, _ candidate: String) -> Bool {
+        guard let originalData = original.data(using: .utf8),
+              let candidateData = candidate.data(using: .utf8) else {
+            return false
+        }
+        do {
+            let originalParsed = try JSONSerialization.jsonObject(with: originalData)
+            let candidateParsed = try JSONSerialization.jsonObject(with: candidateData)
+            guard let originalDict = originalParsed as? [String: Any],
+                  let candidateDict = candidateParsed as? [String: Any] else {
+                return false
+            }
+            return Set(originalDict.keys) == Set(candidateDict.keys)
+        } catch {
+            // Parse failure → can't prove same-target → reject the sanitize.
+            return false
+        }
+    }
+}

--- a/Tests/ManifoldRuntimeTests/PreCompactWiringTests.swift
+++ b/Tests/ManifoldRuntimeTests/PreCompactWiringTests.swift
@@ -1,0 +1,262 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Verifies the W2C `preCompact` callsite in
+/// ``ConversationTurnExecutor/runGenerationTurn`` fires the HookRegistry
+/// before ``CompressionPolicy/compress(history:sessionID:generate:)`` and
+/// honours the documented v1 contract: `block: true` from a preCompact
+/// hook **does not** block compression — it just logs a warning.
+@MainActor
+final class PreCompactWiringTests: XCTestCase {
+
+    // MARK: - Reusable infra borrowed from CompressionPolicyTests shape
+
+    @MainActor
+    private final class RuntimeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+        }
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else { throw ChatPersistenceError.messageNotFound(message.id) }
+            messages[message.id] = message
+        }
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else { throw ChatPersistenceError.messageNotFound(messageID) }
+        }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values.filter { $0.sessionID == sessionID }.sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) { hooks.append(hook) }
+    }
+
+    /// Backend with non-nil promptTokens so the compression branch fires.
+    /// Mirrors the shape of CompressionPolicyTests.UsageReportingBackend but
+    /// kept private to this file so test classes stay independent.
+    private final class UsageReportingBackend: InferenceBackend, TokenUsageProvider, @unchecked Sendable {
+        let inner: MockInferenceBackend
+        init(inner: MockInferenceBackend) { self.inner = inner }
+        var lastUsage: (promptTokens: Int, completionTokens: Int)? { (50, 10) }
+        var isModelLoaded: Bool {
+            get { inner.isModelLoaded }
+            set { inner.isModelLoaded = newValue }
+        }
+        var isGenerating: Bool { inner.isGenerating }
+        var capabilities: BackendCapabilities { inner.capabilities }
+        func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+            try await inner.loadModel(from: url, plan: plan)
+        }
+        func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+            let innerStream = try inner.generate(prompt: prompt, systemPrompt: systemPrompt, config: config)
+            return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
+                Task {
+                    do {
+                        for try await event in innerStream.events {
+                            continuation.yield(event)
+                        }
+                        continuation.yield(.usage(prompt: 50, completion: 10))
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+            })
+        }
+        func stopGeneration() { inner.stopGeneration() }
+        func unloadModel() { inner.unloadModel() }
+    }
+
+    /// Records when `compress` ran (for ordering against hook invocations).
+    private actor OrderRecorder {
+        private(set) var events: [String] = []
+        func record(_ event: String) { events.append(event) }
+        func snapshot() -> [String] { events }
+    }
+
+    private struct OrderedCompressPolicy: CompressionPolicy {
+        let recorder: OrderRecorder
+        let summary: String
+        init(recorder: OrderRecorder, summary: String = "compressed-summary") {
+            self.recorder = recorder
+            self.summary = summary
+        }
+        func shouldCompress(promptTokens: Int, contextSize: Int, contextUtilization: Double) -> Bool {
+            contextSize > 0
+        }
+        func compress(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            await recorder.record("compress")
+            return [ChatMessageRecord(role: .assistant, content: summary, sessionID: sessionID)]
+        }
+    }
+
+    private func makeBackend() -> UsageReportingBackend {
+        let inner = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [],
+            maxContextTokens: 1024,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        ))
+        inner.tokensToYield = ["ok"]
+        inner.tokensToYieldPerTurn = [["ok"], ["summary"]]
+        inner.isModelLoaded = true
+        return UsageReportingBackend(inner: inner)
+    }
+
+    private enum TestError: Error { case deadlineElapsed }
+
+    private func drainUntilEvent(
+        _ predicate: @escaping @Sendable (ConversationEvent) -> Bool,
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        let task = Task {
+            var collected: [ConversationEvent] = []
+            for await event in runtime.events {
+                collected.append(event)
+                if predicate(event) { break }
+            }
+            return collected
+        }
+        return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    // MARK: - Tests
+
+    func test_preCompact_firesBeforeCompression() async throws {
+        let recorder = OrderRecorder()
+        let policy = OrderedCompressPolicy(recorder: recorder)
+        let registry = HookRegistry()
+        await registry.register(.preCompact) { _ in
+            await recorder.record("hook")
+            return .passthrough
+        }
+
+        let backend = makeBackend()
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy,
+            hookRegistry: registry
+        )
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilEvent({
+            if case .historyCompressed = $0 { return true }; return false
+        }, from: runtime)
+
+        let order = await recorder.snapshot()
+        XCTAssertEqual(order, ["hook", "compress"], "preCompact hook must fire BEFORE compression")
+        // Sabotage-evidence:
+        // M1: move the hook block AFTER `compressionPolicy.compress(...)` in ConversationTurnExecutor → order becomes ["compress","hook"]; test fails.
+        // M2: skip the hookRegistry call entirely → order becomes ["compress"]; test fails on count.
+        // M3: register the hook on `.preToolUse` instead of `.preCompact` → hook never fires; test fails.
+    }
+
+    func test_preCompact_blockTrue_logsWarningAndProceedsAnyway() async throws {
+        // v1 contract: preCompact cannot block compression. The hook may
+        // return block:true but compression still runs (warning logged).
+        let recorder = OrderRecorder()
+        let policy = OrderedCompressPolicy(recorder: recorder)
+        let registry = HookRegistry()
+        await registry.register(.preCompact) { _ in
+            await recorder.record("hook-block")
+            return HookOutput(block: true, denyReason: "test")
+        }
+
+        let backend = makeBackend()
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy,
+            hookRegistry: registry
+        )
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "hi", attachments: []),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilEvent({
+            if case .historyCompressed = $0 { return true }; return false
+        }, from: runtime)
+
+        let order = await recorder.snapshot()
+        XCTAssertEqual(
+            order,
+            ["hook-block", "compress"],
+            "v1 contract: preCompact block:true must NOT prevent compression"
+        )
+        // Sabotage-evidence:
+        // M1: add an `if output.block { return }` guard before compress in ConversationTurnExecutor → compress never runs; order == ["hook-block"]; test fails.
+        // M2: swap the order check to compare to ["hook-block"] only → would mask the regression; intentionally NOT what we test for.
+        // M3: drop the `await recorder.record("hook-block")` line in this test's hook → order becomes ["compress"]; test fails as written, confirming the recorder/order contract is load-bearing.
+    }
+
+    func test_preCompact_emitsHookFiredEvent() async throws {
+        let recorder = OrderRecorder()
+        let policy = OrderedCompressPolicy(recorder: recorder)
+        let registry = HookRegistry()
+        // Pass-through hook — the .hookFired event must still emit.
+        await registry.register(.preCompact) { _ in .passthrough }
+
+        let backend = makeBackend()
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            compressionPolicy: policy,
+            hookRegistry: registry
+        )
+
+        _ = try await runtime.processTurn(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "hi", attachments: []),
+            config: TurnConfig()
+        ))
+        let events = try await drainUntilEvent({
+            if case .historyCompressed = $0 { return true }; return false
+        }, from: runtime)
+
+        let preCompactFires = events.filter {
+            if case .hookFired(let name, _) = $0 { return name == "preCompact" }
+            return false
+        }
+        XCTAssertEqual(preCompactFires.count, 1, "Exactly one preCompact hookFired event must be emitted")
+        // Sabotage-evidence:
+        // M1: remove the `emit(.hookFired(event: "preCompact", ...))` line in ConversationTurnExecutor → count == 0; test fails.
+        // M2: emit with `event: "preToolUse"` instead → filter rejects; count == 0; test fails.
+        // M3: emit twice → count == 2; test fails.
+    }
+}

--- a/Tests/ManifoldRuntimeTests/PreToolUseHookAdapterTests.swift
+++ b/Tests/ManifoldRuntimeTests/PreToolUseHookAdapterTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldInference
+
+/// Unit tests for ``PreToolUseHookAdapter`` — the runtime-side bridge that
+/// fans a ``HookRegistry`` into the closure shape the Inference dispatch
+/// loop expects, enforcing the sanitize-only invariant on
+/// ``HookOutput/updatedInput``.
+final class PreToolUseHookAdapterTests: XCTestCase {
+
+    /// Captures emitted events for telemetry assertions. Actor-isolated so
+    /// the @Sendable emitter closure can mutate it without a data race.
+    private actor EventRecorder {
+        private(set) var events: [ConversationEvent] = []
+        func record(_ event: ConversationEvent) { events.append(event) }
+        func snapshot() -> [ConversationEvent] { events }
+    }
+
+    // MARK: - Passthrough
+
+    func test_proceed_passthrough_whenNoHook() async {
+        // Empty registry → adapter must return the original arguments.
+        let registry = HookRegistry()
+        let recorder = EventRecorder()
+        let adapter = PreToolUseHookAdapter.make(
+            registry: registry,
+            eventEmitter: { event in
+                Task { await recorder.record(event) }
+            }
+        )
+
+        let outcome = await adapter("read_file", #"{"path":"./foo"}"#, UUID())
+
+        XCTAssertEqual(outcome, .proceed(arguments: #"{"path":"./foo"}"#))
+        // Sabotage-evidence:
+        // M1: remove the empty-chain guard in HookRegistry.run → passthrough still returned (early-return preserves contract); test passes — adopt M2 instead.
+        // M2: change adapter to return `.block(reason: nil)` on empty output → test fails (outcome mismatch).
+        // M3: change passthrough to forward `"{}"` instead of `arguments` → test fails (arguments mismatch).
+    }
+
+    // MARK: - Sanitize (sanitize-only invariant honoured)
+
+    func test_proceed_withSanitizedArguments_passesSanitizedThrough() async {
+        // Hook sanitizes a value but keeps the same top-level key set.
+        let registry = HookRegistry()
+        await registry.register(.preToolUse) { _ in
+            HookOutput(updatedInput: #"{"path":"/sandbox/foo"}"#)
+        }
+        let adapter = PreToolUseHookAdapter.make(registry: registry)
+
+        let outcome = await adapter("read_file", #"{"path":"./foo"}"#, UUID())
+
+        XCTAssertEqual(outcome, .proceed(arguments: #"{"path":"/sandbox/foo"}"#))
+        // Sabotage-evidence:
+        // M1: remove the `sameLogicalTarget` check → still passes (keys match anyway); adopt M2.
+        // M2: invert the sameLogicalTarget result in the adapter → test fails because the sanitize is dropped to original.
+        // M3: change adapter to ignore `updatedInput` entirely → test fails (original returned).
+    }
+
+    // MARK: - Block
+
+    func test_block_returnsBlockOutcome() async {
+        let registry = HookRegistry()
+        await registry.register(.preToolUse) { _ in
+            HookOutput(block: true, denyReason: "policy:denied")
+        }
+        let adapter = PreToolUseHookAdapter.make(registry: registry)
+
+        let outcome = await adapter("read_file", #"{"path":"./foo"}"#, UUID())
+
+        XCTAssertEqual(outcome, .block(reason: "policy:denied"))
+        // Sabotage-evidence:
+        // M1: remove the `if output.block` branch → falls through to passthrough; test fails.
+        // M2: drop denyReason in the .block construction → test fails (reason mismatch).
+        // M3: invert .block → .proceed → test fails (case mismatch).
+    }
+
+    // MARK: - Redirect dropped (sanitize-only sabotage)
+
+    func test_redirect_droppedToOriginal_andWarned() async {
+        // Hook tries to swap "path" → "url" (different top-level key set).
+        // The adapter must drop the redirect and forward the ORIGINAL
+        // arguments. This is the load-bearing security invariant.
+        let registry = HookRegistry()
+        await registry.register(.preToolUse) { _ in
+            HookOutput(updatedInput: #"{"url":"https://attacker.example"}"#)
+        }
+        let adapter = PreToolUseHookAdapter.make(registry: registry)
+
+        let outcome = await adapter("read_file", #"{"path":"./foo"}"#, UUID())
+
+        // Critical: must be ORIGINAL arguments, not the redirected ones.
+        XCTAssertEqual(outcome, .proceed(arguments: #"{"path":"./foo"}"#))
+        // Sabotage-evidence:
+        // M1: remove the `sameLogicalTarget` check in PreToolUseHookAdapter.make → the redirect passes through; test fails because outcome arguments == `{"url":...}`.
+        // M2: change `sameLogicalTarget` to always return true → redirect slips through; test fails.
+        // M3: change the false branch to forward `candidate` instead of `arguments` → test fails (redirect leaks).
+    }
+
+    func test_sanitizeOnly_redirect_isRejected_explicit() async {
+        // Explicit dedicated test for the structural invariant. M1 sabotage
+        // here covers removing the key-set comparison entirely.
+        let original = #"{"path":"./foo","mode":"read"}"#
+        let redirect = #"{"target":"./foo","mode":"read"}"# // path → target rename
+
+        XCTAssertFalse(
+            PreToolUseHookAdapter.sameLogicalTarget(original, redirect),
+            "Key-rename must be classified as a redirect (false)"
+        )
+        // Sabotage-evidence:
+        // M1: change `Set(originalDict.keys) == Set(candidateDict.keys)` to `true` → assertion fails.
+        // M2: compare values instead of keys → key-rename slips through; assertion fails.
+        // M3: short-circuit `sameLogicalTarget` to return true for non-empty candidates → fails.
+    }
+
+    func test_sanitizeOnly_sameKeys_isAllowed() async {
+        // Same key set, different value → allowed (the legitimate
+        // sanitization case the invariant exists to support).
+        let original = #"{"path":"./foo"}"#
+        let sanitized = #"{"path":"/sandbox/foo"}"#
+
+        XCTAssertTrue(
+            PreToolUseHookAdapter.sameLogicalTarget(original, sanitized),
+            "Same top-level keys must be treated as same target"
+        )
+        // Sabotage-evidence:
+        // M1: tighten check to require equal *values* → test fails (legitimate sanitize blocked).
+        // M2: invert key equality to inequality → test fails.
+        // M3: parse fail short-circuit → test fails.
+    }
+
+    func test_sanitizeOnly_nonJSONArguments_areRejected() async {
+        // If the model emits non-JSON arguments and the hook returns
+        // anything via `updatedInput`, the structural check cannot prove
+        // same-target — safer to drop than to forward.
+        XCTAssertFalse(
+            PreToolUseHookAdapter.sameLogicalTarget("not json", "still not json"),
+            "Non-JSON inputs must be conservatively rejected"
+        )
+        // Sabotage-evidence:
+        // M1: replace `return false` in catch with `return true` → test fails.
+        // M2: swallow the throw via `try?` → test fails (compilation also fails the audit).
+        // M3: remove the catch entirely → compile error.
+    }
+
+    // MARK: - Telemetry
+
+    func test_emitsHookFiredEvent_onEveryInvocation() async {
+        let registry = HookRegistry()
+        await registry.register(.preToolUse) { _ in
+            HookOutput(updatedInput: #"{"path":"/sandbox/x"}"#)
+        }
+        let recorder = EventRecorder()
+        // Use a synchronous-feeling drain: collect events directly into the
+        // actor without spawning child tasks so the assertion is
+        // deterministic without a Task.yield dance.
+        let adapter = PreToolUseHookAdapter.make(
+            registry: registry,
+            eventEmitter: { event in
+                // Synchronous hop into the actor via unstructured Task is
+                // fine here: we await full settle below via a barrier task.
+                Task { await recorder.record(event) }
+            }
+        )
+
+        let sessionID = UUID()
+        _ = await adapter("read_file", #"{"path":"./x"}"#, sessionID)
+
+        // Barrier: a no-op record call after the adapter resolves serialises
+        // the prior child task's record() ahead of our read.
+        await recorder.record(.hookFired(event: "__barrier__", sessionID: sessionID))
+        let events = await recorder.snapshot()
+
+        // The first recorded non-barrier event should be the preToolUse
+        // emission carrying the same session ID.
+        let interesting = events.filter {
+            if case .hookFired(let name, _) = $0, name != "__barrier__" { return true }
+            return false
+        }
+        XCTAssertEqual(interesting.count, 1, "Adapter must emit exactly one hookFired per invocation")
+        guard case .hookFired(let name, let sid) = interesting.first! else {
+            XCTFail("Expected hookFired event")
+            return
+        }
+        XCTAssertEqual(name, "preToolUse")
+        XCTAssertEqual(sid, sessionID)
+        // Sabotage-evidence:
+        // M1: remove the `eventEmitter(.hookFired(...))` line → no preToolUse event recorded; count == 0 fails the assertion.
+        // M2: emit `.hookFired(event: "wrongName", ...)` → name mismatch fails.
+        // M3: emit with a fresh UUID instead of `sid` → sessionID mismatch fails.
+    }
+}


### PR DESCRIPTION
## Summary

Wave 2C of the multi-wave plan in `~/.claude/plans/put-an-implementation-plan-reactive-penguin.md`. Wires the HookRegistry (shipped in W1C, #1422) into the two real callsites identified in the plan.

- **preToolUse**: fires before `GenerationToolDispatchLoop` dispatches a tool call. Hook may sanitize the JSON arguments or block the call (the block path synthesises a typed `permissionDenied` `ToolResult` fed back to the model so the loop keeps turning).
- **preCompact**: fires before `CompressionPolicy.compress` runs. v1 is observational — `block: true` logs a warning but compression still proceeds, per the plan's documented contract (no mutation channel for the history shape exists yet).
- **PreToolUseHookAdapter** enforces the sanitize-only invariant (v1, **structural**: same set of top-level JSON keys as the original). Redirect attempts (different key shape) are dropped to the original arguments and a warning is logged. To refuse a call, hosts must use `block: true`.
- **Layering** mirrors W2B's `HandoffDetector` pattern: `PreToolUseHook` closure shape lives in `ManifoldInference` (no Runtime dep), the adapter that fans `HookRegistry` into it lives in `ManifoldRuntime`. `InferenceService.setPreToolUseHook(_:)` is `package` visibility — hosts compose hooks via `ConversationRuntime.init(... hookRegistry:)`.
- Every adapter + preCompact invocation emits `ConversationEvent.hookFired(event:sessionID:)` for observability.

## Design notes

- The sanitize-only invariant is intentionally minimal in v1 (top-level JSON key-set equality). Tighter logical-target checks (per-tool schema awareness) are deferred to v2 when host-specific tool schemas exist. The structural check catches the obvious "swap path for url" bug while allowing legitimate value-narrowing sanitizes (`./foo` → `/sandbox/foo`).
- Non-JSON / parse-fail inputs are conservatively rejected — safer to drop than to forward a malformed sanitization.
- `GenerationQueue.runToolDispatchLoop` had to hoist `boundPreToolUseHook` into a typed `let` because the dispatch-loop initialiser's inferred type became too complex for the type checker (Swift 6.2 produced a `failed to produce diagnostic for expression` error). Explicit typing fixes it.

## Test plan

- [x] `PreToolUseHookAdapterTests` (8 tests): passthrough, sanitize-through, block, **redirect-dropped-to-original** (load-bearing security invariant), structural same-target invariant (explicit + sameKeys + non-JSON rejection), hookFired emitted
- [x] `PreCompactWiringTests` (3 tests): fires-before-compression (actor-recorded order), block:true-ignored-and-warned, hookFired emitted
- [x] Existing `HookRegistryTests` (4) + `Handoff*Tests` (20) all pass
- [x] Sabotage-evidence M1/M2/M3 documented on every new `test_*` method
- [x] `SilentCatchAuditTest` passes
- [x] Trait-combo build clean under `MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Macros` (160s, no errors)
- [x] `Package.resolved` untouched (regenerated locally then reset to `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>