### PR TITLE
feat(observability): per-token latency + cost meter on SSECloudBackend (#1414)

### DIFF
--- a/Sources/ManifoldCloudCore/InferenceCostEstimator.swift
+++ b/Sources/ManifoldCloudCore/InferenceCostEstimator.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Static cost table and estimator for common cloud inference models.
+///
+/// Rates are per million tokens (input / output) and were captured on
+/// `costTableDate`. When a model is not in the table the estimator returns
+/// a zero cost marked as approximate so callers can distinguish "free"
+/// from "unknown".
+public enum InferenceCostEstimator {
+
+    /// ISO date string of the rate table bundled in this build.
+    public static let costTableDate = "2026-05-24"
+
+    // Per-million token prices: (inputUSD, outputUSD)
+    // Sourced from public pricing pages as of costTableDate.
+    private static let ratesPerMillion: [String: (input: Double, output: Double)] = [
+        "claude-opus-4-7":      (15.00, 75.00),
+        "claude-sonnet-4-6":    (3.00,  15.00),
+        "claude-haiku-4-5":     (0.80,  4.00),
+        "gpt-4o":               (2.50,  10.00),
+        "gpt-4o-mini":          (0.15,  0.60),
+    ]
+
+    /// Estimates the cost of a single inference call.
+    ///
+    /// - Parameters:
+    ///   - provider: Backend name (currently unused for routing; rates are
+    ///     keyed by model identifier alone).
+    ///   - model: Model identifier string. Compared case-insensitively against
+    ///     the rate table; leading/trailing whitespace is stripped.
+    ///   - promptTokens: Number of prompt tokens billed by the provider.
+    ///   - completionTokens: Number of completion tokens billed by the provider.
+    /// - Returns: A tuple with the estimated cost in USD and a flag indicating
+    ///   whether the estimate is approximate (i.e. the model was not in the
+    ///   rate table and the cost is zero rather than accurate).
+    public static func estimatedCost(
+        provider: String,
+        model: String,
+        promptTokens: Int,
+        completionTokens: Int
+    ) -> (usd: Double, isApproximate: Bool) {
+        let key = model.trimmingCharacters(in: .whitespaces).lowercased()
+        // Exact match first; fall back to prefix match for model variants
+        // (e.g. "claude-sonnet-4-6-20261201" → "claude-sonnet-4-6").
+        let rates: (input: Double, output: Double)?
+        if let exact = ratesPerMillion[key] {
+            rates = exact
+        } else {
+            rates = ratesPerMillion.first { key.hasPrefix($0.key) }?.value
+        }
+
+        guard let r = rates else {
+            return (usd: 0, isApproximate: true)
+        }
+
+        let inputCost  = Double(promptTokens)    / 1_000_000 * r.input
+        let outputCost = Double(completionTokens) / 1_000_000 * r.output
+        return (usd: inputCost + outputCost, isApproximate: false)
+    }
+}

--- a/Sources/ManifoldCloudCore/InferenceCostEstimator.swift
+++ b/Sources/ManifoldCloudCore/InferenceCostEstimator.swift
@@ -40,13 +40,18 @@ public enum InferenceCostEstimator {
         completionTokens: Int
     ) -> (usd: Double, isApproximate: Bool) {
         let key = model.trimmingCharacters(in: .whitespaces).lowercased()
-        // Exact match first; fall back to prefix match for model variants
+        // Exact match first; fall back to longest-prefix match for model variants
         // (e.g. "claude-sonnet-4-6-20261201" → "claude-sonnet-4-6").
+        // Longest-prefix wins to avoid "gpt-4o" matching "gpt-4o-mini-20261201"
+        // when both keys are present in the table.
         let rates: (input: Double, output: Double)?
         if let exact = ratesPerMillion[key] {
             rates = exact
         } else {
-            rates = ratesPerMillion.first { key.hasPrefix($0.key) }?.value
+            rates = ratesPerMillion
+                .filter { key.hasPrefix($0.key) }
+                .max(by: { $0.key.count < $1.key.count })
+                .map { $0.value }
         }
 
         guard let r = rates else {

--- a/Sources/ManifoldCloudCore/InferenceMetric.swift
+++ b/Sources/ManifoldCloudCore/InferenceMetric.swift
@@ -19,7 +19,9 @@ public struct InferenceMetric: Sendable {
     /// Number of tokens in the completion.
     public let completionTokens: Int
     /// Time elapsed between request dispatch and the first `.token` event.
-    /// Zero when the stream produced no tokens.
+    /// Zero when the stream produced no tokens. `.thinkingToken` events are
+    /// intentionally excluded — TTFT measures output latency as perceived by
+    /// the end user, not internal reasoning time.
     public let timeToFirstToken: Duration
     /// Average gap between consecutive token events.
     /// Zero when fewer than two tokens were observed.
@@ -36,6 +38,9 @@ public struct InferenceMetric: Sendable {
     /// Short error class name when the call ended in failure, `nil` on success
     /// (e.g. "rateLimited", "networkError", "authenticationFailed").
     public let errorClass: String?
+    /// Wall-clock date and time at which the generation request was dispatched.
+    /// Useful for time-series storage and correlating metrics with external logs.
+    public let timestamp: Date
 
     public init(
         provider: String,
@@ -49,7 +54,8 @@ public struct InferenceMetric: Sendable {
         estimatedCostUSD: Double,
         isCostApproximate: Bool,
         costTableDate: String,
-        errorClass: String?
+        errorClass: String?,
+        timestamp: Date = Date()
     ) {
         self.provider = provider
         self.model = model
@@ -63,6 +69,7 @@ public struct InferenceMetric: Sendable {
         self.isCostApproximate = isCostApproximate
         self.costTableDate = costTableDate
         self.errorClass = errorClass
+        self.timestamp = timestamp
     }
 }
 

--- a/Sources/ManifoldCloudCore/InferenceMetric.swift
+++ b/Sources/ManifoldCloudCore/InferenceMetric.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// A snapshot of latency, cost, and token-count data produced after a single
+/// cloud inference call.
+///
+/// Emitted by ``SSECloudBackend`` after every generation (success or failure)
+/// and forwarded to the configured ``InferenceMetricSink``. Consumers use this
+/// to power dashboards, cost alerts, and latency regression detection without
+/// having to instrument individual backends.
+public struct InferenceMetric: Sendable {
+    /// Human-readable backend name (e.g. "Claude", "OpenAI").
+    public let provider: String
+    /// Model identifier used for the call (e.g. "claude-sonnet-4-6").
+    public let model: String
+    /// Number of tokens in the prompt as reported by the provider.
+    public let promptTokens: Int
+    /// Number of prompt tokens served from the provider's prompt cache (0 when unavailable).
+    public let cachedPromptTokens: Int
+    /// Number of tokens in the completion.
+    public let completionTokens: Int
+    /// Time elapsed between request dispatch and the first `.token` event.
+    /// Zero when the stream produced no tokens.
+    public let timeToFirstToken: Duration
+    /// Average gap between consecutive token events.
+    /// Zero when fewer than two tokens were observed.
+    public let meanInterTokenLatency: Duration
+    /// Wall-clock duration from request dispatch to stream completion or error.
+    public let wallClockDuration: Duration
+    /// Estimated USD cost for the call based on the static rate table.
+    public let estimatedCostUSD: Double
+    /// `true` when the model was not in the known rate table and the cost is
+    /// therefore zero rather than accurate.
+    public let isCostApproximate: Bool
+    /// ISO date string of the rate table used for the cost estimate (e.g. "2026-05-24").
+    public let costTableDate: String
+    /// Short error class name when the call ended in failure, `nil` on success
+    /// (e.g. "rateLimited", "networkError", "authenticationFailed").
+    public let errorClass: String?
+
+    public init(
+        provider: String,
+        model: String,
+        promptTokens: Int,
+        cachedPromptTokens: Int,
+        completionTokens: Int,
+        timeToFirstToken: Duration,
+        meanInterTokenLatency: Duration,
+        wallClockDuration: Duration,
+        estimatedCostUSD: Double,
+        isCostApproximate: Bool,
+        costTableDate: String,
+        errorClass: String?
+    ) {
+        self.provider = provider
+        self.model = model
+        self.promptTokens = promptTokens
+        self.cachedPromptTokens = cachedPromptTokens
+        self.completionTokens = completionTokens
+        self.timeToFirstToken = timeToFirstToken
+        self.meanInterTokenLatency = meanInterTokenLatency
+        self.wallClockDuration = wallClockDuration
+        self.estimatedCostUSD = estimatedCostUSD
+        self.isCostApproximate = isCostApproximate
+        self.costTableDate = costTableDate
+        self.errorClass = errorClass
+    }
+}
+
+// MARK: - Sink Protocol
+
+/// A type that receives ``InferenceMetric`` values produced by cloud backends.
+///
+/// Conform to this protocol to route metrics into observability systems (Datadog,
+/// OpenTelemetry, a local ring buffer, etc.) without coupling the backend layer
+/// to a specific sink implementation.
+public protocol InferenceMetricSink: AnyObject, Sendable {
+    /// Called by the backend after every generation, whether or not it succeeded.
+    func record(_ metric: InferenceMetric) async
+}
+
+// MARK: - In-Memory Ring Buffer
+
+/// A thread-safe, bounded ring buffer of ``InferenceMetric`` values.
+///
+/// The shared singleton is the default sink wired into ``SSECloudBackend``.
+/// Tests and host apps can inject their own sink; this actor is useful as a
+/// lightweight diagnostic tool in debug builds.
+///
+/// When the buffer is full the oldest entry is evicted before the new one is
+/// appended, so memory usage stays constant regardless of call volume.
+public actor InMemoryMetricSink: InferenceMetricSink {
+
+    /// Shared singleton. ``SSECloudBackend`` defaults to this sink so callers
+    /// can read recent metrics without configuring anything.
+    public static let shared = InMemoryMetricSink()
+
+    private var metrics: [InferenceMetric] = []
+    private let capacity: Int
+
+    /// Creates a sink with a custom buffer capacity.
+    /// - Parameter capacity: Maximum number of metrics to retain. Defaults to 100.
+    public init(capacity: Int = 100) {
+        self.capacity = capacity
+    }
+
+    /// Appends `metric`, evicting the oldest entry if the buffer is at capacity.
+    public func record(_ metric: InferenceMetric) {
+        if metrics.count >= capacity { metrics.removeFirst() }
+        metrics.append(metric)
+    }
+
+    /// Returns all retained metrics in insertion order.
+    public func recentMetrics() -> [InferenceMetric] { metrics }
+
+    /// Removes all retained metrics.
+    public func clear() { metrics.removeAll() }
+}

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -122,6 +122,12 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     private var _generationID: UInt64 = 0
     private var _activeEventIDTracker: SSEEventIDTracker?
 
+    /// The sink that receives an ``InferenceMetric`` after every generation call.
+    ///
+    /// Defaults to ``InMemoryMetricSink/shared`` so callers can read recent
+    /// metrics without any configuration. Set to `nil` to disable metric emission.
+    public var metricSink: (any InferenceMetricSink)? = InMemoryMetricSink.shared
+
     public let urlSession: URLSession
 
     /// SSE payload handler that extracts tokens, usage, stream-end signals,
@@ -452,6 +458,9 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         let session = self.urlSession
         let capturedTimeout = streamIdleTimeout
         let capturedBaseURL = baseURL
+        let capturedMetricSink = metricSink
+        let capturedModelName = modelName
+        let capturedBackendName = backendName
 
         // The Task needs to set phases on the GenerationStream, but GenerationStream
         // wraps the stream (chicken-and-egg). Use a WeakBox that the Task captures;
@@ -460,6 +469,10 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         let retryCounter = SendableCounter()
         let maxRetries = (capturedStrategy as? ExponentialBackoffStrategy)?.maxRetries ?? 3
         let weakSelf = WeakBox(self)
+
+        // Tracks per-token timestamps for TTFT and inter-token latency.
+        // Populated via the metric-observing wrapper stream below.
+        let metricTracker = GenerationMetricTracker()
 
         let stream = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
             guard let self else {
@@ -477,6 +490,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                     }
                 }
 
+                var streamError: Error?
                 do {
                     // DNS rebinding guard: verify the endpoint's hostname does not
                     // resolve to a private/reserved address before connecting.
@@ -530,6 +544,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                     await MainActor.run { streamBox.value?.setPhase(.done) }
                     continuation.finish()
                 } catch {
+                    streamError = error
                     if error is CancellationError || Task.isCancelled {
                         continuation.finish()
                     } else {
@@ -537,6 +552,33 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                         await MainActor.run { streamBox.value?.setPhase(.failed(error.localizedDescription)) }
                         continuation.finish(throwing: error)
                     }
+                }
+
+                // Emit metric regardless of outcome so the sink receives both
+                // successful and failed calls.
+                if let sink = capturedMetricSink {
+                    let usage = self?.lastUsage
+                    let promptTokens = usage?.promptTokens ?? 0
+                    let completionTokens = usage?.completionTokens ?? 0
+                    let (costUSD, isApprox) = InferenceCostEstimator.estimatedCost(
+                        provider: capturedBackendName,
+                        model: capturedModelName,
+                        promptTokens: promptTokens,
+                        completionTokens: completionTokens
+                    )
+                    let errorClass = streamError.map { Self.classifyError($0) }
+                    let metric = metricTracker.buildMetric(
+                        provider: capturedBackendName,
+                        model: capturedModelName,
+                        promptTokens: promptTokens,
+                        cachedPromptTokens: 0,
+                        completionTokens: completionTokens,
+                        estimatedCostUSD: costUSD,
+                        isCostApproximate: isApprox,
+                        costTableDate: InferenceCostEstimator.costTableDate,
+                        errorClass: errorClass
+                    )
+                    Task { await sink.record(metric) }
                 }
             }
 
@@ -547,7 +589,35 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
             }
         }
 
-        let generationStream = GenerationStream(stream, idleTimeout: capturedTimeout)
+        // Wrap the raw event stream in a metric-observing layer. Token events
+        // are intercepted to record TTFT and inter-token latency as the consumer
+        // iterates; the tracker is populated before the metric-emission Task
+        // reads it on stream completion. Cancellation propagates inward via
+        // structured-concurrency child task cancellation.
+        let trackedStream: AsyncThrowingStream<GenerationEvent, Error>
+        if capturedMetricSink != nil {
+            trackedStream = AsyncThrowingStream { outerContinuation in
+                let relayTask = Task {
+                    metricTracker.start()
+                    do {
+                        for try await event in stream {
+                            if case .token = event { metricTracker.recordToken() }
+                            outerContinuation.yield(event)
+                        }
+                        outerContinuation.finish()
+                    } catch {
+                        outerContinuation.finish(throwing: error)
+                    }
+                }
+                outerContinuation.onTermination = { @Sendable _ in
+                    relayTask.cancel()
+                }
+            }
+        } else {
+            trackedStream = stream
+        }
+
+        let generationStream = GenerationStream(trackedStream, idleTimeout: capturedTimeout)
         streamBox.value = generationStream
         return generationStream
     }
@@ -923,6 +993,30 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     public func setIsGenerating(_ value: Bool) {
         withStateLock { _isGenerating = value }
     }
+
+    // MARK: - Metric Helpers
+
+    /// Returns a short identifier string for an error suitable for tagging metrics.
+    ///
+    /// Uses switch-on-type patterns over `CloudBackendError` cases so new cases
+    /// get a descriptive label automatically. Falls back to the Swift type name
+    /// for non-cloud errors so observers can distinguish network errors from
+    /// parsing errors without having to decode the full message.
+    static func classifyError(_ error: Error) -> String {
+        if let cloud = error as? CloudBackendError {
+            switch cloud {
+            case .authenticationFailed: return "authenticationFailed"
+            case .rateLimited:          return "rateLimited"
+            case .serverError:          return "serverError"
+            case .networkError:         return "networkError"
+            case .invalidURL:           return "invalidURL"
+            case .backendDeallocated:   return "backendDeallocated"
+            case .timeout:              return "timeout"
+            default:                    return "cloudError"
+            }
+        }
+        return String(describing: type(of: error))
+    }
 }
 
 // MARK: - Sendable Helpers
@@ -946,3 +1040,88 @@ private final class WeakBox<T: AnyObject>: @unchecked Sendable {
     weak var value: T?
     init(_ value: T?) { self.value = value }
 }
+
+// MARK: - Metric Tracking Helpers
+
+/// Accumulates per-token timing data for a single generation call.
+///
+/// Thread-safety via `NSLock` — the same pattern as `SendableCounter` in this
+/// file. Updated from the generation Task (arbitrary thread); read after the
+/// Task completes to build the final ``InferenceMetric``.
+final class GenerationMetricTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var wallStart: ContinuousClock.Instant = ContinuousClock.now
+    private var firstTokenInstant: ContinuousClock.Instant?
+    private var lastTokenInstant: ContinuousClock.Instant?
+    private var interTokenGapsNs: [Int64] = []
+
+    func start() {
+        lock.lock()
+        defer { lock.unlock() }
+        wallStart = ContinuousClock.now
+    }
+
+    func recordToken() {
+        lock.lock()
+        defer { lock.unlock() }
+        let now = ContinuousClock.now
+        if firstTokenInstant == nil {
+            firstTokenInstant = now
+        } else if let last = lastTokenInstant {
+            // Nanosecond precision is sufficient for display; avoid Duration
+            // arithmetic inside the lock to keep it fast.
+            let gapNs = Int64((now - last).components.attoseconds / 1_000_000_000)
+            interTokenGapsNs.append(gapNs)
+        }
+        lastTokenInstant = now
+    }
+
+    func buildMetric(
+        provider: String,
+        model: String,
+        promptTokens: Int,
+        cachedPromptTokens: Int,
+        completionTokens: Int,
+        estimatedCostUSD: Double,
+        isCostApproximate: Bool,
+        costTableDate: String,
+        errorClass: String?
+    ) -> InferenceMetric {
+        lock.lock()
+        defer { lock.unlock() }
+        let wallEnd = ContinuousClock.now
+        let wallClock: Duration = wallStart <= wallEnd ? wallEnd - wallStart : .zero
+
+        let ttft: Duration
+        if let first = firstTokenInstant {
+            ttft = wallStart <= first ? first - wallStart : .zero
+        } else {
+            ttft = .zero
+        }
+
+        let meanITL: Duration
+        if interTokenGapsNs.isEmpty {
+            meanITL = .zero
+        } else {
+            let sumNs = interTokenGapsNs.reduce(Int64(0), +)
+            let avgNs = sumNs / Int64(interTokenGapsNs.count)
+            meanITL = .nanoseconds(avgNs)
+        }
+
+        return InferenceMetric(
+            provider: provider,
+            model: model,
+            promptTokens: promptTokens,
+            cachedPromptTokens: cachedPromptTokens,
+            completionTokens: completionTokens,
+            timeToFirstToken: ttft,
+            meanInterTokenLatency: meanITL,
+            wallClockDuration: wallClock,
+            estimatedCostUSD: estimatedCostUSD,
+            isCostApproximate: isCostApproximate,
+            costTableDate: costTableDate,
+            errorClass: errorClass
+        )
+    }
+}
+

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -557,6 +557,11 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                 // Emit metric regardless of outcome so the sink receives both
                 // successful and failed calls.
                 if let sink = capturedMetricSink {
+                    // `self` is weak here. If the backend was deallocated while the
+                    // stream was in-flight, `lastUsage` is unavailable and we emit a
+                    // metric with zero token counts. This is intentional — the metric
+                    // still records timing and the error class, so cost analysis
+                    // is the only field degraded.
                     let usage = self?.lastUsage
                     let promptTokens = usage?.promptTokens ?? 0
                     let completionTokens = usage?.completionTokens ?? 0
@@ -1051,6 +1056,7 @@ private final class WeakBox<T: AnyObject>: @unchecked Sendable {
 final class GenerationMetricTracker: @unchecked Sendable {
     private let lock = NSLock()
     private var wallStart: ContinuousClock.Instant = ContinuousClock.now
+    private var dispatchDate: Date = Date()
     private var firstTokenInstant: ContinuousClock.Instant?
     private var lastTokenInstant: ContinuousClock.Instant?
     private var interTokenGapsNs: [Int64] = []
@@ -1059,6 +1065,9 @@ final class GenerationMetricTracker: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         wallStart = ContinuousClock.now
+        // Capture a Date alongside ContinuousClock so InferenceMetric carries an
+        // absolute timestamp for time-series storage and log correlation.
+        dispatchDate = Date()
     }
 
     func recordToken() {
@@ -1091,6 +1100,7 @@ final class GenerationMetricTracker: @unchecked Sendable {
         defer { lock.unlock() }
         let wallEnd = ContinuousClock.now
         let wallClock: Duration = wallStart <= wallEnd ? wallEnd - wallStart : .zero
+        let capturedDate = dispatchDate
 
         let ttft: Duration
         if let first = firstTokenInstant {
@@ -1120,7 +1130,8 @@ final class GenerationMetricTracker: @unchecked Sendable {
             estimatedCostUSD: estimatedCostUSD,
             isCostApproximate: isCostApproximate,
             costTableDate: costTableDate,
-            errorClass: errorClass
+            errorClass: errorClass,
+            timestamp: capturedDate
         )
     }
 }

--- a/Tests/ManifoldBackendsTests/InferenceMetricTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceMetricTests.swift
@@ -1,0 +1,352 @@
+import Testing
+import Foundation
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - Cost estimator tests (no trait gate — ManifoldCloudCore is always compiled)
+
+@Suite("InferenceCostEstimator")
+struct InferenceCostEstimatorTests {
+
+    // MARK: - Known Models
+
+    @Test("Claude Sonnet 4-6 cost matches rate table")
+    func claudeSonnet46Cost() {
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "Claude",
+            model: "claude-sonnet-4-6",
+            promptTokens: 1_000_000,
+            completionTokens: 1_000_000
+        )
+        // Input $3/M + Output $15/M = $18 for 1M each
+        #expect(usd == 18.0)
+        #expect(!isApprox)
+    }
+
+    @Test("Claude Opus 4-7 cost matches rate table")
+    func claudeOpus47Cost() {
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "Claude",
+            model: "claude-opus-4-7",
+            promptTokens: 1_000_000,
+            completionTokens: 1_000_000
+        )
+        // Input $15/M + Output $75/M = $90 for 1M each
+        #expect(usd == 90.0)
+        #expect(!isApprox)
+    }
+
+    @Test("Claude Haiku 4-5 cost matches rate table")
+    func claudeHaiku45Cost() {
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "Claude",
+            model: "claude-haiku-4-5",
+            promptTokens: 1_000_000,
+            completionTokens: 1_000_000
+        )
+        // Input $0.80/M + Output $4/M = $4.80
+        #expect(abs(usd - 4.80) < 0.0001)
+        #expect(!isApprox)
+    }
+
+    @Test("GPT-4o cost matches rate table")
+    func gpt4oCost() {
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "OpenAI",
+            model: "gpt-4o",
+            promptTokens: 1_000_000,
+            completionTokens: 1_000_000
+        )
+        // Input $2.50/M + Output $10/M = $12.50
+        #expect(usd == 12.5)
+        #expect(!isApprox)
+    }
+
+    @Test("GPT-4o-mini cost matches rate table")
+    func gpt4oMiniCost() {
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "OpenAI",
+            model: "gpt-4o-mini",
+            promptTokens: 1_000_000,
+            completionTokens: 1_000_000
+        )
+        // Input $0.15/M + Output $0.60/M = $0.75
+        #expect(abs(usd - 0.75) < 0.0001)
+        #expect(!isApprox)
+    }
+
+    @Test("Unknown model returns zero cost and isApproximate = true")
+    func unknownModel() {
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "SomeProvider",
+            model: "totally-unknown-model-xyz",
+            promptTokens: 100,
+            completionTokens: 100
+        )
+        #expect(usd == 0)
+        #expect(isApprox)
+    }
+
+    @Test("Model variant with date suffix is matched via prefix")
+    func modelVariantPrefix() {
+        // Model identifiers with a date suffix (e.g. claude-sonnet-4-6-20261201)
+        // should still resolve against the base rate.
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "Claude",
+            model: "claude-sonnet-4-6-20261201",
+            promptTokens: 1_000_000,
+            completionTokens: 0
+        )
+        #expect(usd == 3.0) // Input only: $3/M
+        #expect(!isApprox)
+    }
+
+    @Test("Zero tokens produces zero cost")
+    func zeroTokens() {
+        let (usd, _) = InferenceCostEstimator.estimatedCost(
+            provider: "Claude",
+            model: "claude-sonnet-4-6",
+            promptTokens: 0,
+            completionTokens: 0
+        )
+        #expect(usd == 0)
+    }
+
+    @Test("Cost table date is set")
+    func costTableDateIsSet() {
+        #expect(!InferenceCostEstimator.costTableDate.isEmpty)
+    }
+}
+
+// MARK: - Ring buffer tests
+
+@Suite("InMemoryMetricSink")
+struct InMemoryMetricSinkTests {
+
+    private func makeMetric(provider: String = "Test", model: String = "m") -> InferenceMetric {
+        InferenceMetric(
+            provider: provider,
+            model: model,
+            promptTokens: 10,
+            cachedPromptTokens: 0,
+            completionTokens: 5,
+            timeToFirstToken: .zero,
+            meanInterTokenLatency: .zero,
+            wallClockDuration: .zero,
+            estimatedCostUSD: 0,
+            isCostApproximate: false,
+            costTableDate: "2026-05-24",
+            errorClass: nil
+        )
+    }
+
+    @Test("Empty sink returns empty metrics")
+    func emptySinkReturnsEmpty() async {
+        let sink = InMemoryMetricSink(capacity: 10)
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.isEmpty)
+    }
+
+    @Test("Recorded metrics are returned in insertion order")
+    func insertionOrder() async {
+        let sink = InMemoryMetricSink(capacity: 10)
+        await sink.record(makeMetric(provider: "A"))
+        await sink.record(makeMetric(provider: "B"))
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.count == 2)
+        #expect(metrics[0].provider == "A")
+        #expect(metrics[1].provider == "B")
+    }
+
+    @Test("Ring buffer evicts oldest entry when capacity is exceeded")
+    func evictsOldestAtCapacity() async {
+        let sink = InMemoryMetricSink(capacity: 3)
+        await sink.record(makeMetric(model: "first"))
+        await sink.record(makeMetric(model: "second"))
+        await sink.record(makeMetric(model: "third"))
+        await sink.record(makeMetric(model: "fourth")) // should evict "first"
+
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.count == 3)
+        #expect(metrics[0].model == "second")
+        #expect(metrics[1].model == "third")
+        #expect(metrics[2].model == "fourth")
+    }
+
+    @Test("Exactly at capacity does not evict")
+    func exactlyAtCapacity() async {
+        let sink = InMemoryMetricSink(capacity: 2)
+        await sink.record(makeMetric(model: "a"))
+        await sink.record(makeMetric(model: "b"))
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.count == 2)
+    }
+
+    @Test("Clear empties the buffer")
+    func clearEmptiesBuffer() async {
+        let sink = InMemoryMetricSink(capacity: 10)
+        await sink.record(makeMetric())
+        await sink.clear()
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.isEmpty)
+    }
+
+    @Test("Shared singleton is non-nil")
+    func sharedSingletonExists() {
+        // Just verify the shared singleton is accessible without crashing.
+        let sink: InMemoryMetricSink = .shared
+        _ = sink
+    }
+}
+
+// MARK: - SSECloudBackend integration tests (require CloudSaaS or Ollama trait)
+
+#if Ollama || CloudSaaS
+
+// Minimal SSE payload handler for tests that exercise SSECloudBackend directly.
+private struct TestPayloadHandler: SSEPayloadHandler {
+    func extractToken(from payload: String) -> String? {
+        guard let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let text = json["token"] as? String else { return nil }
+        return text
+    }
+    func extractUsage(from payload: String) -> (promptTokens: Int?, completionTokens: Int?)? { nil }
+    func isStreamEnd(_ payload: String) -> Bool { payload.contains("[DONE]") }
+    func extractStreamError(from payload: String) -> Error? { nil }
+}
+
+// Concrete SSECloudBackend subclass for integration tests.
+private final class TestSSEBackend: SSECloudBackend {
+    override var backendName: String { "TestBackend" }
+    override var capabilities: BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: false,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        )
+    }
+
+    override func buildRequest(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> URLRequest {
+        let url = baseURL!.appendingPathComponent("generate")
+        return URLRequest(url: url)
+    }
+}
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func sseData(_ json: String) -> Data {
+    Data("data: \(json)\n\n".utf8)
+}
+
+private let sseDone = Data("data: [DONE]\n\n".utf8)
+
+@Suite("SSECloudBackend metric emission", .serialized)
+struct SSECloudBackendMetricTests {
+
+    init() {
+        // Bypass DNS rebinding guard for test hostnames.
+        DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34"] }
+    }
+
+    private func makeBackend() -> (TestSSEBackend, URL) {
+        let session = makeMockSession()
+        let backend = TestSSEBackend(
+            defaultModelName: "gpt-4o",
+            urlSession: session,
+            payloadHandler: TestPayloadHandler()
+        )
+        let baseURL = URL(string: "https://metrics-test-\(UUID().uuidString).test")!
+        backend.configure(baseURL: baseURL, apiKey: "test-key", modelName: "gpt-4o")
+        return (backend, baseURL.appendingPathComponent("generate"))
+    }
+
+    @Test("Metric is emitted to sink on successful generation")
+    func emitsMetricOnSuccess() async throws {
+        let (backend, endpointURL) = makeBackend()
+        let sink = InMemoryMetricSink(capacity: 10)
+        backend.metricSink = sink
+
+        let chunks: [Data] = [
+            sseData(#"{"token":"Hello"}"#),
+            sseData(#"{"token":" world"}"#),
+            sseDone,
+        ]
+        MockURLProtocol.stub(url: endpointURL, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events {}
+
+        // Allow the metric emission Task to complete.
+        try await Task.sleep(for: .milliseconds(100))
+
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.count == 1)
+
+        let metric = try #require(metrics.first)
+        #expect(metric.provider == "TestBackend")
+        #expect(metric.model == "gpt-4o")
+        #expect(metric.errorClass == nil)
+        #expect(!metric.isCostApproximate) // gpt-4o is in the rate table
+    }
+
+    @Test("Metric errorClass is populated on failure")
+    func emitsMetricOnFailure() async throws {
+        let (backend, endpointURL) = makeBackend()
+        let sink = InMemoryMetricSink(capacity: 10)
+        backend.metricSink = sink
+
+        let errorBody = Data(#"{"error":{"message":"Unauthorized"}}"#.utf8)
+        MockURLProtocol.stub(url: endpointURL, response: .immediate(data: errorBody, statusCode: 401))
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        do {
+            let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: GenerationConfig())
+            for try await _ in stream.events {}
+        } catch {
+            // Expected — 401 throws authenticationFailed.
+        }
+
+        // Allow the metric emission Task to complete.
+        try await Task.sleep(for: .milliseconds(100))
+
+        let metrics = await sink.recentMetrics()
+        #expect(metrics.count == 1)
+
+        let metric = try #require(metrics.first)
+        #expect(metric.errorClass == "authenticationFailed")
+    }
+
+    @Test("Setting metricSink to nil disables emission")
+    func nilSinkDisablesEmission() async throws {
+        let (backend, endpointURL) = makeBackend()
+        backend.metricSink = nil
+
+        let chunks: [Data] = [sseData(#"{"token":"hi"}"#), sseDone]
+        MockURLProtocol.stub(url: endpointURL, response: .sse(chunks: chunks, statusCode: 200))
+
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: GenerationConfig())
+        for try await _ in stream.events {}
+
+        // Verify no crash occurs and the default shared sink hasn't grown unexpectedly.
+        let sharedMetrics = await InMemoryMetricSink.shared.recentMetrics()
+        // We can't assert count == 0 because other tests may have written to the
+        // shared sink; just confirm we reach this point without error.
+        _ = sharedMetrics
+    }
+}
+
+#endif // Ollama || CloudSaaS

--- a/Tests/ManifoldBackendsTests/InferenceMetricTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceMetricTests.swift
@@ -102,6 +102,22 @@ struct InferenceCostEstimatorTests {
         #expect(!isApprox)
     }
 
+    @Test("gpt-4o-mini variant uses mini rate, not gpt-4o rate")
+    func gpt4oMiniVariantUsesLongestPrefix() {
+        // "gpt-4o-mini-20261201" has two matching prefixes: "gpt-4o" and "gpt-4o-mini".
+        // The longest-prefix-wins rule must select "gpt-4o-mini" ($0.15/$0.60 per M)
+        // rather than "gpt-4o" ($2.50/$10 per M).
+        let (usd, isApprox) = InferenceCostEstimator.estimatedCost(
+            provider: "OpenAI",
+            model: "gpt-4o-mini-20261201",
+            promptTokens: 1_000_000,
+            completionTokens: 0
+        )
+        // Input $0.15/M → $0.15 for 1M tokens
+        #expect(abs(usd - 0.15) < 0.0001)
+        #expect(!isApprox)
+    }
+
     @Test("Zero tokens produces zero cost")
     func zeroTokens() {
         let (usd, _) = InferenceCostEstimator.estimatedCost(
@@ -312,12 +328,15 @@ struct SSECloudBackendMetricTests {
 
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
 
+        var caughtError: Error?
         do {
             let stream = try backend.generate(prompt: "Hi", systemPrompt: nil, config: GenerationConfig())
             for try await _ in stream.events {}
         } catch {
-            // Expected — 401 throws authenticationFailed.
+            caughtError = error
         }
+        // 401 must produce authenticationFailed, not silently succeed.
+        #expect(caughtError != nil, "Expected stream to throw on 401 response")
 
         // Allow the metric emission Task to complete.
         try await Task.sleep(for: .milliseconds(100))

--- a/Tests/ManifoldCoreTests/SwiftTestingAuditTest.swift
+++ b/Tests/ManifoldCoreTests/SwiftTestingAuditTest.swift
@@ -65,6 +65,7 @@ final class SwiftTestingAuditTest: XCTestCase {
         "ManifoldBackendsTests/CloudBackendSSETests.swift",
         "ManifoldBackendsTests/CloudErrorSanitizerTests.swift",
         "ManifoldBackendsTests/CloudThinkingTokenTests.swift",
+        "ManifoldBackendsTests/InferenceMetricTests.swift",
         "ManifoldBackendsTests/OllamaBackendTests.swift",
         "ManifoldBackendsTests/OpenAICompatEndpointTests.swift",
         "ManifoldBackendsTests/SecureBytesTests.swift",


### PR DESCRIPTION
Closes #1414

## Changes
- `InferenceMetric` value type + `InferenceMetricSink` protocol in `ManifoldCloudCore`
- `InMemoryMetricSink` actor (ring buffer, default capacity 100, shared singleton)
- `InferenceCostEstimator` with 2026-05-24 rate table for Claude + OpenAI models
- `SSECloudBackend` emits one metric per call via a thin observing wrapper stream; tracks TTFT and mean inter-token latency from the consumer side; defaults to `InMemoryMetricSink.shared`, set to `nil` to disable
- `MockInferenceBackend` emits synthetic zero-latency metrics via `mockMetricSink` property
- `ManifoldTestSupport` gains `ManifoldCloudCore` dependency (no cycle: CloudCore→Inference, TestSupport→CloudCore→Inference)
- 18 tests across `InferenceCostEstimatorTests`, `InMemoryMetricSinkTests`, `SSECloudBackendMetricTests` (trait-gated `Ollama || CloudSaaS`)

## Design notes
- Token timing is measured on the output side of the stream (consumer-visible latency) via a wrapper `AsyncThrowingStream`. This avoids modifying every `parseResponseStream` override in the subclass tree.
- Metric emission runs in a fire-and-forget `Task` after the stream completes, preserving the existing `generate()` return type.
- `GenerationMetricTracker` is `@unchecked Sendable` with `NSLock` — same pattern as `SendableCounter` in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)