### PR TITLE
fix: harden UI coordinator actor isolation

### DIFF
--- a/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
@@ -29,55 +29,55 @@ final class ChatGenerationCoordinator {
     // MARK: - State write-back closures
 
     /// Forwards to `ChatViewModel.transitionPhase(to:)`.
-    var onTransitionPhase: (BackendActivityPhase) -> Bool = { _ in false }
+    var onTransitionPhase: @MainActor (BackendActivityPhase) -> Bool = { _ in false }
 
     /// Writes `ChatViewModel.lastTurnState`.
-    var onSetLastTurnState: (ChatViewModel.TurnState) -> Void = { _ in }
+    var onSetLastTurnState: @MainActor (ChatViewModel.TurnState) -> Void = { _ in }
 
     /// Writes `ChatViewModel.backgroundTaskError`.
-    var onSetBackgroundTaskError: (Error?) -> Void = { _ in }
+    var onSetBackgroundTaskError: @MainActor (Error?) -> Void = { _ in }
 
     /// Writes `ChatViewModel.messageIDsWithStreamingThinking`.
-    var onSetMessageIDsWithStreamingThinking: (Set<UUID>) -> Void = { _ in }
+    var onSetMessageIDsWithStreamingThinking: @MainActor (Set<UUID>) -> Void = { _ in }
 
     // MARK: - Read-back closures
 
     /// Returns `ChatViewModel.activeSessionID`.
-    var currentActiveSessionID: () -> UUID? = { nil }
+    var currentActiveSessionID: @MainActor () -> UUID? = { nil }
 
     /// Returns `ChatViewModel.activeSession`.
-    var currentActiveSession: () -> ChatSessionRecord? = { nil }
+    var currentActiveSession: @MainActor () -> ChatSessionRecord? = { nil }
 
     /// Returns `ChatViewModel.messages`.
-    var currentMessages: () -> [ChatMessageRecord] = { [] }
+    var currentMessages: @MainActor () -> [ChatMessageRecord] = { [] }
 
     /// Returns `ChatViewModel.postGenerationTasks`.
-    var currentPostGenerationTasks: () -> [any PostGenerationTask] = { [] }
+    var currentPostGenerationTasks: @MainActor () -> [any PostGenerationTask] = { [] }
 
     // MARK: - Message mutation closures
 
     /// Forwards to `ChatViewModel.mutateMessage(id:_:)`.
-    var mutateMessage: (UUID, (inout ChatMessageRecord) -> Void) -> Bool = { _, _ in false }
+    var mutateMessage: @MainActor (UUID, (inout ChatMessageRecord) -> Void) -> Bool = { _, _ in false }
 
     /// Appends a message to `ChatViewModel.messages`.
-    var appendMessage: (ChatMessageRecord) -> Void = { _ in }
+    var appendMessage: @MainActor (ChatMessageRecord) -> Void = { _ in }
 
     /// Removes messages matching the predicate from `ChatViewModel.messages`.
-    var removeMessages: ((ChatMessageRecord) -> Bool) -> Void = { _ in }
+    var removeMessages: @MainActor ((ChatMessageRecord) -> Bool) -> Void = { _ in }
 
     // MARK: - Side-effect closures
 
     /// Forwards to `ChatViewModel.updateContextEstimate()`.
-    var updateContextEstimate: () -> Void = { }
+    var updateContextEstimate: @MainActor () -> Void = { }
 
     /// Forwards to `ChatViewModel.surfaceError(_:kind:)`.
-    var surfaceError: (any Error, ChatError.Kind) -> Void = { _, _ in }
+    var surfaceError: @MainActor (any Error, ChatError.Kind) -> Void = { _, _ in }
 
     /// Writes `ChatViewModel.errorMessage`.
-    var setErrorMessage: (String?) -> Void = { _ in }
+    var setErrorMessage: @MainActor (String?) -> Void = { _ in }
 
     /// Writes `ChatViewModel.showUpgradeHint` and triggers the callback.
-    var setShowUpgradeHint: (Bool) -> Void = { _ in }
+    var setShowUpgradeHint: @MainActor (Bool) -> Void = { _ in }
 
     /// Forwarded from `ChatViewModel.onSessionBranched`.
     var onSessionBranched: (@MainActor (UUID) async -> Void)?

--- a/Sources/ManifoldUI/ViewModels/ModelLoadCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ModelLoadCoordinator.swift
@@ -35,28 +35,28 @@ final class ModelLoadCoordinator {
 
     /// Forwards to `ChatViewModel.transitionPhase(to:)`. Returns `true` if the
     /// transition was accepted (matches `transitionPhase`'s own return value).
-    var onTransitionPhase: (BackendActivityPhase) -> Bool = { _ in false }
+    var onTransitionPhase: @MainActor (BackendActivityPhase) -> Bool = { _ in false }
 
     /// Forwards to setting `ChatViewModel.errorMessage` to a non-nil string.
-    var onSurfaceError: (String) -> Void = { _ in }
+    var onSurfaceError: @MainActor (String) -> Void = { _ in }
 
     /// Clears `ChatViewModel.errorMessage` (sets it to `nil`).
-    var onClearError: () -> Void = {}
+    var onClearError: @MainActor () -> Void = {}
 
     /// Forwards to setting `ChatViewModel.selectedPromptTemplate`.
-    var onSetSelectedPromptTemplate: (PromptTemplate) -> Void = { _ in }
+    var onSetSelectedPromptTemplate: @MainActor (PromptTemplate) -> Void = { _ in }
 
     /// Forwards to `ChatViewModel.invalidateTokenCaches()`.
-    var onInvalidateTokenCaches: () -> Void = {}
+    var onInvalidateTokenCaches: @MainActor () -> Void = {}
 
     /// Returns `ChatViewModel.isRestoringSession`.
-    var isRestoringSession: () -> Bool = { false }
+    var isRestoringSession: @MainActor () -> Bool = { false }
 
     /// Returns `ChatViewModel.activityPhase`.
-    var currentActivityPhase: () -> BackendActivityPhase = { .idle }
+    var currentActivityPhase: @MainActor () -> BackendActivityPhase = { .idle }
 
     /// Returns the `ModelLoadPlan.Environment` to use for local-model load plans.
-    var currentLoadPlanEnvironment: () -> ModelLoadPlan.Environment = { .current }
+    var currentLoadPlanEnvironment: @MainActor () -> ModelLoadPlan.Environment = { .current }
 
     // MARK: - State
 

--- a/Tests/ManifoldUITests/CoordinatorClosureIsolationTests.swift
+++ b/Tests/ManifoldUITests/CoordinatorClosureIsolationTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import ManifoldInference
+import ManifoldRuntime
+@testable import ManifoldUI
+
+@MainActor
+final class CoordinatorClosureIsolationTests: XCTestCase {
+
+    func test_modelLoadCoordinatorClosureSeamsAreMainActorIsolated_compileOnly() {
+        let coordinator = ModelLoadCoordinator(inferenceService: InferenceService())
+
+        acceptsMainActorTransition(coordinator.onTransitionPhase)
+        acceptsMainActorStringWriter(coordinator.onSurfaceError)
+        acceptsMainActorVoid(coordinator.onClearError)
+        acceptsMainActorPromptTemplateWriter(coordinator.onSetSelectedPromptTemplate)
+        acceptsMainActorVoid(coordinator.onInvalidateTokenCaches)
+        acceptsMainActorBoolReader(coordinator.isRestoringSession)
+        acceptsMainActorPhaseReader(coordinator.currentActivityPhase)
+        acceptsMainActorLoadEnvironmentReader(coordinator.currentLoadPlanEnvironment)
+    }
+
+    func test_generationCoordinatorClosureSeamsAreMainActorIsolated_compileOnly() {
+        let coordinator = ChatGenerationCoordinator(
+            conversationRuntime: ConversationRuntime(
+                messageStore: InMemoryMessageStore(),
+                inferenceService: InferenceService()
+            ),
+            ownsDefaultRuntime: true
+        )
+
+        acceptsMainActorTransition(coordinator.onTransitionPhase)
+        acceptsMainActorTurnStateWriter(coordinator.onSetLastTurnState)
+        acceptsMainActorOptionalErrorWriter(coordinator.onSetBackgroundTaskError)
+        acceptsMainActorThinkingIDsWriter(coordinator.onSetMessageIDsWithStreamingThinking)
+        acceptsMainActorOptionalUUIDReader(coordinator.currentActiveSessionID)
+        acceptsMainActorOptionalSessionReader(coordinator.currentActiveSession)
+        acceptsMainActorMessagesReader(coordinator.currentMessages)
+        acceptsMainActorPostTasksReader(coordinator.currentPostGenerationTasks)
+        acceptsMainActorMessageMutator(coordinator.mutateMessage)
+        acceptsMainActorMessageAppender(coordinator.appendMessage)
+        acceptsMainActorMessageRemover(coordinator.removeMessages)
+        acceptsMainActorVoid(coordinator.updateContextEstimate)
+        acceptsMainActorErrorSurface(coordinator.surfaceError)
+        acceptsMainActorOptionalStringWriter(coordinator.setErrorMessage)
+        acceptsMainActorBoolWriter(coordinator.setShowUpgradeHint)
+    }
+}
+
+private func acceptsMainActorTransition(_ closure: @MainActor (BackendActivityPhase) -> Bool) {
+    _ = closure
+}
+
+private func acceptsMainActorStringWriter(_ closure: @MainActor (String) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorOptionalStringWriter(_ closure: @MainActor (String?) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorVoid(_ closure: @MainActor () -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorPromptTemplateWriter(_ closure: @MainActor (PromptTemplate) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorBoolReader(_ closure: @MainActor () -> Bool) {
+    _ = closure
+}
+
+private func acceptsMainActorPhaseReader(_ closure: @MainActor () -> BackendActivityPhase) {
+    _ = closure
+}
+
+private func acceptsMainActorLoadEnvironmentReader(_ closure: @MainActor () -> ModelLoadPlan.Environment) {
+    _ = closure
+}
+
+private func acceptsMainActorTurnStateWriter(_ closure: @MainActor (ChatViewModel.TurnState) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorOptionalErrorWriter(_ closure: @MainActor (Error?) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorThinkingIDsWriter(_ closure: @MainActor (Set<UUID>) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorOptionalUUIDReader(_ closure: @MainActor () -> UUID?) {
+    _ = closure
+}
+
+private func acceptsMainActorOptionalSessionReader(_ closure: @MainActor () -> ChatSessionRecord?) {
+    _ = closure
+}
+
+private func acceptsMainActorMessagesReader(_ closure: @MainActor () -> [ChatMessageRecord]) {
+    _ = closure
+}
+
+private func acceptsMainActorPostTasksReader(_ closure: @MainActor () -> [any PostGenerationTask]) {
+    _ = closure
+}
+
+private func acceptsMainActorMessageMutator(
+    _ closure: @MainActor (UUID, (inout ChatMessageRecord) -> Void) -> Bool
+) {
+    _ = closure
+}
+
+private func acceptsMainActorMessageAppender(_ closure: @MainActor (ChatMessageRecord) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorMessageRemover(_ closure: @MainActor ((ChatMessageRecord) -> Bool) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorErrorSurface(_ closure: @MainActor (any Error, ChatError.Kind) -> Void) {
+    _ = closure
+}
+
+private func acceptsMainActorBoolWriter(_ closure: @MainActor (Bool) -> Void) {
+    _ = closure
+}


### PR DESCRIPTION
## Summary
- Annotates UI coordinator closure seams in ChatGenerationCoordinator and ModelLoadCoordinator as @MainActor.
- Adds compile-only ManifoldUITests coverage that verifies coordinator closure isolation.
- Patch applied cleanly to main (89cb82acefaffeeaeea616c274d18cb8f3e18645).

## Validation
- GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --profile spike --spike-module ManifoldUITests