### PR TITLE
fix(runtime): make session restore reliable after configure (#1447)

### DIFF
--- a/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
@@ -51,12 +51,53 @@ extension SessionManagerViewModel {
     /// a ``ChatRuntimeBootstrap``. Schedules the initial session load so the UI
     /// matches pre-Phase-1.0 behavior. Direct callers of
     /// ``configure(persistence:autoLoad:diagnostics:)`` must opt in explicitly.
+    ///
+    /// > Important: This overload is **fire-and-forget** — it schedules the
+    /// > initial session fetch as a background `Task` and returns before the
+    /// > fetch completes. ``sessions`` may still be empty immediately after
+    /// > this call returns. Use ``configureAndLoad(bootstrap:)`` when you need
+    /// > ``sessions`` populated before proceeding (e.g. session-restore on
+    /// > launch, scene restoration, or any context where you cannot rely on
+    /// > `SessionListView`'s `.task {}` modifier to trigger the load).
     public func configure(bootstrap: any ChatRuntimeBootstrap) {
         configure(
             persistence: bootstrap.persistenceStores,
             autoLoad: true,
             diagnostics: bootstrap.diagnosticsService
         )
+    }
+
+    /// Bootstrap path that **awaits** the initial session fetch before
+    /// returning.
+    ///
+    /// Identical to ``configure(bootstrap:)`` except that it `await`s
+    /// ``loadSessions()`` so ``sessions`` is populated by the time this method
+    /// returns. Use this from `App.body` launch sequences and scene-restoration
+    /// handlers that need to select or restore a session immediately — for
+    /// example:
+    ///
+    /// ```swift
+    /// .task {
+    ///     await sessionManager.configureAndLoad(bootstrap: runtime)
+    ///     // sessions is now populated; safe to restore active session
+    ///     if let id = restoredSessionID {
+    ///         sessionManager.activeSession = sessionManager.sessions
+    ///             .first { $0.id == id }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Callers that use `SessionListView` and don't need to inspect
+    /// ``sessions`` immediately after configure can continue to use the
+    /// synchronous ``configure(bootstrap:)`` overload — `SessionListView`'s
+    /// `.task {}` modifier will trigger the load at the right time.
+    public func configureAndLoad(bootstrap: any ChatRuntimeBootstrap) async {
+        configure(
+            persistence: bootstrap.persistenceStores,
+            autoLoad: false,
+            diagnostics: bootstrap.diagnosticsService
+        )
+        await loadSessions()
     }
 
     /// Deprecated shim kept for one minor.

--- a/Tests/ManifoldUITests/RuntimeConfigurationTests.swift
+++ b/Tests/ManifoldUITests/RuntimeConfigurationTests.swift
@@ -126,6 +126,77 @@ final class RuntimeConfigurationTests: XCTestCase {
         XCTAssertEqual(persistedIDs, [initialSession.id])
     }
 
+    // MARK: - #1447 session-restore reliability
+
+    /// Regression test for #1447: `configureAndLoad(bootstrap:)` must await
+    /// the initial session fetch so `sessions` is populated immediately after
+    /// the call — without any polling loop.
+    func test_configureAndLoad_sessionsPopulatedBeforeReturn() async throws {
+        let originalConfiguration = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = originalConfiguration }
+
+        let runtime = try ManifoldBootstrap(
+            configuration: ManifoldConfiguration(
+                appName: "SessionRestoreTests",
+                bundleIdentifier: "com.manifoldkit.session-restore-tests"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        // Pre-populate SwiftData with two sessions before configure is called,
+        // matching the real-world scene-restore scenario where sessions already
+        // exist on disk.
+        let s1 = ChatSessionRecord(title: "Restore A")
+        let s2 = ChatSessionRecord(title: "Restore B")
+        try await runtime.persistence.insertSession(s1)
+        try await runtime.persistence.insertSession(s2)
+
+        let sessionManager = SessionManagerViewModel()
+
+        // configureAndLoad must await the initial fetch — no polling required.
+        await sessionManager.configureAndLoad(bootstrap: runtime)
+
+        XCTAssertEqual(
+            sessionManager.sessions.count, 2,
+            "sessions must be populated immediately after configureAndLoad — callers must not need a polling loop (#1447)"
+        )
+        let ids = Set(sessionManager.sessions.map(\.id))
+        XCTAssertTrue(ids.contains(s1.id), "Restore A should be present")
+        XCTAssertTrue(ids.contains(s2.id), "Restore B should be present")
+    }
+
+    /// Verifies that the synchronous `configure(bootstrap:)` fire-and-forget
+    /// path still works — `sessions` is populated after draining `autoLoadTask`.
+    func test_configure_autoLoadEventuallyPopulateSessions() async throws {
+        let originalConfiguration = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = originalConfiguration }
+
+        let runtime = try ManifoldBootstrap(
+            configuration: ManifoldConfiguration(
+                appName: "SessionRestoreAutoLoadTests",
+                bundleIdentifier: "com.manifoldkit.session-restore-autoload-tests"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let s1 = ChatSessionRecord(title: "AutoLoad Session")
+        try await runtime.persistence.insertSession(s1)
+
+        let sessionManager = SessionManagerViewModel()
+        sessionManager.configure(bootstrap: runtime)
+
+        // sessions is empty immediately after the synchronous configure — this
+        // is the documented fire-and-forget behaviour.
+        XCTAssertEqual(
+            sessionManager.sessions.count, 0,
+            "Synchronous configure(bootstrap:) should not block on the fetch — sessions empty before autoLoadTask drains"
+        )
+
+        // After draining the scheduled task, sessions are available.
+        await sessionManager.autoLoadTask?.value
+        XCTAssertEqual(sessionManager.sessions.count, 1)
+    }
+
     func test_configureRuntime_loadsEndpointsAndSwitchUsesFreshEndpointRecords() async throws {
         let originalConfiguration = ManifoldConfiguration.shared
         defer { ManifoldConfiguration.shared = originalConfiguration }


### PR DESCRIPTION
Closes #1447

## Root cause

`SessionManagerViewModel.configure(bootstrap:)` calls `configure(persistence:autoLoad:true,...)`, which schedules `Task { [weak self] in await self?.loadSessions() }` as a fire-and-forget background task and returns immediately. Three independent DX agents hit the same symptom: `sessionVM.sessions` was still empty after `configure` returned, because the initial SwiftData fetch hadn't run yet. They were forced to add polling loops to recover — a clear signal the API was misleading.

## Fix

Added a new `async` method `configureAndLoad(bootstrap:)` on `SessionManagerViewModel` that configures with `autoLoad: false` and then explicitly `await`s `loadSessions()` before returning. Callers that need `sessions` populated synchronously (scene restore, launch-time session selection) use this new method. Callers that rely on `SessionListView`'s `.task {}` modifier can continue using the synchronous `configure(bootstrap:)` overload.

The synchronous `configure(bootstrap:)` doc comment now prominently warns about the fire-and-forget behaviour and points to the new method.

## Tests added (`RuntimeConfigurationTests`)

- `test_configureAndLoad_sessionsPopulatedBeforeReturn` — pre-populates two sessions, calls `configureAndLoad`, asserts `sessions.count == 2` immediately with no polling (regression for #1447)
- `test_configure_autoLoadEventuallyPopulateSessions` — documents and locks the synchronous overload's fire-and-forget contract: `sessions` is empty immediately, populated after `autoLoadTask` drains

🤖 Generated with Claude Code