### PR TITLE
docs(image-gen): add CaseIterable + DocC to public image-gen value types

### DIFF
--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -51,3 +51,19 @@ For the source-backed operational contract around loading, streaming, memory han
 
 - ``GenerationEvent``
 - ``GenerationStream``
+
+### Image generation
+
+The image-generation value types live here (not in `ManifoldMLX`) so non-MLX
+modules — catalog UIs, persistence, runtime — can reference them without
+pulling in a backend family. Concrete backends (``MLXDiffusionBackend``,
+``FluxDiffusionBackend``) live in `ManifoldMLX`; see that module's
+documentation for the high-level vs. direct-backend chooser.
+
+- ``ImageGenerationBackend``
+- ``ImageGenerationService``
+- ``ImageGenerationConfig``
+- ``ImageGenerationEvent``
+- ``ImageModelInfo``
+- ``ImageModelFormat``
+- ``PrecisionVariant``

--- a/Sources/ManifoldInference/Models/ImageModelFormat.swift
+++ b/Sources/ManifoldInference/Models/ImageModelFormat.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Additional cases (e.g. a `gguf` variant for `stable-diffusion.cpp`, or a `coreAI`
 /// case once Apple's Core AI image-gen surface ships) land alongside their conformers
 /// rather than as forward-declared placeholders.
-public enum ImageModelFormat: String, Codable, Hashable, Sendable {
+public enum ImageModelFormat: String, Codable, Hashable, Sendable, CaseIterable {
     /// A directory containing UNet, VAE, and text-encoder weights in MLX-compatible
     /// safetensors form, plus the configs that describe their topology. Loaded by
     /// the MLX diffusion backend (e.g. via `mlx-swift-examples`'s `StableDiffusion`).

--- a/Sources/ManifoldInference/Models/PrecisionVariant.swift
+++ b/Sources/ManifoldInference/Models/PrecisionVariant.swift
@@ -12,7 +12,7 @@ import Foundation
 /// Defaults to ``fullPrecision`` for back-compat: packages downloaded before
 /// fp16 detection shipped have no `variant` field in their on-disk manifest,
 /// and the decoder treats absence as full-precision.
-public enum PrecisionVariant: String, Codable, Hashable, Sendable {
+public enum PrecisionVariant: String, Codable, Hashable, Sendable, CaseIterable {
     /// Full-precision weights — the plain `*.safetensors` file set
     /// (typically fp32 in the on-disk tensor metadata, but the runtime may
     /// up- or down-cast at load time).

--- a/Sources/ManifoldMLX/ManifoldMLX.docc/ManifoldMLX.md
+++ b/Sources/ManifoldMLX/ManifoldMLX.docc/ManifoldMLX.md
@@ -1,0 +1,74 @@
+# ``ManifoldMLX``
+
+MLX-backed inference and image generation for ManifoldKit on Apple Silicon.
+
+## Overview
+
+`ManifoldMLX` is the Apple-Silicon-only family target that plugs MLX-based
+backends into the protocols declared in `ManifoldInference`. It carries two
+distinct surfaces:
+
+- **Text inference** via ``MLXBackend``, a conformer of `InferenceBackend`
+  that drives `mlx-swift-lm` models with the shared generation-event stream,
+  context budgeting, and tool-calling dialect.
+- **Image generation** via ``MLXDiffusionBackend`` and ``FluxDiffusionBackend``,
+  conformers of `ImageGenerationBackend` that drive `mlx-swift-examples`'s
+  StableDiffusion and `mzbac/flux.swift` respectively.
+
+The module is trait-gated behind the `MLX` package trait; apps that don't
+need MLX can build without it. Image generation backends additionally need
+diffusion weights on disk — see ``ImageModelInfo`` for the on-disk shape and
+``ManifoldHuggingFace`` for the downloader.
+
+> Note: `ImageGenerationConfig`, `ImageGenerationEvent`, and `ImageModelInfo`
+> are declared in `ManifoldInference`, not here — they have to sit below the
+> backend family so non-MLX consumers (catalog UIs, persistence, runtime) can
+> reference them without dragging in MLX. Import both modules when wiring
+> image generation:
+>
+> ```swift
+> import ManifoldInference
+> import ManifoldMLX
+> ```
+
+## Topics
+
+### Image generation — high-level entry point
+
+Use ``ImageGenerationService`` (in `ManifoldInference`) when you want the
+framework to manage model lifecycle for you: pass an ``ImageModelInfo``
+descriptor and the service picks the right backend, loads weights, and tears
+the previous model down on switch. This is the recommended path for apps
+that present a model picker or otherwise let the user swap models at
+runtime.
+
+### Image generation — direct backends
+
+Use the backends directly when you want to own loading yourself — for
+example a single-model app that ships one set of weights and never swaps,
+or a CLI that does one generation and exits. Both backends conform to
+``ImageGenerationBackend`` (in `ManifoldInference`) and emit an
+`AsyncThrowingStream<ImageGenerationEvent, any Error>` from `generate`.
+
+- ``MLXDiffusionBackend``
+- ``FluxDiffusionBackend``
+
+### Text inference
+
+- ``MLXBackend``
+- ``MLXCachePolicy``
+
+## When to use which image-gen entry point
+
+| Need | Use |
+|---|---|
+| Multi-model app, user can switch models, want framework to load/unload | ``ImageGenerationService`` |
+| Single-model app, you own the model URL, want minimum surface area | ``FluxDiffusionBackend`` or ``MLXDiffusionBackend`` directly |
+| Persist generated images alongside chat turns | ``ImageGenerationService`` + `ConversationRuntime` |
+| Headless / CLI generation, no persistence | Direct backend |
+
+Both paths emit the same ``ImageGenerationEvent`` stream and write the
+finished image to a file URL on disk (see the type's "Why URL, not CGImage?"
+section). The service path additionally arbitrates against the
+text-inference resource pool so loading a diffusion model evicts an LLM
+that's currently resident, and vice versa.

--- a/Tests/ManifoldInferenceTests/ImageGenerationFoundationsTests.swift
+++ b/Tests/ManifoldInferenceTests/ImageGenerationFoundationsTests.swift
@@ -262,4 +262,22 @@ final class ImageGenerationFoundationsTests: XCTestCase {
         }
         XCTAssertEqual(url.path, "/tmp/stub.png")
     }
+
+    // MARK: - CaseIterable conformance
+
+    /// Locks in `CaseIterable` on the discoverable image-gen value enums.
+    /// Without this, consumers have to guess case names blind (no fix-its,
+    /// no compiler-driven discovery) — see dx-walkthrough finding F4
+    /// (2026-05-24 phase-3 iter-1).
+    func test_imageModelFormat_isCaseIterable_andNonEmpty() {
+        XCTAssertFalse(ImageModelFormat.allCases.isEmpty)
+        XCTAssertTrue(ImageModelFormat.allCases.contains(.mlxDiffusion))
+        XCTAssertTrue(ImageModelFormat.allCases.contains(.fluxSchnell))
+    }
+
+    func test_precisionVariant_isCaseIterable_andNonEmpty() {
+        XCTAssertFalse(PrecisionVariant.allCases.isEmpty)
+        XCTAssertTrue(PrecisionVariant.allCases.contains(.fullPrecision))
+        XCTAssertTrue(PrecisionVariant.allCases.contains(.fp16))
+    }
 }


### PR DESCRIPTION
## Summary

Addresses dx-walkthrough findings **F4, F6, F9** from [SUMMARY.md](../blob/main/scripts/dx-walkthrough/runs/2026-05-24_v0.34.0_phase3-iter1/03-image-gen-app/SUMMARY.md) (phase-3 image-gen archetype, iter 1 — 0/3 working end-to-end).

- **F4** (`API-DISCOVERABILITY`, blocker): `ImageModelFormat` and `PrecisionVariant` now conform to `CaseIterable` so consumers can discover cases via Xcode autocomplete and `.allCases` instead of guessing case names blind (run-1 burned 3 attempts on this before pivoting to a placeholder gradient).
- **F6** (`API-DISCOVERABILITY`, major): `ImageGenerationEvent` payloads were already documented inline (`progress(step, total)` + `completed(URL)` — note the file URL, not `CGImage`, with the rationale in the type's existing doc comment), but the type was unreachable from any DocC entry. The new `ManifoldInference` topic surfaces it so consumers don't have to write `Mirror` reflection.
- **F9** (`API-DISCOVERABILITY`, major): New `Sources/ManifoldMLX/ManifoldMLX.docc/ManifoldMLX.md` includes the chooser between `ImageGenerationService` (high-level, framework-managed lifecycle) and `FluxDiffusionBackend` / `MLXDiffusionBackend` directly (low-level, you own loading).

Also documents the cross-module split (`ImageGenerationConfig`/`Event` live in `ManifoldInference`, backends live in `ManifoldMLX`) that bit run-3 in the iteration.

## Files touched

- `Sources/ManifoldInference/Models/ImageModelFormat.swift` — `+ CaseIterable`
- `Sources/ManifoldInference/Models/PrecisionVariant.swift` — `+ CaseIterable`
- `Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md` — new \"Image generation\" topic linking value types
- `Sources/ManifoldMLX/ManifoldMLX.docc/ManifoldMLX.md` — **new file**, module framing + image-gen chooser
- `Tests/ManifoldInferenceTests/ImageGenerationFoundationsTests.swift` — two CaseIterable lock-in assertions

## Out of scope

This PR is the F4/F6/F9 slice only. Sibling findings from the same SUMMARY are not addressed here:

- F1 (README chat-only) and F2 (broken CHANGELOG snippet) — separate docs PR.
- F3 (default FLUX repo / downloader layout mismatch) — needs a code or repo-mirror decision.
- F5 (`ManifoldVoice` framing) and F7 (`ImageGenerationStore` port) — separate work.
- F8 (DocC seeding across all targets) — partial coverage here (MLX + Inference image-gen surface only). Tracked in #1463 (left open).

## Test plan

- [x] `swift build --traits MLX` — clean
- [x] `swift test --filter ImageGenerationFoundationsTests` — 16/16 pass including 2 new CaseIterable assertions
- [ ] CI green