### PR TITLE
docs: ManifoldSkills + AgentHandoffs + HookSystem articles (W3C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ await source.register(in: registry)
 
 For a complete walkthrough (descriptor setup, lifecycle, and built-in catalog), see `Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md`.
 
+## Skills, Handoffs, and Hooks
+
+Three session-scoped extension points complement MCP for non-MCP hosts:
+
+- **ManifoldSkills** — filesystem-discovered Claude-Code-compatible `SKILL.md` skills, exposed to the model via a single `invoke_skill` dispatch tool. See `Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillsGettingStarted.md`.
+- **Agent handoffs** — multi-persona sessions where the model emits `transfer_to_<name>` to swap the active agent. See `Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/AgentHandoffs.md`.
+- **Hook system** — synchronous `preToolUse` (sanitize/block) and `preCompact` (observe) hooks distinct from the observational event stream. See `Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/HookSystem.md`.
+
 ## Custom Backends
 
 Implement `InferenceBackend` and register it. The protocol takes a precomputed `ModelLoadPlan` so the caller's memory-admission verdict and effective context size flow through to the backend instead of being recomputed:

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/AgentHandoffs.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/AgentHandoffs.md
@@ -1,0 +1,88 @@
+# Agent Handoffs
+
+Run a multi-agent session where one model "transfers" the conversation to another by emitting a synthetic tool call.
+
+## When to use
+
+Agent handoffs let a session host several personas (e.g. a research agent that hands off to a writer agent) without spinning up parallel actors or copying the conversation. One agent is active per turn; the model invokes `transfer_to_<other_agent_name>` and the runtime swaps the active agent in place.
+
+This is **not** a multi-agent peer system. Agents are sequential and turn-scoped — the active agent owns the next turn entirely. For long-lived peer actors, see the v2 Team / Mailbox proposal.
+
+## The moving parts
+
+| Piece | Lives in | Role |
+|---|---|---|
+| ``ManifoldInference/Agent`` | `ManifoldInference` | Value type: `id`, `name`, `systemPrompt`, `description`, `allowedToolNames`. |
+| ``ManifoldInference/AgentHandoff`` | `ManifoldInference` | The detected transfer intent: `targetAgentID` + optional `payload`. |
+| ``ManifoldInference/HandoffDetectionResult`` | `ManifoldInference` | `regular(ToolCall)` vs `handoff(AgentHandoff)`. |
+| ``HandoffToolSource`` | `ManifoldRuntime` | ``SessionToolSource`` that synthesises one `transfer_to_<name>` tool per non-active agent. |
+| ``ManifoldInference/ChatSessionRecord/agents`` | `ManifoldInference` | The session's agent registry — a `[Agent]` snapshot of the SwiftData rows. |
+| ``ManifoldInference/ChatSessionRecord/activeAgentID`` | `ManifoldInference` | Drives system-prompt re-derivation each turn. |
+| ``ConversationEvent/agentHandoff(from:to:)`` | `ManifoldRuntime` | Telemetry case emitted on every swap. |
+
+## End-to-end setup
+
+```swift,no-build
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+
+// 1. Define the agents.
+let researcher = Agent(
+    name: "researcher",
+    systemPrompt: "You research topics and produce a tight outline. Hand off to the writer once the outline is ready.",
+    description: "Researches a topic and produces a structured outline."
+)
+
+let writer = Agent(
+    name: "writer",
+    systemPrompt: "You take an outline and turn it into a polished long-form post.",
+    description: "Turns an outline into a written piece."
+)
+
+// 2. Persist them on the session record (or seed via ManifoldPersistenceSwiftData
+//    using the V9 schema). The active agent owns the next turn.
+let session = ChatSessionRecord(
+    title: "Blog post on X",
+    agents: [researcher, writer],
+    activeAgentID: researcher.id
+)
+
+// 3. Wire HandoffToolSource through ConversationRuntime.
+let handoffSource = HandoffToolSource()
+let runtime = ConversationRuntime(
+    messageStore: messageStore,
+    inferenceService: inferenceService,
+    sessionToolSources: [handoffSource]
+)
+```
+
+On each turn:
+
+1. ``ConversationTurnExecutor`` calls ``HandoffToolSource/toolDefinitions(for:)``, which returns one `transfer_to_<name>` tool per agent other than the active one.
+2. The executor re-derives the active system prompt from `session.activeAgentID → session.agents[id].systemPrompt`. **Prior assistant messages keep their `agentID` attribution** — the *active* prompt is recomputed, history is not rewritten.
+3. The executor prepends a synthesised **Handoff instructions** block to the active agent's system prompt listing the sibling agents and when to transfer. Without this, weak/local models never trigger handoffs.
+4. If the model emits a `transfer_to_<other>` tool call, the dispatch loop intercepts it (it never reaches ``HandoffToolSource/resolve(toolName:arguments:session:)`` — reaching `resolve` indicates missing detector wiring and throws ``HandoffSourceError/handoffMustBeInterceptedUpstream(_:)``).
+5. The runtime updates `session.activeAgentID`, injects a synthetic system-role **boundary message** into the next turn's `structuredHistory` (`"[Handoff from researcher to writer] payload: …"`), and emits ``ConversationEvent/agentHandoff(from:to:)``.
+
+## Per-message attribution
+
+Assistant messages persist their authoring agent's UUID in `ChatMessage.agentID`. This intentionally is **not** a SwiftData `@Relationship`: dangling references are correct when an `Agent` row is later deleted, and UI falls back to a role-based render in that case.
+
+## Limits
+
+### Agent count soft cap
+
+``HandoffToolSource/agentCountSoftCap`` is **4**. Exceeding it does not truncate the advertised list, but every extra agent adds one `transfer_to_<name>` tool to every turn and a warning is logged. Beyond 4, prompt-cache hit rate craters because the tool surface changes on every swap.
+
+### Payload not preserved across turns (v1)
+
+The `payload` field on ``ManifoldInference/AgentHandoff`` is included verbatim in the boundary message injected for the **next turn only**. Subsequent turns no longer see it as a distinct field — it merges into the receiving agent's transcript. Hosts that need durable hand-off context should encode it into the receiving agent's prior assistant message (or wait for v2, which lifts payloads onto a structured field on the new turn).
+
+### `model:` hint on agents
+
+Agents don't carry a `modelID` field in v1; the active model is the session's selected model, not the agent's. Per-agent model selection is on the v2 roadmap.
+
+## Telemetry
+
+Subscribe to ``ConversationRuntime/events`` and filter on ``ConversationEvent/agentHandoff(from:to:)`` for UI handoff chips or analytics. Combine with ``ConversationEvent/hookFired(event:sessionID:)`` and ``ConversationEvent/skillInvoked(name:sessionID:)`` for a full picture of which session-scoped sources fired this turn.

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/HookSystem.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/HookSystem.md
@@ -1,0 +1,122 @@
+# The Hook System
+
+Synchronous mutation/block points in the turn loop, distinct from the observational ``ConversationEvent`` surface.
+
+## When to use
+
+``HookRegistry`` lets a host take a decision at two well-defined points in the turn loop:
+
+- ``HookEvent/preToolUse`` — fires before each tool call dispatches. Hooks may **sanitize** the arguments or **block** the call.
+- ``HookEvent/preCompact`` — fires before history compression runs. In v1 hooks are **observational** here; `block: true` is ignored and compression always proceeds.
+
+For pure observability (token deltas, message-persisted events, etc.) use ``ConversationEvent`` — it ships without the back-pressure / timeout machinery hook handlers carry.
+
+### Hooks do not overlap with MCP approvals
+
+`ManifoldMCP` owns its own approval flow via `MCPApprovalPolicy` and `MCPPersistentToolApprovalStore`. Hooks do **not** participate in MCP approvals and layering a `preToolUse` hook on top of an MCP-approved tool does not double-prompt the user. Per-host policy gating belongs on MCP; per-call sanitisation belongs in hooks.
+
+## Registering hooks
+
+```swift,no-build
+import Foundation
+import ManifoldRuntime
+
+let registry = HookRegistry()
+
+await registry.register(.preToolUse) { input in
+    // ... return a HookOutput
+    return .passthrough
+}
+
+let runtime = ConversationRuntime(
+    messageStore: messageStore,
+    inferenceService: inferenceService,
+    hookRegistry: registry
+)
+```
+
+Hooks for an event run **in registration order**. The chain short-circuits on the first handler returning `block: true`. ``HookOutput/updatedInput`` from one handler is threaded into the next handler's ``HookInput/toolArguments`` so a chain of sanitisers can layer narrowing transforms.
+
+A handler that exceeds the registry's `timeout` (default `.seconds(5)`) is cancelled and treated as ``HookOutput/passthrough``. Slow hooks must never deadlock the turn loop. The clock is injectable for deterministic timeout tests:
+
+```swift,no-build
+import Foundation
+import ManifoldRuntime
+
+let testRegistry = HookRegistry(
+    clock: ContinuousClock(),
+    timeout: .milliseconds(50)
+)
+```
+
+## Sanitize-only invariant on `preToolUse`
+
+``HookOutput/updatedInput`` is **sanitize-only, not redirect**. A hook may narrow `read_file("./foo")` → `read_file("/sandbox/foo")` but must not rewrite the call's logical target. To refuse a call, set `block: true`.
+
+The v1 invariant is **structural**: ``PreToolUseHookAdapter`` requires the sanitized JSON to have the same set of top-level keys as the original. A handler that changes the key shape has its `updatedInput` **dropped** (the original arguments are forwarded to dispatch) and a warning is logged. Tighter logical-target checks (matching specific `path`/`url`/`id` values) are deferred to v2 when host-specific tool schemas are available.
+
+### Example: redacting a credentials field
+
+```swift,no-build
+import Foundation
+import ManifoldRuntime
+
+await registry.register(.preToolUse) { input in
+    guard
+        input.toolName == "post_message",
+        let raw = input.toolArguments,
+        let data = raw.data(using: .utf8),
+        var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        return .passthrough
+    }
+
+    // Keep the top-level keys intact (sanitize-only); just redact the value.
+    if json["api_key"] != nil {
+        json["api_key"] = "[REDACTED]"
+    }
+
+    guard
+        let sanitized = try? JSONSerialization.data(withJSONObject: json),
+        let updated = String(data: sanitized, encoding: .utf8)
+    else {
+        return .passthrough
+    }
+    return HookOutput(updatedInput: updated)
+}
+```
+
+### Example: blocking a tool call outright
+
+```swift,no-build
+import ManifoldRuntime
+
+await registry.register(.preToolUse) { input in
+    if input.toolName == "delete_file" {
+        return HookOutput(block: true, denyReason: "Destructive ops are off in this session.")
+    }
+    return .passthrough
+}
+```
+
+`block: true` short-circuits the chain — later handlers do not run — and the dispatch loop returns a typed denial result to the model rather than calling the tool.
+
+## `preCompact` — observational in v1
+
+The `.preCompact` hook fires at the ``CompressionPolicy`` invocation in ``ConversationTurnExecutor``. v1 surfaces it for telemetry only: the registry runs handlers and emits ``ConversationEvent/hookFired(event:sessionID:)``, but `HookOutput.block` is **ignored** and compression always proceeds.
+
+```swift,no-build
+import ManifoldRuntime
+
+await registry.register(.preCompact) { input in
+    // Observational: log + measure. block: true is ignored in v1.
+    print("preCompact firing for session \(input.sessionID)")
+    return .passthrough
+}
+```
+
+A future revision may let hooks transform the compression-bound context. For now, treat `preCompact` as a structured logging hook.
+
+## Telemetry
+
+Every invocation of every registered hook emits ``ConversationEvent/hookFired(event:sessionID:)`` regardless of outcome (passthrough, mutate, or block). Subscribe to ``ConversationRuntime/events`` if a host UI needs to surface hook activity.

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
@@ -1,0 +1,49 @@
+# ``ManifoldRuntime``
+
+Persistence ports, the conversation turn loop, and the hook + handoff machinery that sits between `ManifoldInference` and a host app's SwiftData store.
+
+## Overview
+
+`ManifoldRuntime` owns the surfaces that need a session record but no concrete persistence backend:
+
+- **Ports** — ``MessageStore``, ``SessionStore``, ``EndpointStore``, ``SamplerPresetStore``, ``BenchmarkCache`` — protocol shapes that `ManifoldPersistenceSwiftData` (or any drop-in alternative) satisfies.
+- **Use cases** — ``ConversationRuntime``, ``PromptContextPipeline``, ``ChatExportService``, ``SessionListService``.
+- **Session-scoped tool contributors** — ``SessionToolSource``, ``HandoffToolSource``, the contract mixins consumers can use to ship their own.
+- **Synchronous hooks** — ``HookRegistry``, ``HookEvent``, ``HookInput``, ``HookOutput`` — the host-mutation seam at `preToolUse` and `preCompact` decision points.
+
+The four backend family targets (`ManifoldMLX`, `ManifoldLlama`, `ManifoldFoundation`, `ManifoldCloud`) and `ManifoldMCP` deliberately do **not** depend on `ManifoldRuntime` — they stay session-free. Persistence-aware orchestration lives here.
+
+## Topics
+
+### Articles
+
+- <doc:AgentHandoffs>
+- <doc:HookSystem>
+
+### Conversation runtime
+
+- ``ConversationRuntime``
+- ``ConversationEvent``
+- ``ConversationStreamHandle``
+
+### Session-scoped tool sources
+
+- ``SessionToolSource``
+- ``HandoffToolSource``
+- ``HandoffSourceError``
+
+### Hook system
+
+- ``HookRegistry``
+- ``HookEvent``
+- ``HookInput``
+- ``HookOutput``
+- ``PreToolUseHookAdapter``
+
+### Persistence ports
+
+- ``MessageStore``
+- ``SessionStore``
+- ``EndpointStore``
+- ``SamplerPresetStore``
+- ``BenchmarkCache``

--- a/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/ClaudeCodeInterop.md
+++ b/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/ClaudeCodeInterop.md
@@ -1,0 +1,52 @@
+# Claude Code Interop
+
+Drop existing Claude Code skill libraries into a ManifoldKit-powered app unchanged.
+
+## The drop-in path
+
+``SkillLoader``'s default search paths match the Claude Code convention. An existing `~/.claude/skills/<name>/SKILL.md` is discovered on first launch with no setup beyond constructing a default loader:
+
+```swift,no-build
+import ManifoldSkills
+
+let loader = SkillLoader()
+let skills = loader.discover()    // includes anything in ~/.claude/skills
+```
+
+## Path priority order
+
+``SkillLoader`` walks these roots in order. **Last wins** on duplicate skill names so a project-local skill overrides a user-wide one — mirroring Claude Code's "project beats user" behaviour.
+
+| # | Path | Scope |
+|---|---|---|
+| 1 | `~/.config/agents/skills` | XDG-style user-wide library |
+| 2 | `~/.agents/skills` | Legacy user-wide library |
+| 3 | `~/.claude/skills` | Claude Code user-wide library |
+| 4 | `$PWD/.agents/skills` | Project-local override |
+| 5 | `$PWD/.claude/skills` | Project-local Claude Code override (highest precedence) |
+
+Within a single root, two `SKILL.md` files declaring the same `name:` are not collapsed — the first occurrence wins and the rest log a warning. Across roots, the later root wins silently (the per-root scan deduplicates by name; the cross-root merge in ``SkillLoader/discover()`` overwrites by name as it walks each root in order).
+
+## What's reused, what isn't
+
+| Claude Code construct | ManifoldKit behaviour |
+|---|---|
+| `SKILL.md` layout + frontmatter | Reused verbatim. See <doc:SkillFileFormat>. |
+| `name`, `description`, `when-to-use`, `argument-hint`, `aliases` | Reused. |
+| `allowed-tools` | Reused with the same gating semantics (intersect the executor's tool list while the skill is active). |
+| `model:` hint | Parsed but **ignored** in v1 — ManifoldKit picks the active model from session settings, not the skill. |
+| Per-skill tool definitions surfaced individually to the model | **Not yet.** v1 ships a single `invoke_skill` dispatcher (capped at 6 skills) to keep the per-turn tool budget bounded. Mirroring Claude Code's per-skill tool pattern is deferred to v2 once prompt-caching ergonomics catch up. |
+
+## Sharing skills between Claude Code and a ManifoldKit app
+
+The simplest workflow:
+
+1. Author skills once in `~/.claude/skills/<name>/SKILL.md`.
+2. Use them from Claude Code as usual.
+3. Launch a ManifoldKit-powered app on the same machine; the skills appear automatically.
+
+No symlink, no env var, no app-specific path is required on macOS.
+
+## iOS
+
+iOS skill discovery requires an entitlement/app-group design that hasn't shipped yet. ``SkillLoader/discover()`` returns `[]` on iOS and logs a one-time warning so app authors notice. The module compiles on iOS as a no-op so trait-gated dependencies still link.

--- a/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillFileFormat.md
+++ b/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillFileFormat.md
@@ -1,0 +1,62 @@
+# SKILL.md File Format
+
+The on-disk shape ``SkillLoader`` parses.
+
+## Layout
+
+A skill is a directory containing exactly one `SKILL.md` file:
+
+```
+<search-root>/<skill-name>/SKILL.md
+```
+
+The Markdown body is the skill's `promptTemplate` — verbatim, with no further processing. The YAML frontmatter at the top of the file carries metadata.
+
+## Frontmatter
+
+Frontmatter is the YAML block delimited by `---` on its own line at the top of the file. A `SKILL.md` without frontmatter is **rejected** and logged as malformed — frontmatter is required for `name` and `description`.
+
+```
+---
+name: explain
+description: Explain a code snippet in plain English.
+aliases:
+  - explainer
+  - eli5
+allowed-tools:
+  - read_file
+when-to-use: Use after pasting a function or class definition.
+argument-hint: A short focus question, optional.
+model: sonnet
+---
+
+<prompt template body — the skill's instructions to the model>
+```
+
+### Required keys
+
+| Key | Type | Behaviour when missing/malformed |
+|---|---|---|
+| `name` | string | Skill is **skipped** and a warning is logged. The name is the canonical identifier in ``SkillRegistry`` and the value the model passes as `skill_name`. |
+| `description` | string | Skill is **skipped** and a warning is logged. Surfaces as the per-skill bullet in the `invoke_skill` tool description. |
+
+### Optional keys
+
+| Key | Type | Behaviour when missing |
+|---|---|---|
+| `aliases` | list of strings (or single string) | Alternate identifiers that resolve to this skill in ``SkillRegistry/skill(named:)``. Defaults to empty. |
+| `allowed-tools` | list of strings | When present, intersects the executor's advertised tool list while the skill is active (strong containment, mirrors Claude Code's `allowed-tools` gating). **Absent** means "no restriction" — equivalent to ``Skill/allowedTools`` being `nil`. **Present with empty list** means "deny all" (prompt-only skill); the skill's prompt template runs but no tools are exposed. |
+| `when-to-use` | string | Routing hint surfaced in the `invoke_skill` **tool description** (not the parameter description, which OpenAI truncates aggressively). Defaults to `nil`. |
+| `argument-hint` | string | Surfaced as the `args` parameter description. Defaults to a generic message. |
+| `model` | string | Skill-author hint for which model class to use. **Parsed but ignored in v1.** |
+
+### Behaviour when the file is unreadable
+
+- File I/O error → the skill is skipped and a warning logged with the path and error.
+- Malformed frontmatter → the skill is skipped and a warning logged.
+- Two `SKILL.md` files within the **same** search-path root with the same `name:` → the first occurrence wins; subsequent duplicates are skipped with a warning.
+- A `name:` collision **across** search-path roots → last-wins, in priority order. See <doc:ClaudeCodeInterop> for the priority table.
+
+## Duplicate-key precedence inside frontmatter
+
+The frontmatter parser is line-oriented; the **last** assignment to a given key in a single file wins. Skill authors should avoid repeating keys — the implicit choice is deliberately not documented as stable.

--- a/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillsGettingStarted.md
+++ b/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillsGettingStarted.md
@@ -1,0 +1,88 @@
+# Getting Started with ManifoldSkills
+
+Wire filesystem-discovered skills into a chat session.
+
+## 1) Discover skills on disk
+
+``SkillLoader`` walks the default Claude-Code-compatible roots and returns the parsed `Skill` values. The default search paths are resolved lazily so iOS / sandboxed builds with no `$HOME` don't crash at module init.
+
+```swift,no-build
+import ManifoldSkills
+
+let loader = SkillLoader()             // uses defaultClaudeCodePaths
+let skills = loader.discover()
+print("Found \(skills.count) skills")
+```
+
+To probe a specific directory (useful for tests or bundling skills inside an app), pass explicit roots:
+
+```swift,no-build
+import Foundation
+import ManifoldSkills
+
+let bundled = Bundle.main.url(forResource: "SampleSkills", withExtension: nil)!
+let loader = SkillLoader(searchPaths: [bundled])
+let skills = loader.discover()
+```
+
+## 2) Load skills into a registry
+
+``SkillRegistry`` is an actor-isolated lookup table keyed by skill name and aliases. Later calls to ``SkillRegistry/load(_:)`` overwrite prior entries — last-wins, matching the path-precedence behaviour of ``SkillLoader/discover()``.
+
+```swift,no-build
+import ManifoldSkills
+
+let registry = SkillRegistry()
+await registry.load(SkillLoader().discover())
+
+if let skill = await registry.skill(named: "explain") {
+    print(skill.promptTemplate)
+}
+```
+
+## 3) Wire a `SkillToolSource` into `ConversationRuntime`
+
+``SkillToolSource`` is a ``ManifoldRuntime/SessionToolSource`` that advertises a single `invoke_skill` dispatcher to the model. Hand it to `ConversationRuntime` through the `sessionToolSources:` parameter — the runtime re-evaluates the advertised tool list every turn.
+
+```swift,no-build
+import ManifoldKit
+import ManifoldRuntime
+import ManifoldSkills
+
+let registry = SkillRegistry()
+await registry.load(SkillLoader().discover())
+let skillSource = SkillToolSource(registry: registry)
+
+let runtime = ConversationRuntime(
+    messageStore: messageStore,
+    inferenceService: inferenceService,
+    sessionToolSources: [skillSource]
+)
+```
+
+The model invokes a skill by calling `invoke_skill` with `{"skill_name": "...", "args": "..."}`. The source resolves the named skill, marks it as the active skill for the session, and returns the rendered prompt template as the tool result. On subsequent turns, ``SkillToolSource/allowedToolNames(for:)`` narrows the advertised tool list to the skill's `allowed-tools` (if any), strongly containing the model's surface area while the skill is in scope.
+
+## 4) Bundling a `SKILL.md` with your app
+
+Drop the `SKILL.md` into a resource directory and point ``SkillLoader`` at it. The directory layout is always `<root>/<skill-name>/SKILL.md`:
+
+```
+MyApp/Resources/SampleSkills/
+└── explain/
+    └── SKILL.md
+```
+
+A minimal `SKILL.md`:
+
+```
+---
+name: explain
+description: Explain a code snippet in plain English.
+when-to-use: Use after pasting a function or class definition.
+---
+
+You are a senior engineer. Rewrite the snippet above as a clear, concise
+explanation of what the code does and why.
+```
+
+See <doc:SkillFileFormat> for every recognised frontmatter key and <doc:ClaudeCodeInterop> for using existing Claude Code skill libraries unchanged.

--- a/Sources/ManifoldSkills/ManifoldSkills.docc/ManifoldSkills.md
+++ b/Sources/ManifoldSkills/ManifoldSkills.docc/ManifoldSkills.md
@@ -1,0 +1,30 @@
+# ``ManifoldSkills``
+
+Filesystem-discovered, prompt-template skills for ManifoldKit chat sessions.
+
+## Overview
+
+`ManifoldSkills` brings the Claude Code skill convention to ManifoldKit-powered apps. Discovery walks five Claude-Code-compatible roots — `~/.config/agents/skills`, `~/.agents/skills`, `~/.claude/skills`, `$PWD/.agents/skills`, and `$PWD/.claude/skills` — and loads any `SKILL.md` it finds with YAML frontmatter.
+
+A ``SkillToolSource`` exposes a single `invoke_skill` dispatch tool to the model. The skill's `promptTemplate` is injected when invoked, and the optional `allowed-tools` frontmatter field narrows the model's tool surface while the skill is active.
+
+**macOS-only in v1.** iOS skill discovery requires an entitlement/app-group design that hasn't shipped yet — on iOS ``SkillLoader/discover()`` returns `[]` and logs a one-time warning.
+
+## Topics
+
+### Essentials
+
+- ``Skill``
+- ``SkillLoader``
+- ``SkillRegistry``
+- ``SkillToolSource``
+
+### Errors
+
+- ``SkillDispatchError``
+
+### Articles
+
+- <doc:SkillsGettingStarted>
+- <doc:SkillFileFormat>
+- <doc:ClaudeCodeInterop>


### PR DESCRIPTION
## Summary

Wave 3C of the multi-wave plan. DocC catalogs for the three modules shipped in Wave 2.

- **ManifoldSkills.docc**: root catalog + 3 articles (GettingStarted, SkillFileFormat, ClaudeCodeInterop).
- **ManifoldRuntime.docc**: new root catalog + `AgentHandoffs.md` (full setup walkthrough, v1 limitations called out honestly) + `HookSystem.md` (`preToolUse` + `preCompact` semantics, sanitize-only invariant).
- README cross-links under a new "Skills, Handoffs, and Hooks" section.

## Test plan

- [x] `swift build --disable-default-traits` clean (36s)
- [x] `swift test --disable-default-traits --filter SilentCatchAuditTest` passes
- [x] `scripts/extract-snippets.sh` correctly classifies all 11 new `swift,no-build` blocks as skipped; the 6 pre-existing executable snippets continue to extract unchanged
- [x] `Package.resolved` untouched in the commit
- [x] All snippets reference public API as merged on main (`SkillLoader`, `SkillRegistry`, `SkillToolSource(registry:)`, `HookRegistry`, `HookOutput`, `Agent`, `ChatSessionRecord`, `ConversationRuntime(sessionToolSources:hookRegistry:)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>