### PR TITLE
docs(dx): add image-gen + iPhone on-device DX walkthrough briefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ tmp/
 # synthesized SUMMARY.md / ROOT_CAUSES.md at the iteration root (those
 # live one level up from run-*/ and are tracked explicitly).
 scripts/dx-walkthrough/runs/*/*/run-*/
+# Phase 4 (iPhone on-device) per-run config — contains device UDID + team ID.
+# Never commit; each developer fills in their own.
+scripts/dx-walkthrough/runs/**/RUN-CONFIG.md
 # Security audit artefacts — must never be committed; contain detailed
 # vulnerability maps with file paths and line numbers.
 SECURITY_REMEDIATION_PLAN*.md

--- a/scripts/dx-walkthrough/briefs/01-chat-cli.md
+++ b/scripts/dx-walkthrough/briefs/01-chat-cli.md
@@ -28,10 +28,10 @@ Don't be alarmed by long initial build times. Log it as friction if it bothers y
 
 ## Working directory
 
-Your app lives at `./app/` relative to wherever this brief is. Create a SwiftPM package there. Reference ManifoldKit via a local path dependency — the MK repo root is at `/Users/roryford/Repos/ManifoldKit`. Use:
+Your app lives at `./app/` relative to wherever this brief is. Create a SwiftPM package there. Reference ManifoldKit via a local path dependency to the repo containing this brief — resolve the absolute path at run time. Use:
 
 ```swift
-.package(name: "ManifoldKit", path: "/Users/roryford/Repos/ManifoldKit")
+.package(name: "ManifoldKit", path: "<absolute path to the ManifoldKit repo containing this brief>")
 ```
 
 (Per CLAUDE.md, `.package(path:)` needs an explicit `name:` to work reliably.)

--- a/scripts/dx-walkthrough/briefs/02-swiftui-chat.md
+++ b/scripts/dx-walkthrough/briefs/02-swiftui-chat.md
@@ -27,10 +27,10 @@ A fresh consumer of ManifoldKit cold-builds all transitive dependencies (hugging
 
 ## Working directory
 
-Your app lives at `./app/` relative to wherever this brief is. Reference ManifoldKit via a local path dependency:
+Your app lives at `./app/` relative to wherever this brief is. Reference ManifoldKit via a local path dependency to the repo containing this brief — resolve the absolute path at run time:
 
 ```swift
-.package(name: "ManifoldKit", path: "/Users/roryford/Repos/ManifoldKit")
+.package(name: "ManifoldKit", path: "<absolute path to the ManifoldKit repo containing this brief>")
 ```
 
 (Per CLAUDE.md, `.package(path:)` needs an explicit `name:` to work reliably.)

--- a/scripts/dx-walkthrough/briefs/03-design-assets/DESIGN-BRIEF.md
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/DESIGN-BRIEF.md
@@ -1,0 +1,124 @@
+# Design Brief: First-Run and Core Generation Experience
+
+**Product**: LocalImage — on-device AI image generation for iPhone, iPad, and macOS  
+**Date**: 2026-05-03  
+**Status**: For design exploration
+
+---
+
+## Product Vision
+
+LocalImage lets anyone generate an image by describing it in plain language. One prompt, one image, no settings to configure.
+
+The contrast case is Draw Things — technically excellent, but built for people who know what a CFG scale is. LocalImage is built for people who don't. Think Canva: sensible defaults, minimal controls, immediate results.
+
+What makes this distinct from Apple's built-in image tools is that it runs fully on-device and without Apple's content guardrails. Users can generate portraits and lifelike images — the kinds of things Apple's own tools restrict.
+
+---
+
+## Target User
+
+Someone who would describe themselves as a regular iPhone user, not a creative professional. They've used Canva or VSCO. They haven't used Stable Diffusion or Midjourney. They don't know what a prompt is in the AI sense — they just know what they want to see.
+
+---
+
+## The Journey
+
+### 1. First Launch
+
+The app cannot generate images until a model has been downloaded (~1–2GB). This is unavoidable, and the design should make it feel like installation, not loading — a one-time setup that unlocks something.
+
+**What this moment needs to communicate:**
+- What's happening and why (a model is being downloaded to your device — so generation stays private and works offline)
+- How long it will take (give a real estimate)
+- That this only happens once
+
+**The opportunity here:** this is the one moment of genuine anticipation in the app. The designer has latitude to make it feel exciting — to seed the user's imagination for what comes next. Example prompts, a visual of what the app can produce, a sense of capability being installed. Don't just show a progress bar on a white screen.
+
+The download should be resumable and tolerant of backgrounding. If the user leaves and returns, they should land back exactly where they left off.
+
+---
+
+### 2. The Prompt
+
+Once the model is ready, the user arrives at the main screen. This is where they spend most of their time.
+
+**The primary action is describing an image.** Voice is the natural default — image descriptions feel more like speech than typing. The design should make voice feel like the obvious first move, with text as a natural alternative.
+
+The interface is conversational: the history of what the user has asked for, and what was generated, lives here. Think of it as a creative conversation with the app rather than a form to fill in.
+
+**What this screen needs:**
+- A clear, low-friction way to start a new prompt (voice or text)
+- The conversation history — prompts and their resulting images
+- Access to the current image in full detail
+
+**What it should not have:**
+- Sliders, settings, or parameters
+- Model selection
+- Anything that requires understanding how diffusion works
+
+---
+
+### 3. Generation
+
+Image generation takes roughly 6–10 seconds on iPhone. This is long enough that silence or a bare spinner feels broken. The design needs to make waiting feel active, not stuck.
+
+**The constraint:** don't show intermediate diffusion steps. They're visually noisy and confusing to anyone who doesn't understand the denoising process. The waiting state should feel intentional and calm.
+
+Beyond that, the designer has latitude: motion, blur-to-sharp reveal, a subtle pulse, an animation that suggests something is being made. The tone should match the product — simple and considered, not playful or gamified.
+
+---
+
+### 4. The Result
+
+The image appears. This is the payoff moment — it should feel like a reveal.
+
+**Primary actions after generation:**
+- **Save** — to the user's photo library
+- **Share** — the native iOS share sheet (covers iMessage, AirDrop, social apps)
+- **Try again** — same prompt, new generation
+- **Refine** — edit the prompt and generate again
+
+The image should be displayed at full prominence. Don't bury it in chrome.
+
+---
+
+## Image Format
+
+All generated images are **768 × 768**. Square. This simplifies layout and is the right balance between quality and generation speed on iPhone.
+
+---
+
+## Content
+
+LocalImage generates images on-device without Apple's content restrictions. Users can generate portraits and realistic images. The app has its own content filter that blocks explicit content, but is otherwise permissive.
+
+This is a meaningful product differentiator and worth communicating clearly at first launch — "generates privately on your device" — without making it feel like the point of the app is to circumvent restrictions.
+
+---
+
+## Platform
+
+iPhone is the primary target. iPad and Mac are in scope but secondary for this phase. Design for iPhone first; the layout should scale gracefully to larger screens.
+
+---
+
+## What This Brief Leaves Open
+
+The following are intentional design decisions, not oversights:
+
+- Visual language, color, and typography
+- How the prompt input is styled and animated
+- The specific treatment of the generation waiting state
+- How images are displayed in the conversation history (grid, list, full-bleed scroll)
+- The reveal transition when the generated image appears
+- Iconography and naming throughout
+
+---
+
+## What to Hand Back
+
+- Flow covering: first launch → download → first prompt → generation → result → save/share
+- Key screen designs for each state
+- The waiting/generation state treatment
+- Notes on any journey decisions that need product input

--- a/scripts/dx-walkthrough/briefs/03-design-assets/LocalImage Flow.html
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/LocalImage Flow.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>LocalImage — Flow</title>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; background: #f0eee9; }
+  * { box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="ios-frame.jsx"></script>
+<script type="text/babel" src="tweaks-panel.jsx"></script>
+<script type="text/babel" src="screens.jsx"></script>
+<script type="text/babel" src="persona.jsx"></script>
+
+<script type="text/babel">
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "showFrame": true,
+  "primaryTheme": "paper",
+  "historyVariant": "feed",
+  "animate": true
+}/*EDITMODE-END*/;
+
+function Phone({ children, theme, showFrame }) {
+  const t = THEMES[theme];
+  if (showFrame) {
+    return (
+      <IOSDevice width={402} height={874} dark={t.statusDark}>
+        {children}
+      </IOSDevice>
+    );
+  }
+  return (
+    <div style={{
+      width: 402, height: 874, overflow: 'hidden', position: 'relative',
+      background: t.bg, fontFamily: LI_FONT,
+      boxShadow: '0 1px 3px rgba(0,0,0,.08), 0 4px 16px rgba(0,0,0,.06)',
+    }}>
+      {children}
+    </div>
+  );
+}
+
+const ART_W = 402, ART_H = 874;
+const ART = (label, id) => ({ width: ART_W, height: ART_H, label, id });
+
+function Flow({ tweaks }) {
+  const t = tweaks.primaryTheme;
+  const showFrame = tweaks.showFrame;
+  const anim = tweaks.animate;
+  const HistoryScreen = tweaks.historyVariant === 'feed' ? ScreenHistoryFeed : ScreenHistoryChat;
+
+  return (
+    <DesignCanvas>
+      <DCSection id="journey" title="LocalImage — full journey"
+        subtitle="First launch → install → prompt → voice → generation → result → history. Tweaks (top-right) switches Paper / Dusk and Chat / Feed.">
+        <DCArtboard {...ART('01 · First launch', 'first')}>
+          <Phone theme={t} showFrame={showFrame}><ScreenFirstLaunch theme={t} anim={anim} /></Phone>
+        </DCArtboard>
+        <DCArtboard {...ART('02 · Installing model', 'download')}>
+          <Phone theme={t} showFrame={showFrame}><ScreenDownload theme={t} anim={anim} /></Phone>
+        </DCArtboard>
+        <DCArtboard {...ART('03 · Empty prompt', 'empty')}>
+          <Phone theme={t} showFrame={showFrame}><ScreenEmptyPrompt theme={t} /></Phone>
+        </DCArtboard>
+        <DCArtboard {...ART('04 · Voice listening', 'voice')}>
+          <Phone theme={t} showFrame={showFrame}><ScreenVoiceListening theme={t} anim={anim} /></Phone>
+        </DCArtboard>
+        <DCArtboard {...ART('05 · Generating', 'generating')}>
+          <Phone theme={t} showFrame={showFrame}><ScreenGenerating theme={t} anim={anim} /></Phone>
+        </DCArtboard>
+        <DCArtboard {...ART('06 · Result', 'result')}>
+          <Phone theme={t} showFrame={showFrame}><ScreenResult theme={t} /></Phone>
+        </DCArtboard>
+        <DCArtboard {...ART(`07 · History — ${tweaks.historyVariant}`, 'history')}>
+          <Phone theme={t} showFrame={showFrame}><HistoryScreen theme={t} /></Phone>
+        </DCArtboard>
+        <DCPostIt top={-30} left={1640} rotate={3} width={230}>
+          Reveal: 600ms crossfade from generating canvas → sharp image. The result page also auto-saves to the in-app library and tells you so — Save to Photos becomes secondary.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="errors" title="Error states"
+        subtitle="The brief left these out. Three the flow needs at minimum.">
+        <DCArtboard label="A · Download interrupted" id="err-download" width={ART_W} height={ART_H}>
+          <Phone theme={t} showFrame={showFrame}><ScreenErrorDownload theme={t} /></Phone>
+        </DCArtboard>
+        <DCArtboard label="B · Generation failed" id="err-gen" width={ART_W} height={ART_H}>
+          <Phone theme={t} showFrame={showFrame}><ScreenErrorGeneration theme={t} /></Phone>
+        </DCArtboard>
+        <DCArtboard label="C · Prompt blocked (content filter)" id="err-block" width={ART_W} height={ART_H}>
+          <Phone theme={t} showFrame={showFrame}><ScreenErrorBlocked theme={t} /></Phone>
+        </DCArtboard>
+        <DCPostIt top={-30} left={900} rotate={-2} width={230}>
+          Tone: explain what happened in plain language, never blame the user, always offer one tap to recover. Download is resumable from the failure point.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="themes" title="Light + Dark = Paper + Dusk"
+        subtitle="Theme follows iOS system setting. Paper for day, Dusk for night. Same tokens — only the surface inverts.">
+        <DCArtboard label="Paper · light" id="paper" width={ART_W} height={ART_H}>
+          <Phone theme="paper" showFrame={showFrame}><ScreenResult theme="paper" /></Phone>
+        </DCArtboard>
+        <DCArtboard label="Dusk · dark" id="dusk" width={ART_W} height={ART_H}>
+          <Phone theme="dusk" showFrame={showFrame}><ScreenResult theme="dusk" /></Phone>
+        </DCArtboard>
+        <DCArtboard label="History · Paper" id="th-paper-h" width={ART_W} height={ART_H}>
+          <Phone theme="paper" showFrame={showFrame}><ScreenHistoryFeed theme="paper" /></Phone>
+        </DCArtboard>
+        <DCArtboard label="History · Dusk" id="th-dusk-h" width={ART_W} height={ART_H}>
+          <Phone theme="dusk" showFrame={showFrame}><ScreenHistoryFeed theme="dusk" /></Phone>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="appicons" title="App icon — six directions"
+        subtitle="Six unbranded explorations. Square iOS-style.">
+        <DCArtboard label="Icon explorations" id="icons" width={580} height={ART_H}>
+          <ScreenAppIcons />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="actions" title="Action sheet — what's behind the …"
+        subtitle="Long-press or tap '⋯' on any history item. Re-use, refine, vary, save, share, delete.">
+        <DCArtboard label="History · long-press menu" id="action-sheet" width={ART_W} height={ART_H}>
+          <Phone theme={t} showFrame={showFrame}><ScreenActionSheet theme={t} /></Phone>
+        </DCArtboard>
+        <DCPostIt top={-30} left={460} rotate={2} width={250}>
+          "Make a variation" is the quiet power feature — same prompt, fresh seed. It's how casual users discover that one prompt has a million possible outputs.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="persona" title="Persona walkthrough — Maya, 34"
+        subtitle="A non-creative-pro Canva user goes through the flow. Her reactions drove the changes below.">
+        <DCArtboard label="Maya walks the flow" id="persona-walk" width={1080} height={2300}>
+          <PersonaWalkthrough />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="larger" title="iPad + macOS — graceful scale-up"
+        subtitle="Brief said iPad/Mac are secondary. Same data model, different shell: persistent library sidebar instead of a stack of screens.">
+        <DCArtboard label="iPad · landscape" id="ipad" width={1180} height={820}>
+          <ScreenIPad theme={t} />
+        </DCArtboard>
+        <DCArtboard label="macOS · window" id="mac" width={920} height={620}>
+          <ScreenMac theme={t} />
+        </DCArtboard>
+        <DCPostIt top={-30} left={1240} rotate={-3} width={260}>
+          On iPhone, history is a destination you push into. On iPad/Mac, it's always visible — there's screen real estate to spare. Composer collapses to a single bar at the bottom of the canvas.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="notes" title="Decisions answered + open questions"
+        subtitle="What this round changed and what's still open for you.">
+        <DCArtboard label="Notes" id="notes-card" width={620} height={ART_H}>
+          <Notes />
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+function Notes() {
+  const Item = ({ n, q, a }) => (
+    <div style={{ marginBottom: 18 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, letterSpacing: 0.6,
+        color: 'rgba(40,30,20,0.5)', textTransform: 'uppercase', marginBottom: 4 }}>{n}</div>
+      <div style={{ fontFamily: '"Tiempos Headline", Georgia, serif',
+        fontSize: 16, lineHeight: 1.3, fontWeight: 500,
+        color: 'rgba(28,24,20,0.95)', marginBottom: 6, letterSpacing: -0.2 }}>{q}</div>
+      <div style={{ fontSize: 13, lineHeight: 1.5, color: 'rgba(28,24,20,0.7)' }}>{a}</div>
+    </div>
+  );
+  return (
+    <div style={{
+      width: '100%', height: '100%', padding: '36px 32px',
+      fontFamily: '-apple-system, system-ui',
+      background: '#FBF8F2', overflow: 'auto',
+    }}>
+      <div style={{ fontFamily: '"Tiempos Headline", Georgia, serif',
+        fontSize: 22, fontWeight: 500, letterSpacing: -0.4, marginBottom: 4 }}>
+        Round 2 — what changed, what's left open
+      </div>
+      <div style={{ fontSize: 12.5, color: 'rgba(28,24,20,0.55)', marginBottom: 22 }}>
+        Notes from your review.
+      </div>
+
+      <div style={{ fontSize: 11, fontFamily: MONO, letterSpacing: 0.6,
+        color: 'rgba(28,24,20,0.45)', textTransform: 'uppercase',
+        marginBottom: 12, paddingBottom: 6, borderBottom: '0.5px solid rgba(28,24,20,0.12)' }}>
+        Resolved
+      </div>
+
+      <Item n="01" q="Light = Paper, Dark = Dusk."
+        a='Two themes only, bound to the iOS system setting. The third "Bright" direction is dropped.' />
+
+      <Item n="02" q="Result hierarchy now matches usage."
+        a={<>
+          <strong>Try again</strong> and <strong>Refine</strong> are the two largest, accent-filled buttons — equal weight and side-by-side. <strong>Save to Photos</strong> and <strong>Share</strong> are quieter ghost buttons below. Every result is auto-saved to the in-app library, so "save" no longer means "or it's gone."
+        </>} />
+
+      <Item n="03" q="Where do images live?"
+        a={<>
+          Two places. (1) The <strong>LocalImage library</strong> — every generation is auto-saved here forever; this is the conversation history. (2) <strong>Photos</strong> — only when the user explicitly taps Save. The result screen says "Saved to LocalImage library · 768²" right under the prompt, so users always know it isn't lost.
+        </>} />
+
+      <Item n="04" q="Suggestion chips now demonstrate stylistic range."
+        a="Six suggestions, each prefixed with a monospace style tag — PHOTO, ILLUSTRATION, PORTRAIT, ABSTRACT, FILM STILL, 3D RENDER. The tag teaches the user that style is part of the prompt, without exposing a 'style picker' control." />
+
+      <Item n="05" q="Three error states added."
+        a={<>
+          <strong>Download interrupted</strong> (resumable from %), <strong>Generation failed</strong> (memory pressure — try again, prompt preserved), and <strong>Prompt blocked</strong> (content filter — explained without scolding, with reassurance that the prompt stayed on-device).
+        </>} />
+
+      <Item n="06" q="Accessibility pass."
+        a={<>
+          Every icon-only button has an <code style={{ fontFamily: MONO, fontSize: 12 }}>aria-label</code>. Every generated image has its prompt as <code style={{ fontFamily: MONO, fontSize: 12 }}>alt</code>. The progress bar exposes <code style={{ fontFamily: MONO, fontSize: 12 }}>aria-valuenow</code>; the live transcript announces with <code style={{ fontFamily: MONO, fontSize: 12 }}>aria-live="polite"</code>; the generating canvas is a labelled <code style={{ fontFamily: MONO, fontSize: 12 }}>role="status"</code>.
+        </>} />
+
+      <Item n="07" q="Back-nav language fixed."
+        a='The Generating and Result screens now use a close (×) — they sit on top of the library, not behind it. Tapping × dismisses back to the library where every generation already lives. "← History" was misleading.' />
+
+      <Item n="08" q="App icon — six directions."
+        a={<>
+          See the icons board. My pick: <strong>Glass lens</strong> or <strong>Window</strong> — both lean on <em>seeing</em> rather than <em>generating</em>, which matches the user's mental model better than aperture or sparkle motifs.
+        </>} />
+
+      <Item n="09" q="Library long-press menu."
+        a={<>
+          Every history item exposes the same six actions via long-press or the "⋯" affordance: <strong>use again</strong>, <strong>refine</strong>, <strong>make a variation</strong>, <strong>save to Photos</strong>, <strong>share</strong>, <strong>delete</strong>. "Make a variation" is the quiet power feature — same prompt, fresh seed.
+        </>} />
+
+      <Item n="10" q="iPad + Mac — same data, different shell."
+        a={<>
+          Brief said secondary, so I'm leaning into "same model, scaled gracefully." The library becomes a persistent left sidebar; the focused image takes the canvas; the composer collapses to a single bar at the bottom. <strong>⌘N</strong> for new prompt, <strong>⌘⇧D</strong> to start voice. No new affordances — just more visible at once.
+        </>} />
+
+      <Item n="11" q="The ⋯ button has one job."
+        a={<>
+          Audited every "⋯" — they meant three different things on three screens. New rule: <strong>⋯ only appears next to a single image</strong> (in the library, or as the long-press handle), and always opens the same action sheet. App-level navigation uses a <strong>settings cog (⚙)</strong> instead. iPad/Mac dropped the ⋯ entirely — Save and Share are inline; long-press a library item for everything else.
+        </>} />
+
+      <Item n="12" q="Privacy vs share — both, framed honestly."
+        a={<>
+          The privacy promise is about the <em>generation</em>; sharing is something the user actively chooses. So: Share button reads <code style={{ fontFamily: MONO, fontSize: 12 }}>Share…</code> (iOS-standard "opens a chooser, you stay in control"), the action-sheet sub-line says "Choose an app — leaves the device only when you pick one," and the Result + iPad/Mac screens carry an <strong>ON DEVICE</strong> chip in the corner so the privacy line never fades on bigger screens. We <em>don't</em> add prompts to share, no "post to community" surfaces — social engagement happens through the user's own networks via the iOS share sheet, not through us.
+        </>} />
+
+      <div style={{ fontSize: 11, fontFamily: MONO, letterSpacing: 0.6,
+        color: 'rgba(28,24,20,0.45)', textTransform: 'uppercase',
+        margin: '28px 0 12px', paddingBottom: 6,
+        borderBottom: '0.5px solid rgba(28,24,20,0.12)' }}>
+        Open for you
+      </div>
+
+      <Item n="A" q="Auto-save to Photos? Or library only?"
+        a="Right now: library auto, Photos manual. The alternative — auto-save to Photos too — is friendlier for casual users but pollutes their camera roll fast. Recommend library-only by default, with a one-time first-run prompt asking if they want everything to also flow to Photos." />
+
+      <Item n="B" q="Naming."
+        a={<>"LocalImage" is descriptive but forgettable. Some to react to: <em>Quill</em>, <em>Pocket Studio</em>, <em>Atelier</em>, <em>Idle</em>, <em>Stillpoint</em>, <em>Frame</em>, <em>Latent</em>. None are right yet — happy to push further once you weigh in.</>} />
+
+      <Item n="C" q="What does the content filter actually block?"
+        a="The Prompt Blocked screen is intentionally vague (no list of words). Need product to confirm copy + whether we offer 'Learn more' as a real link to a policy page or remove it." />
+    </div>
+  );
+}
+
+function App() {
+  const [tweaks, setTweak] = useTweaks(TWEAK_DEFAULTS);
+  return (
+    <React.Fragment>
+      <Flow tweaks={tweaks} />
+      <TweaksPanel title="Tweaks">
+        <TweakSection label="Aesthetic" />
+        <TweakRadio label="Theme" value={tweaks.primaryTheme}
+          options={[{value:'paper',label:'Paper (light)'},{value:'dusk',label:'Dusk (dark)'}]}
+          onChange={(v) => setTweak('primaryTheme', v)} />
+        <TweakSection label="History layout" />
+        <TweakRadio label="Variant" value={tweaks.historyVariant}
+          options={[{value:'chat',label:'Chat'},{value:'feed',label:'Feed'}]}
+          onChange={(v) => setTweak('historyVariant', v)} />
+        <TweakSection label="Presentation" />
+        <TweakToggle label="iPhone bezel" value={tweaks.showFrame}
+          onChange={(v) => setTweak('showFrame', v)} />
+        <TweakToggle label="Animate screens" value={tweaks.animate}
+          onChange={(v) => setTweak('animate', v)} />
+      </TweaksPanel>
+    </React.Fragment>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/scripts/dx-walkthrough/briefs/03-design-assets/LocalImage Intro Video.html
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/LocalImage Intro Video.html
@@ -1,0 +1,871 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>LocalImage — Intro</title>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #0a0a0a; overflow: hidden; }
+  * { box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="animations.jsx"></script>
+
+<script type="text/babel">
+// ─────────────────────────────────────────────────────────────
+// LocalImage — animated intro
+// ─────────────────────────────────────────────────────────────
+
+const PAPER = {
+  bg: '#F4F1EB',
+  surface: '#FBF8F2',
+  surfaceAlt: '#EBE6DB',
+  ink: '#1C1814',
+  inkDim: 'rgba(28,24,20,0.55)',
+  inkFaint: 'rgba(28,24,20,0.28)',
+  line: 'rgba(28,24,20,0.10)',
+  accent: '#1C1814',
+  accentInk: '#FBF8F2',
+};
+
+const SERIF = '"Tiempos Headline", "Charter", "Iowan Old Style", Georgia, serif';
+const SANS  = '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif';
+const MONO  = 'ui-monospace, "SF Mono", Menlo, monospace';
+
+const DURATION = 30;
+
+
+
+// ─────────────────────────────────────────────────────────────
+// Tiny visual building blocks
+// ─────────────────────────────────────────────────────────────
+
+function Chip({ children, x, y, opacity = 1 }) {
+  return (
+    <div style={{
+      position: 'absolute', left: x, top: y,
+      padding: '6px 10px',
+      fontFamily: MONO, fontSize: 10, letterSpacing: 1.2, textTransform: 'uppercase',
+      color: PAPER.ink,
+      background: PAPER.surface,
+      border: `0.5px solid ${PAPER.line}`,
+      borderRadius: 999,
+      opacity,
+    }}>
+      {children}
+    </div>
+  );
+}
+
+// Animated phone-shaped panel — the visual anchor.
+// 320×620, sits inside the Stage. Contents passed as children.
+function PhonePanel({ x, y, scale = 1, children }) {
+  return (
+    <div style={{
+      position: 'absolute', left: x, top: y,
+      width: 320, height: 620,
+      transform: `scale(${scale})`,
+      transformOrigin: 'top left',
+      background: PAPER.surface,
+      borderRadius: 36,
+      overflow: 'hidden',
+      border: `1px solid ${PAPER.line}`,
+      boxShadow: '0 30px 60px rgba(28,24,20,0.18), 0 8px 18px rgba(28,24,20,0.10)',
+    }}>
+      <div style={{ position: 'absolute', inset: 0, padding: '40px 22px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ── Striped placeholder image (matches existing screens.jsx vocabulary)
+function PlaceholderImage({ width, height, hue = 22, hue2 = 200, label, opacity = 1, radius = 18, blur = 0 }) {
+  return (
+    <div style={{
+      width, height, borderRadius: radius, opacity,
+      position: 'relative', overflow: 'hidden',
+      background: `linear-gradient(135deg, oklch(0.62 0.13 ${hue}) 0%, oklch(0.50 0.10 ${hue2}) 100%)`,
+      filter: blur ? `blur(${blur}px)` : 'none',
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: 'repeating-linear-gradient(135deg, rgba(255,255,255,0.07) 0 2px, transparent 2px 9px)',
+        mixBlendMode: 'overlay',
+      }}/>
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: 'radial-gradient(120% 80% at 30% 25%, rgba(255,255,255,0.18) 0%, transparent 55%)',
+      }}/>
+      {label && (
+        <div style={{
+          position: 'absolute', left: 12, bottom: 10,
+          fontFamily: MONO, fontSize: 10, letterSpacing: 0.4, textTransform: 'uppercase',
+          color: 'rgba(255,255,255,0.85)',
+          textShadow: '0 1px 2px rgba(0,0,0,0.4)',
+        }}>{label}</div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scene 1 — wordmark
+// ─────────────────────────────────────────────────────────────
+function SceneOpen({ visible }) {
+  const { progress, localTime } = useSprite();
+  if (!visible) return null;
+
+  const titleOp = clamp((localTime - 0.2) / 0.7, 0, 1);
+  const titleY  = (1 - Easing.easeOutCubic(titleOp)) * 24;
+
+  const tagOp   = clamp((localTime - 1.4) / 0.6, 0, 1);
+  const tagY    = (1 - Easing.easeOutCubic(tagOp)) * 12;
+
+  // Underline draws across
+  const lineW   = clamp((localTime - 1.0) / 0.9, 0, 1);
+
+  // Exit fade in last 0.7s
+  const exit = clamp((localTime - 3.5) / 0.7, 0, 1);
+  const opAll = 1 - exit;
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, opacity: opAll }}>
+      <div style={{
+        position: 'absolute', left: '50%', top: 240,
+        transform: `translate(-50%, ${titleY}px)`,
+        opacity: titleOp,
+        fontFamily: SERIF, fontSize: 96, fontWeight: 500,
+        letterSpacing: -2, color: PAPER.ink,
+        whiteSpace: 'nowrap',
+      }}>
+        LocalImage
+      </div>
+      <div style={{
+        position: 'absolute', left: '50%', top: 360,
+        width: 380, height: 1,
+        transform: 'translateX(-50%)',
+        background: PAPER.line,
+      }}>
+        <div style={{
+          position: 'absolute', left: 0, top: 0, height: 1,
+          width: `${lineW * 100}%`,
+          background: PAPER.ink,
+        }}/>
+      </div>
+      <div style={{
+        position: 'absolute', left: '50%', top: 388,
+        transform: `translate(-50%, ${tagY}px)`,
+        opacity: tagOp,
+        fontFamily: SANS, fontSize: 18, fontWeight: 400,
+        color: PAPER.inkDim, letterSpacing: 0.2,
+      }}>
+        Image generation, on your device.
+      </div>
+
+      {/* monospace details */}
+      <div style={{
+        position: 'absolute', left: 60, top: 60,
+        fontFamily: MONO, fontSize: 11, letterSpacing: 1.6,
+        color: PAPER.inkFaint, textTransform: 'uppercase',
+        opacity: titleOp,
+      }}>v 1.0 · iOS</div>
+      <div style={{
+        position: 'absolute', right: 60, top: 60,
+        fontFamily: MONO, fontSize: 11, letterSpacing: 1.6,
+        color: PAPER.inkFaint, textTransform: 'uppercase',
+        opacity: titleOp,
+      }}>on-device · always</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scene 2 — speak it (waveform + transcript)
+// ─────────────────────────────────────────────────────────────
+function SceneVoice({ visible }) {
+  const { localTime } = useSprite();
+  if (!visible) return null;
+
+  const phoneOp = clamp(localTime / 0.5, 0, 1);
+  const phoneY  = (1 - Easing.easeOutCubic(phoneOp)) * 30;
+
+  const headerOp = clamp((localTime - 0.4) / 0.4, 0, 1);
+
+  // Waveform: 24 vertical bars whose heights wobble
+  const bars = 24;
+  const t = localTime;
+  const transcript = "a quiet harbor at dawn, watercolor";
+  const charsToShow = Math.floor(clamp((localTime - 1.6) / 2.4, 0, 1) * transcript.length);
+  const visibleText = transcript.slice(0, charsToShow);
+
+  const exit = clamp((localTime - 5.4) / 0.6, 0, 1);
+  const opAll = 1 - exit;
+
+  // Big copy on the left
+  const headlineOp = clamp((localTime - 0.5) / 0.6, 0, 1);
+  const headlineY = (1 - Easing.easeOutCubic(headlineOp)) * 18;
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, opacity: opAll }}>
+      {/* Left copy */}
+      <div style={{
+        position: 'absolute', left: 90, top: 220,
+        opacity: headlineOp,
+        transform: `translateY(${headlineY}px)`,
+      }}>
+        <div style={{
+          fontFamily: MONO, fontSize: 11, letterSpacing: 1.6,
+          color: PAPER.inkFaint, textTransform: 'uppercase', marginBottom: 16,
+        }}>01 · prompt</div>
+        <div style={{
+          fontFamily: SERIF, fontSize: 72, fontWeight: 500,
+          letterSpacing: -1.5, color: PAPER.ink, lineHeight: 1.0,
+        }}>Just<br/>speak.</div>
+        <div style={{
+          fontFamily: SANS, fontSize: 16, color: PAPER.inkDim,
+          marginTop: 24, maxWidth: 360, lineHeight: 1.5,
+        }}>
+          Tap, talk, done. No prompts to memorize, no settings to fuss with — describe the picture you want like you'd describe it to a friend.
+        </div>
+      </div>
+
+      {/* Phone on the right */}
+      <div style={{
+        position: 'absolute', left: 800, top: 50,
+        opacity: phoneOp,
+        transform: `translateY(${phoneY}px)`,
+      }}>
+        <PhonePanel x={0} y={0}>
+          <div style={{
+            fontFamily: MONO, fontSize: 9.5, letterSpacing: 1.4,
+            color: PAPER.inkFaint, textTransform: 'uppercase',
+            opacity: headerOp, marginBottom: 32, marginTop: 4,
+          }}>listening</div>
+
+          {/* Big animated waveform */}
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            gap: 4, height: 160, marginTop: 50,
+          }}>
+            {Array.from({ length: bars }).map((_, i) => {
+              const phase = i * 0.35;
+              const h = 12 + Math.abs(Math.sin(t * 4 + phase) * 0.7
+                + Math.sin(t * 2.3 + phase * 1.7) * 0.3) * 100;
+              const o = clamp((localTime - 0.4 - i * 0.02) / 0.4, 0, 1);
+              return (
+                <div key={i} style={{
+                  width: 4, height: h, borderRadius: 2,
+                  background: PAPER.ink,
+                  opacity: o * 0.85,
+                }}/>
+              );
+            })}
+          </div>
+
+          {/* Transcript card */}
+          <div style={{
+            marginTop: 50, padding: '18px 18px',
+            background: PAPER.surfaceAlt, borderRadius: 16,
+            border: `0.5px solid ${PAPER.line}`,
+            minHeight: 90,
+            opacity: clamp((localTime - 1.4) / 0.4, 0, 1),
+          }}>
+            <div style={{
+              fontFamily: MONO, fontSize: 9, letterSpacing: 1.2,
+              color: PAPER.inkFaint, textTransform: 'uppercase', marginBottom: 8,
+            }}>transcript · live</div>
+            <div style={{
+              fontFamily: SERIF, fontSize: 19, color: PAPER.ink,
+              lineHeight: 1.35, letterSpacing: -0.2,
+            }}>
+              {visibleText}
+              <span style={{
+                display: 'inline-block', width: 2, height: 18,
+                background: PAPER.ink, marginLeft: 2,
+                opacity: Math.floor(t * 2) % 2 ? 1 : 0,
+                verticalAlign: 'text-bottom',
+              }}/>
+            </div>
+          </div>
+
+          {/* Mic dot */}
+          <div style={{
+            position: 'absolute', left: '50%', bottom: 48,
+            transform: 'translateX(-50%)',
+            width: 64, height: 64, borderRadius: 32,
+            background: PAPER.ink,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            boxShadow: `0 0 0 ${8 + Math.sin(t * 3) * 4}px rgba(28,24,20,0.08)`,
+          }}>
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none"
+              stroke={PAPER.accentInk} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="9" y="3" width="6" height="12" rx="3"/>
+              <path d="M5 11a7 7 0 0 0 14 0"/>
+              <path d="M12 18v3"/>
+            </svg>
+          </div>
+        </PhonePanel>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scene 3 — generating, on-device
+// ─────────────────────────────────────────────────────────────
+function SceneGenerate({ visible }) {
+  const { localTime } = useSprite();
+  if (!visible) return null;
+
+  const inOp = clamp(localTime / 0.5, 0, 1);
+  const exit = clamp((localTime - 5.4) / 0.6, 0, 1);
+  const opAll = (1 - exit) * inOp;
+
+  // Progress 0 → 1 over 5.5s
+  const progress = clamp(localTime / 5.5, 0, 1);
+
+  // Headline on right
+  const headlineOp = clamp((localTime - 0.4) / 0.6, 0, 1);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, opacity: opAll }}>
+      {/* Phone on left */}
+      <div style={{ position: 'absolute', left: 160, top: 50 }}>
+        <PhonePanel x={0} y={0}>
+          {/* Top chip — ON DEVICE pulses */}
+          <div style={{
+            position: 'absolute', left: 22, top: 22,
+            display: 'flex', alignItems: 'center', gap: 6,
+            padding: '6px 10px',
+            fontFamily: MONO, fontSize: 9, letterSpacing: 1.4, textTransform: 'uppercase',
+            color: PAPER.ink,
+            background: PAPER.surface,
+            border: `0.5px solid ${PAPER.line}`,
+            borderRadius: 999,
+          }}>
+            <span style={{
+              width: 6, height: 6, borderRadius: 3,
+              background: PAPER.ink,
+              opacity: 0.4 + Math.sin(localTime * 4) * 0.4 + 0.4,
+            }}/>
+            on device
+          </div>
+
+          {/* Generating canvas — striped placeholder with shimmer */}
+          <div style={{
+            position: 'absolute', left: 22, top: 90,
+            width: 276, height: 276, borderRadius: 18,
+            overflow: 'hidden',
+            background: PAPER.surfaceAlt,
+            border: `0.5px solid ${PAPER.line}`,
+          }}>
+            {/* Shimmer */}
+            <div style={{
+              position: 'absolute', inset: 0,
+              background: `repeating-linear-gradient(135deg,
+                rgba(28,24,20,0.04) 0 8px,
+                rgba(28,24,20,0.10) 8px 16px)`,
+            }}/>
+            <div style={{
+              position: 'absolute', inset: 0,
+              background: `linear-gradient(110deg,
+                transparent 0%,
+                transparent ${(localTime * 30) % 140 - 30}%,
+                rgba(255,255,255,0.55) ${(localTime * 30) % 140 - 5}%,
+                transparent ${(localTime * 30) % 140 + 20}%,
+                transparent 100%)`,
+            }}/>
+            {/* Faint emerging shape */}
+            <div style={{
+              position: 'absolute', inset: 0,
+              opacity: progress * 0.75,
+            }}>
+              <PlaceholderImage width={276} height={276} hue={22} hue2={200}
+                radius={0} blur={Math.max(0, 16 - progress * 16)} />
+            </div>
+            {/* mono caption */}
+            <div style={{
+              position: 'absolute', left: 12, bottom: 12,
+              fontFamily: MONO, fontSize: 9.5, letterSpacing: 0.4,
+              textTransform: 'uppercase',
+              color: 'rgba(255,255,255,0.85)',
+              textShadow: '0 1px 2px rgba(0,0,0,0.4)',
+              opacity: progress,
+            }}>watercolor · 768²</div>
+          </div>
+
+          {/* Prompt echo */}
+          <div style={{
+            position: 'absolute', left: 22, top: 388,
+            fontFamily: MONO, fontSize: 9, letterSpacing: 1.2,
+            color: PAPER.inkFaint, textTransform: 'uppercase',
+          }}>generating</div>
+          <div style={{
+            position: 'absolute', left: 22, top: 408, right: 22,
+            fontFamily: SERIF, fontSize: 17, color: PAPER.ink,
+            lineHeight: 1.3, letterSpacing: -0.2,
+          }}>
+            "a quiet harbor at dawn, watercolor"
+          </div>
+
+          {/* Progress bar */}
+          <div style={{
+            position: 'absolute', left: 22, right: 22, top: 480,
+            height: 3, borderRadius: 2,
+            background: PAPER.surfaceAlt,
+          }}>
+            <div style={{
+              height: '100%', width: `${progress * 100}%`,
+              background: PAPER.ink, borderRadius: 2,
+              transition: 'width linear',
+            }}/>
+          </div>
+          <div style={{
+            position: 'absolute', left: 22, top: 492,
+            fontFamily: MONO, fontSize: 10, letterSpacing: 1,
+            color: PAPER.inkDim,
+          }}>
+            {Math.round(progress * 100)}% · step {Math.min(20, Math.floor(progress * 20) + 1)}/20
+          </div>
+          <div style={{
+            position: 'absolute', right: 22, top: 492,
+            fontFamily: MONO, fontSize: 10, letterSpacing: 1,
+            color: PAPER.inkDim,
+          }}>
+            ~{Math.max(1, Math.ceil((1 - progress) * 8))}s
+          </div>
+        </PhonePanel>
+      </div>
+
+      {/* Headline right */}
+      <div style={{
+        position: 'absolute', right: 90, top: 220, width: 460, textAlign: 'right',
+        opacity: headlineOp,
+      }}>
+        <div style={{
+          fontFamily: MONO, fontSize: 11, letterSpacing: 1.6,
+          color: PAPER.inkFaint, textTransform: 'uppercase', marginBottom: 16,
+        }}>02 · on device</div>
+        <div style={{
+          fontFamily: SERIF, fontSize: 64, fontWeight: 500,
+          letterSpacing: -1.5, color: PAPER.ink, lineHeight: 1.0,
+        }}>Your phone<br/>thinks for itself.</div>
+        <div style={{
+          fontFamily: SANS, fontSize: 16, color: PAPER.inkDim,
+          marginTop: 24, marginLeft: 'auto', maxWidth: 380, lineHeight: 1.5,
+        }}>
+          Nothing leaves the device. The model runs locally — your prompts, your pictures, your hardware. No upload. No account required.
+        </div>
+
+        {/* Hardware tags */}
+        <div style={{
+          display: 'flex', gap: 8, justifyContent: 'flex-end',
+          marginTop: 28, opacity: clamp((localTime - 1.6) / 0.5, 0, 1),
+        }}>
+          {['Neural Engine', '4.2 GB RAM', '0 KB sent'].map(s => (
+            <div key={s} style={{
+              padding: '6px 10px',
+              fontFamily: MONO, fontSize: 10, letterSpacing: 1.2, textTransform: 'uppercase',
+              color: PAPER.ink,
+              background: PAPER.surface,
+              border: `0.5px solid ${PAPER.line}`,
+              borderRadius: 999,
+            }}>{s}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scene 4 — Result + actions
+// ─────────────────────────────────────────────────────────────
+function SceneResult({ visible }) {
+  const { localTime } = useSprite();
+  if (!visible) return null;
+
+  const inOp = clamp(localTime / 0.6, 0, 1);
+  const exit = clamp((localTime - 5.0) / 0.6, 0, 1);
+  const opAll = (1 - exit) * inOp;
+
+  // Image reveal: starts blurred, sharpens
+  const sharp = clamp((localTime - 0.2) / 1.2, 0, 1);
+  const blur = (1 - sharp) * 18;
+  const scaleImg = 0.96 + sharp * 0.04;
+
+  // Action buttons drop in
+  const actionsOp = clamp((localTime - 1.3) / 0.5, 0, 1);
+  const actionsY = (1 - Easing.easeOutCubic(actionsOp)) * 16;
+
+  // Headline
+  const headOp = clamp((localTime - 0.5) / 0.6, 0, 1);
+
+  // Saved-to-library badge slides in last
+  const savedOp = clamp((localTime - 2.4) / 0.5, 0, 1);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, opacity: opAll }}>
+      {/* Headline */}
+      <div style={{
+        position: 'absolute', left: 90, top: 100,
+        opacity: headOp,
+      }}>
+        <div style={{
+          fontFamily: MONO, fontSize: 11, letterSpacing: 1.6,
+          color: PAPER.inkFaint, textTransform: 'uppercase', marginBottom: 12,
+        }}>03 · result</div>
+        <div style={{
+          fontFamily: SERIF, fontSize: 56, fontWeight: 500,
+          letterSpacing: -1.5, color: PAPER.ink, lineHeight: 1.0,
+        }}>It arrives.</div>
+      </div>
+
+      {/* Image — center stage */}
+      <div style={{
+        position: 'absolute', left: '50%', top: 220,
+        transform: `translateX(-50%) scale(${scaleImg})`,
+        transformOrigin: 'center top',
+        filter: `blur(${blur}px)`,
+        boxShadow: '0 30px 60px rgba(28,24,20,0.18), 0 8px 18px rgba(28,24,20,0.10)',
+        borderRadius: 22,
+      }}>
+        <PlaceholderImage
+          width={380} height={380}
+          hue={22} hue2={200}
+          radius={22}
+          label="harbor · watercolor · 768²"
+        />
+      </div>
+
+      {/* Saved-to-library chip below image */}
+      <div style={{
+        position: 'absolute', left: '50%', top: 620,
+        transform: 'translateX(-50%)',
+        opacity: savedOp,
+        display: 'flex', gap: 8, alignItems: 'center',
+        padding: '8px 14px',
+        background: PAPER.surface,
+        border: `0.5px solid ${PAPER.line}`,
+        borderRadius: 999,
+        fontFamily: MONO, fontSize: 10, letterSpacing: 1.4, textTransform: 'uppercase',
+        color: PAPER.inkDim,
+      }}>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+          stroke={PAPER.ink} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M5 12l5 5 9-11"/>
+        </svg>
+        saved to library
+      </div>
+
+      {/* Action buttons row, right side */}
+      <div style={{
+        position: 'absolute', right: 90, top: 260,
+        width: 260,
+        display: 'flex', flexDirection: 'column', gap: 12,
+        opacity: actionsOp,
+        transform: `translateY(${actionsY}px)`,
+      }}>
+        <button style={{
+          padding: '16px 18px', borderRadius: 14,
+          background: PAPER.ink, color: PAPER.accentInk,
+          border: 'none',
+          fontFamily: SANS, fontSize: 16, fontWeight: 600,
+          letterSpacing: -0.2, textAlign: 'left', cursor: 'default',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        }}>
+          Try again
+          <span style={{ fontFamily: MONO, fontSize: 10, letterSpacing: 1, opacity: 0.6 }}>SEED ↻</span>
+        </button>
+        <button style={{
+          padding: '16px 18px', borderRadius: 14,
+          background: PAPER.ink, color: PAPER.accentInk,
+          border: 'none',
+          fontFamily: SANS, fontSize: 16, fontWeight: 600,
+          letterSpacing: -0.2, textAlign: 'left', cursor: 'default',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        }}>
+          Refine
+          <span style={{ fontFamily: MONO, fontSize: 10, letterSpacing: 1, opacity: 0.6 }}>EDIT ↗</span>
+        </button>
+        <div style={{ height: 8 }}/>
+        <button style={{
+          padding: '14px 18px', borderRadius: 14,
+          background: 'transparent', color: PAPER.ink,
+          border: `0.5px solid ${PAPER.line}`,
+          fontFamily: SANS, fontSize: 15, fontWeight: 500,
+          textAlign: 'left', cursor: 'default',
+        }}>Save to Photos</button>
+        <button style={{
+          padding: '14px 18px', borderRadius: 14,
+          background: 'transparent', color: PAPER.ink,
+          border: `0.5px solid ${PAPER.line}`,
+          fontFamily: SANS, fontSize: 15, fontWeight: 500,
+          textAlign: 'left', cursor: 'default',
+        }}>Share…</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scene 5 — library / private
+// ─────────────────────────────────────────────────────────────
+function SceneLibrary({ visible }) {
+  const { localTime } = useSprite();
+  if (!visible) return null;
+
+  const inOp = clamp(localTime / 0.5, 0, 1);
+  const exit = clamp((localTime - 4.4) / 0.6, 0, 1);
+  const opAll = (1 - exit) * inOp;
+
+  // Stagger 8 grid items in
+  const items = [
+    { hue: 22,  hue2: 200, label: 'harbor' },
+    { hue: 180, hue2: 320, label: 'forest' },
+    { hue: 140, hue2: 30,  label: 'meadow' },
+    { hue: 260, hue2: 40,  label: 'garden' },
+    { hue: 300, hue2: 200, label: 'orchid' },
+    { hue: 10,  hue2: 220, label: 'sunset' },
+    { hue: 200, hue2: 60,  label: 'storm'  },
+    { hue: 340, hue2: 180, label: 'bloom'  },
+  ];
+
+  const headOp = clamp((localTime - 0.4) / 0.6, 0, 1);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, opacity: opAll }}>
+      {/* Headline */}
+      <div style={{
+        position: 'absolute', left: 90, top: 100,
+        opacity: headOp, maxWidth: 460,
+      }}>
+        <div style={{
+          fontFamily: MONO, fontSize: 11, letterSpacing: 1.6,
+          color: PAPER.inkFaint, textTransform: 'uppercase', marginBottom: 12,
+        }}>04 · library</div>
+        <div style={{
+          fontFamily: SERIF, fontSize: 56, fontWeight: 500,
+          letterSpacing: -1.5, color: PAPER.ink, lineHeight: 1.0,
+        }}>Yours alone.</div>
+        <div style={{
+          fontFamily: SANS, fontSize: 16, color: PAPER.inkDim,
+          marginTop: 20, lineHeight: 1.5,
+        }}>
+          Every picture you make is auto-saved to a private library on the device. No cloud. No account. No one watching but you.
+        </div>
+
+        <div style={{
+          display: 'flex', gap: 8, marginTop: 24,
+          opacity: clamp((localTime - 1.2) / 0.4, 0, 1),
+        }}>
+          {['No account', 'No cloud', 'No telemetry'].map(s => (
+            <div key={s} style={{
+              padding: '6px 10px',
+              fontFamily: MONO, fontSize: 10, letterSpacing: 1.2, textTransform: 'uppercase',
+              color: PAPER.ink,
+              background: PAPER.surface,
+              border: `0.5px solid ${PAPER.line}`,
+              borderRadius: 999,
+            }}>{s}</div>
+          ))}
+        </div>
+      </div>
+
+      {/* Grid right side */}
+      <div style={{
+        position: 'absolute', right: 90, top: 90,
+        width: 480,
+        display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12,
+      }}>
+        {items.map((it, i) => {
+          const start = 0.4 + i * 0.08;
+          const op = clamp((localTime - start) / 0.5, 0, 1);
+          const y  = (1 - Easing.easeOutCubic(op)) * 18;
+          return (
+            <div key={i} style={{
+              opacity: op,
+              transform: `translateY(${y}px)`,
+            }}>
+              <PlaceholderImage
+                width={150} height={150}
+                hue={it.hue} hue2={it.hue2}
+                label={it.label}
+                radius={12}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Scene 6 — closing wordmark
+// ─────────────────────────────────────────────────────────────
+function SceneClose({ visible }) {
+  const { localTime } = useSprite();
+  if (!visible) return null;
+
+  const inOp = clamp(localTime / 0.7, 0, 1);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, opacity: inOp }}>
+      <div style={{
+        position: 'absolute', left: '50%', top: 240,
+        transform: 'translateX(-50%)',
+        fontFamily: SERIF, fontSize: 96, fontWeight: 500,
+        letterSpacing: -2, color: PAPER.ink,
+        whiteSpace: 'nowrap',
+      }}>LocalImage</div>
+      <div style={{
+        position: 'absolute', left: '50%', top: 372,
+        transform: 'translateX(-50%)',
+        fontFamily: SANS, fontSize: 18,
+        color: PAPER.inkDim, letterSpacing: 0.2,
+      }}>Private by design.</div>
+
+      <div style={{
+        position: 'absolute', left: '50%', top: 440,
+        transform: 'translateX(-50%)',
+        display: 'flex', gap: 10,
+        opacity: clamp((localTime - 1.0) / 0.6, 0, 1),
+      }}>
+        {['iOS 17+', 'iPad', 'macOS'].map(s => (
+          <div key={s} style={{
+            padding: '6px 12px',
+            fontFamily: MONO, fontSize: 10, letterSpacing: 1.4, textTransform: 'uppercase',
+            color: PAPER.ink,
+            background: PAPER.surface,
+            border: `0.5px solid ${PAPER.line}`,
+            borderRadius: 999,
+          }}>{s}</div>
+        ))}
+      </div>
+
+      <div style={{
+        position: 'absolute', left: '50%', bottom: 80,
+        transform: 'translateX(-50%)',
+        fontFamily: MONO, fontSize: 10, letterSpacing: 1.6,
+        color: PAPER.inkFaint, textTransform: 'uppercase',
+      }}>coming soon</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Paper grain overlay
+// ─────────────────────────────────────────────────────────────
+
+function PaperGrain() {
+  // Subtle warm grain over everything
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, pointerEvents: 'none',
+      background: `radial-gradient(80% 60% at 50% 40%, transparent 0%, rgba(28,24,20,0.05) 100%)`,
+      mixBlendMode: 'multiply',
+    }}/>
+  );
+}
+
+function SceneLabel() {
+  const time = useTime();
+  // Shows a small mono label in the corner indicating which scene we're in
+  let label = '';
+  if (time < 3.9)       label = 'open';
+  else if (time < 9.3)  label = 'prompt';
+  else if (time < 14.7) label = 'on device';
+  else if (time < 19.7) label = 'result';
+  else if (time < 24.1) label = 'library';
+  else                  label = 'fin';
+
+  return (
+    <div style={{
+      position: 'absolute', left: 32, bottom: 28,
+      display: 'flex', alignItems: 'center', gap: 8,
+      fontFamily: MONO, fontSize: 10, letterSpacing: 1.6,
+      color: PAPER.inkFaint, textTransform: 'uppercase',
+    }}>
+      <span style={{
+        width: 6, height: 6, borderRadius: 3,
+        background: PAPER.ink, opacity: 0.6,
+      }}/>
+      LocalImage · {label}
+    </div>
+  );
+}
+
+function ProgressTicker() {
+  const { time, duration } = useTimeline();
+  const pct = Math.round((time / duration) * 100);
+  return (
+    <div style={{
+      position: 'absolute', right: 32, bottom: 28,
+      fontFamily: MONO, fontSize: 10, letterSpacing: 1.6,
+      color: PAPER.inkFaint, textTransform: 'uppercase',
+      fontVariantNumeric: 'tabular-nums',
+    }}>
+      {String(pct).padStart(2, '0')} / 100
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Root
+// ─────────────────────────────────────────────────────────────
+
+function App() {
+  return (
+    <Stage width={1280} height={720} duration={DURATION} background={PAPER.bg} loop={true} autoplay={true}>
+      {/* Sprites overlap by 0.6s so each scene's intro fade covers the previous scene's exit fade. */}
+      {/* Scene 1 — Open (exits 3.5–4.2) */}
+      <Sprite start={0} end={4.2}>
+        <SceneOpen visible />
+      </Sprite>
+
+      {/* Scene 2 — Voice (enters 0–0.5; exits 5.4–6.0; total 6.0s, offset 3.6) */}
+      <Sprite start={3.6} end={9.6}>
+        <SceneVoice visible />
+      </Sprite>
+
+      {/* Scene 3 — Generate (enters 0–0.5; exits 5.4–6.0; total 6.0s, offset 9.0) */}
+      <Sprite start={9.0} end={15.0}>
+        <SceneGenerate visible />
+      </Sprite>
+
+      {/* Scene 4 — Result (enters 0–0.6; exits 5.0–5.6; total 5.6s, offset 14.4) */}
+      <Sprite start={14.4} end={20.0}>
+        <SceneResult visible />
+      </Sprite>
+
+      {/* Scene 5 — Library (enters 0–0.5; exits 4.4–5.0; total 5.0s, offset 19.4) */}
+      <Sprite start={19.4} end={24.4}>
+        <SceneLibrary visible />
+      </Sprite>
+
+      {/* Scene 6 — Close (enters 0–0.7; offset 23.8) */}
+      <Sprite start={23.8} end={DURATION}>
+        <SceneClose visible />
+      </Sprite>
+
+      {/* Always-on chrome */}
+      <PaperGrain />
+      <SceneLabel />
+      <ProgressTicker />
+    </Stage>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/scripts/dx-walkthrough/briefs/03-design-assets/animations.jsx
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/animations.jsx
@@ -1,0 +1,673 @@
+
+// animations.jsx
+// Reusable animation starter: Stage, Timeline, Sprite, easing helpers.
+// Usage (in an HTML file that loads React + Babel):
+//
+//   <Stage width={1280} height={720} duration={10} background="#f6f4ef">
+//     <MyScene />
+//   </Stage>
+//
+// Inside <Stage>, any child can call useTime() to read the current
+// playhead (seconds). Or wrap content in <Sprite start={1} end={4}>...</Sprite>
+// to only render during that window -- children receive a `localTime` and
+// `progress` via the useSprite() hook.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Easing functions (hand-rolled, Popmotion-style) ─────────────────────────
+// All easings take t ∈ [0,1] and return eased t ∈ [0,1] (may overshoot for back/elastic).
+const Easing = {
+  linear: (t) => t,
+
+  // Quad
+  easeInQuad:    (t) => t * t,
+  easeOutQuad:   (t) => t * (2 - t),
+  easeInOutQuad: (t) => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t),
+
+  // Cubic
+  easeInCubic:    (t) => t * t * t,
+  easeOutCubic:   (t) => (--t) * t * t + 1,
+  easeInOutCubic: (t) => (t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1),
+
+  // Quart
+  easeInQuart:    (t) => t * t * t * t,
+  easeOutQuart:   (t) => 1 - (--t) * t * t * t,
+  easeInOutQuart: (t) => (t < 0.5 ? 8 * t * t * t * t : 1 - 8 * (--t) * t * t * t),
+
+  // Expo
+  easeInExpo:  (t) => (t === 0 ? 0 : Math.pow(2, 10 * (t - 1))),
+  easeOutExpo: (t) => (t === 1 ? 1 : 1 - Math.pow(2, -10 * t)),
+  easeInOutExpo: (t) => {
+    if (t === 0) return 0;
+    if (t === 1) return 1;
+    if (t < 0.5) return 0.5 * Math.pow(2, 20 * t - 10);
+    return 1 - 0.5 * Math.pow(2, -20 * t + 10);
+  },
+
+  // Sine
+  easeInSine:    (t) => 1 - Math.cos((t * Math.PI) / 2),
+  easeOutSine:   (t) => Math.sin((t * Math.PI) / 2),
+  easeInOutSine: (t) => -(Math.cos(Math.PI * t) - 1) / 2,
+
+  // Back (overshoot)
+  easeOutBack: (t) => {
+    const c1 = 1.70158, c3 = c1 + 1;
+    return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+  },
+  easeInBack: (t) => {
+    const c1 = 1.70158, c3 = c1 + 1;
+    return c3 * t * t * t - c1 * t * t;
+  },
+  easeInOutBack: (t) => {
+    const c1 = 1.70158, c2 = c1 * 1.525;
+    return t < 0.5
+      ? (Math.pow(2 * t, 2) * ((c2 + 1) * 2 * t - c2)) / 2
+      : (Math.pow(2 * t - 2, 2) * ((c2 + 1) * (t * 2 - 2) + c2) + 2) / 2;
+  },
+
+  // Elastic
+  easeOutElastic: (t) => {
+    const c4 = (2 * Math.PI) / 3;
+    if (t === 0) return 0;
+    if (t === 1) return 1;
+    return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+  },
+};
+
+// ── Core interpolation helpers ──────────────────────────────────────────────
+
+// Clamp a value to [min, max]
+const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+// interpolate([0, 0.5, 1], [0, 100, 50], ease?) -> fn(t)
+// Popmotion-style: linearly maps t across input keyframes to output values,
+// with optional easing per segment (single fn or array of fns).
+function interpolate(input, output, ease = Easing.linear) {
+  return (t) => {
+    if (t <= input[0]) return output[0];
+    if (t >= input[input.length - 1]) return output[output.length - 1];
+    for (let i = 0; i < input.length - 1; i++) {
+      if (t >= input[i] && t <= input[i + 1]) {
+        const span = input[i + 1] - input[i];
+        const local = span === 0 ? 0 : (t - input[i]) / span;
+        const easeFn = Array.isArray(ease) ? (ease[i] || Easing.linear) : ease;
+        const eased = easeFn(local);
+        return output[i] + (output[i + 1] - output[i]) * eased;
+      }
+    }
+    return output[output.length - 1];
+  };
+}
+
+// animate({from, to, start, end, ease})(t) — simpler single-segment tween.
+// Returns `from` before `start`, `to` after `end`.
+function animate({ from = 0, to = 1, start = 0, end = 1, ease = Easing.easeInOutCubic }) {
+  return (t) => {
+    if (t <= start) return from;
+    if (t >= end) return to;
+    const local = (t - start) / (end - start);
+    return from + (to - from) * ease(local);
+  };
+}
+
+// ── Timeline context ────────────────────────────────────────────────────────
+
+const TimelineContext = React.createContext({ time: 0, duration: 10, playing: false });
+
+const useTime = () => React.useContext(TimelineContext).time;
+const useTimeline = () => React.useContext(TimelineContext);
+
+// ── Sprite ──────────────────────────────────────────────────────────────────
+// Renders children only when the playhead is inside [start, end]. Provides
+// a sub-context with `localTime` (seconds since start) and `progress` (0..1).
+//
+//   <Sprite start={2} end={5}>
+//     {({ localTime, progress }) => <Thing x={progress * 100} />}
+//   </Sprite>
+//
+// Or as a plain wrapper — children can call useSprite() themselves.
+
+const SpriteContext = React.createContext({ localTime: 0, progress: 0, duration: 0 });
+const useSprite = () => React.useContext(SpriteContext);
+
+function Sprite({ start = 0, end = Infinity, children, keepMounted = false }) {
+  const { time } = useTimeline();
+  const visible = time >= start && time <= end;
+  if (!visible && !keepMounted) return null;
+
+  const duration = end - start;
+  const localTime = Math.max(0, time - start);
+  const progress = duration > 0 && isFinite(duration)
+    ? clamp(localTime / duration, 0, 1)
+    : 0;
+
+  const value = { localTime, progress, duration, visible };
+
+  return (
+    <SpriteContext.Provider value={value}>
+      {typeof children === 'function' ? children(value) : children}
+    </SpriteContext.Provider>
+  );
+}
+
+// ── Sample sprite components ────────────────────────────────────────────────
+
+// TextSprite: fades/slides text in on entry, holds, then fades out on exit.
+// Props: text, x, y, size, color, font, entryDur, exitDur, align
+function TextSprite({
+  text,
+  x = 0, y = 0,
+  size = 48,
+  color = '#111',
+  font = 'Inter, system-ui, sans-serif',
+  weight = 600,
+  entryDur = 0.45,
+  exitDur = 0.35,
+  entryEase = Easing.easeOutBack,
+  exitEase = Easing.easeInCubic,
+  align = 'left',
+  letterSpacing = '-0.01em',
+}) {
+  const { localTime, duration } = useSprite();
+  const exitStart = Math.max(0, duration - exitDur);
+
+  let opacity = 1;
+  let ty = 0;
+
+  if (localTime < entryDur) {
+    const t = entryEase(clamp(localTime / entryDur, 0, 1));
+    opacity = t;
+    ty = (1 - t) * 16;
+  } else if (localTime > exitStart) {
+    const t = exitEase(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    ty = -t * 8;
+  }
+
+  const translateX = align === 'center' ? '-50%' : align === 'right' ? '-100%' : '0';
+
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x, top: y,
+      transform: `translate(${translateX}, ${ty}px)`,
+      opacity,
+      fontFamily: font,
+      fontSize: size,
+      fontWeight: weight,
+      color,
+      letterSpacing,
+      whiteSpace: 'pre',
+      lineHeight: 1.1,
+      willChange: 'transform, opacity',
+    }}>
+      {text}
+    </div>
+  );
+}
+
+// ImageSprite: scales + fades in; optional Ken Burns drift during hold.
+function ImageSprite({
+  src,
+  x = 0, y = 0,
+  width = 400, height = 300,
+  entryDur = 0.6,
+  exitDur = 0.4,
+  kenBurns = false,
+  kenBurnsScale = 1.08,
+  radius = 12,
+  fit = 'cover',
+  placeholder = null, // {label: string} for striped placeholder
+}) {
+  const { localTime, duration } = useSprite();
+  const exitStart = Math.max(0, duration - exitDur);
+
+  let opacity = 1;
+  let scale = 1;
+
+  if (localTime < entryDur) {
+    const t = Easing.easeOutCubic(clamp(localTime / entryDur, 0, 1));
+    opacity = t;
+    scale = 0.96 + 0.04 * t;
+  } else if (localTime > exitStart) {
+    const t = Easing.easeInCubic(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    scale = (kenBurns ? kenBurnsScale : 1) + 0.02 * t;
+  } else if (kenBurns) {
+    const holdSpan = exitStart - entryDur;
+    const holdT = holdSpan > 0 ? (localTime - entryDur) / holdSpan : 0;
+    scale = 1 + (kenBurnsScale - 1) * holdT;
+  }
+
+  const content = placeholder ? (
+    <div style={{
+      width: '100%', height: '100%',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'repeating-linear-gradient(135deg, #e9e6df 0 10px, #dcd8cf 10px 20px)',
+      color: '#6b6458',
+      fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+      fontSize: 13,
+      letterSpacing: '0.04em',
+      textTransform: 'uppercase',
+    }}>
+      {placeholder.label || 'image'}
+    </div>
+  ) : (
+    <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: fit, display: 'block' }} />
+  );
+
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x, top: y,
+      width, height,
+      opacity,
+      transform: `scale(${scale})`,
+      transformOrigin: 'center',
+      borderRadius: radius,
+      overflow: 'hidden',
+      willChange: 'transform, opacity',
+    }}>
+      {content}
+    </div>
+  );
+}
+
+// RectSprite: simple rectangle that animates position/size/color via props.
+// Useful demo primitive — takes a `render` fn for per-frame customization.
+function RectSprite({
+  x = 0, y = 0,
+  width = 100, height = 100,
+  color = '#111',
+  radius = 8,
+  entryDur = 0.4,
+  exitDur = 0.3,
+  render, // optional: (ctx) => style overrides
+}) {
+  const spriteCtx = useSprite();
+  const { localTime, duration } = spriteCtx;
+  const exitStart = Math.max(0, duration - exitDur);
+
+  let opacity = 1;
+  let scale = 1;
+
+  if (localTime < entryDur) {
+    const t = Easing.easeOutBack(clamp(localTime / entryDur, 0, 1));
+    opacity = clamp(localTime / entryDur, 0, 1);
+    scale = 0.4 + 0.6 * t;
+  } else if (localTime > exitStart) {
+    const t = Easing.easeInQuad(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    scale = 1 - 0.15 * t;
+  }
+
+  const overrides = render ? render(spriteCtx) : {};
+
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x, top: y,
+      width, height,
+      background: color,
+      borderRadius: radius,
+      opacity,
+      transform: `scale(${scale})`,
+      transformOrigin: 'center',
+      willChange: 'transform, opacity',
+      ...overrides,
+    }} />
+  );
+}
+
+
+function Stage({
+  width = 1280,
+  height = 720,
+  duration = 10,
+  background = '#f6f4ef',
+  fps = 60,
+  loop = true,
+  autoplay = true,
+  persistKey = 'animstage',
+  children,
+}) {
+  const [time, setTime] = React.useState(() => {
+    try {
+      const v = parseFloat(localStorage.getItem(persistKey + ':t') || '0');
+      return isFinite(v) ? clamp(v, 0, duration) : 0;
+    } catch { return 0; }
+  });
+  const [playing, setPlaying] = React.useState(autoplay);
+  const [hoverTime, setHoverTime] = React.useState(null);
+  const [scale, setScale] = React.useState(1);
+
+  const stageRef = React.useRef(null);
+  const canvasRef = React.useRef(null);
+  const rafRef = React.useRef(null);
+  const lastTsRef = React.useRef(null);
+
+  // Persist playhead
+  React.useEffect(() => {
+    try { localStorage.setItem(persistKey + ':t', String(time)); } catch {}
+  }, [time, persistKey]);
+
+  // Auto-scale to fit viewport
+  React.useEffect(() => {
+    if (!stageRef.current) return;
+    const el = stageRef.current;
+    const measure = () => {
+      const barH = 44; // playback bar height
+      const s = Math.min(
+        el.clientWidth / width,
+        (el.clientHeight - barH) / height
+      );
+      setScale(Math.max(0.05, s));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [width, height]);
+
+  // Animation loop
+  React.useEffect(() => {
+    if (!playing) {
+      lastTsRef.current = null;
+      return;
+    }
+    const step = (ts) => {
+      if (lastTsRef.current == null) lastTsRef.current = ts;
+      const dt = (ts - lastTsRef.current) / 1000;
+      lastTsRef.current = ts;
+      setTime((t) => {
+        let next = t + dt;
+        if (next >= duration) {
+          if (loop) next = next % duration;
+          else { next = duration; setPlaying(false); }
+        }
+        return next;
+      });
+      rafRef.current = requestAnimationFrame(step);
+    };
+    rafRef.current = requestAnimationFrame(step);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      lastTsRef.current = null;
+    };
+  }, [playing, duration, loop]);
+
+  // Keyboard: space = play/pause, ← → = seek
+  React.useEffect(() => {
+    const onKey = (e) => {
+      if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA')) return;
+      if (e.code === 'Space') {
+        e.preventDefault();
+        setPlaying(p => !p);
+      } else if (e.code === 'ArrowLeft') {
+        setTime(t => clamp(t - (e.shiftKey ? 1 : 0.1), 0, duration));
+      } else if (e.code === 'ArrowRight') {
+        setTime(t => clamp(t + (e.shiftKey ? 1 : 0.1), 0, duration));
+      } else if (e.key === '0' || e.code === 'Home') {
+        setTime(0);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [duration]);
+
+  const displayTime = hoverTime != null ? hoverTime : time;
+
+  const ctxValue = React.useMemo(
+    () => ({ time: displayTime, duration, playing, setTime, setPlaying }),
+    [displayTime, duration, playing]
+  );
+
+  return (
+    <div
+      ref={stageRef}
+      style={{
+        position: 'absolute', inset: 0,
+        display: 'flex', flexDirection: 'column',
+        alignItems: 'center',
+        background: '#0a0a0a',
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      {/* Canvas area — vertically centered in remaining space */}
+      <div style={{
+        flex: 1,
+        width: '100%',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        overflow: 'hidden',
+        minHeight: 0,
+      }}>
+        <div
+          ref={canvasRef}
+          style={{
+            width, height,
+            background,
+            position: 'relative',
+            transform: `scale(${scale})`,
+            transformOrigin: 'center',
+            flexShrink: 0,
+            boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+            overflow: 'hidden',
+          }}
+        >
+          <TimelineContext.Provider value={ctxValue}>
+            {children}
+          </TimelineContext.Provider>
+        </div>
+      </div>
+
+      {/* Playback bar — stacked below canvas, never overlapping */}
+      <PlaybackBar
+        time={displayTime}
+        actualTime={time}
+        duration={duration}
+        playing={playing}
+        onPlayPause={() => setPlaying(p => !p)}
+        onReset={() => { setTime(0); }}
+        onSeek={(t) => setTime(t)}
+        onHover={(t) => setHoverTime(t)}
+      />
+    </div>
+  );
+}
+
+// ── Playback bar ────────────────────────────────────────────────────────────
+// Play/pause, return-to-begin, scrub track, time display.
+// Uses fixed-width time fields so layout doesn't thrash.
+
+function PlaybackBar({ time, duration, playing, onPlayPause, onReset, onSeek, onHover }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+
+  const timeFromEvent = React.useCallback((e) => {
+    const rect = trackRef.current.getBoundingClientRect();
+    const x = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    return x * duration;
+  }, [duration]);
+
+  const onTrackMove = (e) => {
+    if (!trackRef.current) return;
+    const t = timeFromEvent(e);
+    if (dragging) {
+      onSeek(t);
+    } else {
+      onHover(t);
+    }
+  };
+
+  const onTrackLeave = () => {
+    if (!dragging) onHover(null);
+  };
+
+  const onTrackDown = (e) => {
+    setDragging(true);
+    const t = timeFromEvent(e);
+    onSeek(t);
+    onHover(null);
+  };
+
+  React.useEffect(() => {
+    if (!dragging) return;
+    const onUp = () => setDragging(false);
+    const onMove = (e) => {
+      if (!trackRef.current) return;
+      const t = timeFromEvent(e);
+      onSeek(t);
+    };
+    window.addEventListener('mouseup', onUp);
+    window.addEventListener('mousemove', onMove);
+    return () => {
+      window.removeEventListener('mouseup', onUp);
+      window.removeEventListener('mousemove', onMove);
+    };
+  }, [dragging, timeFromEvent, onSeek]);
+
+  const pct = duration > 0 ? (time / duration) * 100 : 0;
+  const fmt = (t) => {
+    const total = Math.max(0, t);
+    const m = Math.floor(total / 60);
+    const s = Math.floor(total % 60);
+    const cs = Math.floor((total * 100) % 100);
+    return `${String(m).padStart(1, '0')}:${String(s).padStart(2, '0')}.${String(cs).padStart(2, '0')}`;
+  };
+
+  const mono = 'JetBrains Mono, ui-monospace, SFMono-Regular, monospace';
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 12,
+      padding: '8px 16px',
+      background: 'rgba(20,20,20,0.92)',
+      borderTop: '1px solid rgba(255,255,255,0.08)',
+      width: '100%',
+      maxWidth: 680,
+      alignSelf: 'center',
+
+      borderRadius: 8,
+      color: '#f6f4ef',
+      fontFamily: 'Inter, system-ui, sans-serif',
+      userSelect: 'none',
+      flexShrink: 0,
+    }}>
+      <IconButton onClick={onReset} title="Return to start (0)">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M3 2v10M12 2L5 7l7 5V2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round"/>
+        </svg>
+      </IconButton>
+      <IconButton onClick={onPlayPause} title="Play/pause (space)">
+        {playing ? (
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <rect x="3" y="2" width="3" height="10" fill="currentColor"/>
+            <rect x="8" y="2" width="3" height="10" fill="currentColor"/>
+          </svg>
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M3 2l9 5-9 5V2z" fill="currentColor"/>
+          </svg>
+        )}
+      </IconButton>
+
+      {/* Current time: fixed width so it doesn't thrash */}
+      <div style={{
+        fontFamily: mono,
+        fontSize: 12,
+        fontVariantNumeric: 'tabular-nums',
+        width: 64, textAlign: 'right',
+        color: '#f6f4ef',
+      }}>
+        {fmt(time)}
+      </div>
+
+      {/* Scrub track */}
+      <div
+        ref={trackRef}
+        onMouseMove={onTrackMove}
+        onMouseLeave={onTrackLeave}
+        onMouseDown={onTrackDown}
+        style={{
+          flex: 1,
+          height: 22,
+          position: 'relative',
+          cursor: 'pointer',
+          display: 'flex', alignItems: 'center',
+        }}
+      >
+        <div style={{
+          position: 'absolute',
+          left: 0, right: 0, height: 4,
+          background: 'rgba(255,255,255,0.12)',
+          borderRadius: 2,
+        }}/>
+        <div style={{
+          position: 'absolute',
+          left: 0, width: `${pct}%`, height: 4,
+          background: 'oklch(72% 0.12 250)',
+          borderRadius: 2,
+        }}/>
+        <div style={{
+          position: 'absolute',
+          left: `${pct}%`, top: '50%',
+          width: 12, height: 12,
+          marginLeft: -6, marginTop: -6,
+          background: '#fff',
+          borderRadius: 6,
+          boxShadow: '0 2px 4px rgba(0,0,0,0.4)',
+        }}/>
+      </div>
+
+      {/* Duration: fixed width */}
+      <div style={{
+        fontFamily: mono,
+        fontSize: 12,
+        fontVariantNumeric: 'tabular-nums',
+        width: 64, textAlign: 'left',
+        color: 'rgba(246,244,239,0.55)',
+      }}>
+        {fmt(duration)}
+      </div>
+    </div>
+  );
+}
+
+function IconButton({ children, onClick, title }) {
+  const [hover, setHover] = React.useState(false);
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        width: 28, height: 28,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: hover ? 'rgba(255,255,255,0.12)' : 'rgba(255,255,255,0.04)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 6,
+        color: '#f6f4ef',
+        cursor: 'pointer',
+        padding: 0,
+        transition: 'background 120ms',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+
+Object.assign(window, {
+  Easing, interpolate, animate, clamp,
+  TimelineContext, useTime, useTimeline,
+  Sprite, SpriteContext, useSprite,
+  TextSprite, ImageSprite, RectSprite,
+  Stage, PlaybackBar,
+});
+

--- a/scripts/dx-walkthrough/briefs/03-design-assets/design-canvas.jsx
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/scripts/dx-walkthrough/briefs/03-design-assets/ios-frame.jsx
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/ios-frame.jsx
@@ -1,0 +1,338 @@
+
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/scripts/dx-walkthrough/briefs/03-design-assets/persona.jsx
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/persona.jsx
@@ -1,0 +1,244 @@
+// Persona walkthrough — Maya, 34, design-adjacent Canva user
+// Renders the 6 main screens at small scale with annotated reactions.
+
+const PERSONA = {
+  name: 'Maya Okafor',
+  age: 34,
+  job: 'Marketing manager · Lagos',
+  caption: 'Uses Canva weekly for posts. Has heard of "AI art" but never touched Midjourney. Asked her cousin to install LocalImage for a moodboard for her sister\'s baby shower.',
+};
+
+const STEPS = [
+  {
+    n: '01',
+    label: 'First launch',
+    Screen: ({ theme, anim }) => <ScreenFirstLaunch theme={theme} anim={anim} />,
+    quotes: [
+      { mood: 'curious', text: '"Oh — these are nice. So this is what it makes."' },
+      { mood: 'reassured', text: '"On my phone. Not the cloud. Good."' },
+    ],
+    insight: 'The reel does the heavy lifting — she now has a mental picture of what "good output" looks like before she\'s typed anything. Privacy line lands as reassurance, not a sales pitch.',
+  },
+  {
+    n: '02',
+    label: 'Installing',
+    Screen: ({ theme, anim }) => <ScreenDownload theme={theme} anim={anim} />,
+    quotes: [
+      { mood: 'patient', text: '"Two minutes is fine. I\'ll come back."' },
+      { mood: 'confused', text: '"Wait — is this every time? Oh, says only once."' },
+    ],
+    insight: 'Critical that "one-time setup" copy sits ABOVE the fold. Without it she would close the app thinking it\'s slow.',
+  },
+  {
+    n: '03',
+    label: 'Empty prompt',
+    Screen: ({ theme }) => <ScreenEmptyPrompt theme={theme} />,
+    quotes: [
+      { mood: 'unsure', text: '"What do I even type?"' },
+      { mood: 'hopeful', text: '"Oh, the chips. \'PHOTO · a wolf in a snowstorm.\' I can copy that shape."' },
+    ],
+    insight: 'Suggestion chips do the teaching — she sees that prompts have a STYLE word and a SUBJECT. Without those tags she\'d type "baby shower decorations" and get a flat image.',
+  },
+  {
+    n: '04',
+    label: 'Voice',
+    Screen: ({ theme, anim }) => <ScreenVoiceListening theme={theme} anim={anim} />,
+    quotes: [
+      { mood: 'natural', text: '"\'Soft pink balloons floating in a sunny living room\' — talking is easier."' },
+    ],
+    insight: 'She would not have written that sentence — too many words. Voice unlocks descriptive prompts for non-writers.',
+  },
+  {
+    n: '05',
+    label: 'Generating',
+    Screen: ({ theme, anim }) => <ScreenGenerating theme={theme} anim={anim} />,
+    quotes: [
+      { mood: 'patient', text: '"It\'s doing something. Not frozen."' },
+    ],
+    insight: 'The breathing animation reads as "thinking." She does NOT pull down to refresh, which she would on a stuck spinner.',
+  },
+  {
+    n: '06',
+    label: 'Result',
+    Screen: ({ theme }) => <ScreenResult theme={theme} />,
+    quotes: [
+      { mood: 'delighted', text: '"Oh that\'s actually pretty."' },
+      { mood: 'iterating', text: '"More gold balloons though. Refine."' },
+      { mood: 'wants to share', text: '"I want to send this to Tola — Share."' },
+    ],
+    insight: 'Try again + Refine being primary catches her actual second move (iterate). Save and Share are visible but quiet — she uses Share when she WANTS to, not because the UI nags her to.',
+  },
+];
+
+function PersonaWalkthrough() {
+  const t = THEMES.paper;
+  const W = 720;
+  return (
+    <div style={{
+      width: '100%', minHeight: '100%',
+      padding: '40px 36px 56px',
+      background: '#FBF8F2',
+      fontFamily: '-apple-system, system-ui',
+      color: 'rgba(28,24,20,0.95)',
+      overflow: 'auto',
+    }}>
+      {/* Persona card */}
+      <div style={{
+        display: 'flex', alignItems: 'flex-start', gap: 20,
+        padding: '20px 22px', borderRadius: 16,
+        background: '#fff', border: '0.5px solid rgba(28,24,20,0.10)',
+        marginBottom: 32,
+      }}>
+        <div style={{
+          width: 64, height: 64, borderRadius: 32, flexShrink: 0,
+          background: 'linear-gradient(135deg, oklch(0.78 0.06 35), oklch(0.58 0.08 25))',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: '#fff', fontSize: 22, fontFamily: '"Tiempos Headline", Georgia, serif',
+          fontWeight: 500, letterSpacing: -0.4,
+        }}>MO</div>
+        <div style={{ flex: 1 }}>
+          <div style={{
+            fontFamily: '"Tiempos Headline", Georgia, serif',
+            fontSize: 22, fontWeight: 500, letterSpacing: -0.3, marginBottom: 2,
+          }}>{PERSONA.name}</div>
+          <div style={{ fontSize: 12, fontFamily: MONO, letterSpacing: 0.5,
+            color: 'rgba(28,24,20,0.55)', textTransform: 'uppercase', marginBottom: 8 }}>
+            {PERSONA.age} · {PERSONA.job}
+          </div>
+          <div style={{ fontSize: 13.5, lineHeight: 1.55, color: 'rgba(28,24,20,0.75)' }}>
+            {PERSONA.caption}
+          </div>
+        </div>
+      </div>
+
+      {/* Walk steps */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+        {STEPS.map((step, i) => (
+          <div key={i} style={{
+            display: 'flex', gap: 22, alignItems: 'flex-start',
+          }}>
+            {/* Mini phone — scaled */}
+            <div style={{ width: 180, flexShrink: 0 }}>
+              <div style={{
+                width: 180, height: 391,
+                transform: 'scale(1)', transformOrigin: 'top left',
+                position: 'relative',
+              }}>
+                <div style={{
+                  position: 'absolute', top: 0, left: 0,
+                  width: 402, height: 874,
+                  transform: 'scale(0.4477)', transformOrigin: 'top left',
+                  background: t.bg, borderRadius: 18, overflow: 'hidden',
+                  boxShadow: '0 1px 3px rgba(0,0,0,.08), 0 6px 18px rgba(0,0,0,.06)',
+                  border: '0.5px solid rgba(28,24,20,0.08)',
+                }}>
+                  <step.Screen theme="paper" anim={false} />
+                </div>
+              </div>
+              <div style={{ marginTop: 8, fontFamily: MONO, fontSize: 10,
+                letterSpacing: 0.6, color: 'rgba(28,24,20,0.45)',
+                textTransform: 'uppercase' }}>
+                {step.n} · {step.label}
+              </div>
+            </div>
+
+            {/* Annotations */}
+            <div style={{ flex: 1, paddingTop: 4 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 14 }}>
+                {step.quotes.map((q, j) => (
+                  <div key={j} style={{
+                    display: 'flex', gap: 12, alignItems: 'flex-start',
+                  }}>
+                    <div style={{
+                      fontSize: 9.5, fontFamily: MONO, letterSpacing: 0.5,
+                      color: 'rgba(28,24,20,0.45)', textTransform: 'uppercase',
+                      paddingTop: 5, minWidth: 92, flexShrink: 0,
+                    }}>{q.mood}</div>
+                    <div style={{
+                      fontFamily: '"Tiempos Headline", Georgia, serif',
+                      fontSize: 17, lineHeight: 1.35, fontStyle: 'italic',
+                      color: 'rgba(28,24,20,0.92)', letterSpacing: -0.2,
+                    }}>{q.text}</div>
+                  </div>
+                ))}
+              </div>
+              <div style={{
+                fontSize: 12.5, lineHeight: 1.55,
+                color: 'rgba(28,24,20,0.65)',
+                paddingLeft: 104, paddingTop: 4,
+                borderTop: '0.5px solid rgba(28,24,20,0.10)',
+                marginTop: 4,
+              }}>
+                <span style={{ fontFamily: MONO, fontSize: 9.5, letterSpacing: 0.5,
+                  color: 'rgba(28,24,20,0.45)', textTransform: 'uppercase',
+                  marginRight: 8 }}>Insight</span>
+                {step.insight}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Pull-out: where Maya broke the design */}
+      <div style={{
+        marginTop: 40, padding: '22px 24px', borderRadius: 16,
+        background: 'oklch(0.96 0.025 70)', border: '0.5px solid oklch(0.85 0.04 70)',
+      }}>
+        <div style={{ fontFamily: '"Tiempos Headline", Georgia, serif',
+          fontSize: 18, fontWeight: 500, letterSpacing: -0.2, marginBottom: 10 }}>
+          Where Maya broke the design — and what changed
+        </div>
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none',
+          display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <li style={{ fontSize: 13, lineHeight: 1.55, color: 'rgba(28,24,20,0.78)' }}>
+            <strong>"What's the dots?"</strong> — She hit "⋯" expecting it to scroll the prompt. We were using "⋯" in three different places to mean three different things. Fixed: <code style={{ fontFamily: MONO, fontSize: 12 }}>⋯</code> only ever means "more actions for THIS image." Library and empty-prompt screens now use a settings cog.
+          </li>
+          <li style={{ fontSize: 13, lineHeight: 1.55, color: 'rgba(28,24,20,0.78)' }}>
+            <strong>"Is share safe?"</strong> — The privacy line on first launch made her wary of the Share button later. Fixed: Share button is labelled <code style={{ fontFamily: MONO, fontSize: 12 }}>Share…</code> (the trailing ellipsis is iOS convention for "opens a chooser, you stay in control"), and the action sheet sub-line reads "Choose an app — leaves the device only when you pick one." Privacy promise stays intact; share is reframed as a deliberate, one-tap user choice.
+          </li>
+          <li style={{ fontSize: 13, lineHeight: 1.55, color: 'rgba(28,24,20,0.78)' }}>
+            <strong>"Saved where?"</strong> — She missed the auto-save line. Fixed: micro-line on the Result screen reads "Saved to LocalImage library · 768²" — now larger weight and pinned right below the prompt where her eye lands.
+          </li>
+          <li style={{ fontSize: 13, lineHeight: 1.55, color: 'rgba(28,24,20,0.78)' }}>
+            <strong>"Why three buttons?"</strong> — On iPad she saw Save / Share / ⋯ and froze. Fixed: ⋯ is gone from iPad and Mac — long-press on a library item is the action sheet, top-right is just Save and Share. iPad/Mac now also show the same <strong>ON DEVICE</strong> chip so the privacy promise doesn't disappear on bigger screens.
+          </li>
+        </ul>
+      </div>
+
+      {/* The new ⋯ rule */}
+      <div style={{
+        marginTop: 24, padding: '20px 22px', borderRadius: 14,
+        background: '#fff', border: '0.5px solid rgba(28,24,20,0.10)',
+      }}>
+        <div style={{ fontFamily: MONO, fontSize: 10, letterSpacing: 0.6,
+          color: 'rgba(28,24,20,0.45)', textTransform: 'uppercase', marginBottom: 8 }}>
+          The new top-right rule
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 18 }}>
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+              <span style={{ fontSize: 18, fontWeight: 700 }}>⚙</span>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>Settings cog</span>
+            </div>
+            <div style={{ fontSize: 12.5, color: 'rgba(28,24,20,0.65)', lineHeight: 1.5 }}>
+              Appears on the home/library screen and the empty prompt screen.
+              Opens app-level settings: theme, voice locale, content filter, model, about.
+            </div>
+          </div>
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+              <span style={{ fontSize: 18, fontWeight: 700 }}>⋯</span>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>Image actions</span>
+            </div>
+            <div style={{ fontSize: 12.5, color: 'rgba(28,24,20,0.65)', lineHeight: 1.5 }}>
+              Only appears next to a single image — long-press in the library, or as
+              an affordance in the corner. Always opens the same action sheet.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.PersonaWalkthrough = PersonaWalkthrough;

--- a/scripts/dx-walkthrough/briefs/03-design-assets/screens.jsx
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/screens.jsx
@@ -1,0 +1,1377 @@
+// screens.jsx — LocalImage screen designs
+// Each screen renders inside a 402×874 iPhone canvas.
+
+const LI_FONT = '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif';
+const MONO = 'ui-monospace, "SF Mono", Menlo, monospace';
+
+// ─────────────────────────────────────────────────────────────
+// Theme palettes
+// ─────────────────────────────────────────────────────────────
+const THEMES = {
+  paper: {
+    name: 'Paper',
+    bg: '#F4F1EB',
+    surface: '#FBF8F2',
+    surfaceAlt: '#EBE6DB',
+    ink: '#1C1814',
+    inkDim: 'rgba(28,24,20,0.55)',
+    inkFaint: 'rgba(28,24,20,0.28)',
+    line: 'rgba(28,24,20,0.10)',
+    accent: '#1C1814',
+    accentInk: '#FBF8F2',
+    danger: '#A8412A',
+    statusDark: false,
+    titleFont: '"Tiempos Headline", "Charter", "Iowan Old Style", Georgia, serif',
+  },
+  dusk: {
+    name: 'Dusk',
+    bg: '#0E0D11',
+    surface: '#171519',
+    surfaceAlt: '#221F25',
+    ink: '#F4F1ED',
+    inkDim: 'rgba(244,241,237,0.60)',
+    inkFaint: 'rgba(244,241,237,0.28)',
+    line: 'rgba(244,241,237,0.12)',
+    accent: '#F4F1ED',
+    accentInk: '#0E0D11',
+    danger: '#E08266',
+    statusDark: true,
+    titleFont: '"Tiempos Headline", "Charter", "Iowan Old Style", Georgia, serif',
+  },
+};
+
+// Subtly-striped placeholder image — never tries to be a real generated image.
+function ImgPlaceholder({ seed = 0, label, theme, style = {}, rounded = 18, alt }) {
+  const hues = [
+    [22, 200], [180, 320], [140, 30], [260, 40],
+    [300, 200], [10, 220], [200, 60], [340, 180],
+  ];
+  const [h1, h2] = hues[seed % hues.length];
+  const dark = theme && theme.statusDark;
+  const l1 = dark ? 0.42 : 0.62;
+  const l2 = dark ? 0.32 : 0.50;
+  return (
+    <div role="img" aria-label={alt || label || 'generated image'} style={{
+      position: 'relative', overflow: 'hidden', borderRadius: rounded,
+      background: `linear-gradient(135deg, oklch(${l1} 0.13 ${h1}) 0%, oklch(${l2} 0.10 ${h2}) 100%)`,
+      ...style,
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: `repeating-linear-gradient(135deg, rgba(255,255,255,0.07) 0 2px, transparent 2px 9px)`,
+        mixBlendMode: 'overlay',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: `radial-gradient(120% 80% at 30% 25%, rgba(255,255,255,0.18) 0%, transparent 55%)`,
+      }} />
+      {label && (
+        <div style={{
+          position: 'absolute', left: 12, bottom: 10,
+          fontFamily: MONO, fontSize: 9.5, letterSpacing: 0.4, textTransform: 'uppercase',
+          color: 'rgba(255,255,255,0.85)',
+          textShadow: '0 1px 2px rgba(0,0,0,0.4)',
+        }}>{label}</div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Icons (always pair with aria-label on the parent button)
+// ─────────────────────────────────────────────────────────────
+const Icon = {
+  mic: (s = 22) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="9" y="3" width="6" height="12" rx="3"/><path d="M5 11a7 7 0 0 0 14 0"/><path d="M12 18v3"/>
+    </svg>
+  ),
+  keyboard: (s = 22) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="2.5" y="6" width="19" height="12" rx="2"/>
+      <path d="M6 10h.01M9 10h.01M12 10h.01M15 10h.01M18 10h.01M6 14h12"/>
+    </svg>
+  ),
+  share: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 16V4M7 9l5-5 5 5"/><path d="M5 14v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5"/>
+    </svg>
+  ),
+  save: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 4v12M6 11l6 6 6-6"/><path d="M5 20h14"/>
+    </svg>
+  ),
+  refresh: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 12a9 9 0 0 1 15.5-6.3L21 8"/><path d="M21 3v5h-5"/>
+      <path d="M21 12a9 9 0 0 1-15.5 6.3L3 16"/><path d="M3 21v-5h5"/>
+    </svg>
+  ),
+  edit: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M4 20h4l10-10-4-4L4 16v4z"/><path d="M14 6l4 4"/>
+    </svg>
+  ),
+  close: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M6 6l12 12M6 18L18 6"/>
+    </svg>
+  ),
+  more: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/>
+    </svg>
+  ),
+  cog: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1"/>
+    </svg>
+  ),
+  download: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 4v12M6 11l6 6 6-6"/><path d="M5 20h14"/>
+    </svg>
+  ),
+  shield: (s = 18) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6l8-3z"/>
+    </svg>
+  ),
+  lock: (s = 16) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/>
+    </svg>
+  ),
+  warn: (s = 20) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 3L2 20h20L12 3z"/><path d="M12 10v5"/><circle cx="12" cy="18" r="0.5" fill="currentColor"/>
+    </svg>
+  ),
+  check: (s = 18) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M5 12l5 5L20 6"/>
+    </svg>
+  ),
+  back: (s = 22) => (
+    <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M15 5l-7 7 7 7"/>
+    </svg>
+  ),
+};
+
+// IconBtn — accessible icon-only button. ALWAYS requires aria-label.
+function IconBtn({ ariaLabel, onClick, children, style = {}, size = 36 }) {
+  return (
+    <button
+      type="button" aria-label={ariaLabel} onClick={onClick}
+      style={{
+        width: size, height: size, borderRadius: size / 2, border: 'none',
+        background: 'transparent', color: 'currentColor', cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 0, ...style,
+      }}>{children}</button>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 1. First Launch
+// ─────────────────────────────────────────────────────────────
+function ScreenFirstLaunch({ theme, anim = true }) {
+  const [tick, setTick] = React.useState(0);
+  React.useEffect(() => {
+    if (!anim) return;
+    const i = setInterval(() => setTick((t) => t + 1), 2200);
+    return () => clearInterval(i);
+  }, [anim]);
+  const t = THEMES[theme];
+  const examples = [
+    'a wolf in a snowstorm', 'porcelain teapot, studio light', 'kid astronaut, polaroid',
+    'hummingbird mid-flight', 'cathedral of moss', 'ramen shop at midnight',
+    '1990s film still, road trip', 'cat in a chef hat', 'paper crane, golden hour',
+  ];
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, position: 'relative', overflow: 'hidden',
+      paddingTop: 60, display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{
+        flex: 1, padding: '32px 20px 20px',
+        display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gridTemplateRows: '1fr 1fr 1fr',
+        gap: 8,
+      }}>
+        {examples.map((ex, i) => {
+          const active = i === (tick % 9);
+          return (
+            <div key={i} style={{
+              position: 'relative', aspectRatio: '1', borderRadius: 14, overflow: 'hidden',
+              transform: active ? 'scale(1)' : 'scale(0.96)',
+              opacity: active ? 1 : 0.55,
+              transition: 'opacity 700ms ease, transform 700ms ease',
+            }}>
+              <ImgPlaceholder seed={i} theme={t} rounded={14} style={{ width: '100%', height: '100%' }} alt={`Example: ${ex}`} />
+              {active && (
+                <div style={{
+                  position: 'absolute', left: 8, right: 8, bottom: 6,
+                  fontSize: 9, fontFamily: MONO, color: 'rgba(255,255,255,0.95)',
+                  textShadow: '0 1px 3px rgba(0,0,0,0.5)', letterSpacing: 0.2,
+                }}>"{ex}"</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ padding: '16px 28px 28px' }}>
+        <div style={{ fontFamily: t.titleFont, fontSize: 32, lineHeight: 1.05,
+          letterSpacing: -0.8, fontWeight: 500, marginBottom: 12 }}>
+          Describe an<br/>image. See it.
+        </div>
+        <div style={{ fontSize: 15, lineHeight: 1.45, color: t.inkDim, marginBottom: 22, maxWidth: 320 }}>
+          A 1.4&nbsp;GB model installs once, then runs entirely on your phone — private, offline, no limits.
+        </div>
+        <button type="button" aria-label="Install model, about two minutes" style={{
+          width: '100%', height: 54, borderRadius: 16, border: 'none',
+          background: t.accent, color: t.accentInk,
+          fontFamily: LI_FONT, fontSize: 17, fontWeight: 600, letterSpacing: -0.2, cursor: 'pointer',
+        }}>
+          Install model · ~2 min
+        </button>
+        <div style={{
+          fontSize: 12, color: t.inkFaint, textAlign: 'center', marginTop: 12,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5,
+        }}>
+          {Icon.lock(12)} Stays on your device. Always.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 2. Download
+// ─────────────────────────────────────────────────────────────
+function ScreenDownload({ theme, progress = 0.42, anim = true }) {
+  const [tick, setTick] = React.useState(0);
+  const [pct, setPct] = React.useState(progress);
+  React.useEffect(() => {
+    if (!anim) return;
+    const i = setInterval(() => setTick((t) => t + 1), 1800);
+    const j = setInterval(() => setPct((p) => Math.min(0.99, p + 0.012)), 600);
+    return () => { clearInterval(i); clearInterval(j); };
+  }, [anim]);
+  const t = THEMES[theme];
+  const seeds = [0, 2, 4, 1, 5, 3, 6, 0, 4];
+  const prompts = [
+    '"a wolf in a snowstorm"', '"porcelain teapot, studio light"',
+    '"kid astronaut, polaroid"', '"hummingbird mid-flight"',
+    '"cathedral of moss"', '"ramen shop at midnight"',
+  ];
+  const seed = seeds[tick % seeds.length];
+  const promptText = prompts[tick % prompts.length];
+  const remainSec = Math.max(8, Math.round((1 - pct) * 130));
+  const mins = Math.floor(remainSec / 60);
+  const secs = remainSec % 60;
+  const remainStr = mins > 0 ? `${mins} min ${secs}s` : `${secs}s`;
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, paddingTop: 60, display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ flex: 1, padding: '40px 28px 24px', position: 'relative' }}>
+        <div style={{
+          width: '100%', aspectRatio: '1', position: 'relative',
+          borderRadius: 22, overflow: 'hidden',
+          boxShadow: t.statusDark
+            ? '0 20px 60px rgba(0,0,0,0.5), inset 0 0 0 1px rgba(255,255,255,0.08)'
+            : '0 20px 50px rgba(0,0,0,0.10), inset 0 0 0 1px rgba(0,0,0,0.04)',
+        }}>
+          <ImgPlaceholder seed={seed} theme={t} rounded={22} style={{ width: '100%', height: '100%' }} alt={`Example output: ${promptText}`} />
+          <div style={{ position: 'absolute', inset: 0,
+            background: 'linear-gradient(to bottom, transparent 55%, rgba(0,0,0,0.45) 100%)' }} />
+          <div style={{ position: 'absolute', left: 18, right: 18, bottom: 16,
+            fontFamily: MONO, fontSize: 11.5, letterSpacing: 0.3, color: 'rgba(255,255,255,0.95)' }}>
+            {promptText}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 12, justifyContent: 'center' }}>
+          {[0,1,2,3,4].map((i) => (
+            <div key={i} style={{
+              width: i === 2 ? 26 : 6, height: 6, borderRadius: 3,
+              background: i === 2 ? t.ink : t.inkFaint, transition: 'all 400ms ease',
+            }} />
+          ))}
+        </div>
+      </div>
+      <div style={{ padding: '12px 28px 32px' }}>
+        <div style={{ fontFamily: t.titleFont, fontSize: 22, lineHeight: 1.15,
+          letterSpacing: -0.4, fontWeight: 500, marginBottom: 4 }}>
+          Installing the model
+        </div>
+        <div style={{ fontSize: 14, color: t.inkDim, marginBottom: 18, lineHeight: 1.4 }}>
+          One-time download. After this, every image stays on your phone.
+        </div>
+        <div role="progressbar" aria-valuenow={Math.round(pct*100)} aria-valuemin="0" aria-valuemax="100"
+          aria-label="Model download progress" style={{
+          height: 4, borderRadius: 2, background: t.line, overflow: 'hidden', marginBottom: 10,
+        }}>
+          <div style={{ height: '100%', width: `${pct * 100}%`, background: t.accent,
+            borderRadius: 2, transition: 'width 600ms ease' }} />
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between',
+          fontSize: 12, color: t.inkDim, fontVariantNumeric: 'tabular-nums',
+          fontFamily: MONO, letterSpacing: 0.2 }}>
+          <span>{Math.round(pct * 1400)} / 1,400 MB</span>
+          <span>{remainStr} remaining</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 3. Empty Prompt — diversity-first suggestions
+// ─────────────────────────────────────────────────────────────
+function ScreenEmptyPrompt({ theme }) {
+  const t = THEMES[theme];
+  // Suggestions chosen to demonstrate stylistic range, not just subject matter.
+  // Style baked into the prompt itself so taps feed a self-contained string.
+  const suggestions = [
+    'a photo of a coffee shop window on a rainy morning',
+    'an illustration of a fox curled up in a paper-cut forest',
+    'a portrait of an elderly fisherman with kind eyes, soft light',
+    'an abstract painting of shapes that feel like a slow exhale',
+    'a 1970s film still, road movie at golden hour',
+    'a 3D render of a tiny ceramic robot on a windowsill',
+  ];
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, position: 'relative', overflow: 'hidden',
+      display: 'flex', flexDirection: 'column', paddingTop: 60,
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '14px 20px 0' }}>
+        <div style={{ fontSize: 17, fontWeight: 600, letterSpacing: -0.2 }}>LocalImage</div>
+        <IconBtn ariaLabel="Settings" size={34} style={{ background: t.surface }}>
+          {Icon.cog(18)}
+        </IconBtn>
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column',
+        padding: '28px 24px 16px', gap: 18, overflow: 'hidden' }}>
+        <div style={{ fontFamily: t.titleFont, fontSize: 28, lineHeight: 1.08,
+          letterSpacing: -0.6, fontWeight: 500 }}>
+          What do you want<br/>to see?
+        </div>
+        <div style={{ fontSize: 12, color: t.inkFaint, fontFamily: MONO,
+          letterSpacing: 0.6, textTransform: 'uppercase' }}>
+          Try one of these — or anything
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {suggestions.map((s, i) => (
+            <button key={i} type="button"
+              aria-label={`Use suggestion: ${s}`}
+              style={{
+                padding: '12px 16px', borderRadius: 12, background: t.surface,
+                border: `0.5px solid ${t.line}`, color: t.ink,
+                textAlign: 'left', cursor: 'pointer', fontFamily: LI_FONT,
+                fontSize: 14, lineHeight: 1.35,
+              }}>
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ padding: '0 20px 40px' }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 12,
+          background: t.surface, borderRadius: 999,
+          padding: '8px 8px 8px 22px',
+          border: `0.5px solid ${t.line}`,
+        }}>
+          <div style={{ flex: 1, fontSize: 15, color: t.inkFaint }}>Tap mic, or type…</div>
+          <IconBtn ariaLabel="Type a prompt instead" style={{ color: t.inkDim }} size={36}>
+            {Icon.keyboard(20)}
+          </IconBtn>
+          <IconBtn ariaLabel="Start voice prompt" size={48} style={{
+            background: t.accent, color: t.accentInk,
+            boxShadow: t.statusDark
+              ? '0 0 0 4px rgba(244,241,237,0.08)'
+              : '0 4px 14px rgba(0,0,0,0.08)',
+          }}>
+            {Icon.mic(22)}
+          </IconBtn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 4. Voice Listening
+// ─────────────────────────────────────────────────────────────
+function ScreenVoiceListening({ theme, anim = true }) {
+  const t = THEMES[theme];
+  const [step, setStep] = React.useState(0);
+  React.useEffect(() => {
+    if (!anim) return;
+    const i = setInterval(() => setStep((s) => (s + 1) % 60), 80);
+    return () => clearInterval(i);
+  }, [anim]);
+  const transcript = "a fox curled up in tall grass at sunset";
+  const heard = transcript.slice(0, Math.min(transcript.length, Math.floor(step * 0.8) + 12));
+  const bars = Array.from({ length: 28 }, (_, i) => {
+    const phase = (step + i * 3) * 0.15;
+    return 0.25 + Math.abs(Math.sin(phase)) * 0.6 + (((i * 137) % 100) / 100) * 0.15;
+  });
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, paddingTop: 60,
+      display: 'flex', flexDirection: 'column', position: 'relative',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', padding: '14px 20px 0' }}>
+        <div style={{ fontSize: 13, color: t.inkDim, fontFamily: MONO, letterSpacing: 0.4 }}>
+          LISTENING
+        </div>
+        <IconBtn ariaLabel="Cancel voice prompt" size={34} style={{ background: t.surface, color: t.ink }}>
+          {Icon.close(18)}
+        </IconBtn>
+      </div>
+
+      <div style={{ flex: 1, padding: '0 28px',
+        display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+        <div aria-live="polite" style={{
+          fontFamily: t.titleFont, fontSize: 26, lineHeight: 1.25,
+          letterSpacing: -0.4, fontWeight: 500, minHeight: 130,
+        }}>
+          <span>"{heard}</span>
+          <span aria-hidden="true" style={{
+            display: 'inline-block', width: 2, height: 22, background: t.accent,
+            marginLeft: 2, verticalAlign: '-3px',
+            opacity: step % 8 < 4 ? 1 : 0.2,
+          }} />
+        </div>
+      </div>
+
+      <div style={{ padding: '0 20px 40px' }}>
+        <div style={{
+          height: 96, borderRadius: 48,
+          background: t.surface,
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '0 16px', border: `0.5px solid ${t.line}`,
+        }}>
+          <IconBtn ariaLabel="Switch to keyboard input" size={56} style={{ opacity: 0.6 }}>
+            {Icon.keyboard(22)}
+          </IconBtn>
+          <div aria-hidden="true" style={{
+            flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            gap: 3, height: 56,
+          }}>
+            {bars.map((b, i) => (
+              <div key={i} style={{
+                width: 3, height: `${b * 100}%`, minHeight: 3, borderRadius: 2,
+                background: t.accent,
+                opacity: 0.55 + Math.sin((step + i * 2) * 0.2) * 0.45,
+              }} />
+            ))}
+          </div>
+          <IconBtn ariaLabel="Stop listening and generate" size={56} style={{
+            background: t.accent, color: t.accentInk,
+          }}>
+            <div style={{ width: 16, height: 16, background: t.accentInk, borderRadius: 3 }} />
+          </IconBtn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 5. Generating
+// ─────────────────────────────────────────────────────────────
+function ScreenGenerating({ theme, anim = true }) {
+  const t = THEMES[theme];
+  const [step, setStep] = React.useState(0);
+  React.useEffect(() => {
+    if (!anim) return;
+    const i = setInterval(() => setStep((s) => s + 1), 60);
+    return () => clearInterval(i);
+  }, [anim]);
+  const breath = 0.5 + Math.sin(step * 0.07) * 0.5;
+  const hue = 22 + step * 0.6;
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, paddingTop: 60,
+      display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '14px 20px 0' }}>
+        <button type="button" aria-label="Close" style={{
+          fontSize: 15, color: t.inkDim, background: 'transparent',
+          border: 'none', cursor: 'pointer', padding: 0,
+          display: 'flex', alignItems: 'center', gap: 4,
+        }}>{Icon.close(20)}</button>
+        <div style={{ fontSize: 13, color: t.inkDim, fontFamily: MONO }}>~7s</div>
+      </div>
+
+      <div style={{ padding: '24px 28px 16px' }}>
+        <div style={{
+          fontSize: 11, letterSpacing: 0.6, textTransform: 'uppercase',
+          color: t.inkFaint, fontFamily: MONO, marginBottom: 8,
+        }}>You asked for</div>
+        <div style={{ fontFamily: t.titleFont, fontSize: 22, lineHeight: 1.25,
+          letterSpacing: -0.3, fontWeight: 500 }}>
+          "a fox curled up in tall grass at sunset"
+        </div>
+      </div>
+
+      <div role="status" aria-live="polite" aria-label="Generating image, about seven seconds remaining"
+        style={{ flex: 1, padding: '8px 28px 28px',
+        display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{
+          width: '100%', aspectRatio: '1', borderRadius: 24,
+          position: 'relative', overflow: 'hidden',
+          background: `radial-gradient(circle at ${50 + Math.sin(step * 0.04) * 20}% ${50 + Math.cos(step * 0.05) * 20}%,
+            oklch(0.72 0.11 ${hue}) 0%,
+            oklch(0.55 0.13 ${hue + 60}) 40%,
+            oklch(0.30 0.08 ${hue + 120}) 100%)`,
+          boxShadow: t.statusDark
+            ? '0 20px 60px rgba(0,0,0,0.5)'
+            : '0 20px 50px rgba(0,0,0,0.10)',
+          transform: `scale(${0.99 + breath * 0.015})`,
+          transition: 'transform 60ms linear',
+        }}>
+          <div style={{ position: 'absolute', inset: '-10%',
+            background: `radial-gradient(50% 40% at ${30 + Math.sin(step * 0.03) * 30}% 50%, rgba(255,255,255,0.4) 0%, transparent 60%)`,
+            mixBlendMode: 'overlay', filter: 'blur(20px)' }} />
+          <div style={{ position: 'absolute', inset: '-10%',
+            background: `radial-gradient(40% 30% at ${70 - Math.cos(step * 0.04) * 20}% ${30 + Math.sin(step * 0.06) * 30}%, rgba(0,0,0,0.25) 0%, transparent 60%)`,
+            mixBlendMode: 'multiply', filter: 'blur(28px)' }} />
+          <div style={{ position: 'absolute', inset: 0,
+            background: 'repeating-linear-gradient(0deg, rgba(0,0,0,0.04) 0 1px, transparent 1px 2px)',
+            mixBlendMode: 'overlay' }} />
+          <div style={{ position: 'absolute', inset: 0,
+            display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{
+              padding: '8px 14px', borderRadius: 999,
+              background: 'rgba(0,0,0,0.35)', backdropFilter: 'blur(10px)',
+              fontFamily: MONO, fontSize: 11, color: 'rgba(255,255,255,0.95)',
+              letterSpacing: 0.6, textTransform: 'uppercase',
+              display: 'flex', alignItems: 'center', gap: 8,
+            }}>
+              <div style={{ width: 6, height: 6, borderRadius: 3, background: '#fff',
+                opacity: 0.4 + breath * 0.6 }} />
+              Making
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 20px 40px', textAlign: 'center' }}>
+        <button type="button" aria-label="Cancel generation" style={{
+          background: 'transparent', border: 'none',
+          color: t.inkDim, fontSize: 15, padding: '8px 16px', cursor: 'pointer',
+        }}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 6. Result — reworked hierarchy: iteration first, save secondary
+// ─────────────────────────────────────────────────────────────
+function ScreenResult({ theme }) {
+  const t = THEMES[theme];
+  const prompt = "a fox curled up in tall grass at sunset";
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, paddingTop: 60,
+      display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '14px 20px 0' }}>
+        <button type="button" aria-label="Close and return to library" style={{
+          fontSize: 15, color: t.inkDim, background: 'transparent',
+          border: 'none', cursor: 'pointer', padding: 0,
+          display: 'flex', alignItems: 'center', gap: 4,
+        }}>{Icon.close(20)}</button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6,
+          fontSize: 11, fontFamily: MONO, color: t.inkFaint, letterSpacing: 0.5 }}>
+          {Icon.shield(13)} ON DEVICE
+        </div>
+      </div>
+
+      <div style={{ padding: '20px 28px 14px' }}>
+        <div style={{ fontFamily: t.titleFont, fontSize: 20, lineHeight: 1.25,
+          letterSpacing: -0.2, fontWeight: 500 }}>
+          "{prompt}"
+        </div>
+        <div style={{ fontSize: 11, color: t.inkFaint, fontFamily: MONO,
+          letterSpacing: 0.5, marginTop: 6 }}>
+          Saved to LocalImage library · 768²
+        </div>
+      </div>
+
+      <div style={{ flex: 1, padding: '4px 28px 16px',
+        display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{
+          width: '100%', aspectRatio: '1', borderRadius: 24,
+          overflow: 'hidden', position: 'relative',
+          boxShadow: t.statusDark
+            ? '0 20px 60px rgba(0,0,0,0.5)'
+            : '0 20px 50px rgba(0,0,0,0.12)',
+        }}>
+          <ImgPlaceholder seed={3} theme={t} rounded={24}
+            style={{ width: '100%', height: '100%' }}
+            alt={`Generated image for the prompt: ${prompt}`} />
+        </div>
+      </div>
+
+      {/* Reworked hierarchy:
+          Primary (full-width pair): Try again + Refine — the iteration loop.
+          Secondary row: Save to Photos · Share — auto-saved already, this is for camera-roll/share. */}
+      <div style={{ padding: '8px 20px 40px' }}>
+        <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
+          <button type="button" aria-label="Try again with the same prompt" style={{
+            flex: 1, height: 56, borderRadius: 16, border: 'none',
+            background: t.accent, color: t.accentInk,
+            fontFamily: LI_FONT, fontSize: 16, fontWeight: 600, letterSpacing: -0.2,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            cursor: 'pointer',
+          }}>
+            {Icon.refresh(20)} Try again
+          </button>
+          <button type="button" aria-label="Refine and edit the prompt" style={{
+            flex: 1, height: 56, borderRadius: 16, border: 'none',
+            background: t.accent, color: t.accentInk,
+            fontFamily: LI_FONT, fontSize: 16, fontWeight: 600, letterSpacing: -0.2,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            cursor: 'pointer', opacity: 0.86,
+          }}>
+            {Icon.edit(20)} Refine
+          </button>
+        </div>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button type="button" aria-label="Save to your Photos" style={{
+            flex: 1, height: 44, borderRadius: 12, border: `0.5px solid ${t.line}`,
+            background: 'transparent', color: t.ink,
+            fontFamily: LI_FONT, fontSize: 14, fontWeight: 500,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+            cursor: 'pointer',
+          }}>
+            {Icon.save(16)} Save to Photos
+          </button>
+          <button type="button" aria-label="Share image" style={{
+            flex: 1, height: 44, borderRadius: 12, border: `0.5px solid ${t.line}`,
+            background: 'transparent', color: t.ink,
+            fontFamily: LI_FONT, fontSize: 14, fontWeight: 500,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+            cursor: 'pointer',
+          }}>
+            {Icon.share(16)} Share
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 7. History — Chat & Feed (image-first)
+// ─────────────────────────────────────────────────────────────
+function HistoryShell({ theme, children }) {
+  const t = THEMES[theme];
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, paddingTop: 60,
+      display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '14px 20px 16px' }}>
+        <div style={{ fontSize: 17, fontWeight: 600, letterSpacing: -0.2 }}>LocalImage</div>
+        <IconBtn ariaLabel="Settings" size={34} style={{ background: t.surface, color: t.ink }}>
+          {Icon.cog(18)}
+        </IconBtn>
+      </div>
+      {children}
+      <div style={{ padding: '12px 20px 40px' }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 10,
+          background: t.surface, borderRadius: 999,
+          padding: '6px 6px 6px 18px', border: `0.5px solid ${t.line}`,
+        }}>
+          <div style={{ flex: 1, fontSize: 14, color: t.inkFaint }}>Describe an image…</div>
+          <IconBtn ariaLabel="Start voice prompt" size={40} style={{ background: t.accent, color: t.accentInk }}>
+            {Icon.mic(20)}
+          </IconBtn>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ScreenHistoryChat({ theme }) {
+  const t = THEMES[theme];
+  const items = [
+    { prompt: 'a wolf in a snowstorm', seed: 0, time: 'Just now' },
+    { prompt: 'porcelain teapot, studio light', seed: 1, time: '2 min ago' },
+    { prompt: 'kid astronaut, polaroid', seed: 2, time: 'Yesterday' },
+  ];
+  return (
+    <HistoryShell theme={theme}>
+      <div style={{ flex: 1, overflow: 'hidden', padding: '8px 20px 0',
+        display: 'flex', flexDirection: 'column', gap: 28 }}>
+        {items.map((it, i) => (
+          <div key={i}>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+              <div style={{ maxWidth: '78%', padding: '10px 14px', borderRadius: 18,
+                background: t.accent, color: t.accentInk,
+                fontSize: 14.5, lineHeight: 1.35 }}>{it.prompt}</div>
+            </div>
+            <div style={{ width: '78%', aspectRatio: '1', borderRadius: 18, overflow: 'hidden',
+              boxShadow: '0 4px 16px rgba(0,0,0,0.06)' }}>
+              <ImgPlaceholder seed={it.seed} theme={t} rounded={18}
+                style={{ width: '100%', height: '100%' }}
+                alt={`Generated image for: ${it.prompt}`} />
+            </div>
+            <div style={{ fontSize: 11, color: t.inkFaint, marginTop: 6,
+              fontFamily: MONO, letterSpacing: 0.3 }}>{it.time}</div>
+          </div>
+        ))}
+      </div>
+    </HistoryShell>
+  );
+}
+
+function ScreenHistoryFeed({ theme }) {
+  const t = THEMES[theme];
+  const items = [
+    { prompt: 'a wolf in a snowstorm', seed: 0, time: 'Just now' },
+    { prompt: 'porcelain teapot, studio light', seed: 1, time: '2 min ago' },
+    { prompt: 'kid astronaut, polaroid', seed: 2, time: 'Yesterday' },
+  ];
+  return (
+    <HistoryShell theme={theme}>
+      <div style={{ flex: 1, overflow: 'hidden', padding: '0 20px',
+        display: 'flex', flexDirection: 'column', gap: 28 }}>
+        {items.map((it, i) => (
+          <div key={i}>
+            <div style={{ width: '100%', aspectRatio: '1', borderRadius: 20, overflow: 'hidden',
+              boxShadow: t.statusDark
+                ? '0 8px 24px rgba(0,0,0,0.4)'
+                : '0 8px 24px rgba(0,0,0,0.08)' }}>
+              <ImgPlaceholder seed={it.seed} theme={t} rounded={20}
+                style={{ width: '100%', height: '100%' }}
+                alt={`Generated image for: ${it.prompt}`} />
+            </div>
+            <div style={{ fontFamily: t.titleFont, fontSize: 17, lineHeight: 1.3,
+              letterSpacing: -0.2, fontWeight: 500, marginTop: 12, color: t.ink }}>"{it.prompt}"</div>
+            <div style={{ fontSize: 11, color: t.inkFaint, marginTop: 4,
+              fontFamily: MONO, letterSpacing: 0.3 }}>{it.time}</div>
+          </div>
+        ))}
+      </div>
+    </HistoryShell>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 8. ERROR STATES
+// ─────────────────────────────────────────────────────────────
+
+function ErrorShell({ theme, kind, title, body, primary, secondary, icon, iconColor }) {
+  const t = THEMES[theme];
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, paddingTop: 60,
+      display: 'flex', flexDirection: 'column',
+    }}>
+      <div style={{ padding: '14px 20px 0', display: 'flex', justifyContent: 'flex-end' }}>
+        <IconBtn ariaLabel="Close" size={34} style={{ background: t.surface, color: t.ink }}>
+          {Icon.close(18)}
+        </IconBtn>
+      </div>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column',
+        alignItems: 'flex-start', justifyContent: 'center', padding: '0 28px' }}>
+        <div style={{
+          width: 56, height: 56, borderRadius: 16, background: t.surface,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: iconColor || t.danger, marginBottom: 22,
+          border: `0.5px solid ${t.line}`,
+        }}>{icon}</div>
+        <div style={{ fontSize: 11, letterSpacing: 0.6, textTransform: 'uppercase',
+          color: t.inkFaint, fontFamily: MONO, marginBottom: 8 }}>{kind}</div>
+        <div style={{ fontFamily: t.titleFont, fontSize: 26, lineHeight: 1.15,
+          letterSpacing: -0.5, fontWeight: 500, marginBottom: 10 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 14.5, lineHeight: 1.5, color: t.inkDim, maxWidth: 320 }}>
+          {body}
+        </div>
+      </div>
+      <div style={{ padding: '0 20px 40px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <button type="button" aria-label={primary.label} style={{
+          width: '100%', height: 54, borderRadius: 16, border: 'none',
+          background: t.accent, color: t.accentInk,
+          fontFamily: LI_FONT, fontSize: 16, fontWeight: 600, cursor: 'pointer',
+        }}>{primary.label}</button>
+        {secondary && (
+          <button type="button" aria-label={secondary.label} style={{
+            width: '100%', height: 44, borderRadius: 12, border: 'none',
+            background: 'transparent', color: t.inkDim,
+            fontFamily: LI_FONT, fontSize: 14, fontWeight: 500, cursor: 'pointer',
+          }}>{secondary.label}</button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ScreenErrorDownload({ theme }) {
+  return (
+    <ErrorShell
+      theme={theme}
+      kind="DOWNLOAD INTERRUPTED"
+      title="Couldn't finish the download"
+      body="The connection dropped at 64%. We've saved your progress — picking up where you left off should only take about a minute on Wi-Fi."
+      icon={Icon.warn(28)}
+      primary={{ label: 'Resume from 64%' }}
+      secondary={{ label: 'Try again later' }}
+    />
+  );
+}
+
+function ScreenErrorGeneration({ theme }) {
+  return (
+    <ErrorShell
+      theme={theme}
+      kind="COULDN'T MAKE THIS ONE"
+      title="Something went sideways"
+      body="The model ran out of memory part-way through. Closing other apps usually fixes it. Your prompt is still saved."
+      icon={Icon.warn(28)}
+      primary={{ label: 'Try again' }}
+      secondary={{ label: 'Edit prompt' }}
+    />
+  );
+}
+
+function ScreenErrorBlocked({ theme }) {
+  const t = THEMES[theme];
+  return (
+    <ErrorShell
+      theme={theme}
+      kind="THIS PROMPT WAS BLOCKED"
+      title="LocalImage skipped this one"
+      body="A small set of prompts is filtered to keep the app safe and welcoming. Your prompt isn't shared anywhere — it stayed on your device."
+      iconColor={t.inkDim}
+      icon={Icon.lock(24)}
+      primary={{ label: 'Edit prompt' }}
+      secondary={{ label: 'Learn more' }}
+    />
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 9. APP ICON EXPLORATIONS
+// ─────────────────────────────────────────────────────────────
+function AppIcon({ size = 120, variant }) {
+  const r = size * 0.225; // iOS squircle radius
+  const common = {
+    width: size, height: size, borderRadius: r,
+    overflow: 'hidden', position: 'relative',
+    boxShadow: '0 8px 24px rgba(0,0,0,0.18), inset 0 0 0 0.5px rgba(255,255,255,0.4)',
+    flexShrink: 0,
+  };
+  if (variant === 'aperture') {
+    return (
+      <div style={{ ...common, background: '#1C1814' }}>
+        <div style={{
+          position: 'absolute', inset: '20%',
+          borderRadius: '50%',
+          background: 'conic-gradient(from 0deg, oklch(0.72 0.16 28), oklch(0.55 0.18 60), oklch(0.45 0.16 220), oklch(0.55 0.16 320), oklch(0.72 0.16 28))',
+          filter: 'blur(2px)',
+        }} />
+        <div style={{
+          position: 'absolute', inset: '32%', borderRadius: '50%',
+          background: '#FBF8F2',
+        }} />
+      </div>
+    );
+  }
+  if (variant === 'wordmark') {
+    return (
+      <div style={{ ...common,
+        background: 'linear-gradient(135deg, #FBF8F2 0%, #EBE6DB 100%)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <div style={{
+          fontFamily: '"Tiempos Headline", Georgia, serif',
+          fontSize: size * 0.5, fontWeight: 500, letterSpacing: -2,
+          color: '#1C1814', lineHeight: 1,
+        }}>Li</div>
+      </div>
+    );
+  }
+  if (variant === 'tile') {
+    return (
+      <div style={{ ...common, background: '#0E0D11' }}>
+        <div style={{
+          position: 'absolute', left: '50%', top: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: '52%', height: '52%', borderRadius: r * 0.6,
+          background: 'linear-gradient(135deg, oklch(0.72 0.16 28) 0%, oklch(0.45 0.18 320) 100%)',
+        }} />
+        <div style={{
+          position: 'absolute', inset: 0,
+          background: `repeating-linear-gradient(135deg, rgba(255,255,255,0.04) 0 ${size*0.04}px, transparent ${size*0.04}px ${size*0.12}px)`,
+        }} />
+      </div>
+    );
+  }
+  if (variant === 'lens') {
+    return (
+      <div style={{ ...common,
+        background: 'radial-gradient(circle at 30% 25%, #F4F1EB 0%, #C9C2B2 50%, #6E6557 100%)',
+      }}>
+        <div style={{
+          position: 'absolute', inset: '18%', borderRadius: '50%',
+          background: 'radial-gradient(circle at 30% 25%, #fff 0%, oklch(0.45 0.16 240) 35%, #0E0D11 90%)',
+          boxShadow: 'inset 0 0 0 2px rgba(0,0,0,0.3)',
+        }} />
+        <div style={{
+          position: 'absolute', inset: '28%', borderRadius: '50%',
+          background: 'radial-gradient(circle at 30% 25%, oklch(0.65 0.20 28) 0%, oklch(0.30 0.15 30) 70%)',
+        }} />
+        <div style={{
+          position: 'absolute', left: '32%', top: '28%',
+          width: '14%', height: '10%', borderRadius: '50%',
+          background: 'rgba(255,255,255,0.7)', filter: 'blur(1px)',
+        }} />
+      </div>
+    );
+  }
+  if (variant === 'spark') {
+    return (
+      <div style={{ ...common,
+        background: 'linear-gradient(180deg, #F4F1EB 0%, #DBD4C3 100%)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <svg width={size * 0.6} height={size * 0.6} viewBox="0 0 24 24" fill="#1C1814" aria-hidden="true">
+          <path d="M12 2 L13.5 9 L21 10.5 L13.5 12 L12 19 L10.5 12 L3 10.5 L10.5 9 Z"/>
+        </svg>
+      </div>
+    );
+  }
+  if (variant === 'window') {
+    return (
+      <div style={{ ...common,
+        background: 'linear-gradient(180deg, oklch(0.72 0.10 60) 0%, oklch(0.42 0.10 28) 60%, oklch(0.22 0.06 280) 100%)',
+      }}>
+        {/* horizon */}
+        <div style={{
+          position: 'absolute', left: 0, right: 0, top: '60%',
+          height: 1, background: 'rgba(0,0,0,0.25)',
+        }} />
+        {/* sun */}
+        <div style={{
+          position: 'absolute', left: '50%', top: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: '34%', height: '34%', borderRadius: '50%',
+          background: 'radial-gradient(circle, oklch(0.92 0.10 80) 0%, oklch(0.78 0.16 50) 70%)',
+          filter: 'blur(0.5px)',
+        }} />
+        {/* frame */}
+        <div style={{
+          position: 'absolute', inset: '12%', borderRadius: r * 0.5,
+          border: '2px solid rgba(255,255,255,0.6)',
+          pointerEvents: 'none',
+        }} />
+      </div>
+    );
+  }
+  return null;
+}
+
+function ScreenAppIcons() {
+  const variants = [
+    { id: 'aperture', name: 'Aperture', tag: 'Camera lens, prism' },
+    { id: 'wordmark', name: 'Tiempos Li', tag: 'Quiet, editorial' },
+    { id: 'tile', name: 'Tile', tag: 'Bold, dark, gradient' },
+    { id: 'lens', name: 'Glass lens', tag: 'Real-world, tactile' },
+    { id: 'spark', name: 'Spark', tag: 'Generation as making' },
+    { id: 'window', name: 'Window', tag: '"See" something' },
+  ];
+  return (
+    <div style={{
+      width: '100%', height: '100%',
+      background: '#FBF8F2', color: '#1C1814',
+      fontFamily: LI_FONT, padding: '40px 32px',
+      overflow: 'auto',
+    }}>
+      <div style={{
+        fontFamily: '"Tiempos Headline", Georgia, serif',
+        fontSize: 24, fontWeight: 500, letterSpacing: -0.4,
+        marginBottom: 6,
+      }}>App icon — six directions</div>
+      <div style={{ fontSize: 12.5, color: 'rgba(28,24,20,0.55)', marginBottom: 28 }}>
+        Springboard size + a smaller in-context size. None of these try to depict AI directly — that aesthetic is already played out.
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 28 }}>
+        {variants.map((v) => (
+          <div key={v.id}>
+            <div style={{ display: 'flex', alignItems: 'flex-end', gap: 12, marginBottom: 10 }}>
+              <AppIcon size={108} variant={v.id} />
+              <AppIcon size={48} variant={v.id} />
+            </div>
+            <div style={{ fontSize: 14, fontWeight: 600, letterSpacing: -0.2 }}>{v.name}</div>
+            <div style={{ fontSize: 12, color: 'rgba(28,24,20,0.55)' }}>{v.tag}</div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ marginTop: 32, padding: '16px 18px', borderRadius: 14,
+        background: '#F4F1EB', fontSize: 12.5, lineHeight: 1.5,
+        color: 'rgba(28,24,20,0.7)' }}>
+        <strong style={{ color: 'rgba(28,24,20,0.9)' }}>Recommendation:</strong> "Glass lens" or "Window".
+        Both communicate <em>seeing</em> rather than <em>generating</em> — which is closer to the user's mental model. Aperture also strong, more tech-forward.
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 10. Action sheet — what's behind the "..." in history
+// ─────────────────────────────────────────────────────────────
+function ScreenActionSheet({ theme }) {
+  const t = THEMES[theme];
+  // Render the feed dimmed underneath, then a bottom sheet.
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <div style={{ position: 'absolute', inset: 0, filter: 'blur(2px) brightness(0.85)' }}>
+        <ScreenHistoryFeed theme={theme} />
+      </div>
+      <div style={{ position: 'absolute', inset: 0,
+        background: t.statusDark ? 'rgba(0,0,0,0.45)' : 'rgba(0,0,0,0.25)' }} />
+      <div style={{
+        position: 'absolute', left: 8, right: 8, bottom: 8,
+        background: t.surface, borderRadius: 20, overflow: 'hidden',
+        boxShadow: '0 -8px 40px rgba(0,0,0,0.18)',
+        border: `0.5px solid ${t.line}`,
+      }}>
+        <div style={{ padding: '12px 18px 6px',
+          fontFamily: MONO, fontSize: 10, letterSpacing: 0.6,
+          color: t.inkFaint, textTransform: 'uppercase' }}>
+          "kid astronaut, polaroid"
+        </div>
+        {[
+          { label: 'Use this prompt again', sub: 'Drops it into the composer', group: 'make' },
+          { label: 'Refine prompt', sub: 'Edit, then generate', group: 'make' },
+          { label: 'Make a variation', sub: 'Same prompt, new seed', group: 'make' },
+          { label: 'Save to Photos', sub: 'Adds a 768² PNG to your camera roll', group: 'send' },
+          { label: 'Share…', sub: 'Choose an app — leaves the device only when you pick one', group: 'send' },
+          { label: 'Copy prompt as text', sub: '', group: 'send' },
+          { label: 'Delete', sub: 'Removes from library', destructive: true, group: 'destroy' },
+        ].map((row, i, arr) => {
+          const prev = arr[i - 1];
+          const groupBreak = prev && prev.group !== row.group;
+          return (
+            <React.Fragment key={i}>
+              {groupBreak && (
+                <div style={{ height: 6, background: t.bg }} />
+              )}
+              <button type="button" aria-label={row.label} style={{
+                display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+                width: '100%', padding: '13px 18px', gap: 2,
+                background: 'transparent', border: 'none', cursor: 'pointer',
+                borderTop: (i === 0 || groupBreak) ? 'none' : `0.5px solid ${t.line}`,
+                textAlign: 'left',
+              }}>
+                <span style={{ fontSize: 16, fontWeight: 500, fontFamily: LI_FONT,
+                  color: row.destructive ? t.danger : t.ink }}>{row.label}</span>
+                {row.sub && <span style={{ fontSize: 12, color: t.inkDim, lineHeight: 1.35 }}>{row.sub}</span>}
+              </button>
+            </React.Fragment>
+          );
+        })}
+        <button type="button" aria-label="Cancel" style={{
+          width: '100%', padding: '14px', fontSize: 16, fontWeight: 600,
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          color: t.inkDim, fontFamily: LI_FONT,
+          borderTop: `0.5px solid ${t.line}`,
+        }}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 11. iPad layout — split view, library left, focused result right
+// ─────────────────────────────────────────────────────────────
+function ScreenIPad({ theme }) {
+  const t = THEMES[theme];
+  const items = [
+    { prompt: 'a wolf in a snowstorm', seed: 0, time: 'Just now' },
+    { prompt: 'porcelain teapot, studio light', seed: 1, time: '2 min' },
+    { prompt: 'kid astronaut, polaroid', seed: 2, time: 'Yesterday' },
+    { prompt: 'hummingbird mid-flight', seed: 3, time: 'Yesterday' },
+    { prompt: 'cathedral of moss', seed: 4, time: '2 d' },
+    { prompt: 'ramen shop at midnight', seed: 5, time: '3 d' },
+  ];
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, display: 'flex', overflow: 'hidden',
+    }}>
+      {/* sidebar */}
+      <div style={{
+        width: 280, borderRight: `0.5px solid ${t.line}`,
+        display: 'flex', flexDirection: 'column', padding: '20px 16px',
+        background: t.surface,
+      }}>
+        <div style={{ fontSize: 17, fontWeight: 600, letterSpacing: -0.2,
+          padding: '4px 8px 16px' }}>LocalImage</div>
+        <button type="button" aria-label="New prompt" style={{
+          padding: '10px 14px', background: t.accent, color: t.accentInk,
+          border: 'none', borderRadius: 12, cursor: 'pointer',
+          fontFamily: LI_FONT, fontSize: 14, fontWeight: 600,
+          textAlign: 'left', marginBottom: 16,
+        }}>+ New prompt</button>
+        <div style={{ fontSize: 10, fontFamily: MONO, letterSpacing: 0.6,
+          color: t.inkFaint, padding: '8px 8px 8px', textTransform: 'uppercase' }}>Library</div>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 4, overflow: 'hidden' }}>
+          {items.map((it, i) => (
+            <div key={i} style={{
+              display: 'flex', gap: 10, padding: '6px 8px', borderRadius: 10,
+              background: i === 2 ? t.surfaceAlt : 'transparent',
+              alignItems: 'center', cursor: 'pointer',
+            }}>
+              <div style={{ width: 36, height: 36, borderRadius: 7, overflow: 'hidden', flexShrink: 0 }}>
+                <ImgPlaceholder seed={it.seed} theme={t} rounded={7}
+                  style={{ width: '100%', height: '100%' }} alt={it.prompt} />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, color: t.ink, lineHeight: 1.3,
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {it.prompt}
+                </div>
+                <div style={{ fontSize: 10, color: t.inkFaint, fontFamily: MONO, letterSpacing: 0.3 }}>
+                  {it.time}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* main canvas */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between',
+          alignItems: 'center', padding: '20px 32px 0' }}>
+          <div style={{ fontFamily: t.titleFont, fontSize: 22, fontWeight: 500,
+            letterSpacing: -0.3 }}>"kid astronaut, polaroid"</div>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6,
+              fontSize: 11, fontFamily: MONO, color: t.inkFaint, letterSpacing: 0.5,
+              marginRight: 4 }}>
+              {Icon.shield(13)} ON DEVICE
+            </div>
+            <button type="button" aria-label="Save to Photos" style={{
+              padding: '8px 14px', borderRadius: 10, fontSize: 13, fontWeight: 500,
+              background: t.surface, border: `0.5px solid ${t.line}`, color: t.ink,
+              cursor: 'pointer', fontFamily: LI_FONT, display: 'flex', alignItems: 'center', gap: 6,
+            }}>{Icon.save(15)} Save</button>
+            <button type="button" aria-label="Share image" style={{
+              padding: '8px 14px', borderRadius: 10, fontSize: 13, fontWeight: 500,
+              background: t.surface, border: `0.5px solid ${t.line}`, color: t.ink,
+              cursor: 'pointer', fontFamily: LI_FONT, display: 'flex', alignItems: 'center', gap: 6,
+            }}>{Icon.share(15)} Share</button>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          padding: '24px 32px' }}>
+          <div style={{ width: 540, height: 540, borderRadius: 24, overflow: 'hidden',
+            boxShadow: t.statusDark
+              ? '0 30px 80px rgba(0,0,0,0.5)'
+              : '0 30px 60px rgba(0,0,0,0.12)' }}>
+            <ImgPlaceholder seed={2} theme={t} rounded={24}
+              style={{ width: '100%', height: '100%' }} alt="kid astronaut, polaroid" />
+          </div>
+        </div>
+
+        <div style={{ padding: '0 32px 32px' }}>
+          <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
+            <button type="button" style={{
+              flex: 1, height: 52, borderRadius: 14, border: 'none',
+              background: t.accent, color: t.accentInk,
+              fontFamily: LI_FONT, fontSize: 15, fontWeight: 600, cursor: 'pointer',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            }}>{Icon.refresh(18)} Try again</button>
+            <button type="button" style={{
+              flex: 1, height: 52, borderRadius: 14, border: 'none',
+              background: t.accent, color: t.accentInk,
+              fontFamily: LI_FONT, fontSize: 15, fontWeight: 600, cursor: 'pointer', opacity: 0.86,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            }}>{Icon.edit(18)} Refine</button>
+          </div>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            background: t.surface, borderRadius: 999, padding: '6px 6px 6px 18px',
+            border: `0.5px solid ${t.line}`,
+          }}>
+            <div style={{ flex: 1, fontSize: 14, color: t.inkFaint }}>Describe an image…</div>
+            <IconBtn ariaLabel="Start voice prompt" size={40}
+              style={{ background: t.accent, color: t.accentInk }}>{Icon.mic(20)}</IconBtn>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// 12. macOS layout — window chrome + same split, denser
+// ─────────────────────────────────────────────────────────────
+function ScreenMac({ theme }) {
+  const t = THEMES[theme];
+  const items = [
+    { prompt: 'a wolf in a snowstorm', seed: 0, time: 'Just now' },
+    { prompt: 'porcelain teapot, studio light', seed: 1, time: '2 min' },
+    { prompt: 'kid astronaut, polaroid', seed: 2, time: 'Yesterday' },
+    { prompt: 'hummingbird mid-flight', seed: 3, time: 'Yesterday' },
+  ];
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: t.bg, color: t.ink,
+      fontFamily: LI_FONT, display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    }}>
+      {/* title bar */}
+      <div style={{
+        height: 38, display: 'flex', alignItems: 'center',
+        padding: '0 14px', borderBottom: `0.5px solid ${t.line}`,
+        background: t.surface, gap: 8,
+      }}>
+        <div style={{ display: 'flex', gap: 6 }}>
+          <div style={{ width: 12, height: 12, borderRadius: 6, background: '#FF5F57' }} />
+          <div style={{ width: 12, height: 12, borderRadius: 6, background: '#FEBC2E' }} />
+          <div style={{ width: 12, height: 12, borderRadius: 6, background: '#28C840' }} />
+        </div>
+        <div style={{ flex: 1, textAlign: 'center', fontSize: 12, color: t.inkDim, fontWeight: 500 }}>
+          LocalImage
+        </div>
+        <div style={{ width: 54 }} />
+      </div>
+
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {/* sidebar */}
+        <div style={{
+          width: 220, borderRight: `0.5px solid ${t.line}`, padding: '14px 10px',
+          background: t.surface, display: 'flex', flexDirection: 'column',
+        }}>
+          <button type="button" style={{
+            padding: '8px 12px', background: t.accent, color: t.accentInk,
+            border: 'none', borderRadius: 8, cursor: 'pointer',
+            fontFamily: LI_FONT, fontSize: 12, fontWeight: 600,
+            textAlign: 'left', marginBottom: 12,
+          }}>+ New prompt  ⌘N</button>
+          <div style={{ fontSize: 9.5, fontFamily: MONO, letterSpacing: 0.6,
+            color: t.inkFaint, padding: '6px 8px', textTransform: 'uppercase' }}>Library</div>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, overflow: 'hidden' }}>
+            {items.map((it, i) => (
+              <div key={i} style={{
+                display: 'flex', gap: 8, padding: '5px 8px', borderRadius: 6,
+                background: i === 2 ? t.surfaceAlt : 'transparent',
+                alignItems: 'center', cursor: 'pointer',
+              }}>
+                <div style={{ width: 22, height: 22, borderRadius: 4, overflow: 'hidden', flexShrink: 0 }}>
+                  <ImgPlaceholder seed={it.seed} theme={t} rounded={4}
+                    style={{ width: '100%', height: '100%' }} alt={it.prompt} />
+                </div>
+                <div style={{ flex: 1, fontSize: 12, lineHeight: 1.3,
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {it.prompt}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* main */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between',
+            alignItems: 'center', padding: '14px 20px', borderBottom: `0.5px solid ${t.line}` }}>
+            <div style={{ fontFamily: t.titleFont, fontSize: 16, fontWeight: 500,
+              letterSpacing: -0.2 }}>"kid astronaut, polaroid"</div>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button type="button" style={{
+                padding: '5px 10px', borderRadius: 6, fontSize: 11, fontWeight: 500,
+                background: 'transparent', border: `0.5px solid ${t.line}`, color: t.ink,
+                cursor: 'pointer', fontFamily: LI_FONT,
+              }}>Save</button>
+              <button type="button" style={{
+                padding: '5px 10px', borderRadius: 6, fontSize: 11, fontWeight: 500,
+                background: 'transparent', border: `0.5px solid ${t.line}`, color: t.ink,
+                cursor: 'pointer', fontFamily: LI_FONT,
+              }}>Share</button>
+            </div>
+          </div>
+
+          <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px' }}>
+            <div style={{ width: 360, height: 360, borderRadius: 16, overflow: 'hidden',
+              boxShadow: t.statusDark ? '0 16px 40px rgba(0,0,0,0.5)' : '0 16px 32px rgba(0,0,0,0.10)' }}>
+              <ImgPlaceholder seed={2} theme={t} rounded={16}
+                style={{ width: '100%', height: '100%' }} alt="kid astronaut, polaroid" />
+            </div>
+          </div>
+
+          <div style={{ padding: '0 20px 18px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" style={{
+                flex: 1, height: 36, borderRadius: 8, border: 'none',
+                background: t.accent, color: t.accentInk,
+                fontFamily: LI_FONT, fontSize: 13, fontWeight: 600, cursor: 'pointer',
+              }}>↻ Try again</button>
+              <button type="button" style={{
+                flex: 1, height: 36, borderRadius: 8, border: 'none',
+                background: t.accent, color: t.accentInk,
+                fontFamily: LI_FONT, fontSize: 13, fontWeight: 600, cursor: 'pointer', opacity: 0.86,
+              }}>✎ Refine</button>
+            </div>
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              background: t.surface, borderRadius: 8, padding: '6px 6px 6px 12px',
+              border: `0.5px solid ${t.line}`,
+            }}>
+              <div style={{ flex: 1, fontSize: 12.5, color: t.inkFaint }}>Describe an image, or press ⌘⇧D for voice…</div>
+              <IconBtn ariaLabel="Start voice prompt" size={26}
+                style={{ background: t.accent, color: t.accentInk }}>{Icon.mic(14)}</IconBtn>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  THEMES, LI_FONT, MONO,
+  ScreenFirstLaunch, ScreenDownload, ScreenEmptyPrompt,
+  ScreenVoiceListening, ScreenGenerating, ScreenResult,
+  ScreenHistoryChat, ScreenHistoryFeed,
+  ScreenErrorDownload, ScreenErrorGeneration, ScreenErrorBlocked,
+  ScreenAppIcons, AppIcon,
+  ScreenActionSheet, ScreenIPad, ScreenMac,
+  ImgPlaceholder, Icon, IconBtn,
+});

--- a/scripts/dx-walkthrough/briefs/03-design-assets/tweaks-panel.jsx
+++ b/scripts/dx-walkthrough/briefs/03-design-assets/tweaks-panel.jsx
@@ -1,0 +1,425 @@
+
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;width:100%;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel" data-noncommentable=""
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">{children}</div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+function TweakColor({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <input type="color" className="twk-swatch" value={value}
+             onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/scripts/dx-walkthrough/briefs/03-image-gen-app.md
+++ b/scripts/dx-walkthrough/briefs/03-image-gen-app.md
@@ -1,0 +1,134 @@
+# Brief: LocalImage — Designer-to-App, Voice + Image Generation (macOS)
+
+You are a Swift developer who has just heard about **ManifoldKit** — a Swift framework for building local-first AI apps on Apple platforms. Until now you've mostly seen it pitched as a chat framework. A designer has handed you a brief and a runnable flow file for a small voice-driven image-generation app, and you want to evaluate whether ManifoldKit is the right foundation to build it on.
+
+This is a **vibe-coding** exercise: you're given a designer brief and a visual flow, and your job is to bring it to life as a working SwiftUI app using ManifoldKit's public surface. You're not extending ManifoldKit — you're consuming it.
+
+## What you're building
+
+**LocalImage** — a native SwiftUI **macOS** app (the design is iPhone-first; you'll implement it as mac for this phase — physical iPhone is phase 4) that:
+
+1. Greets the user on first launch with a clear "we need to download a model" moment, downloads a diffusion model, and persists it locally
+2. Lets the user describe an image **by voice** (speech-to-text into the prompt field) or by typing
+3. Generates a 768×768 image on-device via MLX diffusion
+4. Shows the generated image at full prominence with Save / Try again / Refine actions
+5. Keeps a history of prompts + generated images across launches
+
+Voice is **required**, not a stretch goal — this phase exists to exercise both the image-generation and voice surfaces of ManifoldKit. If you can't get voice working from the public docs, log it as a blocker in FRICTION.md and pivot to text-only — but make sure the friction is captured, because that's the signal we're after.
+
+## The design inputs
+
+All design inputs live in `./design-assets/` (sibling directory to this brief):
+
+1. **`DESIGN-BRIEF.md`** — prose design brief: product vision, target user (non-technical, Canva-style), the journey across first-launch / prompt / generation / result, and what's intentionally left open.
+2. **`LocalImage Flow.html`** — runnable React/Babel iPhone-framed flow viewer. Open in a browser to see the rendered flow:
+   ```
+   open scripts/dx-walkthrough/briefs/03-design-assets/"LocalImage Flow.html"
+   ```
+3. **`screens.jsx`** — the underlying screen source. Every screen is a named React component with concrete copy, layout, and state. Read this directly; it's more reliable than trying to render the HTML headlessly.
+
+Screens defined in `screens.jsx`: `FirstLaunch`, `Download`, `EmptyPrompt`, `VoiceListening`, `Generating`, `Result`, `HistoryChat`, `HistoryFeed`, error states (`ErrorDownload`, `ErrorGeneration`, `ErrorBlocked`), `ActionSheet`, plus `IPad` and `Mac` layout variants. The `Mac` variant is your primary visual reference for this phase.
+
+Treat these as a real design handoff. Your job is to make the app feel like the brief and the flow describe, using ManifoldKit's public surface.
+
+## Constraints
+
+- **Target**: macOS 26, Swift 6, SwiftUI. Native macOS app (not Catalyst).
+- **You may read**:
+  - ManifoldKit's `README.md`, anything under `docs/`, anything under `Sources/*/Documentation.docc/`, the package's `Package.swift`, repo-root markdown
+  - The `Example/Examples/MinimalExample/` directory if one exists
+  - Everything in `./design-assets/` (HTML + JSX + DESIGN-BRIEF.md)
+- **You may NOT read**:
+  - ManifoldKit's source files (`Sources/Manifold*/**/*.swift`) or its tests (`Tests/**`). The whole point is testing whether the *public* surface is sufficient.
+  - Any other implementation of LocalImage you happen to find on this machine. If you spot one, log the temptation in FRICTION.md and stay out of it.
+- **Backend choice**: image gen is `MLXDiffusionBackend` (shipped v0.16.2). For text input alongside the prompt composer, you may or may not need an LLM backend — read the design brief and decide. For voice, look at what ManifoldKit's voice module offers.
+- **Budget**: ~90 minutes of focused work. The first-run download will eat real wall-clock time — that's part of the test. If you're stuck on one problem for more than 3 substantive attempts, log it in FRICTION.md and pivot.
+- **Models**: the first-run download path is part of what we're testing. Let it run end-to-end if you can. If you find documented helpers to seed a model from disk, use them and log how discoverable they were.
+
+## Cold build time
+
+A fresh consumer of ManifoldKit cold-builds all transitive dependencies (huggingface, MLX, llama, etc.). The first `swift build` can take 5–10 minutes on Apple Silicon. Don't be alarmed; log it as friction if it bothers you, but the dependency tree is what it is.
+
+## Working directory
+
+Your app lives at `./app/` relative to wherever this brief is invoked from (typically inside a `runs/<date>_<tag>/03-image-gen-app/` directory). Create a SwiftPM package or Xcode project there. Reference ManifoldKit via a local path dependency to the repo containing this brief — typically two directories up from the brief, but resolve the actual path at run time:
+
+```swift
+.package(name: "ManifoldKit", path: "<absolute path to the ManifoldKit repo containing this brief>")
+```
+
+(Per CLAUDE.md, `.package(path:)` needs an explicit `name:` to work reliably.)
+
+## Required behavior (acceptance criteria)
+
+- [ ] App compiles cleanly (warnings allowed, errors not)
+- [ ] App launches and shows a SwiftUI window
+- [ ] First-run: app surfaces a clear "model needed" state and either downloads a diffusion model or lets the user point at a local one
+- [ ] **Voice input works**: user can tap a mic affordance, speak a prompt, and see the transcription land in the prompt field. (If voice can't be made to work from public docs, that's a finding — log it.)
+- [ ] Generation produces a 768×768 image on success (capture a screenshot)
+- [ ] After closing and relaunching the app, prior prompts + images are still visible
+- [ ] At least one of: Save / Try again / Refine actions on a generated image
+
+You do not need to match the design pixel-for-pixel. You do need the **shape** of the journey to match the brief: first-run → prompt (voice or text) → waiting state → reveal → history. Capture a screenshot of each state via `xcrun screencapture`.
+
+## Deliverables
+
+In your run directory you should produce:
+
+1. **`./app/`** — the working Swift package or Xcode project
+2. **`./FRICTION.md`** — your friction log (template below). **This is the most important deliverable.**
+3. **`./session.log`** — final build + launch output, plus any captured screenshots referenced by filename
+4. **`./screenshots/`** — at least one screenshot of the running app (first-run, prompt, generated image)
+5. **`./NOTES.md`** — 10–15 lines: which backend/path you picked, what felt like a chat-framework-trying-to-do-image-gen, where the design brief outran what MK's public surface supports, your overall verdict on MK as a foundation for non-chat apps
+
+## FRICTION.md template
+
+Start the file with this header, then append entries as you go. Log friction **as it happens**, not at the end — you will forget.
+
+```markdown
+# Friction log — image-gen-app archetype (phase 3, macOS)
+
+Agent: <your model name>
+Date: <run date>
+ManifoldKit version: <from version.txt or git tag>
+
+---
+
+## Entry 1
+- **Trying to**: <what you were attempting>
+- **Expected**: <based on docs / API names, what you thought would happen>
+- **Actual**: <what happened — error, missing API, confusing behavior>
+- **Resolution**: <how you got past it, or "gave up and pivoted">
+- **Category**: DOC-MISSING | DOC-WRONG | API-DISCOVERABILITY | API-ERGONOMICS | API-GAP | DESIGN-VS-API-MISMATCH
+- **Severity**: blocker | major | minor | papercut
+
+## Entry 2
+...
+```
+
+**Log liberally.** Surfaces of interest unique to this archetype:
+
+- Discovering that ManifoldKit *does* image generation at all (it markets itself as a chat framework)
+- `MLXDiffusionBackend` discoverability — is it findable from the top-level README?
+- The first-run download UX: does MK give you primitives for "model needed → download → ready," or do you have to invent them?
+- How image generation events are surfaced — is there a streaming/progress signal you can hang a waiting-state UI off, or just a single async result?
+- Persistence of image history — does the SwiftData/persistence layer assume "messages" and stretch awkwardly for "image generations," or is it shape-agnostic?
+- Voice input: is `ManifoldVoice` accessible without dragging chat assumptions in? What `NS*UsageDescription` keys does the docs tell you to add?
+- The umbrella `import ManifoldKit` — does it cover image gen and voice, or do you need specialised imports?
+- Design-vs-API mismatches: where the brief describes a UX moment that the public API doesn't naturally support
+
+## What we're trying to learn
+
+This is the third archetype in a DX walkthrough series. Archetypes 1 (chat-cli) and 2 (swiftui-chat) covered the chat happy path. This one tests whether ManifoldKit is *only* a chat framework or whether it lives up to its "local-first AI" framing for non-chat apps that exercise its image-gen + voice modules. It also tests the **designer-to-app** path: can a developer take a real design handoff and ship it on top of MK, or does the framework's chat-shaped surface force the design to bend?
+
+Phase 4 will repeat this exercise on a physical iPhone to get the on-device truth. Phase 3 keeps the variables low (mac, Metal-available, no signing dance) so the friction signal is about MK's public API, not about iOS deployment plumbing.
+
+**Be honest.** If MK is clearly a chat framework that bolted on image gen, say so. If the public surface composes cleanly for non-chat apps, say so. If the design brief asks for things MK has no opinion on, call those out specifically.
+
+## Reporting back
+
+When done (or when time/attempts are exhausted), respond with:
+- Whether the app works (yes / no / partially) — call out specifically: did first-run work? did voice work? did generation work? does history persist?
+- Path to your run directory
+- The 3 highest-severity friction entries, verbatim
+- One-line overall verdict on MK as a foundation for non-chat AI apps

--- a/scripts/dx-walkthrough/briefs/04-iphone-design-to-app.md
+++ b/scripts/dx-walkthrough/briefs/04-iphone-design-to-app.md
@@ -1,0 +1,174 @@
+# Brief: LocalImage — iPhone Design-to-App, On-Device End-to-End
+
+You are a Swift developer evaluating **ManifoldKit** as the foundation for a small iPhone app. A designer has handed you a flow file describing a voice-driven, on-device image-generation app. Your job is to take that design and ship it as a working app **on your actual iPhone** — not the simulator.
+
+This is the highest-fidelity DX exercise in the series. Phase 3 ran the same design as a macOS app to isolate signal about MK's public API. Phase 4 adds the iPhone-deployment surface on top: iOS-specific APIs, code signing, on-device download, real microphone, real Metal on A-series silicon, real share sheet, real Photos save.
+
+## Why this is a manual, periodic run
+
+- Requires a physical iPhone (iOS Simulator can't run Metal-backed MLX diffusion; voice in simulator is unreliable)
+- Requires code signing and a trusted developer profile on the device
+- Costs ~90–120 minutes of focused time including cold build + device install
+- Not CI-friendly — there is no good way to drive a physical device from GitHub Actions
+
+Run this **pre-release** or on a periodic cadence (e.g. monthly), not per-PR. The goal is honest signal about whether a vibe-coder can ship a ManifoldKit-powered app to their phone in a sitting.
+
+## Pre-flight checklist (developer to complete before starting)
+
+Before invoking the agent, the developer needs to have:
+
+- [ ] A physical iPhone running iOS 26+ connected via USB or Wi-Fi pairing
+- [ ] Developer Mode enabled on the iPhone (`Settings > Privacy & Security > Developer Mode`)
+- [ ] An Apple ID / Personal Team signed into Xcode (free tier works for personal/dev installs)
+- [ ] Xcode 26+ installed
+- [ ] `xcrun devicectl list devices` shows the iPhone in the output
+- [ ] *(Optional but recommended)* `brew install libimobiledevice` so the agent can capture screenshots via `idevicescreenshot`. Without it, you'll capture screenshots manually from the device.
+
+Fill in your specifics in `./RUN-CONFIG.md` at the start of the run (template below). **Do not commit `RUN-CONFIG.md` to the public repo** — it contains your device UDID and team ID. It's gitignored by default under `runs/`.
+
+## What you're building
+
+**LocalImage** — a native SwiftUI **iOS** app that:
+
+1. Greets the user on first launch with a clear "we need to download a model" moment, downloads a diffusion model in the background (resumable, survives backgrounding), and persists it locally
+2. Lets the user describe an image **by voice** (the design's primary input mode) or by typing
+3. Generates a 768×768 image on-device via MLX diffusion on Apple silicon
+4. Shows the generated image with Save (to Photos) / Share (iOS share sheet) / Try again / Refine
+5. Keeps a history of prompts + generated images across launches
+
+## The design inputs
+
+Same bundle as phase 3 — all in `./design-assets/` (sibling to this brief):
+
+1. **`DESIGN-BRIEF.md`** — prose design brief
+2. **`LocalImage Flow.html`** — runnable iPhone-framed flow viewer:
+   ```
+   open scripts/dx-walkthrough/briefs/03-design-assets/"LocalImage Flow.html"
+   ```
+3. **`screens.jsx`** — every screen as a named React component with concrete copy and state
+
+For phase 4 the **iPhone screens are the primary visual reference** (not the `Mac` variant). The design is iPhone-first; this is where you ship it the way the designer intended.
+
+## Constraints
+
+- **Target**: iOS 26, Swift 6, SwiftUI, native iOS app deployed to a physical iPhone
+- **You may read**:
+  - ManifoldKit's `README.md`, `docs/`, `Sources/*/Documentation.docc/`, `Package.swift`, repo-root markdown
+  - The `Example/Examples/MinimalExample/` directory if one exists
+  - Everything in `./design-assets/`
+- **You may NOT read**:
+  - ManifoldKit's source files (`Sources/Manifold*/**/*.swift`) or its tests (`Tests/**`)
+  - Any other LocalImage implementation on this machine
+- **Backend**: image gen is `MLXDiffusionBackend`. Voice via the voice module. Choose what the docs guide you toward.
+- **Budget**: 90–120 minutes. First-time-on-device install + trust dance + cold MK build will eat 15–20 minutes of that before you write meaningful app code.
+- **Signing**: use the developer's Personal Team / Apple ID (in `RUN-CONFIG.md`). On first install the developer will need to trust the certificate on the device (`Settings > General > VPN & Device Management`).
+
+## RUN-CONFIG.md template
+
+Create this at the start of your run. **Do not commit it.** The agent reads it for device-specific values.
+
+```markdown
+# Run config — phase 4 (iPhone)
+
+DEVICE_NAME: <e.g. "Rory's iPhone">
+DEVICE_UDID: <from `xcrun devicectl list devices`>
+TEAM_ID: <10-char team ID from Xcode > Settings > Accounts, or "PERSONAL" for free-tier>
+BUNDLE_ID: <e.g. com.example.localimage — must be unique to your team>
+HAS_LIBIMOBILEDEVICE: <true|false>
+```
+
+## Working directory
+
+Your app lives at `./app/` relative to this brief's run directory. You'll need an **Xcode project** (not pure SwiftPM exec) so you can configure Info.plist, signing, and a device-deployable scheme. Reference ManifoldKit via a local path package:
+
+```swift
+.package(name: "ManifoldKit", path: "<absolute path to the ManifoldKit repo containing this brief>")
+```
+
+## Info.plist keys you'll need
+
+The voice path almost certainly needs these. Photos save needs the third. If MK's docs tell you which keys to add, follow the docs; if they don't, that's a friction entry.
+
+- `NSMicrophoneUsageDescription`
+- `NSSpeechRecognitionUsageDescription`
+- `NSPhotoLibraryAddUsageDescription`
+
+## Build & deploy commands
+
+The agent should drive the device install via `xcodebuild`. Typical shape:
+
+```bash
+xcodebuild \
+  -project app/LocalImage.xcodeproj \
+  -scheme LocalImage \
+  -configuration Debug \
+  -destination "platform=iOS,id=$DEVICE_UDID" \
+  -allowProvisioningUpdates \
+  install
+```
+
+After install, launch via:
+
+```bash
+xcrun devicectl device process launch \
+  --device "$DEVICE_UDID" \
+  --start-stopped \
+  <bundle-id>
+```
+
+If `xcodebuild install` fails on signing, fall back to opening the project in Xcode and hitting Run — log every signing-related friction step.
+
+## Required behavior (acceptance criteria)
+
+- [ ] App builds and installs on the physical iPhone (not simulator)
+- [ ] App launches and the launch screen / first-run state appears
+- [ ] First-run model download starts, makes progress, and survives at least one app backgrounding (lock the phone for 30s, return, download resumes)
+- [ ] Voice input works on real mic: tap mic, speak, transcription appears in prompt
+- [ ] Image generation produces a 768×768 PNG on-device (no cloud calls during gen — verify with Charles/Proxyman if you have it, or just by airplane-moding the phone before generation)
+- [ ] Generated image can be saved to Photos
+- [ ] After force-quitting and relaunching, history persists
+- [ ] Capture screenshots of: first-launch, download, voice-listening, generating, result, history
+
+## Screenshot capture
+
+If `HAS_LIBIMOBILEDEVICE` is true:
+```bash
+idevicescreenshot -u "$DEVICE_UDID" screenshots/<state>.png
+```
+
+Otherwise the developer captures via the device (side button + volume up) and AirDrops to the run directory. Note in the friction log how awkward this was — that's the kind of papercut the periodic run is designed to surface.
+
+## Deliverables
+
+1. **`./app/`** — Xcode project
+2. **`./FRICTION.md`** — friction log (same template as phase 3, with category `IOS-DEPLOYMENT` added)
+3. **`./session.log`** — final build / install / launch output
+4. **`./screenshots/`** — the 6 screen captures listed above
+5. **`./NOTES.md`** — 10–15 lines covering: iOS-specific MK surface (Info.plist, background download, file protection, share sheet integration), what worked vs phase 3's mac run, what got harder, your verdict on shipping an MK app to a real iPhone
+
+**`./RUN-CONFIG.md` is private — leave it out of any committed artefact.**
+
+## FRICTION.md categories (extended for phase 4)
+
+In addition to phase 3 categories (DOC-MISSING, DOC-WRONG, API-DISCOVERABILITY, API-ERGONOMICS, API-GAP, DESIGN-VS-API-MISMATCH), use:
+
+- `IOS-DEPLOYMENT` — signing, provisioning, device trust, Info.plist key discovery, scheme configuration
+- `IOS-RUNTIME` — anything that worked on mac in phase 3 but breaks on device (jetsam, file protection, background lifecycle, mic permissions)
+
+## What we're trying to learn (phase 4 vs phase 3)
+
+Phase 3 isolated MK's public API on a forgiving target. Phase 4 layers iOS deployment on top. The comparison is the point:
+
+- **Findings present in both phases** → MK public API issues
+- **Findings only in phase 4** → MK iOS-specific gaps (Info.plist docs missing, background download fragile, jetsam not handled, share-sheet integration awkward, etc.)
+- **Findings phase 3 had that phase 4 didn't** → mac-specific quirks that don't matter for the iPhone story
+
+Be specific about which bucket each entry falls into.
+
+## Reporting back
+
+When done (or when time/attempts are exhausted), respond with:
+- Whether the app works on device (yes / no / partially) — call out specifically: did device install succeed? did the cert trust dance work? did background download survive? did voice work on real mic? did Photos save work?
+- Path to your run directory
+- The 3 highest-severity friction entries, verbatim, with their phase-3-vs-4 bucket noted
+- One-line overall verdict on shipping an MK-powered app to an actual iPhone in a single sitting

--- a/scripts/dx-walkthrough/briefs/README.md
+++ b/scripts/dx-walkthrough/briefs/README.md
@@ -1,0 +1,39 @@
+# DX walkthrough briefs
+
+Each brief frames a fresh ManifoldKit consumer's journey through a specific archetype. Briefs are read by an agent (or developer) that has not seen ManifoldKit's internals — they exercise the **public surface** only and produce a friction log.
+
+## Phases
+
+| # | Brief | Target | Surfaces | Cost | Cadence |
+|---|-------|--------|----------|------|---------|
+| 01 | `01-chat-cli.md` | macOS terminal | Chat happy path, streaming, backend choice | ~30 min | Per release |
+| 02 | `02-swiftui-chat.md` | macOS SwiftUI | `ChatView`, persistence, `ChatViewModel`, SwiftData | ~60 min | Per release |
+| 03 | `03-image-gen-app.md` | macOS SwiftUI | `MLXDiffusionBackend`, voice (`ManifoldVoice`), designer-to-app | ~90 min | Per release |
+| 04 | `04-iphone-design-to-app.md` | **Physical iPhone** | All of 03 + iOS deployment, signing, on-device download, jetsam, share sheet, Photos | ~90–120 min | Pre-release / periodic |
+
+Phases 01–03 are cheap-ish and can run on any Apple Silicon mac. **Phase 04 requires a physical iPhone, Apple Developer account / Personal Team, and a signing dance.** It is intentionally manual and not CI-gated.
+
+## Shared design assets
+
+`03-design-assets/` contains a real designer handoff (prose brief + runnable iPhone-framed flow viewer + JSX source for every screen). Phases 03 and 04 both consume it. The flow file is best opened in a browser:
+
+```
+open scripts/dx-walkthrough/briefs/03-design-assets/"LocalImage Flow.html"
+```
+
+## Privacy / public-repo conventions
+
+- Briefs are committed and public; they must not contain personal paths, UDIDs, team IDs, or model paths specific to the maintainer's machine. They reference the MK repo via a placeholder path the runner fills in.
+- Phase 04 creates a `RUN-CONFIG.md` in the run directory containing the developer's device UDID, team ID, and bundle ID. **`RUN-CONFIG.md` is gitignored** — never commit it.
+- Run artefacts (`runs/*/*/run-*/`) are gitignored. Only the per-iteration `SUMMARY.md` / `ROOT_CAUSES.md` get committed.
+
+## Adding a new brief
+
+Pick an archetype that exercises a surface 01–04 don't already cover (e.g. RAG document Q&A, tool-calling agent, BYO-UI without `ChatView`). Match the existing brief shape:
+
+- One-paragraph framing ("you are a developer evaluating MK for X")
+- Required behaviour as a checkbox list
+- Read allowlist + denylist (denylist always includes `Sources/Manifold*/**/*.swift` and `Tests/**`)
+- Deliverables (`app/`, `FRICTION.md`, `session.log`, `NOTES.md`, screenshots)
+- FRICTION.md template with archetype-specific categories
+- "What we're trying to learn" — the specific public-surface question this archetype is built to answer


### PR DESCRIPTION
## Summary

- Adds phase 3 (`03-image-gen-app.md`) — macOS DX walkthrough exercising `MLXDiffusionBackend` + `ManifoldVoice` from a real designer handoff
- Adds phase 4 (`04-iphone-design-to-app.md`) — physical-iPhone end-to-end run with pre-flight checklist + per-developer `RUN-CONFIG.md` (gitignored). Manual / pre-release / periodic only — not CI-gated
- Adds shared design bundle under `03-design-assets/`: prose brief, runnable React/Babel iPhone-framed flow viewer (`LocalImage Flow.html`), and source JSX for every screen (`screens.jsx` has 15 named screens incl. error + iPad/Mac variants)
- Adds `briefs/README.md` documenting phase cadence and public-repo conventions
- Scrubs personal paths from `01-chat-cli.md` / `02-swiftui-chat.md` so the whole `briefs/` tree is portable
- Gitignores `RUN-CONFIG.md` so device UDIDs / team IDs can never be committed

The phase 3 + 4 split is deliberate: same design bundle, different deployment target. Findings present in both phases point at MK public-API friction; findings only in phase 4 point at iOS-deployment friction. Manual run cadence keeps Apple-Silicon + physical-device costs off CI.

## Test plan

- [ ] `briefs/README.md` renders correctly on GitHub
- [ ] `open scripts/dx-walkthrough/briefs/03-design-assets/"LocalImage Flow.html"` displays the iPhone-framed flow in a browser
- [ ] Skim `screens.jsx` — copy and layout for every state is readable as source
- [ ] Phase 3 trial run (separate session) before relying on it as a release gate
- [ ] Phase 4 trial run (manual, with a real iPhone) — defer until needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)