### PR TITLE
feat(runtime): widen ManifoldBootstrap + per-scenario rebind

### DIFF
--- a/Example/Advanced/DemoContentView.swift
+++ b/Example/Advanced/DemoContentView.swift
@@ -52,6 +52,14 @@ struct DemoContentView: View {
     /// step (the demo still runs, just without per-agent rendering).
     var sessionStore: (any SessionStore)?
 
+    /// The live ``ConversationRuntime`` the demo built at app init. The
+    /// scenario runner rebinds the runtime's per-session knobs
+    /// (``ConversationRuntime/updateSessionToolSources(_:)`` /
+    /// ``ConversationRuntime/updateHookRegistry(_:)``) per scenario card
+    /// rather than rebuilding the runtime — same instance, swapped
+    /// bindings.
+    var conversationRuntime: ConversationRuntime?
+
     /// Buffer holding any ``InboundPayload`` that arrived during the
     /// cold-launch window, before the runtime finished bootstrapping.
     /// Drained once the mounted view can safely hand off to `ChatViewModel`.
@@ -419,7 +427,8 @@ struct DemoContentView: View {
                 sessions: sessionManager,
                 registry: toolRegistry,
                 sandboxRoot: sandboxRoot,
-                sessionStore: sessionStore
+                sessionStore: sessionStore,
+                conversationRuntime: conversationRuntime
             )
         }
     }

--- a/Example/Advanced/ManifoldDemoApp.swift
+++ b/Example/Advanced/ManifoldDemoApp.swift
@@ -219,6 +219,7 @@ struct ManifoldDemoApp: App {
                         sandboxRoot: sandboxRoot,
                         ragService: runtime.ragService,
                         sessionStore: runtime.persistence,
+                        conversationRuntime: runtime.conversationRuntime,
                         pendingPayloadBuffer: pendingPayloadBuffer,
                         pendingDemoScenarioID: pendingDemoScenarioID
                     )

--- a/Example/Advanced/Scenarios/DemoScenarioRunner.swift
+++ b/Example/Advanced/Scenarios/DemoScenarioRunner.swift
@@ -30,14 +30,24 @@ enum DemoScenarioRunner {
     /// 5. If `sessionStore` is supplied AND the scenario populated
     ///    `agents`/`activeAgentID`, persist them onto the session record
     ///    before the first prompt is sent.
-    /// 6. Prefill the composer and, when `autoSend` is true, send.
+    /// 6. If `conversationRuntime` is supplied, rebind its
+    ///    `sessionToolSources` + `hookRegistry` to whatever the scenario
+    ///    populated. The runtime is built once at app init via
+    ///    `ManifoldBootstrap`, so per-scenario knobs flow through the
+    ///    `update*` mutators on the live instance — see
+    ///    `ConversationRuntime.updateSessionToolSources(_:)`. The previous
+    ///    scenario's bindings are cleared on every call (empty sources,
+    ///    `nil` registry) before the new scenario's are applied, so a
+    ///    scenario that opts out of either surface starts clean.
+    /// 7. Prefill the composer and, when `autoSend` is true, send.
     static func run(
         _ scenario: DemoScenario,
         chat: ChatViewModel,
         sessions: SessionManagerViewModel,
         registry: ToolRegistry,
         sandboxRoot: URL,
-        sessionStore: (any SessionStore)? = nil
+        sessionStore: (any SessionStore)? = nil,
+        conversationRuntime: ConversationRuntime? = nil
     ) async {
         guard !chat.isGenerating else { return }
 
@@ -79,6 +89,16 @@ enum DemoScenarioRunner {
         } catch {
             chat.errorMessage = "Failed to start scenario: \(error.localizedDescription)"
             return
+        }
+
+        // Bind the per-scenario `sessionToolSources` + `hookRegistry` onto
+        // the live runtime. Always overwrite — a previous scenario that
+        // installed e.g. a HandoffToolSource must not bleed into the next
+        // card. The runtime's executor reads bindings at the top of every
+        // turn, so this takes effect on the prompt we're about to send.
+        if let conversationRuntime {
+            await conversationRuntime.updateSessionToolSources(context.sessionToolSources)
+            await conversationRuntime.updateHookRegistry(context.hookRegistry)
         }
 
         chat.systemPrompt = scenario.systemPrompt

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -139,6 +139,8 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil,
         makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
     ) throws {
         // Capture the previous configuration before any mutation so a failure
@@ -200,7 +202,9 @@ public final class ManifoldBootstrap {
                 sessionStore: resolvedPersistence,
                 inferenceService: resolvedInferenceService,
                 ragService: resolvedRAGService,
-                usageStore: resolvedUsageStore
+                usageStore: resolvedUsageStore,
+                sessionToolSources: sessionToolSources,
+                hookRegistry: hookRegistry
             )
             self.imageGenerationService = imageGenerationService
             if let imageGenerationService {
@@ -227,7 +231,9 @@ public final class ManifoldBootstrap {
         endpointStore: SwiftDataEndpointStore,
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
-        ragService: RAGService? = nil
+        ragService: RAGService? = nil,
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
     ) {
         self.inferenceService = inferenceService
         self.diagnostics = diagnostics
@@ -243,7 +249,9 @@ public final class ManifoldBootstrap {
             sessionStore: persistence,
             inferenceService: inferenceService,
             ragService: ragService,
-            usageStore: usageStore
+            usageStore: usageStore,
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry
         )
         self.imageGenerationService = imageGenerationService
         if let imageGenerationService {
@@ -261,6 +269,8 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil,
         makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
     ) -> (progress: AsyncStream<RuntimeBootstrapMilestone>, task: Task<ManifoldBootstrap, any Error>) {
         let (stream, continuation) = AsyncStream.makeStream(
@@ -305,7 +315,9 @@ public final class ManifoldBootstrap {
                     benchmarkCache: benchmarkCache,
                     endpointStore: endpointStore,
                     usageStore: usageStore,
-                    imageGenerationService: imageGenerationService
+                    imageGenerationService: imageGenerationService,
+                    sessionToolSources: sessionToolSources,
+                    hookRegistry: hookRegistry
                 )
             } catch {
                 ManifoldConfiguration.shared = previousConfiguration

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -66,6 +66,12 @@ public final class ConversationRuntime: Sendable {
 
     private let executor: ConversationTurnExecutor
 
+    /// Host-mutable holder for the per-session knobs the executor reads at
+    /// the top of each turn. Exposed through the `update*` mutators below
+    /// so a host that built the runtime once at app init can swap context
+    /// per scenario card / per agent flow without rebuilding.
+    private let bindings: RuntimeBindingsBox
+
     // MARK: Event stream
 
     /// Lifecycle event stream. Single-consumer by design — see the type
@@ -211,6 +217,11 @@ public final class ConversationRuntime: Sendable {
         self.events = AsyncStream(bufferingPolicy: .bufferingOldest(500)) { cap = $0 }
         let continuation = cap!
         self.continuation = continuation
+        let bindings = RuntimeBindingsBox(
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry
+        )
+        self.bindings = bindings
         self.executor = ConversationTurnExecutor(
             persistence: persistence,
             inferenceService: inferenceService,
@@ -226,9 +237,30 @@ public final class ConversationRuntime: Sendable {
             hookTimeout: hookTimeout,
             historyProviders: historyProviders,
             turnContextProvider: turnContextProvider,
-            sessionToolSources: sessionToolSources,
-            hookRegistry: hookRegistry
+            bindings: bindings
         )
+    }
+
+    // MARK: Host-mutable bindings
+
+    /// Replaces the per-session tool contributors used by subsequent turns.
+    ///
+    /// Used by host-app scenario machinery (e.g. the demo's per-card
+    /// runtime swap) that builds the runtime once at app init and then
+    /// needs to swap which sources are advertised on each turn. The
+    /// executor re-reads bindings at the top of every send turn, so the
+    /// new sources take effect on the next turn without an executor
+    /// rebuild. In-flight streams are not reconfigured — cancel and
+    /// resend if mid-stream rebind is required.
+    public func updateSessionToolSources(_ sources: [any SessionToolSource]) async {
+        await bindings.updateSessionToolSources(sources)
+    }
+
+    /// Replaces the ``HookRegistry`` used by subsequent turns. Pass `nil`
+    /// to detach hooks. Same per-turn rebind semantics as
+    /// ``updateSessionToolSources(_:)``.
+    public func updateHookRegistry(_ registry: HookRegistry?) async {
+        await bindings.updateHookRegistry(registry)
     }
 
     deinit {

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -21,16 +21,14 @@ struct ConversationTurnExecutor: Sendable {
     /// ``TurnContext/appData`` and forwarded to ``CompletedTurn/appData`` so
     /// ``GenerationHook`` implementations receive it without a side-channel.
     private let turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?
-    /// Per-session tool contributors. Threaded through from
-    /// `ConversationRuntime.init`; consumed in `readAdvertisedToolDefinitions()`
-    /// in Wave 2 (W2A/W2B). Storing it now keeps the public/package inits
-    /// source-compatible across the wave boundary.
-    private let sessionToolSources: [any SessionToolSource]
-    /// Optional ``HookRegistry`` wired in by ``ConversationRuntime``. When
-    /// non-nil the executor (W2C) installs a ``PreToolUseHookAdapter`` on
-    /// the inference service and invokes the registry's ``HookEvent/preCompact``
-    /// chain before ``CompressionPolicy/compress(history:sessionID:generate:)``.
-    private let hookRegistry: HookRegistry?
+    /// Mutable holder for `sessionToolSources` + `hookRegistry`. The executor
+    /// reads a snapshot once per turn (top of the send loop) so a host call
+    /// to ``ConversationRuntime/updateSessionToolSources(_:)`` /
+    /// ``ConversationRuntime/updateHookRegistry(_:)`` made between turns
+    /// takes effect on the next turn without rebuilding the runtime. See
+    /// ``RuntimeBindingsBox`` for the rationale (host-app demo swaps per
+    /// scenario card; full runtime rebuild would be overkill).
+    private let bindings: RuntimeBindingsBox
 
     init(
         persistence: ConversationPersistencePort,
@@ -47,8 +45,7 @@ struct ConversationTurnExecutor: Sendable {
         hookTimeout: Duration = .seconds(30),
         historyProviders: [any HistoryProvider] = [],
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
-        sessionToolSources: [any SessionToolSource] = [],
-        hookRegistry: HookRegistry? = nil
+        bindings: RuntimeBindingsBox
     ) {
         self.persistence = persistence
         self.inferenceService = inferenceService
@@ -64,8 +61,7 @@ struct ConversationTurnExecutor: Sendable {
         self.hookTimeout = hookTimeout
         self.historyAssembler = HistoryAssembler(providers: historyProviders)
         self.turnContextProvider = turnContextProvider
-        self.sessionToolSources = sessionToolSources
-        self.hookRegistry = hookRegistry
+        self.bindings = bindings
     }
 
     // MARK: Send flow
@@ -538,6 +534,14 @@ struct ConversationTurnExecutor: Sendable {
         // flows or hosts without a SessionStore wired in; both paths are
         // identical to the legacy single-agent surface.
         var sessionRecord: ChatSessionRecord? = await persistence.fetchSession(sessionID: sessionID)
+
+        // Snapshot the host-mutable bindings once per turn. A
+        // `ConversationRuntime.updateSessionToolSources(_:)` /
+        // `updateHookRegistry(_:)` call concurrent with this turn takes
+        // effect on the *next* turn — deliberately, so a long in-flight
+        // generation isn't reconfigured mid-stream.
+        let (turnSessionToolSources, turnHookRegistry) = await bindings.snapshot()
+
         let activeAgent: Agent? = {
             guard let sessionRecord, let activeID = sessionRecord.activeAgentID else { return nil }
             return sessionRecord.agents.first(where: { $0.id == activeID })
@@ -571,10 +575,10 @@ struct ConversationTurnExecutor: Sendable {
         // adapt the registry into the closure shape the dispatch loop
         // accepts. The adapter enforces the sanitize-only invariant and
         // emits `.hookFired(event: "preToolUse", ...)` on every call.
-        if let hookRegistry {
+        if let turnHookRegistry {
             let emit = self.eventSink
             let adapter = PreToolUseHookAdapter.make(
-                registry: hookRegistry,
+                registry: turnHookRegistry,
                 eventEmitter: { event in emit(event) }
             )
             await inferenceService.setPreToolUseHook(adapter)
@@ -662,7 +666,10 @@ struct ConversationTurnExecutor: Sendable {
         // tool but limiting which names go on the wire works without
         // unregistering the executor. Fetched on the main actor because the
         // registry and InferenceService accessors are both MainActor-isolated.
-        let advertisedTools: [ToolDefinition] = await readAdvertisedToolDefinitions()
+        let advertisedTools: [ToolDefinition] = await readAdvertisedToolDefinitions(
+            sessionToolSources: turnSessionToolSources,
+            sessionRecord: sessionRecord
+        )
 
         let token: InferenceService.GenerationRequestToken
         let stream: GenerationStream
@@ -1079,14 +1086,14 @@ struct ConversationTurnExecutor: Sendable {
                 // hook that returns block:true logs a warning but compression
                 // still runs. Emit `.hookFired(event: "preCompact", ...)`
                 // regardless so observability stays consistent.
-                if let hookRegistry {
+                if let turnHookRegistry {
                     let input = HookInput(
                         event: .preCompact,
                         sessionID: sessionID,
                         toolName: nil,
                         toolArguments: nil
                     )
-                    let output = await hookRegistry.run(input)
+                    let output = await turnHookRegistry.run(input)
                     emit(.hookFired(event: "preCompact", sessionID: sessionID))
                     if output.block {
                         Log.inference.warning(
@@ -1192,24 +1199,70 @@ struct ConversationTurnExecutor: Sendable {
         return await registry.isCancelled(handle)
     }
 
-    @MainActor
-    private func readAdvertisedToolDefinitions() async -> [ToolDefinition] {
-        // TODO(W2A/W2B): fold `sessionToolSources` into the advertised list —
-        // union the per-session `toolDefinitions(for:)` with the registry's
-        // and intersect with each source's `allowedToolNames(for:)` (Skills
-        // allowed-tools enforcement). Per-session ChatSessionRecord lookup
-        // moves here from the call site.
-        guard let registry = inferenceService.toolRegistry else { return [] }
-        let definitions = registry.advertisedDefinitions
+    private func readAdvertisedToolDefinitions(
+        sessionToolSources: [any SessionToolSource],
+        sessionRecord: ChatSessionRecord?
+    ) async -> [ToolDefinition] {
+        // Base registry definitions — host-installed tools the executor
+        // already advertises today. Read from MainActor.
+        let registryDefinitions: [ToolDefinition] = await MainActor.run {
+            inferenceService.toolRegistry?.advertisedDefinitions ?? []
+        }
+
+        // Per-session source contributions. Each source's
+        // `toolDefinitions(for:)` returns the definitions it owns for this
+        // session — e.g. ``HandoffToolSource`` synthesising one
+        // `transfer_to_<name>` per non-active agent. Skipped when we don't
+        // have a session record to scope the query.
+        var sourceDefinitions: [ToolDefinition] = []
+        if let sessionRecord {
+            for source in sessionToolSources {
+                let defs = await source.toolDefinitions(for: sessionRecord)
+                sourceDefinitions.append(contentsOf: defs)
+            }
+        }
+
+        // Union — sources can override the registry's view of a tool of
+        // the same name by appearing later, but in practice the namespaces
+        // don't overlap (registry: bespoke executors; sources: synthesised
+        // tools). De-dupe by name to keep the wire shape stable.
+        var unioned: [ToolDefinition] = registryDefinitions
+        var seen = Set(registryDefinitions.map(\.name))
+        for def in sourceDefinitions where !seen.contains(def.name) {
+            unioned.append(def)
+            seen.insert(def.name)
+        }
+
+        // Apply allowed-tools intersection across sources. A `nil` return
+        // from `allowedToolNames(for:)` means "no restriction" — only
+        // non-nil sets participate in the intersection. Skills uses this
+        // to clamp the model's tool surface while a skill is active.
+        if let sessionRecord {
+            var allowList: Set<String>? = nil
+            for source in sessionToolSources {
+                if let allowed = await source.allowedToolNames(for: sessionRecord) {
+                    if let current = allowList {
+                        allowList = current.intersection(allowed)
+                    } else {
+                        allowList = allowed
+                    }
+                }
+            }
+            if let allowList {
+                unioned = unioned.filter { allowList.contains($0.name) }
+            }
+        }
+
         // When the active backend declares a hard cap on how many tools it can
         // handle per turn, truncate the list before building the GenerationConfig.
         // The definitions are already sorted alphabetically by ToolRegistry, so
         // `prefix` always picks the same lexicographically-first N tools —
         // deterministic ordering keeps the "X of Y tools enabled" UI stable.
-        if let cap = inferenceService.capabilities?.maxAdvertisedToolCount, definitions.count > cap {
-            return Array(definitions.prefix(cap))
+        let cap = await MainActor.run { inferenceService.capabilities?.maxAdvertisedToolCount }
+        if let cap, unioned.count > cap {
+            return Array(unioned.prefix(cap))
         }
-        return definitions
+        return unioned
     }
 
     @MainActor

--- a/Sources/ManifoldRuntime/Services/RuntimeBindingsBox.swift
+++ b/Sources/ManifoldRuntime/Services/RuntimeBindingsBox.swift
@@ -1,0 +1,48 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - RuntimeBindingsBox
+//
+// Mutable holder for per-session knobs that the host wants to swap on a live
+// `ConversationRuntime` instance without rebuilding the runtime.
+//
+// Today this covers two surfaces:
+//   - `sessionToolSources`: the per-session tool contributors folded into the
+//     advertised tool list each turn (Skills, handoff).
+//   - `hookRegistry`: the registry consulted for `preToolUse` sanitisation and
+//     the observational `preCompact` event.
+//
+// `ConversationRuntime` is `Sendable` and its executor is a `struct` with
+// `let` fields — neither can hold mutable state directly. The box is an
+// actor (same pattern as ``InFlightStreamRegistry``) so the executor's
+// per-turn reads serialise cleanly with the host's mutator calls, no lock
+// required.
+//
+// Bindings are read once per turn at the top of the send loop, so an
+// update applied between turns takes effect on the next turn without
+// touching an in-flight stream. Hosts that need mid-stream rebind would
+// have to cancel and restart — that's deliberate.
+actor RuntimeBindingsBox {
+    private var sessionToolSources: [any SessionToolSource]
+    private var hookRegistry: HookRegistry?
+
+    init(
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
+    ) {
+        self.sessionToolSources = sessionToolSources
+        self.hookRegistry = hookRegistry
+    }
+
+    func snapshot() -> (sources: [any SessionToolSource], hooks: HookRegistry?) {
+        (sessionToolSources, hookRegistry)
+    }
+
+    func updateSessionToolSources(_ sources: [any SessionToolSource]) {
+        sessionToolSources = sources
+    }
+
+    func updateHookRegistry(_ registry: HookRegistry?) {
+        hookRegistry = registry
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeRebindTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeRebindTests.swift
@@ -1,0 +1,387 @@
+import XCTest
+import ManifoldInference
+import ManifoldTestSupport
+@testable import ManifoldRuntime
+
+/// Exercises the per-turn rebind path: a host that built the runtime once
+/// at app init can swap `sessionToolSources` / `hookRegistry` via the
+/// `update*` mutators and the change takes effect on the *next* turn.
+///
+/// Closes the W3B/W4 deferral: the demo app's `DemoScenarioRunner` calls
+/// these mutators before kicking off a scenario's prompt, swapping context
+/// per scenario card without rebuilding the runtime.
+@MainActor
+final class ConversationRuntimeRebindTests: XCTestCase {
+
+    // MARK: - Stores (shared shape with HandoffScenarioTests)
+
+    final class InMemoryMessageStore: MessageStore {
+        var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+        }
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+        func deleteMessage(_ messageID: UUID) async throws { messages.removeValue(forKey: messageID) }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values.filter { $0.sessionID == sessionID }.sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) { hooks.append(hook) }
+    }
+
+    final class InMemorySessionStore: SessionStore {
+        var sessions: [UUID: ChatSessionRecord] = [:]
+        func insertSession(_ session: ChatSessionRecord) async throws { sessions[session.id] = session }
+        func updateSession(_ session: ChatSessionRecord) async throws { sessions[session.id] = session }
+        func deleteSession(_ sessionID: UUID) async throws { sessions.removeValue(forKey: sessionID) }
+        func deleteAll() async throws { sessions.removeAll() }
+        func fetchSessions() async throws -> [ChatSessionRecord] {
+            sessions.values.sorted { $0.updatedAt > $1.updatedAt }
+        }
+        func addPostWriteHook(_ hook: any SessionStorePostWriteHook) {}
+    }
+
+    // MARK: - Fixtures
+
+    /// Minimal `SessionToolSource` that surfaces a single fixed tool. Used
+    /// to assert the executor's per-turn snapshot folds the source's
+    /// contributions into the advertised list when bindings are populated,
+    /// and drops them when the binding is cleared.
+    struct StubToolSource: SessionToolSource {
+        let toolName: String
+        func toolDefinitions(for session: ChatSessionRecord) async -> [ToolDefinition] {
+            [ToolDefinition(name: toolName, description: "stub", parameters: .object([:]))]
+        }
+        func resolve(toolName: String, arguments: String, session: ChatSessionRecord) async throws -> ToolResult {
+            ToolResult(callId: "", content: "")
+        }
+    }
+
+    private struct Fixture {
+        let runtime: ConversationRuntime
+        let mock: MockInferenceBackend
+        let messageStore: InMemoryMessageStore
+        let sessionStore: InMemorySessionStore
+        let sessionID: UUID
+    }
+
+    private func makeFixture(
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
+    ) async throws -> Fixture {
+        // Tool-capable capabilities: the executor's union of registry +
+        // sessionToolSources can produce a non-empty `tools` list, and
+        // `GenerationQueue.enqueue` throws if `tools.isEmpty == false`
+        // while the backend reports `supportsToolCalling == false`. The
+        // rebind path is a no-op on a backend that can't carry tools.
+        let mock = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        ))
+        mock.isModelLoaded = true
+        // Yield a single token per turn so the executor runs the happy
+        // path (assistant message persisted) rather than the empty-response
+        // drop path — the drop branch still emits streamFinished but
+        // observability is cleaner when we keep both turns symmetric.
+        mock.tokensToYield = ["ok"]
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let messageStore = InMemoryMessageStore()
+        let sessionStore = InMemorySessionStore()
+        let runtime = ConversationRuntime(
+            messageStore: messageStore,
+            sessionStore: sessionStore,
+            inferenceService: inference,
+            pipeline: nil,
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry
+        )
+        let sessionID = UUID()
+        try await sessionStore.insertSession(
+            ChatSessionRecord(id: sessionID, title: "Rebind")
+        )
+        return Fixture(
+            runtime: runtime,
+            mock: mock,
+            messageStore: messageStore,
+            sessionStore: sessionStore,
+            sessionID: sessionID
+        )
+    }
+
+    /// Collects events until either `.streamFinished` fires or the deadline
+    /// elapses. Mirrors the helper in ``HandoffScenarioTests`` so the two
+    /// suites stay shape-compatible.
+    private func collectUntilStreamFinished(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        let task = Task {
+            var collected: [ConversationEvent] = []
+            for await event in runtime.events {
+                collected.append(event)
+                if case .streamFinished = event { return collected }
+            }
+            return collected
+        }
+        return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw CocoaError(.userCancelled)
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    /// Polls the bag until at least `atLeast` `.streamFinished` events have
+    /// been observed. Used by `test_updateHookRegistry_takesEffectOnNextTurn`
+    /// to demarcate turn boundaries on a single shared event collector.
+    private func waitForStreamFinishedCount(
+        _ bag: EventBag,
+        atLeast target: Int,
+        deadline: Duration
+    ) async throws {
+        let start = ContinuousClock().now
+        while ContinuousClock().now - start < deadline {
+            let count = await bag.snapshot().reduce(into: 0) { acc, event in
+                if case .streamFinished = event { acc += 1 }
+            }
+            if count >= target { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("waitForStreamFinishedCount: did not observe \(target) streamFinished events within \(deadline)")
+    }
+
+    /// Hoisted out so multiple tests can share the type. Re-declared here
+    /// because nested actor types can't be referenced outside their enclosing
+    /// function in Swift today.
+    actor EventBag {
+        var events: [ConversationEvent] = []
+        func append(_ e: ConversationEvent) { events.append(e) }
+        func snapshot() -> [ConversationEvent] { events }
+    }
+
+    // MARK: - Tests
+
+    /// Turn 1 with no sources advertises nothing. After
+    /// `updateSessionToolSources` installs a source, turn 2 advertises its
+    /// tool. The point of the test is the *rebind*, not the wiring of
+    /// sources at init time.
+    func test_updateSessionToolSources_takesEffectOnNextTurn() async throws {
+        let fx = try await makeFixture()
+
+        // Turn 1: no sources installed.
+        _ = try await fx.runtime.processTurn(
+            TurnInput(sessionID: fx.sessionID, kind: .send(text: "hi"))
+        )
+        _ = try await collectUntilStreamFinished(from: fx.runtime)
+        let turn1Tools = fx.mock.lastConfig?.tools ?? []
+        XCTAssertFalse(
+            turn1Tools.contains(where: { $0.name == "fixture_tool" }),
+            "fixture_tool must not appear before updateSessionToolSources is called"
+        )
+
+        // Rebind: install a source that advertises `fixture_tool`.
+        await fx.runtime.updateSessionToolSources([StubToolSource(toolName: "fixture_tool")])
+
+        // Turn 2: the executor snapshots bindings at the top of the turn,
+        // so the new source must be advertised on this send.
+        _ = try await fx.runtime.processTurn(
+            TurnInput(sessionID: fx.sessionID, kind: .send(text: "hi again"))
+        )
+        _ = try await collectUntilStreamFinished(from: fx.runtime)
+        let turn2Tools = fx.mock.lastConfig?.tools ?? []
+        XCTAssertTrue(
+            turn2Tools.contains(where: { $0.name == "fixture_tool" }),
+            "fixture_tool must be advertised after updateSessionToolSources rebind; got: \(turn2Tools.map(\.name))"
+        )
+        // Sabotage-evidence: M1 stub `updateSessionToolSources` to a no-op
+        //   → turn2 advertised list stays empty; XCTAssertTrue trips.
+        // Sabotage-evidence: M2 read bindings ONCE at init in the executor
+        //   (revert to `let sessionToolSources`) → same trip.
+        // Sabotage-evidence: M3 return [] from `readAdvertisedToolDefinitions`'s
+        //   source branch → same trip.
+    }
+
+    /// Passing `[]` to `updateSessionToolSources` after a non-empty bind
+    /// must clear the previous advertisement. Resets between demo
+    /// scenarios rely on this.
+    func test_updateSessionToolSources_nil_resetsToEmpty() async throws {
+        let fx = try await makeFixture(
+            sessionToolSources: [StubToolSource(toolName: "fixture_tool")]
+        )
+
+        // Turn 1: source installed at init — tool should be advertised.
+        _ = try await fx.runtime.processTurn(
+            TurnInput(sessionID: fx.sessionID, kind: .send(text: "hi"))
+        )
+        _ = try await collectUntilStreamFinished(from: fx.runtime)
+        XCTAssertTrue(
+            (fx.mock.lastConfig?.tools ?? []).contains(where: { $0.name == "fixture_tool" }),
+            "precondition: turn 1 should advertise the init-time source's tool"
+        )
+
+        // Clear sources.
+        await fx.runtime.updateSessionToolSources([])
+
+        // Turn 2: nothing advertised.
+        _ = try await fx.runtime.processTurn(
+            TurnInput(sessionID: fx.sessionID, kind: .send(text: "hi again"))
+        )
+        _ = try await collectUntilStreamFinished(from: fx.runtime)
+        XCTAssertFalse(
+            (fx.mock.lastConfig?.tools ?? []).contains(where: { $0.name == "fixture_tool" }),
+            "after updateSessionToolSources([]), no source-contributed tools should remain"
+        )
+        // Sabotage-evidence: M1 make `updateSessionToolSources` append rather
+        //   than replace → turn2 still advertises fixture_tool; XCTAssertFalse trips.
+        // Sabotage-evidence: M2 cache the initial sources in the executor and
+        //   ignore the box snapshot → same trip.
+    }
+
+    /// Installing a `HookRegistry` with a registered `.preToolUse` handler
+    /// must be visible on the next turn. We assert via
+    /// `ConversationEvent.hookFired(event: "preToolUse", ...)`: the
+    /// `PreToolUseHookAdapter` emits that event on every dispatch, so
+    /// triggering a tool call after the rebind proves the new registry is
+    /// wired.
+    ///
+    /// The handler itself is a passthrough — we're testing the binding,
+    /// not the sanitiser shape.
+    func test_updateHookRegistry_takesEffectOnNextTurn() async throws {
+        // Use a real `ToolRegistry` with an executor registered so the
+        // dispatch loop actually fires the preToolUse adapter. Without a
+        // matching executor the dispatch loop short-circuits before the
+        // adapter runs, and we can't observe hookFired downstream.
+        let echoExecutor = TypedToolExecutor<EchoArgs, EchoArgs>(
+            definition: ToolDefinition(
+                name: "echo_tool",
+                description: "echoes args",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([:])
+                ])
+            ),
+            handler: { args in args }
+        )
+        let toolRegistry = ToolRegistry(tools: [echoExecutor])
+
+        let mock = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        ))
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["ok"]
+        // Schedule the mock to drive both user turns:
+        //   - user-turn 1: generate() → no tool calls, tokens ["ok"]
+        //   - user-turn 2: generate() #1 → ONE tool call, no tokens
+        //                  generate() #2 (post-dispatch) → no tool calls, tokens ["ok"]
+        // scriptedToolCallsPerTurn pops once per generate() call; the same
+        // applies to tokensToYieldPerTurn. The three entries below cover
+        // the three generate() invocations across the two user turns.
+        mock.scriptedToolCallsPerTurn = [
+            [], // user-turn 1
+            [ToolCall(id: "tc-1", toolName: "echo_tool", arguments: "{}")], // user-turn 2, first generate()
+            [] // user-turn 2, post-dispatch generate()
+        ]
+        mock.tokensToYieldPerTurn = [["ok"], [], ["ok"]]
+
+        let inference = InferenceService(backend: mock, name: "Mock", toolRegistry: toolRegistry)
+        let messageStore = InMemoryMessageStore()
+        let sessionStore = InMemorySessionStore()
+        let runtime = ConversationRuntime(
+            messageStore: messageStore,
+            sessionStore: sessionStore,
+            inferenceService: inference,
+            pipeline: nil
+        )
+        let sessionID = UUID()
+        try await sessionStore.insertSession(ChatSessionRecord(id: sessionID, title: "Hook"))
+
+        // Single long-running collector across both turns. `runtime.events`
+        // is single-consumer — creating a second `for await` over it after
+        // the first has consumed .streamFinished does not reliably observe
+        // subsequent turn events. Drain on one task and demarcate turns
+        // ourselves.
+        let bag = EventBag()
+        let drain = Task.detached {
+            for await event in runtime.events {
+                await bag.append(event)
+            }
+        }
+        defer { drain.cancel() }
+
+        // Turn 1: no hook registry installed.
+        let h1 = try await runtime.processTurn(
+            TurnInput(sessionID: sessionID, kind: .send(text: "go"))
+        )
+        _ = h1
+        // Spin until we observe turn 1's terminal streamFinished.
+        try await waitForStreamFinishedCount(bag, atLeast: 1, deadline: .seconds(5))
+        let turn1Events = await bag.snapshot()
+        XCTAssertFalse(
+            turn1Events.contains(where: {
+                if case .hookFired(let name, _) = $0 { return name == "preToolUse" } else { return false }
+            }),
+            "preToolUse hookFired must not appear before updateHookRegistry is called"
+        )
+
+        // Install a passthrough registry.
+        let hookRegistry = HookRegistry()
+        await hookRegistry.register(.preToolUse) { _ in .passthrough }
+        await runtime.updateHookRegistry(hookRegistry)
+
+        // Turn 2: the dispatch loop must run through the new adapter.
+        _ = try await runtime.processTurn(
+            TurnInput(sessionID: sessionID, kind: .send(text: "go again"))
+        )
+        try await waitForStreamFinishedCount(bag, atLeast: 2, deadline: .seconds(5))
+        let turn2Events = await bag.snapshot()
+        // Filter to events emitted AFTER turn 1's first streamFinished —
+        // events accumulate across turns; we only assert about turn 2.
+        var seenFirstFinish = false
+        let postTurn1: [ConversationEvent] = turn2Events.compactMap { event in
+            if seenFirstFinish { return event }
+            if case .streamFinished = event { seenFirstFinish = true }
+            return nil
+        }
+        XCTAssertTrue(
+            postTurn1.contains(where: {
+                if case .hookFired(let name, _) = $0 { return name == "preToolUse" } else { return false }
+            }),
+            "preToolUse hookFired must appear after updateHookRegistry rebind; turn2-only events: \(postTurn1.map { String(describing: $0) })"
+        )
+        // Sabotage-evidence: M1 stub `updateHookRegistry` to a no-op
+        //   → turn2 emits no preToolUse hookFired; XCTAssertTrue trips.
+        // Sabotage-evidence: M2 revert the executor's hookRegistry read to a
+        //   one-shot init capture → same trip.
+    }
+
+    /// Argument type for the echo executor used in
+    /// `test_updateHookRegistry_takesEffectOnNextTurn`. Reflexive
+    /// `Codable` over an empty payload so the dispatch loop can pass JSON
+    /// `{}` through unchanged.
+    struct EchoArgs: Codable, Sendable {}
+
+}


### PR DESCRIPTION
## Summary

Closes the W3B/W4 deferral. The new demo cards (`skill-explain`, `handoff-research-write`, `hook-input-sanitize`) now actually drive the live runtime through the Wave 2 surfaces — before this PR, `DemoScenarioRuntimeContext.sessionToolSources` / `hookRegistry` were populated but never bound to the `ConversationRuntime` the demo app built at init time.

- `ManifoldBootstrap.init / .build (... sessionToolSources:, hookRegistry:)` — additive parameters with defaults; threaded to `ConversationRuntime`.
- `ConversationRuntime.updateSessionToolSources(_:)` + `updateHookRegistry(_:)` — public mutators that take effect on the next turn (the executor snapshots a per-turn copy via a new `RuntimeBindingsBox` actor — same pattern as `InFlightStreamRegistry`).
- `ConversationTurnExecutor.readAdvertisedToolDefinitions` now folds per-session source contributions into the advertised list and applies the allowed-tool-name intersection (closes the W2A/W2B TODO).
- `DemoScenarioRunner` swaps context per scenario card via the mutators and resets to empty between scenarios.

### Design choice — Option A vs B

Picked Option A (mutator on the live runtime) over Option B (rebuild the runtime per scenario). The host builds the runtime once at app init; per-scenario rebuilds would force an ill-defined cutover on in-flight streams. The executor's existing per-turn re-evaluation gives us the seam for free.

## Test plan

- [x] New `ConversationRuntimeRebindTests` (3 tests) exercise the rebind path with `MockInferenceBackend` — sources, nil-reset, and the hook-adapter path
- [x] Existing `HandoffScenarioTests` still pass (3 tests)
- [x] Full `ManifoldRuntimeTests` suite still passes (369 tests)
- [x] `SilentCatchAuditTest` passes
- [x] Sabotage-evidence verified locally on every new test (broken-state never committed)
- [x] Package.resolved untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>