### PR TITLE
fix(ui): turnkey relaunch restore + canonical multi-session guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ struct MyChatApp: App {
 ```
 
 See [docs/QUICKSTART.md](docs/QUICKSTART.md) for backend selection, traits, and configuration.
+Building a multi-session SwiftUI app with a sidebar, persisted chats, and relaunch restore? See [docs/SWIFTUI-MULTI-SESSION.md](docs/SWIFTUI-MULTI-SESSION.md) — the canonical end-to-end guide.
 Building a CLI, server, or non-SwiftUI consumer? See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) — compile-tested Foundation Models, local GGUF, and Ollama / OpenAI examples.
 Full runnable: [`Example/Examples/MinimalExample`](Example/Examples/MinimalExample).
 

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -104,19 +104,25 @@ public enum ManifoldKit {
             let sessionManager = SessionManagerViewModel()
             await sessionManager.configureAndLoad(bootstrap: bootstrap)
 
-            // A2-F4: ensure the documented `quickStart()` → `ChatView()` path
-            // produces a usable chat surface on first launch.
+            // A2-F4 + #1464: ensure the documented `quickStart()` → `ChatView()`
+            // path produces a usable chat surface on first launch, and that
+            // relaunch restores the previously active conversation rather than
+            // a stray blank session.
             //
             // `sessionManager.sessions` is now populated (above), so we can
             // branch on it directly rather than re-fetching from persistence.
-            if sessionManager.sessions.isEmpty {
+            if let restored = await sessionManager.selectInitialSession() {
+                sessionManager.activeSession = restored
+                await viewModel.switchToSession(restored)
+            } else {
+                // No persisted sessions — mint a fresh one so the composer
+                // is enabled on first launch. Subsequent relaunches will go
+                // through the restore branch above.
                 let initialSession = ChatSessionRecord(title: "New Chat")
                 try await bootstrap.persistence.insertSession(initialSession)
-                await viewModel.switchToSession(initialSession)
-                // Reload so sessionManager reflects the newly created session.
                 await sessionManager.loadSessions()
-            } else if let mostRecent = sessionManager.sessions.first {
-                await viewModel.switchToSession(mostRecent)
+                sessionManager.activeSession = initialSession
+                await viewModel.switchToSession(initialSession)
             }
 
             return QuickStartResult(bootstrap: bootstrap, viewModel: viewModel, sessionManager: sessionManager)

--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/BuildingAChatUI.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/BuildingAChatUI.md
@@ -99,8 +99,17 @@ struct MyApp: App {
             chatVM.configure(bootstrap: bootstrap)
             chatVM.refreshModels()
 
+            // 3a. Configure the session manager **and await its initial load**
+            //     so `sessionVM.sessions` is populated before the next step
+            //     inspects it. The plain `configure(bootstrap:)` overload
+            //     kicks the load off as a fire-and-forget Task and returns
+            //     immediately, which is the race that produced the
+            //     duplicate-blank-session bug fixed in #1464. Use
+            //     `configureAndLoad(bootstrap:)` from any bootstrap path that
+            //     wants relaunch-safe restore — it awaits the first page so
+            //     `sessions` is materially ready on return.
             let sessionVM = SessionManagerViewModel()
-            sessionVM.configure(bootstrap: bootstrap)
+            await sessionVM.configureAndLoad(bootstrap: bootstrap)
 
             // 4. Wire automatic session-title generation from the first
             //    message of a new chat. `inferenceService` is shared.
@@ -114,24 +123,24 @@ struct MyApp: App {
                 }
             }
 
-            // 5. Activate (or create) an initial session so `ChatView`'s
+            // 5. Restore (or create) an initial session so `ChatView`'s
             //    composer is enabled on first launch.
             //
-            //    Note: `??` cannot propagate `async`/`throws` into its RHS, so
-            //    this is written as an explicit if/else rather than
-            //    `sessions.first ?? (try? await createSession())`.
-            //    `createSession()` is `async throws -> ChatSessionRecord`, and
-            //    `sessions` is `[ChatSessionRecord]`, so both branches yield
-            //    the same type.
-            let initial: ChatSessionRecord?
-            if let existing = sessionVM.sessions.first {
-                initial = existing
-            } else {
-                initial = try? await sessionVM.createSession()
-            }
-            if let initial {
-                sessionVM.activeSession = initial
-                await chatVM.switchToSession(initial)
+            //    `selectInitialSession()` implements the relaunch-safe
+            //    selection policy: prefer the previously active session,
+            //    fall back to the most recent non-empty conversation, and
+            //    only return `nil` when the store really is empty (#1464).
+            //    The host decides whether to mint a blank session at that
+            //    point — minting one *before* the restore probe is the
+            //    naive pattern that produced repeated blank rows on
+            //    relaunch.
+            if let restored = await sessionVM.selectInitialSession() {
+                sessionVM.activeSession = restored
+                await chatVM.switchToSession(restored)
+                chatVM.dispatchSelectedLoad()
+            } else if let fresh = try? await sessionVM.createSession() {
+                sessionVM.activeSession = fresh
+                await chatVM.switchToSession(fresh)
                 chatVM.dispatchSelectedLoad()
             }
 
@@ -317,7 +326,12 @@ struct ModernApp: App {
         chatVM.configure(bootstrap: bootstrap)
 
         let sessionVM = SessionManagerViewModel()
-        sessionVM.configure(bootstrap: bootstrap)
+        await sessionVM.configureAndLoad(bootstrap: bootstrap)
+
+        if let restored = await sessionVM.selectInitialSession() {
+            sessionVM.activeSession = restored
+            await chatVM.switchToSession(restored)
+        }
 
         self.bootstrap = bootstrap
         self.chatViewModel = chatVM
@@ -326,7 +340,11 @@ struct ModernApp: App {
 }
 ```
 
-Both view models must be configured from the bootstrap: ``ChatViewModel/configure(bootstrap:)`` wires persistence, the endpoint store, and (when present) the image-generation runtime. `SessionManagerViewModel.configure(bootstrap:)` wires the same persistence plus diagnostics. Skipping the session-manager configuration leaves it on a nil-persistence path that fails on first save.
+Both view models must be configured from the bootstrap: ``ChatViewModel/configure(bootstrap:)`` wires persistence, the endpoint store, and (when present) the image-generation runtime. `SessionManagerViewModel.configureAndLoad(bootstrap:)` wires the same persistence plus diagnostics **and awaits the initial session-list load** before returning. Skipping the session-manager configuration leaves it on a nil-persistence path that fails on first save; using the non-awaiting `configure(bootstrap:)` overload from a relaunch-aware host produces the duplicate-blank-session race described in #1464.
+
+### Relaunch / restore guarantees
+
+After ``SessionManagerViewModel/configureAndLoad(bootstrap:)`` returns, `sessions` reflects the first persisted page. Calling ``SessionManagerViewModel/selectInitialSession()`` returns the session the host should restore as `activeSession`, preferring (in order) the previously active session, the most recent non-empty conversation, and finally the most recent session in the list. It returns `nil` only when no sessions exist — at which point the host decides whether to mint a fresh blank session. Assigning the returned record (or any subsequent user selection) to `activeSession` automatically persists it as the new last-active session for the next relaunch. No custom polling or wait heuristics are required.
 
 Keep ``ChatViewModel/configure(persistence:)`` for adopters that provide custom ``SessionStore`` / ``MessageStore`` impls (e.g. an in-memory test fixture, or a non-SwiftData backing store) — construct ``ChatViewModel`` and ``SessionManagerViewModel`` directly and call `configure(persistence:)`. The shipped SwiftData bootstrap and custom stores both satisfy the same runtime-port boundary.
 

--- a/Sources/ManifoldUI/ManifoldUI.docc/ManifoldUI.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/ManifoldUI.md
@@ -66,11 +66,12 @@ struct MyApp: App {
         chatVM.refreshModels()
 
         let sessionVM = SessionManagerViewModel()
-        sessionVM.configure(bootstrap: bootstrap)
+        await sessionVM.configureAndLoad(bootstrap: bootstrap)
 
-        let initial = sessionVM.sessions.first
+        let initial = await sessionVM.selectInitialSession()
             ?? (try? await sessionVM.createSession())
         if let initial {
+            sessionVM.activeSession = initial
             await chatVM.switchToSession(initial)
             chatVM.dispatchSelectedLoad()
         }

--- a/Sources/ManifoldUI/ViewModels/SessionManagerViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/SessionManagerViewModel.swift
@@ -37,7 +37,17 @@ public final class SessionManagerViewModel {
 
     public private(set) var sessions: [ChatSessionRecord] = []
     public private(set) var hasMoreSessions: Bool = false
-    public var activeSession: ChatSessionRecord?
+    public var activeSession: ChatSessionRecord? {
+        didSet {
+            // #1464: persist the active-session ID across relaunches so the
+            // documented `BuildingAChatUI` bootstrap can restore the previously
+            // viewed conversation without each host re-inventing the
+            // bookkeeping. The store is injected (see `lastActiveStore`) so
+            // `--parallel` test runs do not collide on `UserDefaults.standard`.
+            guard oldValue?.id != activeSession?.id else { return }
+            lastActiveStore.write(activeSession?.id)
+        }
+    }
 
     public var searchScope: SessionSearchScope = .titles
     public var searchQuery: String = ""
@@ -74,7 +84,15 @@ public final class SessionManagerViewModel {
     var persistence: (any SessionStore & MessageStore)? { _persistence }
     private var _persistence: (any SessionStore & MessageStore)?
 
-    public init() {}
+    /// Bookkeeping for the most recently activated session ID. Used by
+    /// ``selectInitialSession()`` on relaunch to prefer the previously
+    /// viewed conversation over an arbitrary newest entry. Injected so
+    /// `swift test --parallel` does not flake on shared `UserDefaults.standard`.
+    private let lastActiveStore: LastActiveSessionStore
+
+    public init(userDefaults: UserDefaults = .standard) {
+        self.lastActiveStore = LastActiveSessionStore(defaults: userDefaults)
+    }
 
     deinit {
         consumerTaskBox.cancel()
@@ -407,6 +425,62 @@ public final class SessionManagerViewModel {
         service?.clearSearch()
     }
 
+    // MARK: - Initial-session selection (#1464)
+
+    /// Picks the session a relaunching host should restore as ``activeSession``.
+    ///
+    /// Selection policy (first match wins):
+    /// 1. The previously active session (persisted across relaunches), when it
+    ///    still exists in ``sessions``.
+    /// 2. The most recent session whose message count is greater than zero —
+    ///    i.e. prefer real conversations over a stray empty `"New Chat"` row
+    ///    that may have been minted by a previous launch's bootstrap.
+    /// 3. The first session in ``sessions`` (already sorted most-recent-first
+    ///    by the persistence layer).
+    /// 4. `nil` when ``sessions`` is empty. The host decides whether to mint a
+    ///    fresh blank session at that point — this helper deliberately does
+    ///    not create one. Creating a session pre-restore is what produced the
+    ///    duplicate-blank-row behaviour in #1464.
+    ///
+    /// Call this **after** ``configureAndLoad(bootstrap:)`` (or any other path
+    /// that resolves the initial session page) and use the returned record to
+    /// drive both ``activeSession`` and the chat view model's
+    /// `switchToSession(_:)`. The act of assigning the returned record to
+    /// ``activeSession`` records it as the new last-active session, so the
+    /// next relaunch will prefer the same row.
+    ///
+    /// - Returns: The session to restore, or `nil` when there are no sessions.
+    public func selectInitialSession() async -> ChatSessionRecord? {
+        guard !sessions.isEmpty else { return nil }
+
+        // 1. Previously active session, if it still exists.
+        if let lastActiveID = lastActiveStore.read(),
+           let restored = sessions.first(where: { $0.id == lastActiveID }) {
+            return restored
+        }
+
+        // 2. Most recent non-empty session. We probe message counts via the
+        //    MessageStore rather than a session field because the record type
+        //    is storage-agnostic and does not carry a counter. The probe is
+        //    bounded to the current page — restoring a session that lives on
+        //    a deeper page is not worth a full fetch on the cold path.
+        if let messages = _persistence {
+            for session in sessions {
+                do {
+                    let recent = try await messages.fetchRecentMessages(for: session.id, limit: 1)
+                    if !recent.isEmpty { return session }
+                } catch {
+                    Log.persistence.warning(
+                        "selectInitialSession: message probe failed for \(session.id, privacy: .public): \(String(describing: error), privacy: .public)"
+                    )
+                }
+            }
+        }
+
+        // 3. Fallback: first session (most recent by updatedAt).
+        return sessions.first
+    }
+
     // MARK: - Service guard
 
     private func requireService(
@@ -422,6 +496,28 @@ public final class SessionManagerViewModel {
             throw ChatPersistenceError.providerNotConfigured
         }
         return service
+    }
+}
+
+/// Persists the most recently activated session ID across launches so the
+/// SwiftUI bootstrap can prefer it on relaunch (#1464). `UserDefaults` is
+/// injected so test runs don't collide on `UserDefaults.standard`; see the
+/// `userDefaults:` parameter on ``SessionManagerViewModel/init(userDefaults:)``.
+private struct LastActiveSessionStore {
+    static let defaultsKey = "manifoldkit.sessionManager.lastActiveSessionID"
+    let defaults: UserDefaults
+
+    func read() -> UUID? {
+        guard let raw = defaults.string(forKey: Self.defaultsKey) else { return nil }
+        return UUID(uuidString: raw)
+    }
+
+    func write(_ id: UUID?) {
+        if let id {
+            defaults.set(id.uuidString, forKey: Self.defaultsKey)
+        } else {
+            defaults.removeObject(forKey: Self.defaultsKey)
+        }
     }
 }
 

--- a/Tests/ManifoldUITests/SessionRestoreIntegrationTests.swift
+++ b/Tests/ManifoldUITests/SessionRestoreIntegrationTests.swift
@@ -1,0 +1,172 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import ManifoldUI
+import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Integration coverage for the multi-session relaunch / restore path
+/// fixed in #1464. These tests exercise ``SessionManagerViewModel`` against
+/// a real in-memory SwiftData store (no persistence mocks) so the cold-start
+/// race that the issue describes is reproduced end-to-end.
+///
+/// Each test uses a per-test ``UserDefaults`` suite so the persisted
+/// last-active session ID does not leak between cases under
+/// `swift test --parallel`.
+@MainActor
+final class SessionRestoreIntegrationTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try makeInMemoryContainer()
+        suiteName = "manifoldkit.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeVM() -> SessionManagerViewModel {
+        let vm = SessionManagerViewModel(userDefaults: defaults)
+        let provider = SwiftDataPersistenceProvider(modelContext: container.mainContext)
+        vm.configure(persistence: provider, autoLoad: false)
+        return vm
+    }
+
+    private func insertSession(
+        id: UUID = UUID(),
+        title: String = "Persisted",
+        updatedAt: Date = Date(),
+        messageBodies: [String] = []
+    ) async throws -> ChatSessionRecord {
+        let provider = SwiftDataPersistenceProvider(modelContext: container.mainContext)
+        let record = ChatSessionRecord(id: id, title: title, updatedAt: updatedAt)
+        try await provider.insertSession(record)
+        for body in messageBodies {
+            let msg = ChatMessageRecord(
+                role: .user,
+                content: body,
+                sessionID: record.id
+            )
+            try await provider.insertMessage(msg)
+        }
+        return record
+    }
+
+    // MARK: - #1464 coverage
+
+    /// Cold start with N persisted sessions and M messages — the first
+    /// observation after `configureAndLoad`/`loadSessions` sees all of them.
+    /// The pre-fix bug was that `configure(bootstrap:)` returned before the
+    /// fire-and-forget load Task ran, so `sessions` was empty on the first
+    /// inspection.
+    func test_coldStart_withPersistedSessions_restoresThemBeforeFirstObservation() async throws {
+        let s1 = try await insertSession(title: "First", updatedAt: Date(timeIntervalSinceNow: -100))
+        let s2 = try await insertSession(title: "Second", updatedAt: Date(timeIntervalSinceNow: -50), messageBodies: ["hello"])
+
+        let vm = makeVM()
+        await vm.loadSessions()
+
+        XCTAssertEqual(vm.sessions.count, 2, "Both persisted sessions should be visible after the awaited load")
+        XCTAssertTrue(vm.sessions.contains(where: { $0.id == s1.id }))
+        XCTAssertTrue(vm.sessions.contains(where: { $0.id == s2.id }))
+    }
+
+    /// Cold start with zero persisted sessions — `selectInitialSession()`
+    /// returns `nil` rather than minting a blank `New Chat`. This is the
+    /// invariant that lets the host decide whether to create one, instead
+    /// of the framework producing the duplicate-blank-session behaviour
+    /// reported on relaunch.
+    func test_coldStart_emptyStore_doesNotMintBlankSession() async throws {
+        let vm = makeVM()
+        await vm.loadSessions()
+
+        let restored = await vm.selectInitialSession()
+        XCTAssertNil(restored, "selectInitialSession must not synthesize a session when the store is empty")
+        XCTAssertTrue(vm.sessions.isEmpty, "loadSessions must not write any new rows when the store is empty")
+    }
+
+    /// Cold start with persisted sessions including a previously active one
+    /// — that session is restored even when the most-recent row is a stray
+    /// blank session minted by an earlier launch's naive bootstrap.
+    func test_coldStart_prefersPreviouslyActiveSessionOverNewerBlankRow() async throws {
+        let older = try await insertSession(
+            title: "Active conversation",
+            updatedAt: Date(timeIntervalSinceNow: -1000),
+            messageBodies: ["original content"]
+        )
+        // Newer row, but empty — what a previous-launch naive bootstrap
+        // would have minted.
+        _ = try await insertSession(
+            title: "New Chat",
+            updatedAt: Date()
+        )
+
+        // Persist "older" as the last-active session.
+        defaults.set(older.id.uuidString, forKey: "manifoldkit.sessionManager.lastActiveSessionID")
+
+        let vm = makeVM()
+        await vm.loadSessions()
+        let restored = await vm.selectInitialSession()
+
+        XCTAssertEqual(restored?.id, older.id, "The previously active session should be preferred over a newer blank row")
+    }
+
+    /// Cold start with no last-active marker — `selectInitialSession()`
+    /// still prefers the most recent **non-empty** session over a newer
+    /// blank `New Chat` row.
+    func test_coldStart_prefersMostRecentNonEmptyOverNewerBlank() async throws {
+        let nonEmpty = try await insertSession(
+            title: "Has messages",
+            updatedAt: Date(timeIntervalSinceNow: -500),
+            messageBodies: ["history"]
+        )
+        _ = try await insertSession(
+            title: "Newer but empty",
+            updatedAt: Date()
+        )
+
+        let vm = makeVM()
+        await vm.loadSessions()
+        let restored = await vm.selectInitialSession()
+
+        XCTAssertEqual(restored?.id, nonEmpty.id, "A non-empty older session should win over a newer empty one")
+    }
+
+    /// Assigning to `activeSession` persists the ID so the next cold start
+    /// can restore it. This is the bridge between user selection and the
+    /// relaunch policy.
+    func test_activeSession_assignmentPersistsLastActiveID_forNextRelaunch() async throws {
+        let a = try await insertSession(title: "A")
+        let b = try await insertSession(title: "B", updatedAt: Date(timeIntervalSinceNow: 10))
+
+        let vm = makeVM()
+        await vm.loadSessions()
+        vm.activeSession = a
+
+        // Simulate relaunch with a fresh VM bound to the same defaults.
+        let vm2 = SessionManagerViewModel(userDefaults: defaults)
+        vm2.configure(
+            persistence: SwiftDataPersistenceProvider(modelContext: container.mainContext),
+            autoLoad: false
+        )
+        await vm2.loadSessions()
+        let restored = await vm2.selectInitialSession()
+
+        XCTAssertEqual(restored?.id, a.id, "Active session set in the first launch must be restored in the next")
+        XCTAssertNotEqual(restored?.id, b.id, "Newer row must not override the recorded last-active session")
+    }
+}

--- a/docs/SWIFTUI-MULTI-SESSION.md
+++ b/docs/SWIFTUI-MULTI-SESSION.md
@@ -1,0 +1,289 @@
+# Building a Multi-Session SwiftUI Chat App
+
+The canonical guide for SwiftUI hosts that want a sidebar of chats, a chat
+detail view, persisted history, and turnkey relaunch restore. This document
+supersedes the per-doc fragments adopters previously had to stitch together
+(`docs/QUICKSTART.md`, `BuildingAChatUI.md`, `Example/Examples/MinimalExample/`,
+the README quickstart) for SwiftUI multi-session use.
+
+If you only need a single-session chat surface, stop here and read
+`docs/QUICKSTART.md` — it covers the one-call `ManifoldKit.quickStart()` path
+and the simplest `ChatView` placement.
+
+## 1. Pick the recommended path
+
+Two real bootstrap shapes ship today. Pick the one that matches the level
+of control your app needs:
+
+| You want… | Path | When to use |
+|-----------|------|-------------|
+| Defaults — bootstrap, persistence, backends, restored session, all wired in one call | **`ManifoldKit.quickStart(configuration:)`** | Default for new apps. Single-session, multi-session, or sidebar-style hosts that don't need a custom `InferenceService` or a launch progress bar. |
+| Control — own `InferenceService`, custom model container, custom backend mix, or a launch progress UI | **Manual `ManifoldBootstrap.build(...)` bootstrap** | Apps with bespoke launch UI, alternate model containers (encrypted, app-group), or non-default backend registries. |
+
+The two paths share the **same view models**. The only difference is whether
+ManifoldKit does the bootstrap dance for you, or your app drives it itself.
+The relaunch / restore guarantees in section 5 apply to both.
+
+## 2. The recommended default path — `ManifoldKit.quickStart`
+
+```swift
+import SwiftUI
+import ManifoldKit            // umbrella: ManifoldInference + ManifoldRuntime
+                              // + ManifoldPersistenceSwiftData + ManifoldBackends + ManifoldUI
+
+@main
+struct MyChatApp: App {
+    @State private var kit: QuickStartResult?
+    @State private var startupError: Error?
+
+    var body: some Scene {
+        WindowGroup {
+            if let kit {
+                RootView()
+                    .environment(kit.viewModel)
+                    .environment(kit.sessionManager)
+                    .modelContainer(kit.bootstrap.modelContainer)
+            } else if let startupError {
+                ContentUnavailableView(
+                    "Failed to start",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(String(describing: startupError))
+                )
+            } else {
+                ProgressView("Starting…")
+                    .task {
+                        do {
+                            kit = try await ManifoldKit.quickStart(
+                                configuration: .init(
+                                    appName: "My Chat",
+                                    bundleIdentifier: "com.example.mychat"
+                                )
+                            )
+                        } catch {
+                            startupError = error
+                        }
+                    }
+            }
+        }
+    }
+}
+
+struct RootView: View {
+    @Environment(ChatViewModel.self) var chatVM
+    @Environment(SessionManagerViewModel.self) var sessionVM
+
+    var body: some View {
+        NavigationSplitView {
+            SessionListView()
+        } detail: {
+            ChatView(showModelManagement: .constant(false))
+        }
+        .onChange(of: sessionVM.activeSession) { _, newSession in
+            guard let newSession,
+                  chatVM.activeSession?.id != newSession.id else { return }
+            Task { await chatVM.switchToSession(newSession) }
+        }
+    }
+}
+```
+
+That's the whole app. `quickStart` builds the bootstrap, registers the
+compiled-in default backends, configures both view models, **awaits the
+initial session-list load**, and selects the previously active session (or
+mints a fresh one if the store is empty). On every subsequent relaunch the
+sidebar comes back populated and the previously open chat is already
+selected — no host-side wait/restore heuristic required.
+
+## 3. When to use the manual bootstrap path
+
+Drop down to `ManifoldBootstrap.build(...)` when you need:
+
+- A launch progress bar driven by
+  ``ManifoldPersistenceSwiftData/RuntimeBootstrapMilestone``
+- A custom ``InferenceService`` (custom retry strategy, custom URLSession,
+  observability hooks)
+- A custom model container (e.g. encrypted store, app-group container)
+- A non-default backend mix (omit one of the families, register a custom
+  backend)
+
+The full manual scaffold lives in the
+[``BuildingAChatUI``](../Sources/ManifoldUI/ManifoldUI.docc/Articles/BuildingAChatUI.md)
+DocC article. Two rules are non-obvious enough to call out here:
+
+1. **Use `await sessionVM.configureAndLoad(bootstrap: bootstrap)`**, not the
+   fire-and-forget `configure(bootstrap:)` overload. The latter schedules
+   the first session-list fetch as a detached `Task` and returns
+   immediately, so reading `sessionVM.sessions` on the next line still
+   sees the empty initial state. That race produced the duplicate-blank-
+   session bug reported in #1464.
+2. **Call `await sessionVM.selectInitialSession()` before deciding whether
+   to mint a fresh session.** It returns the session the host should
+   restore (previously active → most recent non-empty → first), or `nil`
+   when the store really is empty. Minting a `"New Chat"` row pre-restore
+   is the naive pattern that produced repeated blank rows on relaunch.
+
+A minimal manual bootstrap that does both:
+
+```swift
+let (progress, task) = ManifoldBootstrap.build(
+    configuration: ManifoldConfiguration(
+        appName: "My Chat",
+        bundleIdentifier: "com.example.mychat"
+    )
+)
+for await _ in progress { /* drain milestones or drive a progress bar */ }
+let bootstrap = try await task.value
+DefaultBackends.register(with: bootstrap.inferenceService)
+
+let chatVM = ChatViewModel(
+    inferenceService: bootstrap.inferenceService,
+    conversationRuntime: bootstrap.conversationRuntime
+)
+chatVM.configure(bootstrap: bootstrap)
+
+let sessionVM = SessionManagerViewModel()
+await sessionVM.configureAndLoad(bootstrap: bootstrap)
+
+if let restored = await sessionVM.selectInitialSession() {
+    sessionVM.activeSession = restored
+    await chatVM.switchToSession(restored)
+} else if let fresh = try? await sessionVM.createSession() {
+    sessionVM.activeSession = fresh
+    await chatVM.switchToSession(fresh)
+}
+```
+
+## 4. Backend-specific startup steps
+
+The bootstrap above wires the view models for **any** backend. The
+backend-specific work is per-family and lives outside the SwiftUI surface
+proper.
+
+### Foundation (on-device, iOS 26 / macOS 26+)
+
+No additional steps. `DefaultBackends.register(with:)` installs
+`FoundationBackend` automatically when the OS version qualifies. The chat
+view model auto-selects the Foundation model on first launch via
+``ChatViewModel/foundationModelProvider``; override it (or set
+``ChatViewModel/onFirstLaunch``) if you want to show an onboarding sheet
+instead.
+
+### Local GGUF (llama.cpp) and MLX
+
+Local models need a downloaded weights file before the chat surface can
+generate. Use ``ManifoldUIModelManagement`` (a separate product) to give
+users a model browser, downloader, and storage UI. See
+``ManifoldUIModelManagement.ModelManagementSheet`` for the canonical sheet.
+
+> Note: the discovery story for sideloaded GGUFs from `~/Documents/Models`
+> versus the app-scoped Application Support directory is being tightened in
+> a separate workstream (#1468). This guide does not try to re-document
+> those rules.
+
+### Ollama, OpenAI, Anthropic (cloud)
+
+Cloud backends need at least one configured ``APIEndpointRecord`` before
+the user can pick a model. Mount
+``ManifoldUIModelManagement.APIConfigurationView`` from your
+`ChatView(showModelManagement:apiConfiguration:)` to give users the
+endpoint editor. Hosts that pre-configure endpoints in code (e.g. for an
+internal demo) can skip the UI entirely and write directly to
+`bootstrap.endpointStore`.
+
+## 5. When `ManifoldUIModelManagement` is required
+
+`ManifoldUIModelManagement` is the **separate, explicitly imported**
+product that hosts the model browser, downloader, storage UI, and API
+endpoint editor. The dependency edge runs `ManifoldUIModelManagement →
+ManifoldUI` (never the reverse), which is why these views are not visible
+from `ManifoldUI` alone.
+
+Mount it via closure injection on `ChatView`:
+
+```swift
+import ManifoldUI
+import ManifoldUIModelManagement
+
+struct RootView: View {
+    @State private var showModelManagement = false
+
+    var body: some View {
+        ChatView(
+            showModelManagement: $showModelManagement,
+            apiConfiguration: { APIConfigurationView() }
+        )
+        .sheet(isPresented: $showModelManagement) {
+            ModelManagementSheet()
+        }
+    }
+}
+```
+
+You need to import `ManifoldUIModelManagement` when your app surfaces:
+
+- a model browser / downloader UI for local GGUF or MLX weights
+- an API endpoint editor for cloud backends
+- the combined model-management sheet (``ModelManagementSheet``)
+
+Cloud-only apps that pre-configure endpoints in code, or apps that build
+their own settings UI, can skip `ManifoldUIModelManagement` entirely and
+use `ChatView(showModelManagement:)` — the `APIConfig == EmptyView`
+convenience initializer supplies an empty sheet.
+
+## 6. Persistence and relaunch guarantees
+
+With either bootstrap path, ManifoldKit gives you the following without
+any custom host code:
+
+- **Sessions persist across launches.** Every created session, message, and
+  pinned/agent state is written to a SwiftData store under the
+  configuration's bundle identifier.
+- **`sessions` is populated when `configureAndLoad(bootstrap:)` (or
+  `quickStart`) returns.** No polling, no `Task.sleep`, no
+  `withTimeout` heuristics required.
+- **`selectInitialSession()` returns the right session to restore.**
+  Preference order: previously active → most recent non-empty → first in
+  the list. Returns `nil` only when the store is empty.
+- **Assigning to `sessionVM.activeSession` persists the choice.** The next
+  cold start will restore the same session. This works for user
+  selections in the sidebar and for `selectInitialSession()`'s return
+  value alike.
+
+Things the host is **still** responsible for:
+
+- Deciding whether to mint a fresh `"New Chat"` when
+  `selectInitialSession()` returns `nil`. The manual scaffold above shows
+  the recommended shape. `quickStart` does this for you.
+- Wiring `sessionVM.activeSession` → `chatVM.switchToSession(_:)` (the
+  `onChange` snippet in section 2 covers the common case).
+- Calling `chatVM.refreshModels()` after backend changes (e.g. after a
+  download finishes or an endpoint is added).
+
+## 7. Common pitfalls
+
+- **Calling `SessionManagerViewModel.configure(bootstrap:)` (non-`await`
+  overload) and then reading `sessions` on the next line.** The load is
+  fire-and-forget. Use `configureAndLoad(bootstrap:)` for relaunch-safe
+  flows.
+- **Minting a `"New Chat"` row before `selectInitialSession()`.** This is
+  the pattern that produced "the sidebar gained a blank row on every
+  relaunch" in #1464. Always restore first, then mint only if restore
+  returned `nil`.
+- **Wiring persistence late from `.task` on the root view.** Pre-runtime
+  hosts did this; the bootstrap path makes it unnecessary. Configure the
+  view models once during startup and pass them through `.environment`.
+- **Forgetting `DefaultBackends.register(with: bootstrap.inferenceService)`.**
+  Without it, no backend will satisfy a generation request and the
+  composer's send button will appear inert. `quickStart` registers
+  defaults for you.
+
+## Related
+
+- ``ManifoldKit.quickStart(configuration:)`` — one-call facade
+- ``BuildingAChatUI`` (DocC) — full manual scaffold walkthrough
+- ``ManifoldUIModelManagement.ModelManagementSheet`` — combined model
+  selection / download / storage UI
+- ``ManifoldConfiguration/Features`` — feature flags for hiding UI that
+  doesn't apply to your deployment
+- #1464 — the multi-session relaunch / restore fix this guide reflects
+- #1465 — the issue requesting this canonical guide


### PR DESCRIPTION
Closes #1464
Closes #1465

## Root cause (confirmed)

Two interleaved bugs in the documented `BuildingAChatUI.md` multi-session SwiftUI bootstrap:

1. **Race** — `SessionManagerViewModel.configure(bootstrap:)` schedules the first `loadSessions()` as a fire-and-forget `Task` and returns immediately. Startup code that reads `sessions.first` on the next line sees the empty initial state and mints a fresh blank `"New Chat"` before the persisted page lands. That blank row sticks around, so each relaunch adds another (matches run-2's "4 sessions / 0 messages" SQLite signal).
2. **Selection policy** — even when the load wins the race, picking `sessions.first` lands on the newest row, which is often the empty `"New Chat"` minted by the previous launch's naive bootstrap. The user's actual conversation lives one row down and requires manual reselection (matches run-1's "newer empty session was restored first" signal).

`ManifoldKit.quickStart(...)` already used `configureAndLoad` for the race, but still selected `sessions.first` — so it dodged bug 1 but not bug 2 on a multi-session store. The `BuildingAChatUI` path was hit by both.

## Fix shape (source-compatible)

- **`SessionManagerViewModel`**
  - `init(userDefaults: UserDefaults = .standard)` — injected so `--parallel` tests don't collide on the shared instance.
  - `activeSession` now has a `didSet` that persists the last-active session ID under `manifoldkit.sessionManager.lastActiveSessionID`.
  - New `selectInitialSession() async -> ChatSessionRecord?` with policy `previously active → most recent non-empty → first → nil`. Probes message counts via the injected `MessageStore`; bounded to the current page. Returns `nil` (rather than minting) when the store is empty — the host decides at that point.
- **`QuickStart`** now drives `selectInitialSession()` so the one-call path is turnkey on relaunch.
- **`BuildingAChatUI.md`** (and the brief `ManifoldUI.md` snippet) now use `await sessionVM.configureAndLoad(bootstrap: bootstrap)` plus `selectInitialSession()`. A new "Relaunch / restore guarantees" section spells out the contract.
- **`docs/SWIFTUI-MULTI-SESSION.md`** (new) is the canonical end-to-end guide requested in #1465: recommended default path (`quickStart`), when to drop into the manual bootstrap, backend-specific load steps, when `ManifoldUIModelManagement` is required, persistence/relaunch guarantees, and common pitfalls. README links to it.

**No breaking changes.** Existing call sites continue to compile and run; the `configure(bootstrap:)` non-`await` overload is retained for adopters who already invoke it.

## Tests

`Tests/ManifoldUITests/SessionRestoreIntegrationTests.swift` — 5 cases, real in-memory SwiftData store (no persistence mocks), per-test `UserDefaults(suiteName:)` to avoid `--parallel` collisions:

- cold start with N persisted sessions surfaces them before first observation
- cold start with empty store does **not** synthesize a blank session
- previously active session wins over a newer blank row (last-active marker present)
- most-recent non-empty wins over a newer blank row (no last-active marker)
- assigning `activeSession` in one launch is restored on the next

Sabotage verification: replaced the policy with `return sessions.first` — 4/5 cases failed as expected (`test_coldStart_withPersistedSessions_restoresThemBeforeFirstObservation` is intentionally orthogonal and still passes). Reverted before commit.

## Gates run

- `swift test --filter "SessionManagerViewModelTests|SessionRestoreIntegrationTests|QuickStartTests"` — 27 passed, 0 failed.
- `swift test --filter 'ManifoldUITests\.'` — **605 passed, 0 failed.**
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — Build complete.

Did not run the full `scripts/test.sh --profile local` end-to-end; the fix is bounded to `ManifoldUI` view-model state and a small `QuickStart` edit. Trait-combo build is green, which is the cheapest cross-trait correctness check.

## Out of scope

#1468 (local GGUF discovery / load reliability) is a separate worker; this PR does not touch model discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)