### PR TITLE
fix(test): add BackgroundURLSessionCoordinator to traffic boundary allowlist

### DIFF
--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -173,6 +173,11 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // Model download path — HuggingFace GGUF/MLX downloads.
         "ManifoldHuggingFace/BackgroundDownloadManager.swift",
         "ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift",
+        // Carved out of BackgroundDownloadManager in #1456 — owns the
+        // URLSession lifecycle (lazy init + invalidation) so the delegate
+        // extension file stays free of session state. Same background-download
+        // boundary; no new outbound surface.
+        "ManifoldHuggingFace/BackgroundURLSessionCoordinator.swift",
         "ManifoldHuggingFace/HuggingFaceService.swift",
         // Diffusion model download path — multi-file safetensors layout
         // (UNet, VAE, text encoders, tokenizers, scheduler). Sibling to the
@@ -319,7 +324,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         Self.assertNoOffenders(offenders)
 
         XCTAssertLessThanOrEqual(
-            Self.networkIOAllowlist.count, 43,
+            Self.networkIOAllowlist.count, 44,
             "networkIOAllowlist exceeds cap. Each new entry weakens the rule — re-architect rather than expand the list."
         )
     }


### PR DESCRIPTION
## Summary

- `BackgroundURLSessionCoordinator.swift` was introduced in #1456 (decomposition of `BackgroundDownloadManager`) but was not added to `TrafficBoundaryAuditTest.networkIOAllowlist`, causing the test to fail under `--profile local` (all traits)
- Adds the file to the allowlist with a justification comment; bumps the cap from 43 → 44
- No production code changes

## Test plan

- [x] `swift test --disable-default-traits --traits HuggingFace --filter TrafficBoundaryAuditTest/test_rule1_networkIOOnlyInAllowlistedFiles` passes
- [x] Full `scripts/test.sh --profile local` run passes (one failure before this fix, zero after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)