### PR TITLE
feat(ui): expose SessionManagerViewModel from quickStart() and await initial session load

### DIFF
--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -42,17 +42,19 @@ public enum ManifoldKit {
     ///
     /// ```swift
     /// let kit = try await ManifoldKit.quickStart()
-    /// // kit.viewModel — a configured ChatViewModel
-    /// // kit.bootstrap — keep alive for the lifetime of the app
+    /// // kit.viewModel      — a configured ChatViewModel
+    /// // kit.sessionManager — sessions already loaded; wire to a sidebar list
+    /// // kit.bootstrap      — keep alive for the lifetime of the app
     /// ```
     ///
     /// - Parameter configuration: The framework configuration. Defaults to
     ///   ``ManifoldInference/ManifoldConfiguration/default`` — fine for
     ///   demos and tests, but production apps should pass an explicit
     ///   configuration with their own bundle identifier.
-    /// - Returns: A ``QuickStartResult`` carrying both the bootstrap and the
-    ///   view model. The caller owns the bootstrap and must retain it for
-    ///   the lifetime of the chat runtime.
+    /// - Returns: A ``QuickStartResult`` carrying the bootstrap, the chat view
+    ///   model, and a session manager with the initial session page already
+    ///   loaded. The caller owns the bootstrap and must retain it for the
+    ///   lifetime of the chat runtime.
     public static func quickStart(
         configuration: ManifoldConfiguration = .default
     ) async throws -> QuickStartResult {
@@ -93,40 +95,38 @@ public enum ManifoldKit {
             viewModel.configure(persistence: bootstrap.persistence)
             viewModel.configure(endpointStore: bootstrap.endpointStore)
 
+            // Wire the session manager and await its initial load so that
+            // `sessionManager.sessions` is populated before this call returns
+            // (#1447). Using `configureAndLoad(bootstrap:)` instead of the
+            // fire-and-forget `configure(bootstrap:)` eliminates the race
+            // window that forced consumers to invent polling heuristics on
+            // relaunch.
+            let sessionManager = SessionManagerViewModel()
+            await sessionManager.configureAndLoad(bootstrap: bootstrap)
+
             // A2-F4: ensure the documented `quickStart()` → `ChatView()` path
-            // produces a usable chat surface on first launch. `ChatView`
-            // disables its composer when `viewModel.activeSession == nil`, so
-            // a fresh install (no persisted sessions) would otherwise render
-            // a "No session selected" placeholder with no documented way to
-            // create one through the high-level API.
+            // produces a usable chat surface on first launch.
             //
-            // We auto-create a single empty session iff the store is empty.
-            // When sessions already exist (relaunch, restored backup, host
-            // app that created its own session first), this is a no-op and
-            // the host's existing selection logic takes over.
-            //
-            // Model loading is intentionally orthogonal — a session with no
-            // model loaded still unblocks the composer, and the welcome
-            // empty-state for model selection lives in `ChatView`. See
-            // A2-F1 for the separate "auto-select a model when available"
-            // gap.
-            let existingSessions = try await bootstrap.persistence.fetchSessions(offset: 0, limit: 1)
-            if existingSessions.isEmpty {
+            // `sessionManager.sessions` is now populated (above), so we can
+            // branch on it directly rather than re-fetching from persistence.
+            if sessionManager.sessions.isEmpty {
                 let initialSession = ChatSessionRecord(title: "New Chat")
                 try await bootstrap.persistence.insertSession(initialSession)
                 await viewModel.switchToSession(initialSession)
-            } else if let mostRecent = existingSessions.first {
+                // Reload so sessionManager reflects the newly created session.
+                await sessionManager.loadSessions()
+            } else if let mostRecent = sessionManager.sessions.first {
                 await viewModel.switchToSession(mostRecent)
             }
 
-            return QuickStartResult(bootstrap: bootstrap, viewModel: viewModel)
+            return QuickStartResult(bootstrap: bootstrap, viewModel: viewModel, sessionManager: sessionManager)
         } catch {
             throw ManifoldKitError.from(error)
         }
     }
 }
 
-/// The pair returned by ``ManifoldKit/ManifoldKit/quickStart(configuration:)``.
+/// The result returned by ``ManifoldKit/ManifoldKit/quickStart(configuration:)``.
 ///
 /// `bootstrap` owns the inference service, SwiftData container, persistence
 /// adapters, and ``ConversationRuntime``. Retain it for the lifetime of the
@@ -136,16 +136,30 @@ public enum ManifoldKit {
 /// `ChatView` (or your own SwiftUI surface) as you would a manually
 /// constructed view model.
 ///
-/// `QuickStartResult` is `Sendable` because both fields are `@MainActor`
+/// `sessionManager` is a ``SessionManagerViewModel`` configured against the
+/// same bootstrap and with its initial session page already loaded (#1425).
+/// Pass it to a sidebar or session-list surface alongside `viewModel` — no
+/// additional `configure` or `loadSessions` call is required.
+///
+/// `QuickStartResult` is `Sendable` because all fields are `@MainActor`
 /// reference types; the struct itself carries no mutable state.
 @MainActor
 public struct QuickStartResult: Sendable {
     public let bootstrap: ManifoldBootstrap
     public let viewModel: ChatViewModel
+    /// A session manager pre-wired to `bootstrap` with the initial session
+    /// page already loaded. Use this to drive multi-session UI (sidebar,
+    /// create/delete/rename) without additional setup.
+    public let sessionManager: SessionManagerViewModel
 
-    public init(bootstrap: ManifoldBootstrap, viewModel: ChatViewModel) {
+    public init(
+        bootstrap: ManifoldBootstrap,
+        viewModel: ChatViewModel,
+        sessionManager: SessionManagerViewModel
+    ) {
         self.bootstrap = bootstrap
         self.viewModel = viewModel
+        self.sessionManager = sessionManager
     }
 }
 

--- a/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
@@ -51,12 +51,37 @@ extension SessionManagerViewModel {
     /// a ``ChatRuntimeBootstrap``. Schedules the initial session load so the UI
     /// matches pre-Phase-1.0 behavior. Direct callers of
     /// ``configure(persistence:autoLoad:diagnostics:)`` must opt in explicitly.
+    ///
+    /// > Note: This overload schedules `loadSessions()` as a fire-and-forget
+    /// > `Task` (via `autoLoad: true`), so `sessions` may be empty on the first
+    /// > observation after this call returns. Callers that need sessions
+    /// > populated synchronously — such as `quickStart()` — should use
+    /// > ``configureAndLoad(bootstrap:)`` instead.
     public func configure(bootstrap: any ChatRuntimeBootstrap) {
         configure(
             persistence: bootstrap.persistenceStores,
             autoLoad: true,
             diagnostics: bootstrap.diagnosticsService
         )
+    }
+
+    /// Bootstrap path that awaits the initial session load before returning.
+    ///
+    /// Unlike ``configure(bootstrap:)`` (which schedules `loadSessions()` as a
+    /// fire-and-forget `Task`), this overload drives the initial page fetch to
+    /// completion inline. ``sessions`` is therefore populated the moment this
+    /// call returns — callers do not need polling or wait heuristics on
+    /// relaunch. This is the fix for #1447.
+    public func configureAndLoad(bootstrap: any ChatRuntimeBootstrap) async {
+        configure(
+            persistence: bootstrap.persistenceStores,
+            autoLoad: false,
+            diagnostics: bootstrap.diagnosticsService
+        )
+        // Drive the first page synchronously so callers see a populated
+        // `sessions` array immediately after `await`. `autoLoad: false` above
+        // prevents a concurrent fire-and-forget Task from racing this fetch.
+        await loadSessions()
     }
 
     /// Deprecated shim kept for one minor.

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -16,13 +16,14 @@ import ManifoldPersistenceSwiftData
 @MainActor
 final class QuickStartTests: XCTestCase {
 
-    /// The happy path: `quickStart()` returns a bootstrap and a view model
-    /// that share the same inference service and have persistence wired up.
+    /// The happy path: `quickStart()` returns a bootstrap, a view model, and
+    /// a session manager that share the same inference service and have
+    /// persistence wired up.
     ///
     /// We use the internal `_quickStart` seam with an in-memory SwiftData
     /// container so the test doesn't touch the on-disk Application Support
     /// store the default factory derives.
-    func test_quickStart_returnsBootstrappedViewModel() async throws {
+    func test_quickStart_returnsBootstrappedViewModelAndSessionManager() async throws {
         let result = try await ManifoldKit._quickStart(
             configuration: .default,
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
@@ -43,6 +44,12 @@ final class QuickStartTests: XCTestCase {
         // sharing") and is populated from the inference service the
         // bootstrap built.
         XCTAssertNotNil(result.viewModel.modelRegistry)
+
+        // Session-manager side (#1425/#1447): `sessionManager` is wired and
+        // sessions are populated the moment quickStart() returns — no polling
+        // or extra loadSessions() call needed.
+        XCTAssertFalse(result.sessionManager.sessions.isEmpty,
+            "sessionManager.sessions must be populated immediately after quickStart() returns (no polling required) — regression guard for #1447")
     }
 
     /// Errors from any step in the bootstrap chain must be reduced through
@@ -93,12 +100,15 @@ final class QuickStartTests: XCTestCase {
             "quickStart() must auto-create an initial session so ChatView's composer is enabled on first launch (A2-F4)."
         )
 
-        // And the session is actually persisted, so the SessionManagerViewModel
-        // sidebar in the host app's first-paint sees it without an extra
-        // round-trip.
+        // And the session is already visible in sessionManager.sessions (#1425,
+        // #1447) — no additional loadSessions() or polling needed.
         let persisted = try await result.bootstrap.persistence.fetchSessions()
         XCTAssertEqual(persisted.count, 1)
         XCTAssertEqual(persisted.first?.id, result.viewModel.activeSession?.id)
+        XCTAssertEqual(result.sessionManager.sessions.count, 1,
+            "sessionManager.sessions must reflect the auto-created session immediately (#1447)")
+        XCTAssertEqual(result.sessionManager.sessions.first?.id, result.viewModel.activeSession?.id,
+            "sessionManager and viewModel must share the same active session")
     }
 
     /// Symmetric guard: when persistence already contains sessions (e.g.
@@ -143,6 +153,11 @@ final class QuickStartTests: XCTestCase {
         // And the view model picked one of them rather than minting a new id.
         let active = try XCTUnwrap(secondResult.viewModel.activeSession)
         XCTAssertTrue(persistedIDs.contains(active.id))
+
+        // sessionManager also reflects both sessions without extra loadSessions()
+        // calls — #1447 guarantee applies to the relaunch path too.
+        XCTAssertEqual(secondResult.sessionManager.sessions.count, 2,
+            "sessionManager.sessions must reflect persisted sessions on relaunch immediately (#1447)")
     }
 
     /// Compile-time check that `QuickStartResult` is `Sendable`. The README's


### PR DESCRIPTION
## Summary
- Adds `sessionManager: SessionManagerViewModel` to `QuickStartResult` so consumers can reach multi-session UI (sidebar list, create/delete/rename) from the `quickStart()` happy path without dropping down to `ManifoldBootstrap.build(...)` (#1425)
- Makes `SessionManagerViewModel.configureAndLoad(bootstrap:)` await the initial session load so `sessions` is populated before the call returns, eliminating the need for consumer-side polling/wait heuristics on relaunch (#1447)

Closes #1425, #1447

## Root causes found

**#1425:** `QuickStartResult` only held `bootstrap` and `viewModel`. Consumers who wanted a `SessionManagerViewModel` had to construct one, call `configure(bootstrap:)`, and await `autoLoadTask` themselves — with no documented path from `quickStart()`.

**#1447:** `configure(bootstrap:)` on `SessionManagerViewModel` delegated to `configure(persistence:autoLoad: true)`, which schedules `loadSessions()` as a fire-and-forget `Task { }`. The `configure` call returned immediately while the fetch was still in flight, leaving `sessions` empty on the first observation.

## What changed

- **`Sources/ManifoldKit/QuickStart.swift`** — `QuickStartResult` gains a `sessionManager: SessionManagerViewModel` field with updated init and DocC. `_quickStart()` constructs a `SessionManagerViewModel`, calls `configureAndLoad(bootstrap:)` (the new async overload), and uses the already-loaded `sessions` array for the A2-F4 empty-store branch instead of a separate `fetchSessions` call.
- **`Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift`** — Adds `configureAndLoad(bootstrap:)` async overload that uses `autoLoad: false` then `await loadSessions()`, driving the first page synchronously. The existing synchronous `configure(bootstrap:)` is preserved unchanged so all existing call sites (`ConsumerRuntimeHarness`, `RuntimeBootstrapMigrationGuardTests`, `RuntimeConfigurationTests`) continue compiling without modification.
- **`Tests/ManifoldKitTests/QuickStartTests.swift`** — Updated happy-path test renamed + extended with session manager assertions; A2-F4 test adds `sessionManager.sessions` count check; non-empty relaunch test adds same. All assertions fire with no intermediate `loadSessions()` call — that is the regression guard.

## Test plan
- [x] `swift build --build-tests --disable-default-traits` passes
- [x] `QuickStartResult.sessionManager` is accessible and non-nil after `quickStart()` returns
- [x] `sessionManager.sessions` contains persisted sessions immediately after `configureAndLoad(bootstrap:)` returns — asserted in `test_quickStart_returnsBootstrappedViewModelAndSessionManager` and `test_quickStart_autoCreatesInitialSession_whenStoreIsEmpty`
- [x] `sessionManager.sessions` reflects both sessions on relaunch — asserted in `test_quickStart_selectsExistingSession_whenStoreIsNonEmpty`
- [x] Existing session manager tests pass (55 tests, 0 failures)
- [x] Existing `RuntimeConfigurationTests` pass — synchronous `configure(bootstrap:)` overload unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)