### PR TITLE
ci: run sabotage audits nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,8 @@ jobs:
       - name: Upload test diagnostics on failure
         # swift test does not produce .xcresult bundles, so we upload whatever
         # diagnostics the failing step left behind (captured stdout/stderr,
-        # plus any xcresult bundles if they exist).
+        # watchdog stall snapshots/backtrace tails, plus any xcresult bundles
+        # if they exist).
         if: failure()
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -4,12 +4,13 @@ name: Nightly slow tests
 #  - LargeSessionListPerformanceTests — XCTMeasure perf baselines (~65s)
 #  - IntegratedStreamingPerformanceTests — full pipeline TTFT/cadence/E2E baselines (~20s)
 #  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s)
+#  - ManifoldAuditSabotageSuiteTests — SABOTAGE=1 audit tripwire proof
 #  - ManifoldMCPE2ESmokeTests — explicitly gated MCP streamable-HTTP E2E smoke
-# These are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
+# Most are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
 # job leaves that unset so they skip there. Local `swift test` runs them
-# unconditionally (CI is also unset locally). MCP E2E remains separately gated
-# by RUN_MCP_E2E=1 and a narrow smoke filter so npx/network subprocess tests do
-# not run here.
+# unconditionally (CI is also unset locally). The sabotage suite is separately
+# gated by SABOTAGE=1, and MCP E2E remains separately gated by RUN_MCP_E2E=1
+# plus a narrow smoke filter so npx/network subprocess tests do not run here.
 
 on:
   schedule:
@@ -74,6 +75,25 @@ jobs:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-traffic-boundary-audit.log
         run: scripts/test.sh --filter "ManifoldInferenceTests.TrafficBoundaryAuditTest" --disable-default-traits --skip-update --min-passed 1
 
+      - name: Test — Audit sabotage suite
+        id: test-audit-sabotage
+        env:
+          SABOTAGE: "1"
+          MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-audit-sabotage.log
+        run: |
+          set -euo pipefail
+          scripts/test.sh --filter "ManifoldAuditSabotageSuiteTests" --disable-default-traits --skip-update --min-passed 1
+          echo "Audit sabotage suite proof (SABOTAGE=${SABOTAGE}):"
+          grep -E "Test Case '-\\[ManifoldAuditSabotageSuiteTests\\.|TOTAL RUN:|Passed:|RESULT: PASSED" "$MANIFOLD_TEST_OUTPUT_FILE" || true
+          if ! grep -qE "Test Case '-\\[ManifoldAuditSabotageSuiteTests\\." "$MANIFOLD_TEST_OUTPUT_FILE"; then
+            echo "::error::Sabotage suite log did not contain any ManifoldAuditSabotageSuiteTests test-case lines."
+            exit 1
+          fi
+          if grep -q "Set SABOTAGE=1 to run sabotage suite" "$MANIFOLD_TEST_OUTPUT_FILE"; then
+            echo "::error::Sabotage suite skipped despite SABOTAGE=1."
+            exit 1
+          fi
+
       - name: Test — MCP streamable HTTP E2E smoke
         id: test-mcp-e2e-smoke
         env:
@@ -128,6 +148,7 @@ jobs:
           LARGE_SESSION_LIST_FAILED: ${{ steps.test-large-session-list.outcome == 'failure' }}
           INTEGRATED_STREAMING_FAILED: ${{ steps.test-integrated-streaming.outcome == 'failure' }}
           TRAFFIC_BOUNDARY_AUDIT_FAILED: ${{ steps.test-traffic-boundary-audit.outcome == 'failure' }}
+          AUDIT_SABOTAGE_FAILED: ${{ steps.test-audit-sabotage.outcome == 'failure' }}
           MCP_E2E_SMOKE_FAILED: ${{ steps.test-mcp-e2e-smoke.outcome == 'failure' }}
           OPERATIONAL_FAILED: ${{ steps.test-operational.outcome == 'failure' }}
           COVERAGE_THRESHOLDS_FAILED: ${{ steps.test-coverage-thresholds.outcome == 'failure' }}
@@ -140,6 +161,7 @@ jobs:
             echo "large-session-list-failed=${LARGE_SESSION_LIST_FAILED}"
             echo "integrated-streaming-failed=${INTEGRATED_STREAMING_FAILED}"
             echo "traffic-boundary-audit-failed=${TRAFFIC_BOUNDARY_AUDIT_FAILED}"
+            echo "audit-sabotage-failed=${AUDIT_SABOTAGE_FAILED}"
             echo "mcp-e2e-smoke-failed=${MCP_E2E_SMOKE_FAILED}"
             echo "operational-failed=${OPERATIONAL_FAILED}"
             echo "coverage-thresholds-failed=${COVERAGE_THRESHOLDS_FAILED}"

--- a/docs/QA-PRACTICES.md
+++ b/docs/QA-PRACTICES.md
@@ -93,7 +93,7 @@ Failures print the offending file/line plus the allowlist mechanism. Most audits
 ```bash
 SABOTAGE=1 swift test --filter ManifoldAuditSabotageSuiteTests --disable-default-traits
 ```
-Without `SABOTAGE=1` every test skips immediately — the suite is nightly-only because it does temp-dir setup per test.
+Without `SABOTAGE=1` every test skips immediately — the suite is nightly-only because it does temp-dir setup per test. The scheduled `nightly-slow-tests` workflow runs it with `SABOTAGE=1`, `--min-passed 1`, and a log proof check for `ManifoldAuditSabotageSuiteTests` test-case lines so a skipped sabotage lane cannot look green.
 
 **Extend.** When you add a new audit (practice 2), pair it with a sabotage test:
 

--- a/scripts/ci-test-with-watchdog.sh
+++ b/scripts/ci-test-with-watchdog.sh
@@ -12,9 +12,9 @@
 # min, total 60 min wasted per push (last 5 main pushes all hit this).
 #
 # This wrapper:
-#   1. Runs `scripts/test.sh "$@"` and tees its output to a log file (test.sh
-#      already does this when MANIFOLD_TEST_OUTPUT_FILE is set; we point it at
-#      our own file so we don't fight over it).
+#   1. Runs `scripts/test.sh "$@"` and captures stdout + stderr to a log file
+#      (test.sh already does this when MANIFOLD_TEST_OUTPUT_FILE is set; we
+#      point it at our own file so we don't fight over it).
 #   2. Monitors the log for SwiftPM's streaming "[N/M] Testing Module.Suite/test"
 #      lines — under --parallel these are the only reliable per-worker progress
 #      signal (per-case `Test Case '...' passed` lines are emitted only by some
@@ -25,6 +25,9 @@
 #      SIGABRT (not SIGTERM/SIGKILL) is deliberate: it triggers the Swift
 #      runtime's crash handler, which prints a backtrace per thread for every
 #      worker, naming the test case that was running on the stuck worker.
+#      The wrapper also writes process snapshots and log tails into
+#      test-diagnostics/ so failure artifacts preserve stall evidence even
+#      when the live Actions log is truncated.
 #   4. The wrapper exits with the same exit code scripts/test.sh would have
 #      returned, so CI's existing failure plumbing (artifact upload, etc.)
 #      keeps working unchanged.
@@ -49,7 +52,10 @@
 #   STALL_SECONDS=N     Kill the swift test process tree if no progress line
 #                       has appeared in N seconds. Default: 180.
 #   WATCHDOG_LOG=path   Path to the watchdog's progress log. Default:
-#                       $MANIFOLD_TEST_OUTPUT_FILE if set, else a tmpfile.
+#                       $MANIFOLD_TEST_OUTPUT_FILE.
+#   WATCHDOG_DIAGNOSTICS_DIR=path
+#                       Directory for watchdog-specific process snapshots.
+#                       Default: directory containing WATCHDOG_LOG.
 #
 # Exit codes
 # ----------
@@ -65,15 +71,27 @@ PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 # The wrapper and test.sh both want to control the log path. Point test.sh at
 # the same file we tail, so we don't duplicate the tee pipeline.
 if [[ -z "${MANIFOLD_TEST_OUTPUT_FILE:-}" ]]; then
-    MANIFOLD_TEST_OUTPUT_FILE="${TMPDIR:-/tmp}/test_output.txt"
+    MANIFOLD_TEST_OUTPUT_FILE="$PACKAGE_DIR/test-diagnostics/test-output.txt"
     export MANIFOLD_TEST_OUTPUT_FILE
 fi
 WATCHDOG_LOG="${WATCHDOG_LOG:-$MANIFOLD_TEST_OUTPUT_FILE}"
+WATCHDOG_DIAGNOSTICS_DIR="${WATCHDOG_DIAGNOSTICS_DIR:-$(dirname "$WATCHDOG_LOG")}"
+WATCHDOG_LOG_BASENAME="$(basename "$WATCHDOG_LOG")"
+WATCHDOG_DIAGNOSTICS_FILE="$WATCHDOG_DIAGNOSTICS_DIR/watchdog-${WATCHDOG_LOG_BASENAME%.log}.diagnostics.txt"
 
 # Pre-create the log so `tail -F` doesn't sit on a missing file. The trailing
 # newline is intentional: it gives the wrapper a baseline mtime to compare.
-mkdir -p "$(dirname "$WATCHDOG_LOG")"
+mkdir -p "$(dirname "$WATCHDOG_LOG")" "$WATCHDOG_DIAGNOSTICS_DIR"
 : > "$WATCHDOG_LOG"
+: > "$WATCHDOG_DIAGNOSTICS_FILE"
+{
+    echo "ci-test-with-watchdog diagnostics"
+    echo "started-at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "stall-seconds=$STALL_SECONDS"
+    echo "watchdog-log=$WATCHDOG_LOG"
+    echo "arguments=$*"
+    echo ""
+} >> "$WATCHDOG_DIAGNOSTICS_FILE"
 
 # Background-launch scripts/test.sh. We use the same shell-quoting shape the
 # CI step uses so the wrapper is a drop-in replacement.
@@ -97,15 +115,84 @@ aborted_by_watchdog=0
 progress_pattern='^\[[0-9]+/[0-9]+\] Testing |^Test Case .* (passed|failed|skipped)|^[✔✘↩] (Test|Suite) '
 
 # Snapshot the descendant swift-test / xctest pid set so we can SIGABRT them
-# all on stall. macOS lacks `pgrep -P --recursive`; walking the tree by name
-# is good enough because the wrapper itself is the only thing in this job
-# launching swift test.
+# all on stall without touching unrelated Swift work that may be running on the
+# same host.
+collect_descendant_pids() {
+    local root="$1"
+    local queue=("$root")
+    local pid
+    local child
+
+    while ((${#queue[@]} > 0)); do
+        pid="${queue[0]}"
+        queue=("${queue[@]:1}")
+        while read -r child; do
+            [[ -z "$child" ]] && continue
+            echo "$child"
+            queue+=("$child")
+        done < <(ps -axo pid=,ppid= 2>/dev/null | awk -v parent="$pid" '$2 == parent { print $1 }')
+    done
+}
+
 collect_test_descendants() {
-    # Match the binaries SwiftPM spawns: `swift-test` driver, the per-target
-    # `xctest` runners, and the Swift Testing executable. Strip the wrapper's
-    # own pid from the list defensively (it shouldn't match, but be safe).
-    pgrep -lf 'swift-test|xctest|swift-testing' 2>/dev/null \
-        | awk -v me=$$ '$1 != me { print $1 }'
+    local pid
+    local command
+
+    while read -r pid; do
+        [[ -z "$pid" ]] && continue
+        command=$(ps -p "$pid" -o command= 2>/dev/null || true)
+        case "$command" in
+            *swift-test*|*xctest*|*swift-testing*|*"swift test"*)
+                echo "$pid"
+                ;;
+        esac
+    done < <(collect_descendant_pids "$TEST_PID")
+}
+
+append_process_snapshot() {
+    local label="$1"
+
+    {
+        echo "## $label"
+        echo "captured-at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo "test-pid=$TEST_PID"
+        echo ""
+        echo "### descendant process tree"
+        local descendants
+        descendants=$(collect_descendant_pids "$TEST_PID" || true)
+        if [[ -n "$descendants" ]]; then
+            while read -r pid; do
+                [[ -z "$pid" ]] && continue
+                ps -p "$pid" -o pid=,ppid=,pgid=,stat=,etime=,command= 2>/dev/null || true
+            done <<< "$descendants"
+        else
+            echo "(no descendants)"
+        fi
+        echo ""
+        echo "### matching test processes"
+        ps -axo pid=,ppid=,pgid=,stat=,etime=,command= 2>/dev/null \
+            | awk '/swift-test|xctest|swift-testing|swift test/ && $0 !~ /awk/ { print }' \
+            || true
+        echo ""
+    } >> "$WATCHDOG_DIAGNOSTICS_FILE"
+}
+
+append_log_tail() {
+    local label="$1"
+    local lines="${2:-200}"
+
+    {
+        echo "## $label"
+        echo "captured-at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo "source=$WATCHDOG_LOG"
+        echo ""
+        if [[ -f "$WATCHDOG_LOG" ]]; then
+            tail -"$lines" "$WATCHDOG_LOG" || true
+        else
+            echo "(watchdog log missing)"
+        fi
+        echo ""
+    } >> "$WATCHDOG_DIAGNOSTICS_FILE"
 }
 
 while kill -0 "$TEST_PID" 2>/dev/null; do
@@ -139,18 +226,34 @@ while kill -0 "$TEST_PID" 2>/dev/null; do
         echo "───────────────────────────────────────────"
         echo ""
 
+        append_process_snapshot "processes before SIGABRT"
+        append_log_tail "log tail before SIGABRT" 200
+
         descendants=$(collect_test_descendants)
         if [[ -n "$descendants" ]]; then
             echo "ci-test-with-watchdog: SIGABRT -> $(echo "$descendants" | tr '\n' ' ')"
+            {
+                echo "## signals"
+                echo "sigabrt-at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+                echo "pids=$(echo "$descendants" | tr '\n' ' ')"
+                echo ""
+            } >> "$WATCHDOG_DIAGNOSTICS_FILE"
             # shellcheck disable=SC2086
             kill -ABRT $descendants 2>/dev/null || true
             # Give the runtime a few seconds to dump backtraces, then SIGKILL
             # any that ignored SIGABRT so we don't deadlock the job step.
             sleep 10
+            append_process_snapshot "processes after SIGABRT grace period"
+            append_log_tail "log tail after SIGABRT grace period" 400
             # shellcheck disable=SC2086
             kill -KILL $descendants 2>/dev/null || true
         else
             echo "ci-test-with-watchdog: no swift-test/xctest descendants found to abort."
+            {
+                echo "## signals"
+                echo "no swift-test/xctest descendants found to abort"
+                echo ""
+            } >> "$WATCHDOG_DIAGNOSTICS_FILE"
         fi
 
         # Also SIGTERM the scripts/test.sh wrapper so its `wait` returns.
@@ -169,7 +272,10 @@ if (( aborted_by_watchdog == 1 )); then
     # 124 == GNU `timeout` convention for "process killed by watchdog". This
     # is distinct from scripts/test.sh's own exit codes (0/1/2/3) so a CI log
     # reader can immediately tell apart "test bug" from "test hang".
+    append_process_snapshot "processes after scripts/test.sh wait"
+    append_log_tail "final log tail after watchdog abort" 400
     echo "::error::ci-test-with-watchdog: aborted by stall watchdog (no progress for ${STALL_SECONDS}s)."
+    echo "::error::watchdog diagnostics captured at ${WATCHDOG_DIAGNOSTICS_FILE}"
     exit 124
 fi
 


### PR DESCRIPTION
## Summary
- Run `ManifoldAuditSabotageSuiteTests` in the scheduled nightly slow-tests workflow with `SABOTAGE=1` and log proof checks.
- Preserve watchdog stall diagnostics in CI failure artifacts.
- Document that the sabotage audit lane is nightly-gated and proof-checked.

## Validation
- `bash -n scripts/ci-test-with-watchdog.sh`
- Ruby YAML parse: `.github/workflows/ci.yml`, `.github/workflows/nightly-slow-tests.yml`
- `SABOTAGE=1 scripts/test.sh --filter "ManifoldAuditSabotageSuiteTests" --disable-default-traits --skip-update --min-passed 1`