### PR TITLE
docs(imagegen): publish discoverable image-gen DX surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,17 +612,24 @@ backend.cachePolicy = .disabled  // opt out if needed
 
 #### On-device image generation with FLUX.1 Schnell ([#1178](https://github.com/roryford/ManifoldKit/issues/1178))
 
-`FluxDiffusionBackend` brings FLUX.1 Schnell on-device image generation to ManifoldKit via MLX. The backend generates 1024×1024 images in four denoising steps using the pre-quantized `argmaxinc/mlx-FLUX.1-schnell-4bit-quantized` weights (~7 GB, Apache 2.0, ungated). The curated diffusion catalog has been updated to ship this model as the default, replacing the previous SD 2.1 and SDXL Turbo entries whose licenses were incompatible with App Store distribution.
+`FluxDiffusionBackend` brings FLUX.1 Schnell on-device image generation to ManifoldKit via MLX. The backend generates 1024×1024 images in four denoising steps. Provide a local directory containing FLUX weights — either flux.swift's quantized layout (with `metadata.json`) or the standard diffusers layout — to `loadModel(from:)`, then iterate the `AsyncThrowingStream<ImageGenerationEvent, Error>` returned by `generate(prompt:config:)`. See [`docs/QUICKSTART-IMAGE-GEN.md`](docs/QUICKSTART-IMAGE-GEN.md) for the end-to-end shape including download options.
 
 ```swift
+import Foundation
+import ManifoldInference
 import ManifoldMLX
 
 let backend = FluxDiffusionBackend()
-let image = try await backend.generate(
-    prompt: "a red fox in a snowy forest, photorealistic",
-    steps: 4,
-    size: CGSize(width: 1024, height: 1024)
-)
+try await backend.loadModel(from: URL(fileURLWithPath: "/path/to/FLUX.1-schnell"))
+
+let config = ImageGenerationConfig(steps: 4, width: 1024, height: 1024, seed: 42)
+let stream = try backend.generate(prompt: "a red fox in a snowy forest", config: config)
+for try await event in stream {
+    switch event {
+    case .progress(let step, let total): print("\(step)/\(total)")
+    case .completed(let url): print("wrote \(url.path)")
+    }
+}
 ```
 
 ### Features
@@ -1163,7 +1170,7 @@ imageService.registerMLXDiffusionBackend()  // Apple Silicon only
 chatViewModel.configure(bootstrap)           // wires both runtimes in one call
 ```
 
-The first concrete conformer, `MLXDiffusionBackend`, ships in `BaseChatBackends` behind the existing `MLX` trait and auto-detects SD 2.1 Base and SDXL Turbo layouts from the weights directory. `DiffusionModelCatalog` seeds the install UI with both models; `HuggingFaceService` gains a parallel `downloadDiffusionModel(from:to:progress:)` path for the multi-file safetensors layout. `MLXDiffusionBackend` depends on `mlx-swift-examples` at a revision pin (`357c97f`) pending the upstream library's next tagged release.
+The first concrete conformer, `MLXDiffusionBackend`, ships in `BaseChatBackends` behind the existing `MLX` trait and auto-detects SD 2.1 Base and SDXL Turbo layouts from the weights directory. `DiffusionModelCatalog` seeds the install UI with both models; `HuggingFaceService` gains a parallel `downloadDiffusionModel(from:to:progress:)` path for the multi-file safetensors layout. `MLXDiffusionBackend` depends on `mlx-swift-examples` at a revision pin (`357c97f`) pending the upstream library's next tagged release. See [`docs/QUICKSTART-IMAGE-GEN.md`](docs/QUICKSTART-IMAGE-GEN.md) for a compile-tested end-to-end snippet.
 
 See [#1002](https://github.com/roryford/BaseChatKit/issues/1002), [#1003](https://github.com/roryford/BaseChatKit/pull/1003), [#1008](https://github.com/roryford/BaseChatKit/pull/1008), [#1009](https://github.com/roryford/BaseChatKit/pull/1009), [#1016](https://github.com/roryford/BaseChatKit/pull/1016), [#1018](https://github.com/roryford/BaseChatKit/pull/1018), [#1024](https://github.com/roryford/BaseChatKit/pull/1024), [#1025](https://github.com/roryford/BaseChatKit/pull/1025), [#1027](https://github.com/roryford/BaseChatKit/pull/1027), [#1028](https://github.com/roryford/BaseChatKit/pull/1028).
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@ A modular SwiftUI framework for building chat interfaces powered by local and cl
 
 ManifoldKit ships a production-ready chat UI with pluggable inference backends, model management, and SwiftData persistence. Drop it into your app, call one bootstrap, and you have a working chat interface that survives real failures — streaming retries, latest-wins model handoff, memory admission, certificate pinning, and a mock backend for app-level testing. See [docs/RELIABILITY.md](docs/RELIABILITY.md) for the source-backed contract.
 
-## Beyond chat
-
-The same backend, model-management, persistence, and download infrastructure that powers the chat UI is reusable for non-chat consumers. The framing is "chat-first" because that's the most complete reference integration, but the public surface explicitly supports:
-
-- **On-device image generation** — `FluxDiffusionBackend` (FLUX.1 Schnell, 1024×1024 in 4 steps) and `MLXDiffusionBackend` (SDXL Turbo) conform to `ImageGenerationBackend` and stream `ImageGenerationEvent`s exactly like text inference streams `GenerationEvent`. See [docs/QUICKSTART-IMAGE-GEN.md](docs/QUICKSTART-IMAGE-GEN.md) for an end-to-end example.
-- **Standalone speech-to-text / text-to-speech** — `ManifoldVoice` wraps Apple `Speech` + `AVFoundation` behind a chat-agnostic `VoiceConversationController` that anything (image-gen prompt fields, search bars, CLI dictation) can drive. See [docs/QUICKSTART-VOICE.md](docs/QUICKSTART-VOICE.md).
-- **CLI / server / non-SwiftUI consumers** — backends, model management, and persistence work without `ChatView`. See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md).
-
 ## Hello World
 
 Add the package, then drop this into your app entry point. `ManifoldKit.quickStart()` builds the SwiftData container, registers the compiled-in backends, and wires up a `ChatViewModel` in one call. Errors surface as [`ManifoldKitError`](Sources/ManifoldInference/ManifoldKitError.swift).
@@ -52,6 +44,14 @@ See [docs/QUICKSTART.md](docs/QUICKSTART.md) for backend selection, traits, and 
 Building a multi-session SwiftUI app with a sidebar, persisted chats, and relaunch restore? See [docs/SWIFTUI-MULTI-SESSION.md](docs/SWIFTUI-MULTI-SESSION.md) — the canonical end-to-end guide.
 Building a CLI, server, or non-SwiftUI consumer? See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) — compile-tested Foundation Models, local GGUF, and Ollama / OpenAI examples.
 Full runnable: [`Example/Examples/MinimalExample`](Example/Examples/MinimalExample).
+
+## Beyond chat
+
+The same backend, model-management, persistence, and download infrastructure that powers the chat UI is reusable for non-chat consumers. The framing is "chat-first" because that's the most complete reference integration, but the public surface explicitly supports:
+
+- **On-device image generation** — `FluxDiffusionBackend` (FLUX.1 Schnell, 1024×1024 in 4 steps) and `MLXDiffusionBackend` (SDXL Turbo) conform to `ImageGenerationBackend` and stream `ImageGenerationEvent`s exactly like text inference streams `GenerationEvent`. See [docs/QUICKSTART-IMAGE-GEN.md](docs/QUICKSTART-IMAGE-GEN.md) for an end-to-end example.
+- **Standalone speech-to-text / text-to-speech** — `ManifoldVoice` wraps Apple `Speech` + `AVFoundation` behind a chat-agnostic `VoiceConversationController` that anything (image-gen prompt fields, search bars, CLI dictation) can drive. See [docs/QUICKSTART-VOICE.md](docs/QUICKSTART-VOICE.md).
+- **CLI / server / non-SwiftUI consumers** — backends, model management, and persistence work without `ChatView`. See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md).
 
 ## Feature Matrix
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A modular SwiftUI framework for building chat interfaces powered by local and cl
 
 ManifoldKit ships a production-ready chat UI with pluggable inference backends, model management, and SwiftData persistence. Drop it into your app, call one bootstrap, and you have a working chat interface that survives real failures — streaming retries, latest-wins model handoff, memory admission, certificate pinning, and a mock backend for app-level testing. See [docs/RELIABILITY.md](docs/RELIABILITY.md) for the source-backed contract.
 
+## Beyond chat
+
+The same backend, model-management, persistence, and download infrastructure that powers the chat UI is reusable for non-chat consumers. The framing is "chat-first" because that's the most complete reference integration, but the public surface explicitly supports:
+
+- **On-device image generation** — `FluxDiffusionBackend` (FLUX.1 Schnell, 1024×1024 in 4 steps) and `MLXDiffusionBackend` (SDXL Turbo) conform to `ImageGenerationBackend` and stream `ImageGenerationEvent`s exactly like text inference streams `GenerationEvent`. See [docs/QUICKSTART-IMAGE-GEN.md](docs/QUICKSTART-IMAGE-GEN.md) for an end-to-end example.
+- **Standalone speech-to-text / text-to-speech** — `ManifoldVoice` wraps Apple `Speech` + `AVFoundation` behind a chat-agnostic `VoiceConversationController` that anything (image-gen prompt fields, search bars, CLI dictation) can drive. See [docs/QUICKSTART-VOICE.md](docs/QUICKSTART-VOICE.md).
+- **CLI / server / non-SwiftUI consumers** — backends, model management, and persistence work without `ChatView`. See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md).
+
 ## Hello World
 
 Add the package, then drop this into your app entry point. `ManifoldKit.quickStart()` builds the SwiftData container, registers the compiled-in backends, and wires up a `ChatViewModel` in one call. Errors surface as [`ManifoldKitError`](Sources/ManifoldInference/ManifoldKitError.swift).

--- a/docs/QUICKSTART-IMAGE-GEN.md
+++ b/docs/QUICKSTART-IMAGE-GEN.md
@@ -1,0 +1,174 @@
+# ManifoldKit Image-Gen Quickstart
+
+A one-page tutorial for adding on-device image generation to any Swift app. No
+`ChatView`, no `ChatViewModel` — `FluxDiffusionBackend` is a sibling backend
+that conforms to `ImageGenerationBackend` and streams progress + the final
+file URL through an `AsyncThrowingStream`.
+
+> **Platform.** Apple Silicon Mac (FLUX.1 Schnell needs ~7 GB of unified
+> memory headroom). Bring-your-own URL — the backend takes a local directory
+> URL and does not download. See [§4](#4-picking-a-model) for which HuggingFace
+> repo layouts the bundled `HuggingFaceService` downloader accepts.
+
+---
+
+## 1. Add the `MLX` trait
+
+In your consumer `Package.swift`:
+
+```swift,no-build
+dependencies: [
+    .package(
+        url: "https://github.com/roryford/ManifoldKit.git",
+        from: "0.34.0", // x-release-please-version
+        traits: [
+            .trait(name: "MLX"),
+        ]
+    ),
+],
+targets: [
+    .executableTarget(
+        name: "MyImageApp",
+        dependencies: [
+            .product(name: "ManifoldMLX", package: "ManifoldKit"),
+            .product(name: "ManifoldInference", package: "ManifoldKit"),
+        ]
+    ),
+],
+```
+
+`MLX` is in the default trait set, so this works without the explicit
+`traits:` array too. Two public types live in two modules — the backend in
+`ManifoldMLX`, the value types (`ImageGenerationConfig`,
+`ImageGenerationEvent`) in `ManifoldInference`. Both imports are required.
+
+---
+
+## 2. End-to-end snippet
+
+`loadModel(from:)` is mandatory before the first `generate(prompt:config:)`
+call — calling `generate` on a fresh backend throws
+`FluxDiffusionError.notLoaded`. The `URL` is the on-disk directory containing
+the FLUX weights (either flux.swift's quantized layout with `metadata.json`,
+or the standard diffusers layout with `safetensors`). How you obtain that
+directory is your choice — `HuggingFaceService.downloadDiffusionModel` is one
+option (see [§4](#4-picking-a-model)).
+
+```swift
+import Foundation
+import ManifoldInference
+import ManifoldMLX
+
+@main
+struct ImageGen {
+    static func main() async throws {
+        // 1. Construct the backend.
+        let backend = FluxDiffusionBackend()
+
+        // 2. Load weights from a local directory. The URL must point at the
+        //    unpacked FLUX model directory — not a single file.
+        let modelDirectory = URL(
+            fileURLWithPath: "/path/to/FLUX.1-schnell"
+        )
+        try await backend.loadModel(from: modelDirectory)
+
+        // 3. Configure the run. FLUX Schnell is distilled to 1–4 steps;
+        //    `guidanceScale: nil` lets the backend apply its own default.
+        let config = ImageGenerationConfig(
+            steps: 4,
+            width: 1024,
+            height: 1024,
+            seed: 42,
+            outputDirectory: FileManager.default.temporaryDirectory
+        )
+
+        // 4. `generate` returns an AsyncThrowingStream. Iterate it to observe
+        //    progress; the terminal `.completed(url)` event carries the
+        //    PNG's file URL. The file is fully written before the event
+        //    is yielded.
+        let stream = try backend.generate(prompt: "a red fox in a snowy forest", config: config)
+        for try await event in stream {
+            switch event {
+            case .progress(let step, let total):
+                print("step \(step)/\(total)")
+            case .completed(let url):
+                print("wrote \(url.path)")
+            }
+        }
+
+        // 5. Free GPU memory when you're done. `unloadModel` is safe to call
+        //    even if the backend was never loaded.
+        backend.unloadModel()
+    }
+}
+```
+
+### Cancelling mid-run
+
+The stream's `onTermination` hook drives `stopGeneration()` for you when the
+iterator is torn down (drop the `for try await` early, cancel the enclosing
+`Task`, etc.). To stop without tearing down the iterator, call
+`backend.stopGeneration()` directly — the next denoising step observes the
+flag, throws `CancellationError`, and finishes the stream.
+
+---
+
+## 3. Using `ImageGenerationService` (optional)
+
+If you're managing multiple image models or want backend lifecycle parity
+with `InferenceService`, wire `ImageGenerationService`:
+
+```swift
+import ManifoldInference
+import ManifoldMLX
+
+@MainActor
+func makeService() -> ImageGenerationService {
+    let service = ImageGenerationService()
+    service.registerFluxDiffusionBackend()   // wires `.fluxSchnell` format
+    return service
+}
+```
+
+Call `service.loadModel(_:)` with an `ImageModelInfo` (resolved from your
+storage layer); call `service.generate(prompt:config:)` for the same
+`AsyncThrowingStream<ImageGenerationEvent, Error>` shape as the bare-backend
+path above.
+
+---
+
+## 4. Picking a model
+
+The bundled `HuggingFaceService.downloadDiffusionModel` validator requires the
+standard **diffusers layout**: a `model_index.json` at the repo root plus
+`vae/config.json`, `vae/diffusion_pytorch_model.safetensors`, and a
+`unet/` or `transformer/` weights directory. Repos that use the
+**diffusionkit** layout (single quantized blob + `metadata.json` at root)
+will fail validation against the bundled downloader with `HTTP 404 for
+model_index.json`. Two paths:
+
+- **Use a diffusers-layout repo with the bundled downloader.** The curated
+  catalog (`DiffusionModelCatalogEntry` in `ManifoldUIModelManagement`) ships
+  `stabilityai/sdxl-turbo` for exactly this reason — it loads through
+  `MLXDiffusionBackend` and passes the validator out of the box.
+- **Use any layout you want with your own download path.** `FluxDiffusionBackend`
+  itself doesn't care about repo layout — it sniffs `metadata.json` at load
+  time and falls back to the diffusers `Flux1Schnell(hub:modelDirectory:)`
+  path. If you already have FLUX weights on disk (downloaded with
+  `huggingface-cli`, `hf_hub_download`, or a custom tool), point
+  `loadModel(from:)` at the directory and skip the bundled downloader.
+
+Either way, the URL passed to `loadModel(from:)` is always a **directory**,
+not a file.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `FluxDiffusionError.notLoaded` thrown from `generate` | You called `generate` before `loadModel(from:)` completed. Await the load before the first generate. |
+| `HTTP 404 for model_index.json` from `downloadDiffusionModel` | Repo uses diffusionkit layout; the bundled validator requires diffusers layout. See [§4](#4-picking-a-model). |
+| `FluxDiffusionError.noLatentsProduced` | The denoising loop yielded zero latents — typically a cancellation that fired before step 1. Increase `steps` or remove the early stop. |
+| Process OOM during decode | FLUX Schnell needs ~7 GB headroom; close other GPU-using apps or `unloadModel()` after each generation. |
+| Stream finishes without `.completed` and without throwing | The generation was cancelled via `stopGeneration()` or task cancellation. This is the contract — `onTermination` runs `stopGeneration` for you when the iterator drops. |


### PR DESCRIPTION
## Summary

DX walkthrough phase-3 iter1 (image-gen archetype, three parallel runs vs v0.34.0) found that ManifoldKit's public framing is chat-only, the only public image-gen code snippet (CHANGELOG v0.23.0) is signature-wrong, and the curated default repo named there is incompatible with the bundled HuggingFaceService downloader. This PR fixes all three.

### Closes #1460 — README + QUICKSTART surface image-gen
- New "Beyond chat" section in README above Hello World; links to image-gen + voice + CLI QUICKSTARTs as first-class non-chat paths.
- New `docs/QUICKSTART-IMAGE-GEN.md` mirrors the shape of `QUICKSTART-CLI.md` / `QUICKSTART-VOICE.md`: package wiring, end-to-end snippet, optional `ImageGenerationService` path, "Picking a model" section, troubleshooting table.

### Closes #1461 — CHANGELOG snippet now compiles
- v0.23.0 snippet replaced. Real shape: `loadModel(from: URL)` first, then `generate(prompt:config:) throws -> AsyncThrowingStream<ImageGenerationEvent, Error>`. Imports both `ManifoldInference` (for `ImageGenerationConfig`) and `ManifoldMLX` (for the backend).
- Both v0.16.2 and v0.23.0 entries now point at `docs/QUICKSTART-IMAGE-GEN.md` so future consumers land in a doc that gets test-tracked instead of the changelog.
- Snippet was verified by building a scratch SwiftPM consumer against this worktree (`swift build` clean).

### Closes #1462 — default-repo incompatibility
- Picked option 3 (least blast radius): the curated catalog (`DiffusionModelCatalog.curated`) already ships `stabilityai/sdxl-turbo` (diffusers layout) — only stale prose in the v0.23.0 CHANGELOG entry pointed at the broken `argmaxinc/mlx-FLUX.1-schnell-4bit-quantized` repo. That sentence is gone.
- `QUICKSTART-IMAGE-GEN.md §4 "Picking a model"` documents the diffusers-vs-diffusionkit layout requirement and gives consumers two unblocked paths: use SDXL Turbo through the bundled downloader, or pre-download FLUX weights to disk and point `loadModel(from:)` directly at the directory (the backend already sniffs both layouts).
- No live-network smoke test added per task brief; nightly tier is the right home for that.

## Verification

- `swift build` (default traits): clean.
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`: clean.
- Scratch SwiftPM consumer compiled the QUICKSTART snippet end-to-end (deleted before commit).
- `changelog-lint` only runs on Release-Please branches, so historical-entry edits don't trip it.
- `Package.resolved` not staged.

## Test plan

- [ ] CI green (default-trait build + lint passes)
- [ ] Reviewer: open `docs/QUICKSTART-IMAGE-GEN.md` and copy the §2 snippet into a scratch consumer — should compile.

Closes #1460
Closes #1461
Closes #1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)