### PR TITLE
feat(skills): parse block-style YAML lists in SKILL.md frontmatter

### DIFF
--- a/Sources/ManifoldSkills/YAMLFrontmatter.swift
+++ b/Sources/ManifoldSkills/YAMLFrontmatter.swift
@@ -11,9 +11,11 @@ import Foundation
 ///   - `key: value`                — plain string scalar
 ///   - `key: "value"` / `'value'`  — quoted scalar (handles inner colons)
 ///   - `key: [a, b, c]`            — flow-style list
+///   - `key:\n  - a\n  - b`        — block-style list (indent must be
+///                                   consistent within the list; terminates at
+///                                   next top-level key or end-of-frontmatter)
 ///
 /// **Not supported (returns nil from `parse(_:)`):**
-///   - Block-style lists (`key:\n  - a\n  - b`)
 ///   - Nested mappings
 ///   - Multi-line scalars (`>`, `|`)
 ///
@@ -54,13 +56,46 @@ internal enum SkillFrontmatterParser {
         guard let closing = fence else { return nil }
 
         var fields: [String: SkillFrontmatterValue] = [:]
-        for line in lines[1..<closing] {
+        var index = 1
+        while index < closing {
+            let line = lines[index]
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            // Skip blank lines + comment-only lines. Indented `- ` items that
+            // appear without an immediately-preceding `key:` opener are stray
+            // garbage (an unterminated block list from a removed key); the
+            // outer loop ignores them rather than failing the whole document.
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                index += 1
+                continue
+            }
+            // Only top-level keys (no leading whitespace) are recognised at
+            // this layer. Indented lines that aren't part of an active block
+            // list are skipped — block-list collection happens inside
+            // `parseKeyValue`'s caller below.
+            if line.first == " " || line.first == "\t" {
+                index += 1
+                continue
+            }
             guard let pair = parseKeyValue(trimmed) else {
                 return nil
             }
-            fields[pair.0] = pair.1
+            // A bare `key:` with no inline value is a block-list opener.
+            // Look ahead for `<indent>- value` lines; absence of any items is
+            // not an error — the key just resolves to an empty list. Mixed or
+            // inconsistent indents inside the block fail the whole document.
+            if case .string("") = pair.1 {
+                let (block, consumed) = collectBlockList(lines: lines, start: index + 1, closing: closing)
+                switch block {
+                case .invalid:
+                    return nil
+                case .items(let values):
+                    fields[pair.0] = .list(values)
+                    index += consumed
+                }
+            } else {
+                fields[pair.0] = pair.1
+            }
+            index += 1
         }
 
         let body: String
@@ -100,6 +135,73 @@ internal enum SkillFrontmatterParser {
         guard let first = value.first, first == "\"" || first == "'" else { return nil }
         guard value.count >= 2, value.last == first else { return nil }
         return String(value.dropFirst().dropLast())
+    }
+
+    /// Outcome of a block-list lookahead. `invalid` collapses the whole
+    /// frontmatter parse (mixed indents); `items` covers both the empty-list
+    /// case (`aliases:\n` followed immediately by a top-level key) and the
+    /// populated case.
+    private enum BlockListResult {
+        case invalid
+        case items([String])
+    }
+
+    /// Reads `<indent>- value` lines starting at `start` until the first line
+    /// that is not part of the list (top-level key, end-of-frontmatter, or a
+    /// differently-indented `- ` item which is treated as inconsistent).
+    ///
+    /// Returns the items collected plus the number of lines consumed past
+    /// `start`. Blank lines and comment lines (`# …`) are skipped without
+    /// terminating the list, matching YAML semantics.
+    private static func collectBlockList(lines: [String], start: Int, closing: Int) -> (BlockListResult, Int) {
+        var items: [String] = []
+        var indent: Int?
+        var consumed = 0
+        var cursor = start
+        while cursor < closing {
+            let line = lines[cursor]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Blank lines + comments inside a block list do not terminate it.
+            // (Top-level vs. indented makes no difference for blanks; an
+            // indented `# comment` line still doesn't end the list.)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                cursor += 1
+                consumed += 1
+                continue
+            }
+
+            let leadingSpaces = line.prefix { $0 == " " }.count
+            // A non-indented line ends the list (next top-level key, or any
+            // other non-list content).
+            if leadingSpaces == 0 {
+                break
+            }
+
+            // Indented content that isn't `- ` ends the list — we don't try to
+            // parse nested mappings.
+            guard trimmed.hasPrefix("- ") || trimmed == "-" else {
+                break
+            }
+
+            if let expected = indent {
+                if leadingSpaces != expected {
+                    return (.invalid, consumed)
+                }
+            } else {
+                indent = leadingSpaces
+            }
+
+            let rawItem = String(trimmed.dropFirst(trimmed == "-" ? 1 : 2))
+                .trimmingCharacters(in: .whitespaces)
+            // Strip matched quotes so `- "with, comma"` round-trips like the
+            // flow-list path.
+            let item = unquote(rawItem) ?? rawItem
+            items.append(item)
+            cursor += 1
+            consumed += 1
+        }
+        return (.items(items), consumed)
     }
 
     /// Parses YAML flow-style `[a, b, "c, d"]`. Returns `nil` on unterminated

--- a/Tests/ManifoldSkillsTests/SkillLoaderTests.swift
+++ b/Tests/ManifoldSkillsTests/SkillLoaderTests.swift
@@ -61,6 +61,42 @@ final class SkillLoaderTests: XCTestCase {
         #endif
     }
 
+    func test_discover_blockStyleAliases_roundTrip() throws {
+        // End-to-end smoke: a SKILL.md authored with idiomatic block-style
+        // `aliases:` must surface as a `Skill` with the expected aliases array.
+        // This guards the loader path that calls `SkillFrontmatterParser` and
+        // then collapses `.list(...)` into `Skill.aliases`.
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let dir = root.appendingPathComponent("explain", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let frontmatter = """
+        ---
+        name: explain
+        description: Explain a snippet of code.
+        aliases:
+          - eli5
+          - simple
+        ---
+        BODY
+        """
+        try frontmatter.write(to: dir.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+
+        let loader = SkillLoader(searchPaths: [root])
+        let discovered = loader.discover()
+        XCTAssertEqual(discovered.count, 1)
+        XCTAssertEqual(discovered.first?.name, "explain")
+        XCTAssertEqual(discovered.first?.aliases, ["eli5", "simple"])
+        XCTAssertTrue(discovered.first?.promptTemplate.contains("BODY") ?? false)
+        // Sabotage-evidence: M1 change one of the `- ` to `* ` — block list
+        // ends empty and aliases assertion fails; M2 unindent both items —
+        // they become top-level non-key garbage and the file fails to parse;
+        // M3 rename `aliases:` → `alia:` — Skill.aliases falls back to [].
+        #endif
+    }
+
     func test_discover_lastWinsDedup_acrossPaths() throws {
         #if !os(macOS)
         throw XCTSkip("Discovery is macOS-only in v1")

--- a/Tests/ManifoldSkillsTests/YAMLFrontmatterTests.swift
+++ b/Tests/ManifoldSkillsTests/YAMLFrontmatterTests.swift
@@ -101,6 +101,139 @@ final class YAMLFrontmatterTests: XCTestCase {
         // can't find `aliases` and fails.
     }
 
+    func test_parse_listBlockStyle_parses() {
+        let doc = """
+        ---
+        name: x
+        description: x
+        aliases:
+          - eli5
+          - simple
+        ---
+        """
+        guard let parsed = SkillFrontmatterParser.parse(doc) else {
+            return XCTFail("Expected valid parse")
+        }
+        XCTAssertEqual(parsed.fields["aliases"], .list(["eli5", "simple"]))
+        // Sabotage-evidence: M1 reduce the indent on `- simple` to 1 space (vs.
+        // 2 on `- eli5`) — inconsistent-indent path returns nil; M2 swap the
+        // `- ` for `* ` (unsupported bullet) — list terminates after the key
+        // and the value comes back as `.list([])`; M3 drop the trailing `---`
+        // — fence detection fails and `parse` returns nil.
+    }
+
+    func test_parse_listBlockStyle_singleItem() {
+        let doc = """
+        ---
+        name: x
+        description: x
+        aliases:
+          - eli5
+        ---
+        """
+        guard let parsed = SkillFrontmatterParser.parse(doc) else {
+            return XCTFail("Expected valid parse")
+        }
+        XCTAssertEqual(parsed.fields["aliases"], .list(["eli5"]))
+    }
+
+    func test_parse_listBlockStyle_emptyAllowed() {
+        let doc = """
+        ---
+        aliases:
+
+        name: foo
+        description: bar
+        ---
+        """
+        guard let parsed = SkillFrontmatterParser.parse(doc) else {
+            return XCTFail("Expected valid parse")
+        }
+        XCTAssertEqual(parsed.fields["aliases"], .list([]))
+        XCTAssertEqual(parsed.fields["name"], .string("foo"))
+        // Sabotage-evidence: M1 add `  - eli5` between `aliases:` and the
+        // blank line — assertion now sees `.list(["eli5"])`; M2 rename
+        // `aliases:` → `alias:` — key check fails; M3 remove the blank line
+        // separator — `name:` is still detected as a top-level key and the
+        // empty-list resolution still holds.
+    }
+
+    func test_parse_listBlockStyle_stopAtNextKey() {
+        let doc = """
+        ---
+        aliases:
+          - eli5
+        name: foo
+        description: bar
+        ---
+        """
+        guard let parsed = SkillFrontmatterParser.parse(doc) else {
+            return XCTFail("Expected valid parse")
+        }
+        XCTAssertEqual(parsed.fields["aliases"], .list(["eli5"]))
+        XCTAssertEqual(parsed.fields["name"], .string("foo"))
+        XCTAssertEqual(parsed.fields["description"], .string("bar"))
+        // Sabotage-evidence: M1 indent `name: foo` with two spaces — it'd be
+        // skipped at the outer loop and `name` key assertion fails; M2 swap
+        // `- eli5` for `  eli5` (no dash) — list terminates empty and
+        // aliases-assertion fails; M3 drop closing `---` — parse returns nil.
+    }
+
+    func test_parse_listBlockStyle_inconsistentIndent_rejected() {
+        let doc = """
+        ---
+        name: foo
+        description: bar
+        aliases:
+          - eli5
+            - simple
+        ---
+        """
+        // The existing parser returns nil for malformed flow lists; the block
+        // path matches that behaviour rather than silently dropping the key.
+        XCTAssertNil(SkillFrontmatterParser.parse(doc))
+        // Sabotage-evidence: M1 normalise both items to two-space indent →
+        // parse succeeds and the nil assert fails; M2 remove the second item
+        // entirely → single-item list parses fine; M3 strip closing `---` →
+        // still nil but for the fence reason (acceptable).
+    }
+
+    func test_parse_listBlockStyle_commentLinesSkipped() {
+        let doc = """
+        ---
+        name: foo
+        description: bar
+        aliases:
+          # leading comment
+          - eli5
+          # mid comment
+          - simple
+        ---
+        """
+        guard let parsed = SkillFrontmatterParser.parse(doc) else {
+            return XCTFail("Expected valid parse")
+        }
+        XCTAssertEqual(parsed.fields["aliases"], .list(["eli5", "simple"]))
+    }
+
+    func test_parse_listBlockStyle_quotedItem_unquoted() {
+        // Block items mirror the flow-list behaviour around matched quotes so
+        // values with commas or leading whitespace round-trip cleanly.
+        let doc = """
+        ---
+        name: x
+        description: x
+        aliases:
+          - "with, comma"
+          - 'single quoted'
+        ---
+        """
+        guard let parsed = SkillFrontmatterParser.parse(doc) else {
+            return XCTFail("Expected valid parse")
+        }
+        XCTAssertEqual(parsed.fields["aliases"], .list(["with, comma", "single quoted"]))
+    }
+
     func test_parse_quotedString_unescapesQuotes() {
         let doc = """
         ---


### PR DESCRIPTION
## Summary

Closes a v1 limitation surfaced during Wave 3B: `SkillFrontmatterParser` only handled flow-style `aliases: [eli5]`, silently rejecting the more common block style. Now both work.

- Block-style lists parse: `aliases:\n  - eli5\n  - simple` → `["eli5", "simple"]`
- Stop at next top-level key or end-of-frontmatter
- Comments inside lists skipped
- Empty block lists → `[]`
- Quoted items (`- "with, comma"`) round-trip like the flow path
- Inconsistent indents inside a block list fail the whole document (matches existing "malformed flow list → nil" behaviour)

## Test plan

- [x] 7 new `YAMLFrontmatterTests` cases (block-style happy paths + termination + comments + empty + inconsistent-indent + quoted items)
- [x] Bundled-SKILL smoke test in `SkillLoaderTests.test_discover_blockStyleAliases_roundTrip` verifies end-to-end `SkillLoader` path
- [x] Sabotage-evidence on the new tests
- [x] `SilentCatchAuditTest` passes
- [x] `Package.resolved` untouched

Generated with Claude Code

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>