### PR TITLE
feat(demo,docs,ci): integration + release prep (W4)

### DIFF
--- a/Example/Advanced.xcodeproj/project.pbxproj
+++ b/Example/Advanced.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		BF0028000000000000000000 /* ManifoldAppIntents in Frameworks */ = {isa = PBXBuildFile; productRef = F30008000000000000000000 /* ManifoldAppIntents */; };
 		BF0029100000000000000000 /* ManifoldVoice in Frameworks */ = {isa = PBXBuildFile; productRef = F30009000000000000000000 /* ManifoldVoice */; };
 		BF0030000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
+		BF0041000000000000000000 /* RuntimeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10041000000000000000000 /* RuntimeHandler.swift */; };
+		BF0042000000000000000000 /* DemoScenarioRuntimeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10042000000000000000000 /* DemoScenarioRuntimeContext.swift */; };
 		BF0031000000000000000000 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10031000000000000000000 /* ShareViewController.swift */; };
 		BF0032000000000000000000 /* PendingSharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10030000000000000000000 /* PendingSharePayload.swift */; };
 		BF0033000000000000000000 /* ActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10034000000000000000000 /* ActionViewController.swift */; };
@@ -120,6 +122,8 @@
 		F10023000000000000000000 /* AppIntentToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentToolsView.swift; sourceTree = "<group>"; };
 		F10024000000000000000000 /* DemoNowTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoNowTool.swift; sourceTree = "<group>"; };
 		F10030000000000000000000 /* PendingSharePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSharePayload.swift; sourceTree = "<group>"; };
+		F10041000000000000000000 /* RuntimeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents/RuntimeHandler.swift; sourceTree = "<group>"; };
+		F10042000000000000000000 /* DemoScenarioRuntimeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scenarios/DemoScenarioRuntimeContext.swift; sourceTree = "<group>"; };
 		F10031000000000000000000 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		F10032000000000000000000 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
 		F10033000000000000000000 /* ShareExtensionInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ShareExtensionInfo.plist; sourceTree = "<group>"; };
@@ -223,6 +227,8 @@
 				F10022000000000000000000 /* SetReminderIntent.swift */,
 				F10023000000000000000000 /* AppIntentToolsView.swift */,
 				F10024000000000000000000 /* DemoNowTool.swift */,
+				F10041000000000000000000 /* RuntimeHandler.swift */,
+				F10042000000000000000000 /* DemoScenarioRuntimeContext.swift */,
 				A02001000000000000000000 /* Extensions */,
 			);
 			path = Advanced;
@@ -443,6 +449,8 @@
 				BF0027000000000000000000 /* AppIntentToolsView.swift in Sources */,
 				BF0029000000000000000000 /* DemoNowTool.swift in Sources */,
 				BF0030000000000000000000 /* PendingSharePayload.swift in Sources */,
+				BF0041000000000000000000 /* RuntimeHandler.swift in Sources */,
+				BF0042000000000000000000 /* DemoScenarioRuntimeContext.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Advanced/DemoContentView.swift
+++ b/Example/Advanced/DemoContentView.swift
@@ -45,6 +45,13 @@ struct DemoContentView: View {
     /// the demo bootstraps without ``RAGConfiguration``.
     let ragService: RAGService?
 
+    /// Optional session store used by ``DemoScenarioRunner`` to persist
+    /// scenario-provided agents/`activeAgentID` onto the freshly-created
+    /// session before the first prompt runs. When `nil`, scenarios that
+    /// populate ``DemoScenarioRuntimeContext/agents`` no-op the persistence
+    /// step (the demo still runs, just without per-agent rendering).
+    var sessionStore: (any SessionStore)?
+
     /// Buffer holding any ``InboundPayload`` that arrived during the
     /// cold-launch window, before the runtime finished bootstrapping.
     /// Drained once the mounted view can safely hand off to `ChatViewModel`.
@@ -411,7 +418,8 @@ struct DemoContentView: View {
                 chat: viewModel,
                 sessions: sessionManager,
                 registry: toolRegistry,
-                sandboxRoot: sandboxRoot
+                sandboxRoot: sandboxRoot,
+                sessionStore: sessionStore
             )
         }
     }

--- a/Example/Advanced/Intents/RuntimeHandler.swift
+++ b/Example/Advanced/Intents/RuntimeHandler.swift
@@ -24,9 +24,14 @@ actor RuntimeHandler: AskManifoldHandler {
     }
 
     func ask(_ prompt: String) async throws -> String {
-        let stream = try inferenceService.generate(
-            messages: [(role: "user", content: prompt)]
-        )
+        // `InferenceService` is `@MainActor`-isolated; `generate(messages:)`
+        // returns a `GenerationStream` whose `events` is a Sendable
+        // AsyncSequence. Hop to the main actor to call `generate`, then
+        // consume the stream off-actor.
+        let service = inferenceService
+        let stream = try await MainActor.run {
+            try service.generate(messages: [(role: "user", content: prompt)])
+        }
         var reply = ""
         for try await event in stream.events {
             if case .token(let chunk) = event {

--- a/Example/Advanced/ManifoldDemoApp.swift
+++ b/Example/Advanced/ManifoldDemoApp.swift
@@ -218,6 +218,7 @@ struct ManifoldDemoApp: App {
                         toolRegistry: toolRegistry,
                         sandboxRoot: sandboxRoot,
                         ragService: runtime.ragService,
+                        sessionStore: runtime.persistence,
                         pendingPayloadBuffer: pendingPayloadBuffer,
                         pendingDemoScenarioID: pendingDemoScenarioID
                     )

--- a/Example/Advanced/Scenarios/DemoScenario.swift
+++ b/Example/Advanced/Scenarios/DemoScenario.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ManifoldInference
+import ManifoldRuntime
 
 /// Declarative description of a tap-to-try demonstration in ManifoldDemo.
 ///
@@ -58,6 +59,21 @@ struct DemoScenario: Identifiable, Sendable {
     /// `nil` for the four P1 scenarios — they share the global demo tool set.
     let configure: (@MainActor @Sendable (ToolRegistry) -> Void)?
 
+    /// Richer configuration entry point that lets a scenario populate the
+    /// per-session tool sources, hook registry, and agent roster the Wave 2
+    /// surfaces introduced. Invoked AFTER ``configure`` so a scenario can do
+    /// both (install variant tool executors AND attach agents) without
+    /// fighting two parallel closures.
+    ///
+    /// The runner constructs a fresh ``DemoScenarioRuntimeContext``, passes
+    /// it `inout`, then applies ``DemoScenarioRuntimeContext/agents`` and
+    /// ``DemoScenarioRuntimeContext/activeAgentID`` to the new session via
+    /// the supplied ``SessionStore``. ``sessionToolSources`` and
+    /// ``hookRegistry`` are observed for the future runtime-rebuild path
+    /// (today the demo shares one runtime across all scenarios — see the
+    /// context type docs).
+    let configureContext: (@MainActor @Sendable (inout DemoScenarioRuntimeContext) -> Void)?
+
     /// Synthetic `transfer_to_<agent>` tool names the scenario is expected to
     /// emit. Asserted loudly by the W3B scripted UITest harness — the demo
     /// fails clearly when a handoff fails to materialise (per plan §Demo
@@ -84,6 +100,7 @@ struct DemoScenario: Identifiable, Sendable {
         autoSend: Bool,
         accessibilityID: String,
         configure: (@MainActor @Sendable (ToolRegistry) -> Void)? = nil,
+        configureContext: (@MainActor @Sendable (inout DemoScenarioRuntimeContext) -> Void)? = nil,
         expectedHandoffs: [String]? = nil,
         minCapableModel: ModelCapabilityTier? = nil
     ) {
@@ -97,6 +114,7 @@ struct DemoScenario: Identifiable, Sendable {
         self.autoSend = autoSend
         self.accessibilityID = accessibilityID
         self.configure = configure
+        self.configureContext = configureContext
         self.expectedHandoffs = expectedHandoffs
         self.minCapableModel = minCapableModel
     }

--- a/Example/Advanced/Scenarios/DemoScenarioRunner.swift
+++ b/Example/Advanced/Scenarios/DemoScenarioRunner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ManifoldInference
+import ManifoldRuntime
 import ManifoldUI
 
 /// Composition seam shared by every entry point that launches a scenario:
@@ -15,7 +16,10 @@ enum DemoScenarioRunner {
     ///    against an active stream.
     /// 2. Reset the registry to the baseline tool set, then invoke the
     ///    scenario's optional `configure` closure to install variants.
-    /// 3. Create a new session, activate it on `sessionManager`, and then
+    /// 3. Build a fresh ``DemoScenarioRuntimeContext`` and invoke the
+    ///    optional ``DemoScenario/configureContext`` so the scenario can
+    ///    attach agents, session tool sources, or a hook registry.
+    /// 4. Create a new session, activate it on `sessionManager`, and then
     ///    call `chat.switchToSession(session)` directly. `DemoContentView`'s
     ///    `onChange(of: sessionManager.activeSession)` also calls
     ///    `switchToSession` — but onChange runs on the next view-update
@@ -23,18 +27,25 @@ enum DemoScenarioRunner {
     ///    value when `sendMessage()` runs below. Doing the switch here
     ///    makes the sequencing deterministic; the onChange path stays in
     ///    place for sidebar-driven switches.
-    /// 4. Prefill the composer and, when `autoSend` is true, send.
+    /// 5. If `sessionStore` is supplied AND the scenario populated
+    ///    `agents`/`activeAgentID`, persist them onto the session record
+    ///    before the first prompt is sent.
+    /// 6. Prefill the composer and, when `autoSend` is true, send.
     static func run(
         _ scenario: DemoScenario,
         chat: ChatViewModel,
         sessions: SessionManagerViewModel,
         registry: ToolRegistry,
-        sandboxRoot: URL
+        sandboxRoot: URL,
+        sessionStore: (any SessionStore)? = nil
     ) async {
         guard !chat.isGenerating else { return }
 
         DemoTools.resetToDefaults(on: registry, root: sandboxRoot)
         scenario.configure?(registry)
+
+        var context = DemoScenarioRuntimeContext(toolRegistry: registry)
+        scenario.configureContext?(&context)
 
         do {
             let session = try await sessions.createSession(title: scenario.title)
@@ -42,6 +53,29 @@ enum DemoScenarioRunner {
             // Deterministic switch — don't wait on the onChange propagation
             // cycle in DemoContentView. See the sequence doc above.
             await chat.switchToSession(session)
+
+            // Persist agents/activeAgentID if the scenario populated them.
+            // The scenario authored these values inside `configureContext`;
+            // we apply them via SessionStore so the runtime sees them on
+            // the next turn.
+            if let sessionStore, !context.agents.isEmpty || context.activeAgentID != nil {
+                var record = session
+                record.agents = context.agents
+                // Guard against a dangling activeAgentID pointer rather
+                // than persisting it.
+                if let active = context.activeAgentID,
+                   context.agents.contains(where: { $0.id == active }) {
+                    record.activeAgentID = active
+                } else if context.activeAgentID != nil {
+                    Log.ui.warning("DemoScenarioRunner: scenario \(scenario.id, privacy: .public) set activeAgentID that doesn't match any agent — clearing")
+                    record.activeAgentID = nil
+                }
+                do {
+                    try await sessionStore.updateSession(record)
+                } catch {
+                    Log.ui.warning("DemoScenarioRunner: failed to persist agents for \(scenario.id, privacy: .public): \(String(describing: error), privacy: .public)")
+                }
+            }
         } catch {
             chat.errorMessage = "Failed to start scenario: \(error.localizedDescription)"
             return

--- a/Example/Advanced/Scenarios/DemoScenarioRuntimeContext.swift
+++ b/Example/Advanced/Scenarios/DemoScenarioRuntimeContext.swift
@@ -1,0 +1,74 @@
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+
+/// Richer configuration context a ``DemoScenario`` populates before its
+/// turn loop runs.
+///
+/// Closes the W3B runtime-wiring deferral (Wave 4 of the
+/// `put-an-implementation-plan-reactive-penguin.md` plan). Before this
+/// type existed, ``DemoScenario/configure`` could only install variant
+/// tool executors against a `ToolRegistry` — there was no path to attach
+/// the per-session ``SessionToolSource``, ``HookRegistry``, agent roster,
+/// or active-agent pointer that Wave 2 introduced. As a result, the three
+/// W3B demo cards (`skill-explain`, `handoff-research-write`,
+/// `hook-input-sanitize`) compiled but did not actually exercise the
+/// Wave 2 surfaces against a live runtime.
+///
+/// The runner builds a fresh context per invocation, lets the scenario
+/// mutate it in-place, then:
+///
+/// 1. Applies ``agents`` and ``activeAgentID`` to the just-created
+///    ``ChatSessionRecord`` via the supplied ``SessionStore``.
+/// 2. Surfaces ``sessionToolSources`` and ``hookRegistry`` as fields the
+///    host can read to decide whether to spin a scenario-scoped
+///    ``ConversationRuntime`` (today the demo shares one runtime across
+///    all scenarios, so these fields are observed but not yet bound to
+///    the live runtime — a follow-up will plumb them through
+///    `ManifoldBootstrap`).
+///
+/// The fields are `var` and `append`-friendly so multiple scenarios that
+/// share a configure helper can compose without overwriting each other.
+@MainActor
+public struct DemoScenarioRuntimeContext {
+
+    /// Shared tool registry — same instance every scenario sees, so a
+    /// `configure` closure can install or override executors for variant
+    /// behaviour (e.g. a deliberately-slow `sample_repo_search`).
+    public let toolRegistry: ToolRegistry
+
+    /// Append-friendly list of per-session tool sources. A scenario that
+    /// needs `transfer_to_<agent>` synthesis adds a ``HandoffToolSource``
+    /// here; one that wants skills adds a ``SkillToolSource``. Empty by
+    /// default.
+    public var sessionToolSources: [any SessionToolSource]
+
+    /// Optional hook registry the scenario wants installed (e.g. a
+    /// `preToolUse` sanitiser). `nil` means the scenario opts out of
+    /// hooks; the runtime falls back to its default no-op shape.
+    public var hookRegistry: HookRegistry?
+
+    /// Agents to attach to the freshly-created ``ChatSessionRecord``. The
+    /// runner applies these via ``SessionStore/updateSession(_:)`` after
+    /// `configure` returns, before the first prompt is sent.
+    public var agents: [Agent]
+
+    /// Initial active agent for the session. Must reference an `id` in
+    /// ``agents`` — the runner logs a warning and clears the pointer on
+    /// mismatch rather than persisting a dangling reference.
+    public var activeAgentID: UUID?
+
+    public init(
+        toolRegistry: ToolRegistry,
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil,
+        agents: [Agent] = [],
+        activeAgentID: UUID? = nil
+    ) {
+        self.toolRegistry = toolRegistry
+        self.sessionToolSources = sessionToolSources
+        self.hookRegistry = hookRegistry
+        self.agents = agents
+        self.activeAgentID = activeAgentID
+    }
+}

--- a/Example/Advanced/Scenarios/DemoScenarios.swift
+++ b/Example/Advanced/Scenarios/DemoScenarios.swift
@@ -139,6 +139,14 @@ enum DemoScenarios {
     /// and Writer produces the final prose. The `expectedHandoffs` assertion
     /// fires LOUDLY if the model never emits the transfer call — the scripted
     /// UITest path mimics the successful run for deterministic CI.
+    /// Two pinned agent IDs so the `configureContext` closure can install
+    /// a stable roster and so tests can pin the expected `activeAgentID`.
+    /// Using deterministic UUIDs (rather than `UUID()` inside the closure)
+    /// keeps the scenario's behaviour reproducible run-to-run, which is
+    /// important for the scripted UITest path.
+    static let researcherAgentID = UUID(uuidString: "00000000-0000-0000-0000-00000000A001")!
+    static let writerAgentID = UUID(uuidString: "00000000-0000-0000-0000-00000000A002")!
+
     static let handoffResearchWrite = DemoScenario(
         id: "handoff-research-write",
         title: "Handoff: Researcher → Writer",
@@ -154,6 +162,28 @@ enum DemoScenarios {
         autoSend: true,
         accessibilityID: "demo-card-handoff-research-write",
         configure: nil,
+        // Wires the two-agent roster onto the freshly-created session so the
+        // turn loop's HandoffToolSource sees both agents and can synthesise
+        // `transfer_to_writer`. Researcher is active first; the handoff
+        // tool-call flips `activeAgentID` to Writer for the next turn.
+        configureContext: { context in
+            let researcher = Agent(
+                id: researcherAgentID,
+                name: "Researcher",
+                systemPrompt: "You are Researcher. Produce a tight outline, then call `transfer_to_writer` with the outline as the `payload` so Writer can draft prose.",
+                description: "Outlines a topic before handing off to Writer.",
+                allowedToolNames: nil
+            )
+            let writer = Agent(
+                id: writerAgentID,
+                name: "Writer",
+                systemPrompt: "You are Writer. Turn Researcher's outline into three short paragraphs of clear prose.",
+                description: "Drafts prose from an outline.",
+                allowedToolNames: nil
+            )
+            context.agents = [researcher, writer]
+            context.activeAgentID = researcherAgentID
+        },
         expectedHandoffs: ["transfer_to_writer"],
         // 3B-class models cannot reliably emit transfer_to_* on first attempt;
         // gate at .balanced (≈8B+) so the card shows an "install a larger

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -132,6 +132,11 @@ public enum FeatureMatrix {
             unlocks: [.toolCalling]
         ),
         ManifoldTrait(
+            name: "Skills",
+            description: "Enable the ManifoldSkills target: Claude-Code-compatible filesystem skill discovery (~/.claude/skills/<name>/SKILL.md) plus a single `invoke_skill` dispatch tool. macOS-only in v1 — compiles on iOS as a no-op registry.",
+            unlocks: [.toolCalling]
+        ),
+        ManifoldTrait(
             name: "Fuzz",
             description: "Enable real inference backends in fuzz-chat (Ollama, Llama, Foundation). Required by scripts/fuzz.sh; not needed for swift test or xcodebuild test.",
             unlocks: []

--- a/docs/FeatureMatrix.md
+++ b/docs/FeatureMatrix.md
@@ -18,5 +18,6 @@ Do not edit by hand — re-run the script.
 | `MLX` | Enable the MLX inference backend (requires Apple Silicon) | `localInference`, `mlxBackend`, `visionInput`, `imageGeneration` |
 | `Ollama` | Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major. | `ollama`, `toolCalling`, `embeddings` |
 | `Server` | Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency. | `embeddings` |
+| `Skills` | Enable the ManifoldSkills target: Claude-Code-compatible filesystem skill discovery (~/.claude/skills/<name>/SKILL.md) plus a single `invoke_skill` dispatch tool. macOS-only in v1 — compiles on iOS as a no-op registry. | `toolCalling` |
 | `Tools` | Enable the ManifoldTools end-to-end tool-calling validation harness and its `manifold-tools` CLI. | `toolCalling` |
 | `Voice` | Enable the ManifoldVoice speech I/O spike and voice composer UI. | `voiceIO` |


### PR DESCRIPTION
## Summary

Wave 4 of the multi-wave plan in `~/.claude/plans/put-an-implementation-plan-reactive-penguin.md`. Closes two deferred items from W3B and does release prep.

- **A — Demo runtime wiring**: `DemoScenario` gains an additive `configureContext` closure taking `inout DemoScenarioRuntimeContext` so scenarios can populate `sessionToolSources` / `hookRegistry` / `agents` / `activeAgentID` before the demo's `ConversationRuntime` is built. `DemoScenarioRunner` now takes an optional `SessionStore` and persists scenario-provided agents onto the freshly-created session record. The W3B `handoff-research-write` scenario installs a Researcher + Writer roster on the session before the first turn — closes the W3B deferral for the handoff path.

  **Constraint observed (not fixed here)**: `sessionToolSources` and `hookRegistry` are populated on the context but not yet bound to a live `ConversationRuntime` — the demo shares one runtime built once at app init via `ManifoldBootstrap`, which does not yet accept either parameter. The context fields are surfaced so a follow-up that widens `ManifoldBootstrap.init` (or builds a per-scenario runtime) has a place to read them. `skill-explain` and `hook-input-sanitize` still rely on app-init wiring, not per-scenario configuration.

- **B — pbxproj orphan fix**: restored the `Example/Advanced/Intents/RuntimeHandler.swift` entry that PR #1379 dropped. Once the file actually compiled, a Swift-6 actor-isolation bug surfaced (`RuntimeHandler` is an `actor`, `InferenceService.generate` is `@MainActor`) — fixed with a `MainActor.run { … }` hop. Also wired the new `DemoScenarioRuntimeContext.swift` into the same pbxproj.

  Verified by `xcodebuild -project Example/Advanced.xcodeproj -scheme Advanced -destination 'platform=macOS' build-for-testing CODE_SIGNING_ALLOWED=NO`: `** TEST BUILD SUCCEEDED **`.

- **C — README cross-links**: README already has a `## Skills, Handoffs, and Hooks` section (added in W3) that links to the three new DocC articles — verified the article paths exist. CHANGELOG: no edit; Release Please will create the next entry on merge and the maintainer rewrites bullets per the Prisma-style Highlights convention.

- **D — CI cost measurement**: `scripts/test.sh --profile local` on this branch passes in **4:40 (280s wall, 188% CPU)**. The first attempt failed in 7:31 after `FeatureMatrixTests.testEveryPackageManifestTraitHasMatrixEntry` flagged that `Skills` was declared in `Package.swift` but missing from `Sources/ManifoldKit/FeatureMatrix.swift` — pre-existing gap from W2A. Fixed it in this PR (added the trait entry + regenerated `docs/FeatureMatrix.md`).

- **E — Trait-combo build sweep**: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Macros,Skills` succeeds (`Build complete! (69.38s)`).

## Test gap

No new unit test for `DemoScenarioRuntimeContext` shipped. The type lives in `Example/Advanced` (an Xcode-only target) and references both `ManifoldRuntime` and `ManifoldInference`, but `AdvancedUITests` only links `ManifoldInference`. Moving the file into a Swift-package-reachable location would force `DemoScenarioRuntimeContext` into a public-library surface for the sake of a single test — disproportionate. The shape is exercised end-to-end by the demo card itself (`handoff-research-write` populating the context's `agents` field and seeing them persisted onto the session).

## Test plan

- [x] `swift build --disable-default-traits` — clean
- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Macros,Skills` — clean (69s)
- [x] `scripts/test.sh --profile local` — PASSED (4:40)
- [x] `SilentCatchAuditTest` — passes
- [x] `FeatureMatrixTests` — passes after Skills trait added
- [x] `xcodebuild … build-for-testing` (Advanced scheme, macOS) — succeeds
- [x] `Package.resolved` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>