### PR TITLE
docs: document high-value QA practices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Use `scripts/test.sh` — it runs configured suites and prints an honest summary
 
 For trait conventions, suite layout, classification (Unit / Integration / E2E), and the per-backend conformance walkthrough, see [`Tests/README.md`](Tests/README.md). It is the canonical entry point for "how do I add a backend / test / suite?".
 
+Four cross-cutting QA practices live outside the unit/integration/E2E pyramid — DX walkthroughs, audit tests, the audit sabotage suite, and cold-start conformance gates. See [`docs/QA-PRACTICES.md`](docs/QA-PRACTICES.md) for what each one catches, how to run it, and how to extend it.
+
 - Use `XCTestCase` for new tests; match `@Suite`/`@Test` in files that already use Swift Testing.
 - A test that hits SwiftData is an integration test — name and place it accordingly.
 - Do not mock the persistence layer. Use in-memory SwiftData stores.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,11 @@ new port (into `ManifoldRuntime`) — never to add the reverse import. Reviewers
 will push back on `// swiftlint:disable` style escape hatches in the audit
 allowlists; the cap on each allowlist is intentionally low.
 
+`TrafficBoundaryAuditTest` is one of 19 audit tests in the repo. For the wider
+pattern — how audit tests work, when to add a new one, the sabotage suite that
+keeps them honest, plus DX walkthroughs and cold-start conformance gates — see
+[`docs/QA-PRACTICES.md`](docs/QA-PRACTICES.md).
+
 ## Pre-push checklist
 
 **Run before every push.** CI is macOS-only with a 10× billing multiplier; each

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -272,6 +272,10 @@ scripts/test-mlx-integration.sh  # wires discovery env vars into .xctestrun
 For standalone targeting via Xcode scheme, set `MLX_VLM` in the manifest and
 run the `ManifoldE2ETests` scheme with the `MLX` trait enabled.
 
+### Cross-cutting QA practices
+
+Beyond the unit/integration/E2E pyramid below, ManifoldKit ships four cross-cutting QA practices: **DX walkthroughs** ([`scripts/dx-walkthrough/`](../scripts/dx-walkthrough/README.md)), **audit tests** (19 files matching `Tests/*/*AuditTest*.swift`), an **audit sabotage suite** ([`Tests/ManifoldAuditSabotageSuiteTests/`](ManifoldAuditSabotageSuiteTests/AuditSabotageSuiteTests.swift)), and **cold-start conformance gates** (described below). For the discovery doc — what each catches, why it exists, how to run, how to extend — see [`docs/QA-PRACTICES.md`](../docs/QA-PRACTICES.md).
+
 ### Cold-start conformance gates
 
 Cold-start gates scaffold a fresh SwiftPM consumer in a tmpdir, depend on this repo via `.package(path:, name: "ManifoldKit", ...)`, and exercise the public surface from outside — catching breakage that in-tree tests miss because the in-tree compiler sees internals the fresh consumer cannot. Each gate's CI job in `.github/workflows/ci.yml` lists its own script path under `paths:` so edits to the gate re-trigger the gate (see `feedback_ci_path_filter_self_validation`).

--- a/docs/QA-PRACTICES.md
+++ b/docs/QA-PRACTICES.md
@@ -1,0 +1,146 @@
+# ManifoldKit QA practices
+
+Four cross-cutting QA practices guard ManifoldKit beyond its unit / integration / E2E test pyramid. Each one catches a class of regression that ordinary tests miss. This page is the discovery doc — what each practice is, why it exists, how to run it, and how to extend it.
+
+For day-to-day test conventions (suites, traits, layering), see [`Tests/README.md`](../Tests/README.md). For module/architecture rules and pre-push gates, see [`CLAUDE.md`](../CLAUDE.md).
+
+| Practice | Scope | Lives at | Doc |
+|---|---|---|---|
+| DX walkthroughs | Forced-blindness fresh-developer DX regression | [`scripts/dx-walkthrough/`](../scripts/dx-walkthrough/) | [README](../scripts/dx-walkthrough/README.md) |
+| Audit tests | File-walking discipline rules (19 files) | `Tests/*/Manifold*AuditTest*.swift` | this doc |
+| Sabotage suite | Verifies the audit tests still catch what they claim | [`Tests/ManifoldAuditSabotageSuiteTests/`](../Tests/ManifoldAuditSabotageSuiteTests/) | this doc |
+| Cold-start conformance gates | Public-surface tests run from a fresh consumer outside the repo | [`scripts/cold-start-*.sh`](../scripts/) | [Tests/README § Cold-start](../Tests/README.md#cold-start-conformance-gates) |
+
+---
+
+## 1. DX walkthroughs
+
+**What.** A forced-blindness harness in [`scripts/dx-walkthrough/`](../scripts/dx-walkthrough/). Three agents play "fresh Swift developer", each follows an archetype brief (e.g. [`01-chat-cli.md`](../scripts/dx-walkthrough/briefs/01-chat-cli.md), [`02-swiftui-chat.md`](../scripts/dx-walkthrough/briefs/02-swiftui-chat.md)), and is forbidden from reading `Sources/Manifold*/**/*.swift` or `Tests/**`. They log friction as they go. Friction logs are synthesized into a per-iteration `SUMMARY.md` and diffed against prior iterations.
+
+**Why.** In-tree tests cannot tell you whether a new developer with only `README.md`, `docs/`, and `Documentation.docc/` can ship a chat in 30 minutes. DX walkthroughs measure that directly. Recent runs (`scripts/dx-walkthrough/runs/2026-05-23_v0.33.0-iter*/`) caught broken doc snippets that compiled in-repo but referenced renamed types from outside the umbrella — those findings motivated the CI snippet-compile gate in PR #1417 and a string of fixes (#1392, #1393, #1397, #1401).
+
+**Run it.**
+```sh
+scripts/dx-walkthrough/run.sh 01-chat-cli iter5
+```
+Scaffolds `runs/<date>_v<ver>_<label>/<archetype>/run-{1,2,3}/` and prints three self-contained dispatch prompts to hand to the Agent tool with `isolation=worktree`.
+
+**Compare iterations.**
+```sh
+scripts/dx-walkthrough/compare.sh \
+  runs/2026-05-23_v0.33.0/01-chat-cli \
+  runs/2026-05-23_v0.33.0-iter4/01-chat-cli
+```
+Heuristic markdown diff; groups findings into Disappeared, Persisted, New.
+
+**Extend.** Add a new archetype `.md` file under `scripts/dx-walkthrough/briefs/`. Keep the forced-blindness rule. The [walkthrough README](../scripts/dx-walkthrough/README.md) is the canonical reference.
+
+---
+
+## 2. Audit tests
+
+**What.** A pattern: a single XCTest file walks `Sources/` (or `Package.swift`, or `.docc` articles) and grep-asserts a discipline rule. Each one bans an entire class of regression. As of writing there are 19 such files. Representative examples:
+
+| Audit | Rule it enforces | Origin |
+|---|---|---|
+| `SilentCatchAuditTest` | `try?` and empty `catch { }` are banned in `Sources/` outside an idiom/path allowlist | #242 / PR #262 |
+| `TrafficBoundaryAuditTest` | 4-rule import-graph and HTTP-egress allowlist (`URLSession` per-file, hostname allowlists, no UI→Backends imports, …) | architecture invariants — see [CONTRIBUTING.md § Architecture invariants](../CONTRIBUTING.md#architecture-invariants) |
+| `PackageTraitGateAuditTest` | Gate consumer→library edges in `Package.swift`, not library→library | trait-combo build pain |
+| `ProtocolLocationAuditTest` | Cross-family protocols live in `ManifoldInference`, not the umbrella |  |
+| `UserDefaultsStandardAuditTest` | Production code must accept an injected `UserDefaults`, not touch `.standard` | #734 / #761 (parallel-test flake) |
+| `SessionConstructionAuditTest` | `URLSession(` constructor only inside `URLSessionProvider.swift` |  |
+| `DNSRebindingCoverageAuditTest` | Cloud backends must route through `DNSRebindingGuard` |  |
+| `AgentsMdAuditTest` | `AGENTS.md` ↔ `CLAUDE.md` stay aligned |  |
+| `TestSuiteSilentSkipAuditTest` | XCTSkip without an explicit reason is banned |  |
+
+**Why.** A reviewer's eye is the wrong layer to catch "did this PR add a new `URLSession(...)` outside the allowlist", "did anyone import `ManifoldBackends` from UI again", or "is there a fresh `try?` swallowing errors in production". Each audit codifies a rule that bled into a real bug (or is one Swift compile away from a real bug), then plants a tripwire. The cost is one test file per rule; the payoff is the rule never silently rots back in.
+
+**Run them.** They live in the regular suites and run under `--disable-default-traits` in CI:
+
+```bash
+swift test --filter ManifoldInferenceTests --disable-default-traits   # SilentCatchAudit, TrafficBoundaryAudit, …
+swift test --filter ManifoldBackendsTests   --disable-default-traits   # SessionConstructionAudit, DNSRebindingCoverageAudit, …
+swift test --filter ManifoldCoreTests       --disable-default-traits   # PackageTraitGateAudit, UserDefaultsStandardAudit, …
+swift test --filter ManifoldRuntimeTests    --disable-default-traits   # ProtocolLocationAudit
+```
+
+Failures print the offending file/line plus the allowlist mechanism. Most audits expose a path-based allowlist file (e.g. `silent_catch_allowlist.txt`) sitting beside the test; some also support "idiom" allowlists for globally-approved patterns.
+
+**Extend — adding a new audit.**
+
+1. Pick the right home target. Audits sit in whichever `Tests/Manifold*Tests/` suite is closest to the surface they police — `Inference` for protocol/error rules, `Backends` for cloud/HTTP rules, `Core` for cross-cutting rules, `Runtime` for layering.
+2. Walk `Sources/` (or `Package.swift`, or whatever artifact you're policing) with `FileManager`. Read each `.swift` file as a `String`. Don't `@testable import` — audits look at source as data, not the linked binary.
+3. Emit a fingerprint per violation in the form `relative/path.swift:trimmed line` and check against a sibling allowlist file. Use `#`-prefixed comments + blank-line tolerance. Keep the allowlist short — every entry is debt.
+4. Document the rule and the approval shape in a file-header doc-comment. Cite the issue or PR that motivated the rule.
+5. Add a sabotage entry (see practice 3 below) so the audit can't quietly rot into a no-op.
+
+`SilentCatchAuditTest.swift` is the canonical reference implementation — header doc, idiom rules, path allowlist, stale-allowlist check.
+
+---
+
+## 3. Audit sabotage suite
+
+**What.** [`Tests/ManifoldAuditSabotageSuiteTests/AuditSabotageSuiteTests.swift`](../Tests/ManifoldAuditSabotageSuiteTests/AuditSabotageSuiteTests.swift) (454 LOC). One test per file-walking audit. Each test:
+
+1. Creates a temp directory mimicking the relevant source layout.
+2. Writes a file containing a known violation of the rule the audit enforces.
+3. Reimplements the audit's check logic inline (SwiftPM forbids `@testable import` of test targets, so logic is inlined minimally).
+4. Asserts the violation is detected.
+
+**Why.** Audit tests are line-grep heuristics with allowlists. Over time, an allowlist entry can drift, a regex can be loosened to land an unrelated fix, or the audit can be skipped for trait reasons and quietly turn into a no-op. The sabotage suite is the "who watches the watchers" guard. Without it, an audit could pass for a year while no longer catching what it advertises. Originated in PR #1290 (Phase 5 cloud-helper deletion).
+
+**Run it.**
+```bash
+SABOTAGE=1 swift test --filter ManifoldAuditSabotageSuiteTests --disable-default-traits
+```
+Without `SABOTAGE=1` every test skips immediately — the suite is nightly-only because it does temp-dir setup per test.
+
+**Extend.** When you add a new audit (practice 2), pair it with a sabotage test:
+
+1. Pick a representative violation of the rule.
+2. Create a temp dir, write the violating file at the right relative path.
+3. Inline the audit's detection logic (regex, scan, whatever the audit uses).
+4. Assert the violation is detected. The test PASSES when the audit would correctly flag the file.
+5. Open the suite with `try requireSabotageMode()` so the test no-ops without `SABOTAGE=1`.
+
+Existing tests in the suite serve as templates — `test_sessionConstructionAudit_detectsViolation` is the simplest shape.
+
+---
+
+## 4. Cold-start conformance gates
+
+**What.** Three shell scripts that scaffold a fresh SwiftPM consumer in a `mktemp -d` tmpdir, link ManifoldKit by local `path:`, and exercise the public surface from outside the repo.
+
+| Tier | Script | Surface |
+|---|---|---|
+| 1 | [`scripts/cold-start-conformance.sh`](../scripts/cold-start-conformance.sh) | Low-level public API: `InferenceBackend`, `InferenceService`, `GenerationStream` consumption. Runs one chat turn through a tiny inline fake backend. |
+| 2 | [`scripts/cold-start-tier2-bootstrap.sh`](../scripts/cold-start-tier2-bootstrap.sh) | `ManifoldBootstrap` + `ChatViewModel` orchestration — the high-level path real chat apps use. Drives one user → assistant turn via `vm.inputText` + `await vm.sendMessage()`. |
+| 3 | [`scripts/cold-start-tier3-chatview.sh`](../scripts/cold-start-tier3-chatview.sh) | `ManifoldUI` `ChatView` composition with `@State` view models, `.environment(_:)` injection, and the `apiConfiguration: () -> View` view-builder closure. |
+
+**Why.** The in-tree compiler sees internals a fresh consumer cannot. A public API can quietly stop being usable from outside the repo — a forgotten `internal`, a missing `@_exported import`, a `Package.swift` link shape break — and every in-tree test still passes. Cold-start audits in early 2026 found that most of the friction documented by external agents was exactly this shape. Tier 1 originated in PR #1097 to gate the next layer of breakage.
+
+**Run them.**
+```bash
+scripts/cold-start-conformance.sh        # tier 1
+scripts/cold-start-tier2-bootstrap.sh    # tier 2
+scripts/cold-start-tier3-chatview.sh     # tier 3
+```
+Each takes ~30s on a warm cache. They run in CI on every PR; each CI job lists its own script path in the workflow's `paths:` filter so edits to the gate re-trigger the gate.
+
+**Extend.** Adding a tier or widening an existing one:
+
+1. Copy the closest existing script.
+2. Build a minimal consumer `Package.swift` in `$WORK`. Pin the local package with explicit `name: "ManifoldKit"` — `.package(path:)` derives identity from the last path component, which breaks under worktree checkouts.
+3. Scaffold consumer source that uses *only* products a real downstream consumer can reach. Roll inline fakes for anything that lives in `ManifoldTestSupport` — that target is deliberately not a public product.
+4. `swift build` + `swift run` against the consumer. The script should exit non-zero on any compile or runtime failure.
+5. Add a CI job in `.github/workflows/ci.yml` and include the script path in `paths:` so the gate self-validates.
+
+The tier-2 script's long header doc-comment is the canonical "why and how" reference for the gate scaffold pattern, including the `ManifoldBootstrap` SwiftData-container collision footgun that motivated explicit `makeModelContainer:` overrides.
+
+---
+
+## When to use which
+
+- Public API or first-time-user friction → DX walkthrough (slow, high-signal) + cold-start gate (fast, narrow).
+- "This kind of bug keeps coming back" → audit test + sabotage entry.
+- Architecture invariant (module layering, HTTP egress, persistence boundaries) → audit test, cited in [CONTRIBUTING.md § Architecture invariants](../CONTRIBUTING.md#architecture-invariants).


### PR DESCRIPTION
## Summary

Adds [`docs/QA-PRACTICES.md`](../blob/docs/qa-practice-documentation/docs/QA-PRACTICES.md) — a discovery doc for four cross-cutting QA practices that previously had no single home:

1. **DX walkthroughs** (`scripts/dx-walkthrough/`)
2. **Audit tests** (19 files matching `Tests/*/*AuditTest*.swift`)
3. **Audit sabotage suite** (`Tests/ManifoldAuditSabotageSuiteTests/`)
4. **Cold-start conformance gates** (`scripts/cold-start-*.sh`)

For each: what it is, why it exists (with the motivating incident / PR where discoverable from git log), how to run, how to extend.

Additive only: no production code, no tests, no restructured docs. Adds cross-references from `CLAUDE.md`, `Tests/README.md`, and `CONTRIBUTING.md` so the practice is discoverable from each entry point.

## Coverage matrix — before vs after

| Practice | CLAUDE.md | Tests/README.md | CONTRIBUTING.md | Own README / header | Discovery doc |
|---|---|---|---|---|---|
| DX walkthroughs | before: none / after: linked | before: none / after: linked | before: none / after: (via QA doc link) | yes ([scripts/dx-walkthrough/README.md](../blob/main/scripts/dx-walkthrough/README.md)) | NEW |
| Audit tests (pattern) | before: 3 incidental mentions / after: + linked | before: none (only sabotage-evidence section) / after: linked | before: only `TrafficBoundaryAuditTest` / after: + pattern pointer | per-file headers only | NEW |
| Sabotage suite | before: none / after: linked | before: none / after: linked | before: none / after: (via QA doc link) | file header doc-comment only | NEW |
| Cold-start gates | before: 1 footnote / after: + linked | before: tier table / after: tier table + linked | before: none / after: (via QA doc link) | none (header doc-comments in scripts) | NEW |

Audit tests had the worst coverage: 19 files, no shared "pattern" doc, no "how to add one" guidance. Cold-start gates were already partly documented in `Tests/README.md`; this PR fleshes out the "why" and "extend" sections. DX walkthroughs were well-documented in their own dir but undiscoverable from the top-level docs.

## What was added

- **`docs/QA-PRACTICES.md`** (new, ~145 lines) — discovery doc with 1–2 paragraphs per practice (what / why / run / extend) and a "when to use which" footer.
- **`CLAUDE.md`** — 1-paragraph pointer to the discovery doc in the "Test conventions" section.
- **`Tests/README.md`** — new "Cross-cutting QA practices" subsection at the top of the cold-start area, listing all four practices and linking the discovery doc.
- **`CONTRIBUTING.md`** — 1-paragraph pointer at the end of the "Architecture invariants" section so the `TrafficBoundaryAuditTest` callout opens onto the wider audit-test pattern.

## Open gaps (not fixed in this PR)

- **Per-script docstring**: `scripts/cold-start-conformance.sh` has a good header doc-comment; tier 2 and tier 3 also document themselves well. No gap.
- **`AGENTS.md` cross-reference**: `AGENTS.md` does not mention any of the four practices. It's auto-aligned to `CLAUDE.md` via `AgentsMdAuditTest`, so this is intentional and not a gap — `AGENTS.md` is a Claude-only artifact.
- **Audit-test motivating incidents**: For most audits the motivating issue/PR was discoverable from git history; for a handful (e.g. `WireNoveltyAuditTest`, `ContractTestSupportSplitAuditTest`) the QA doc only names what the rule enforces and leaves the origin field blank rather than confabulate. Maintainer can fill these in over time.
- **Sabotage suite CI cadence**: the file header says "Nightly-only" with a `SABOTAGE=1` gate. I did not verify a nightly workflow actually invokes it — the doc says "nightly-only because it does temp-dir setup per test" matching the file's own claim. Worth confirming the workflow exists.

## Test plan

- [ ] `swift build` succeeds (no source changes, doc-only PR)
- [ ] Markdown links in `docs/QA-PRACTICES.md` resolve from the doc's location
- [ ] `AgentsMdAuditTest` is green (no `CLAUDE.md` ↔ `AGENTS.md` drift — the CLAUDE.md change is a 1-paragraph addition under the existing "Test conventions" section)