### PR TITLE
fix: add transactional message mutations

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -16,7 +16,7 @@ import SwiftData
 /// SwiftData `@Model` objects and plain ``ChatSessionRecord`` /
 /// ``ChatMessageRecord`` value types at the boundary.
 @MainActor
-public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
+public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, TransactionalMessageStore {
 
     private let modelContext: ModelContext
 
@@ -204,14 +204,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
     // MARK: - Messages
 
     public func insertMessage(_ record: ChatMessageRecord) async throws {
-        let message = ChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
-        message.id = record.id
-        message.timestamp = record.timestamp
-        message.promptTokens = record.promptTokens
-        message.completionTokens = record.completionTokens
-        message.kind = record.kind
-        message.citations = record.citations
-        message.agentID = record.agentID
+        let message = makeSwiftDataMessage(from: record)
         modelContext.insert(message)
         try modelContext.save()
         await fireMessageHooks(record)
@@ -221,12 +214,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
         guard let message = try fetchSwiftDataMessage(id: record.id) else {
             throw ChatPersistenceError.messageNotFound(record.id)
         }
-        message.contentParts = record.contentParts
-        message.promptTokens = record.promptTokens
-        message.completionTokens = record.completionTokens
-        message.kind = record.kind
-        message.citations = record.citations
-        message.agentID = record.agentID
+        applyMutableMessageFields(from: record, to: message)
         try modelContext.save()
         await fireMessageHooks(record)
     }
@@ -279,6 +267,48 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
         try modelContext.save()
     }
 
+    public func performMessageMutations(_ mutations: [MessageStoreMutation]) async throws {
+        guard !mutations.isEmpty else { return }
+
+        var writtenRecords: [ChatMessageRecord] = []
+        do {
+            for mutation in mutations {
+                switch mutation {
+                case let .insert(record):
+                    modelContext.insert(makeSwiftDataMessage(from: record))
+                    writtenRecords.append(record)
+                case let .update(record):
+                    guard let message = try fetchSwiftDataMessage(id: record.id) else {
+                        throw ChatPersistenceError.messageNotFound(record.id)
+                    }
+                    applyMutableMessageFields(from: record, to: message)
+                    writtenRecords.append(record)
+                case let .delete(messageID):
+                    guard let message = try fetchSwiftDataMessage(id: messageID) else {
+                        throw ChatPersistenceError.messageNotFound(messageID)
+                    }
+                    modelContext.delete(message)
+                case let .deleteMessages(sessionID):
+                    let descriptor = FetchDescriptor<ChatMessage>(
+                        predicate: #Predicate { $0.sessionID == sessionID }
+                    )
+                    for message in try modelContext.fetch(descriptor) {
+                        modelContext.delete(message)
+                    }
+                }
+            }
+
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+
+        for record in writtenRecords {
+            await fireMessageHooks(record)
+        }
+    }
+
     // MARK: - Hooks
 
     public func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
@@ -320,6 +350,27 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore {
             predicate: #Predicate { $0.id == id }
         )
         return try modelContext.fetch(descriptor).first
+    }
+
+    private func makeSwiftDataMessage(from record: ChatMessageRecord) -> ChatMessage {
+        let message = ChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
+        message.id = record.id
+        message.timestamp = record.timestamp
+        message.promptTokens = record.promptTokens
+        message.completionTokens = record.completionTokens
+        message.kind = record.kind
+        message.citations = record.citations
+        message.agentID = record.agentID
+        return message
+    }
+
+    private func applyMutableMessageFields(from record: ChatMessageRecord, to message: ChatMessage) {
+        message.contentParts = record.contentParts
+        message.promptTokens = record.promptTokens
+        message.completionTokens = record.completionTokens
+        message.kind = record.kind
+        message.citations = record.citations
+        message.agentID = record.agentID
     }
 }
 

--- a/Sources/ManifoldRuntime/Protocols/MessageStore.swift
+++ b/Sources/ManifoldRuntime/Protocols/MessageStore.swift
@@ -89,6 +89,41 @@ public protocol MessageStore: AnyObject, Sendable {
     func addPostWriteHook(_ hook: any MessageStorePostWriteHook)
 }
 
+// MARK: - Transactional batch mutations
+
+/// A single message-store mutation that can be grouped with other mutations.
+///
+/// ``TransactionalMessageStore`` conformers apply a batch of these operations
+/// as one unit of work so multi-row edits can commit consistently.
+public enum MessageStoreMutation: Sendable, Equatable {
+    /// Insert a new message record.
+    case insert(ChatMessageRecord)
+    /// Update an existing message record.
+    case update(ChatMessageRecord)
+    /// Delete one message by id.
+    case delete(UUID)
+    /// Delete every message belonging to a session.
+    case deleteMessages(sessionID: UUID)
+}
+
+/// Optional ``MessageStore`` capability for atomic multi-message writes.
+///
+/// Existing stores do not need to conform. Callers should probe with
+/// `as? any TransactionalMessageStore` and fall back to the legacy per-row
+/// operations when the capability is unavailable.
+@MainActor
+public protocol TransactionalMessageStore: MessageStore {
+    /// Applies every mutation in order and commits them as one unit.
+    ///
+    /// Implementations should fire ``MessageStorePostWriteHook`` only after
+    /// the full batch commits, and only for inserted or updated records.
+    ///
+    /// - Throws: The first validation or storage error encountered. If the
+    ///   underlying store supports rollback, no partial mutation should be
+    ///   visible after the error.
+    func performMessageMutations(_ mutations: [MessageStoreMutation]) async throws
+}
+
 // MARK: - Default pagination
 
 extension MessageStore {

--- a/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
@@ -31,6 +31,29 @@ struct ConversationPersistencePort: Sendable {
     }
 
     @MainActor
+    func performMessageMutations(_ mutations: [MessageStoreMutation]) async throws {
+        guard !mutations.isEmpty else { return }
+
+        if let transactionalStore = messageStore as? any TransactionalMessageStore {
+            try await transactionalStore.performMessageMutations(mutations)
+            return
+        }
+
+        for mutation in mutations {
+            switch mutation {
+            case let .insert(message):
+                try await messageStore.insertMessage(message)
+            case let .update(message):
+                try await messageStore.updateMessage(message)
+            case let .delete(messageID):
+                try await messageStore.deleteMessage(messageID)
+            case let .deleteMessages(sessionID):
+                try await messageStore.deleteMessages(for: sessionID)
+            }
+        }
+    }
+
+    @MainActor
     func fetchMessages(sessionID: UUID) async throws -> [ChatMessageRecord] {
         try await messageStore.fetchMessages(for: sessionID)
     }

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataTransactionalMutationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataTransactionalMutationTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldTestSupport
+
+@MainActor
+final class SwiftDataTransactionalMutationTests: XCTestCase {
+
+    private var stack: InMemoryPersistenceHarness.Stack!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        stack = try InMemoryPersistenceHarness.make()
+    }
+
+    override func tearDown() async throws {
+        stack = nil
+        try await super.tearDown()
+    }
+
+    private var provider: SwiftDataPersistenceProvider { stack.provider }
+
+    func test_performMessageMutations_commitsBatchAndFiresHooksAfterCommit() async throws {
+        let session = ChatSessionRecord(title: "Transactional")
+        try await provider.insertSession(session)
+
+        var existing = ChatMessageRecord(role: .user, content: "before", sessionID: session.id)
+        try await provider.insertMessage(existing)
+        let inserted = ChatMessageRecord(role: .assistant, content: "new", sessionID: session.id)
+
+        let hook = RecordingMessageHook()
+        provider.addPostWriteHook(hook)
+
+        existing.content = "after"
+        try await provider.performMessageMutations([
+            .update(existing),
+            .insert(inserted),
+        ])
+
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.map(\.content), ["after", "new"])
+        XCTAssertEqual(hook.records.map(\.messageID), [existing.id, inserted.id])
+    }
+
+    func test_performMessageMutations_rollsBackStagedUpdateWhenLaterMutationFails() async throws {
+        let session = ChatSessionRecord(title: "Rollback")
+        try await provider.insertSession(session)
+
+        var first = ChatMessageRecord(role: .user, content: "before", sessionID: session.id)
+        let second = ChatMessageRecord(role: .assistant, content: "keep", sessionID: session.id)
+        try await provider.insertMessage(first)
+        try await provider.insertMessage(second)
+
+        let missingID = UUID()
+        first.content = "after"
+
+        do {
+            try await provider.performMessageMutations([
+                .update(first),
+                .delete(missingID),
+            ])
+            XCTFail("Expected batch to fail on missing delete target")
+        } catch {
+            XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(missingID))
+        }
+
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.map(\.content), ["before", "keep"])
+    }
+
+    func test_performMessageMutations_doesNotFireHooksWhenBatchRollsBack() async throws {
+        let session = ChatSessionRecord(title: "Hook Rollback")
+        try await provider.insertSession(session)
+
+        var record = ChatMessageRecord(role: .user, content: "before", sessionID: session.id)
+        try await provider.insertMessage(record)
+
+        let hook = RecordingMessageHook()
+        provider.addPostWriteHook(hook)
+
+        record.content = "after"
+        do {
+            try await provider.performMessageMutations([
+                .update(record),
+                .delete(UUID()),
+            ])
+            XCTFail("Expected batch to fail")
+        } catch {
+            XCTAssertTrue(error is ChatPersistenceError)
+        }
+
+        XCTAssertEqual(hook.records.count, 0)
+    }
+}
+
+private final class RecordingMessageHook: MessageStorePostWriteHook, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "SwiftDataTransactionalMutationTests.RecordingMessageHook")
+    private var _records: [(messageID: UUID, sessionID: UUID)] = []
+
+    func messageDidWrite(_ record: ChatMessageRecord, in sessionID: ChatSessionRecord.ID) async {
+        queue.sync {
+            _records.append((record.id, sessionID))
+        }
+    }
+
+    var records: [(messageID: UUID, sessionID: UUID)] {
+        queue.sync { _records }
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationPersistencePortTransactionalMutationTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationPersistencePortTransactionalMutationTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldInference
+
+@MainActor
+final class ConversationPersistencePortTransactionalMutationTests: XCTestCase {
+
+    func test_performMessageMutations_usesTransactionalCapabilityAndRollsBackInjectedFailure() async throws {
+        let sessionID = UUID()
+        let original = ChatMessageRecord(role: .user, content: "before", sessionID: sessionID)
+        let store = TransactionalFakeMessageStore(initialMessages: [original])
+        store.injectedFailureAfterApplyingMutationCount = 1
+        let port = ConversationPersistencePort(messageStore: store, sessionStore: nil)
+
+        var updated = original
+        updated.content = "after"
+
+        do {
+            try await port.performMessageMutations([
+                .update(updated),
+                .delete(UUID()),
+            ])
+            XCTFail("Expected injected transaction failure")
+        } catch TransactionalFakeMessageStore.InjectedError.transactionFailed {
+            // Expected failure path.
+        }
+
+        let messages = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(messages.map(\.content), ["before"])
+        XCTAssertEqual(store.transactionCallCount, 1)
+        XCTAssertEqual(store.individualMutationCallCount, 0)
+    }
+
+    func test_performMessageMutations_fallsBackToLegacyMessageStoreMethods() async throws {
+        let sessionID = UUID()
+        let first = ChatMessageRecord(role: .user, content: "first", sessionID: sessionID)
+        let second = ChatMessageRecord(role: .assistant, content: "second", sessionID: sessionID)
+        var updatedFirst = first
+        updatedFirst.content = "updated"
+
+        let store = LegacyMessageStore()
+        let port = ConversationPersistencePort(messageStore: store, sessionStore: nil)
+
+        try await port.performMessageMutations([
+            .insert(first),
+            .insert(second),
+            .update(updatedFirst),
+            .delete(second.id),
+        ])
+
+        let messages = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(messages.map(\.id), [first.id])
+        XCTAssertEqual(messages.first?.content, "updated")
+        XCTAssertEqual(store.insertCallCount, 2)
+        XCTAssertEqual(store.updateCallCount, 1)
+        XCTAssertEqual(store.deleteCallCount, 1)
+    }
+}
+
+@MainActor
+private final class TransactionalFakeMessageStore: TransactionalMessageStore {
+    enum InjectedError: Error {
+        case transactionFailed
+    }
+
+    private var messages: [UUID: ChatMessageRecord]
+    var injectedFailureAfterApplyingMutationCount: Int?
+    private(set) var transactionCallCount = 0
+    private(set) var individualMutationCallCount = 0
+
+    init(initialMessages: [ChatMessageRecord] = []) {
+        self.messages = Dictionary(uniqueKeysWithValues: initialMessages.map { ($0.id, $0) })
+    }
+
+    func performMessageMutations(_ mutations: [MessageStoreMutation]) async throws {
+        transactionCallCount += 1
+        let snapshot = messages
+        var appliedCount = 0
+
+        do {
+            for mutation in mutations {
+                try apply(mutation)
+                appliedCount += 1
+                if injectedFailureAfterApplyingMutationCount == appliedCount {
+                    throw InjectedError.transactionFailed
+                }
+            }
+        } catch {
+            messages = snapshot
+            throw error
+        }
+    }
+
+    func insertMessage(_ message: ChatMessageRecord) async throws {
+        individualMutationCallCount += 1
+        messages[message.id] = message
+    }
+
+    func updateMessage(_ message: ChatMessageRecord) async throws {
+        individualMutationCallCount += 1
+        guard messages[message.id] != nil else {
+            throw ChatPersistenceError.messageNotFound(message.id)
+        }
+        messages[message.id] = message
+    }
+
+    func deleteMessage(_ messageID: UUID) async throws {
+        individualMutationCallCount += 1
+        guard messages.removeValue(forKey: messageID) != nil else {
+            throw ChatPersistenceError.messageNotFound(messageID)
+        }
+    }
+
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+        messages.values
+            .filter { $0.sessionID == sessionID }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    func deleteMessages(for sessionID: UUID) async throws {
+        individualMutationCallCount += 1
+        messages = messages.filter { $0.value.sessionID != sessionID }
+    }
+
+    private func apply(_ mutation: MessageStoreMutation) throws {
+        switch mutation {
+        case let .insert(message):
+            messages[message.id] = message
+        case let .update(message):
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        case let .delete(messageID):
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        case let .deleteMessages(sessionID):
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+    }
+}
+
+@MainActor
+private final class LegacyMessageStore: MessageStore {
+    private var messages: [UUID: ChatMessageRecord] = [:]
+    private(set) var insertCallCount = 0
+    private(set) var updateCallCount = 0
+    private(set) var deleteCallCount = 0
+
+    func insertMessage(_ message: ChatMessageRecord) async throws {
+        insertCallCount += 1
+        messages[message.id] = message
+    }
+
+    func updateMessage(_ message: ChatMessageRecord) async throws {
+        updateCallCount += 1
+        guard messages[message.id] != nil else {
+            throw ChatPersistenceError.messageNotFound(message.id)
+        }
+        messages[message.id] = message
+    }
+
+    func deleteMessage(_ messageID: UUID) async throws {
+        deleteCallCount += 1
+        guard messages.removeValue(forKey: messageID) != nil else {
+            throw ChatPersistenceError.messageNotFound(messageID)
+        }
+    }
+
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+        messages.values
+            .filter { $0.sessionID == sessionID }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    func deleteMessages(for sessionID: UUID) async throws {
+        messages = messages.filter { $0.value.sessionID != sessionID }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds transactional message mutation APIs to MessageStore and ConversationPersistencePort.
- Implements SwiftData transactional message mutations.
- Adds runtime and SwiftData persistence tests for commit/rollback behavior.

## Validation
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --profile spike --spike-module ManifoldRuntimeTests`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --profile spike --spike-module ManifoldPersistenceSwiftDataTests`

Patch applied cleanly to `main`.