### PR TITLE
fix: track runtime turn tasks

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -268,7 +268,9 @@ public final class ConversationRuntime: Sendable {
         turnTasks.cancelAll()
         let registry = registry
         let inferenceService = inferenceService
-        Task {
+        // Use Task.detached so the teardown hop does not inherit an
+        // unspecified executor context from the non-isolated deinit.
+        Task.detached {
             let tokens = await registry.markAllCancelled()
             for token in tokens {
                 await inferenceService.cancelAsync(token)

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -85,6 +85,7 @@ public final class ConversationRuntime: Sendable {
     // MARK: In-flight state
 
     private let registry = InFlightStreamRegistry()
+    private let turnTasks = ConversationTurnTaskRegistry()
 
     // MARK: Diagnostics (test-injectable)
 
@@ -264,7 +265,20 @@ public final class ConversationRuntime: Sendable {
     }
 
     deinit {
+        turnTasks.cancelAll()
+        let registry = registry
+        let inferenceService = inferenceService
+        Task {
+            let tokens = await registry.markAllCancelled()
+            for token in tokens {
+                await inferenceService.cancelAsync(token)
+            }
+        }
         continuation.finish()
+    }
+
+    package var activeTurnTaskCount: Int {
+        turnTasks.count
     }
 
     // MARK: Canonical entry point
@@ -291,19 +305,22 @@ public final class ConversationRuntime: Sendable {
                 sessionID: input.sessionID,
                 text: text,
                 attachments: attachments,
-                config: input.config
+                config: input.config,
+                taskRegistry: turnTasks
             )
         case .regenerate:
             return try await executor.runRegenerateFlow(
                 sessionID: input.sessionID,
-                config: input.config
+                config: input.config,
+                taskRegistry: turnTasks
             )
         case let .edit(messageID, text):
             return try await executor.runEditFlow(
                 sessionID: input.sessionID,
                 messageID: messageID,
                 text: text,
-                config: input.config
+                config: input.config,
+                taskRegistry: turnTasks
             )
         case let .branch(messageID, newSessionID, newSessionTitle, generateAfter):
             return try await executor.runBranchFlow(
@@ -312,7 +329,8 @@ public final class ConversationRuntime: Sendable {
                 newSessionID: newSessionID,
                 newSessionTitle: newSessionTitle,
                 generateAfter: generateAfter,
-                config: input.config
+                config: input.config,
+                taskRegistry: turnTasks
             )
         }
     }
@@ -328,6 +346,7 @@ public final class ConversationRuntime: Sendable {
     /// underlying inference layer.
     public func cancel(_ handle: ConversationStreamHandle) async {
         let token = await registry.markCancelled(handle)
+        turnTasks.cancel(handle)
         guard let token else { return }
         await inferenceService.cancelAsync(token)
     }

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -70,7 +70,8 @@ struct ConversationTurnExecutor: Sendable {
         sessionID: UUID,
         text: String,
         attachments rawAttachments: [MessagePart],
-        config: TurnConfig
+        config: TurnConfig,
+        taskRegistry: ConversationTurnTaskRegistry
     ) async throws -> ConversationStreamHandle {
         let handle = ConversationStreamHandle()
 
@@ -124,11 +125,9 @@ struct ConversationTurnExecutor: Sendable {
             emit(.sessionTouchFailed(sessionID: sessionID))
         }
 
-        // Detach the streaming work onto an unstructured task so the
-        // command returns the handle promptly. The task captures `self`
-        // strongly for the duration of the turn — releases via the
-        // registry when the turn ends.
-        Task.detached { [self] in
+        // Launch the streaming work through the runtime-owned task registry
+        // so cancellation and completion bookkeeping have one owner.
+        await taskRegistry.launch(handle: handle) { [self] in
             // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
             for hook in generationHooks {
                 await hook.willBeginTurn(sessionID: sessionID)
@@ -170,7 +169,8 @@ struct ConversationTurnExecutor: Sendable {
 
     func runRegenerateFlow(
         sessionID: UUID,
-        config: TurnConfig
+        config: TurnConfig,
+        taskRegistry: ConversationTurnTaskRegistry
     ) async throws -> ConversationStreamHandle {
         let handle = ConversationStreamHandle()
 
@@ -195,7 +195,7 @@ struct ConversationTurnExecutor: Sendable {
         }
         emit(.messageRemoved(messageID: lastAssistant.id))
 
-        Task.detached { [self] in
+        await taskRegistry.launch(handle: handle) { [self] in
             // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
             for hook in generationHooks {
                 await hook.willBeginTurn(sessionID: sessionID)
@@ -236,7 +236,8 @@ struct ConversationTurnExecutor: Sendable {
         sessionID: UUID,
         messageID: UUID,
         text: String,
-        config: TurnConfig
+        config: TurnConfig,
+        taskRegistry: ConversationTurnTaskRegistry
     ) async throws -> ConversationStreamHandle? {
         // Fetch history synchronously so we can locate the target message
         // and delete trailing messages before returning. Callers observe
@@ -285,7 +286,7 @@ struct ConversationTurnExecutor: Sendable {
         }
 
         let handle = ConversationStreamHandle()
-        Task.detached { [self] in
+        await taskRegistry.launch(handle: handle) { [self] in
             // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
             for hook in generationHooks {
                 await hook.willBeginTurn(sessionID: sessionID)
@@ -329,7 +330,8 @@ struct ConversationTurnExecutor: Sendable {
         newSessionID: UUID,
         newSessionTitle: String?,
         generateAfter: Bool,
-        config: TurnConfig
+        config: TurnConfig,
+        taskRegistry: ConversationTurnTaskRegistry
     ) async throws -> ConversationStreamHandle? {
         // Fetch source history synchronously so callers observe ordering:
         // `.sessionBranched` fires before `processTurn` returns.
@@ -408,7 +410,7 @@ struct ConversationTurnExecutor: Sendable {
             thinkingStreamingBatchCharacterLimit: 128,
             loopDetectionEnabled: true
         )
-        Task.detached { [self] in
+        await taskRegistry.launch(handle: handle) { [self] in
             // Re-fetch from the new session so the history reflects the
             // persisted copies with their new IDs and sessionID.
             var history: [ChatMessageRecord]
@@ -858,6 +860,9 @@ struct ConversationTurnExecutor: Sendable {
         // late-cancel that could still mark the handle cancelled and confuse
         // observers.
         let cancelled = await isCancelled(handle: handle)
+        if cancelled {
+            await inferenceService.cancelAsync(token)
+        }
         await registry.unregister(handle: handle)
 
         // Capture token usage off the active backend before any subsequent

--- a/Sources/ManifoldRuntime/Services/ConversationTurnTaskRegistry.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnTaskRegistry.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Owns unstructured turn tasks launched by ``ConversationTurnExecutor``.
+///
+/// The runtime intentionally returns a ``ConversationStreamHandle`` before
+/// generation completes. This registry centralises the unstructured task
+/// boundary so handles can be cancelled and completed tasks cannot linger in
+/// per-runtime bookkeeping.
+package final class ConversationTurnTaskRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tasks: [ConversationStreamHandle: Task<Void, Never>] = [:]
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return tasks.count
+    }
+
+    @discardableResult
+    func launch(
+        handle: ConversationStreamHandle,
+        priority: TaskPriority? = nil,
+        operation: @escaping @Sendable () async -> Void
+    ) async -> Task<Void, Never> {
+        let gate = ConversationTurnTaskStartGate()
+        let task = Task.detached(priority: priority) { [weak self] in
+            await gate.wait()
+            defer { self?.unregister(handle) }
+            await operation()
+        }
+
+        let previous = store(task, for: handle)
+        previous?.cancel()
+
+        await gate.open()
+        return task
+    }
+
+    func cancel(_ handle: ConversationStreamHandle) {
+        lock.lock()
+        let task = tasks[handle]
+        lock.unlock()
+        task?.cancel()
+    }
+
+    func cancelAll() {
+        lock.lock()
+        let activeTasks = Array(tasks.values)
+        tasks.removeAll()
+        lock.unlock()
+        for task in activeTasks {
+            task.cancel()
+        }
+    }
+
+    private func unregister(_ handle: ConversationStreamHandle) {
+        lock.lock()
+        tasks.removeValue(forKey: handle)
+        lock.unlock()
+    }
+
+    private func store(
+        _ task: Task<Void, Never>,
+        for handle: ConversationStreamHandle
+    ) -> Task<Void, Never>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return tasks.updateValue(task, forKey: handle)
+    }
+}
+
+private actor ConversationTurnTaskStartGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}

--- a/Sources/ManifoldRuntime/Services/InFlightStreamRegistry.swift
+++ b/Sources/ManifoldRuntime/Services/InFlightStreamRegistry.swift
@@ -35,6 +35,13 @@ actor InFlightStreamRegistry {
         return entries[handle.id]
     }
 
+    /// Marks every active handle cancelled and returns the tokens that should
+    /// be forwarded to ``InferenceService/cancelAsync(_:)`` during teardown.
+    func markAllCancelled() -> [InferenceService.GenerationRequestToken] {
+        cancelled.formUnion(entries.keys)
+        return Array(entries.values)
+    }
+
     func isCancelled(_ handle: ConversationStreamHandle) -> Bool {
         cancelled.contains(handle.id)
     }

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -86,6 +86,94 @@ private final class RuntimeUsageBackend: InferenceBackend, TokenUsageProvider, @
     }
 }
 
+private actor RuntimeTaskLifecycleFlag {
+    private var isSet = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !isSet else { return }
+        isSet = true
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+
+    func wait() async {
+        if isSet { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}
+
+private final class HangingRuntimeBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool { true }
+    var isGenerating: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isGenerating
+    }
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+    var stopCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _stopCallCount
+    }
+
+    private let lock = NSLock()
+    private var _isGenerating = false
+    private var _stopCallCount = 0
+    private var activeContinuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation?
+    private let started = RuntimeTaskLifecycleFlag()
+    private let terminated = RuntimeTaskLifecycleFlag()
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {}
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        lock.lock()
+        _isGenerating = true
+        lock.unlock()
+
+        return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { [self] continuation in
+            lock.lock()
+            activeContinuation = continuation
+            lock.unlock()
+            Task { await started.signal() }
+            continuation.onTermination = { @Sendable [self] _ in
+                lock.lock()
+                activeContinuation = nil
+                _isGenerating = false
+                lock.unlock()
+                Task { await terminated.signal() }
+            }
+        })
+    }
+
+    func stopGeneration() {
+        lock.lock()
+        _stopCallCount += 1
+        _isGenerating = false
+        lock.unlock()
+    }
+
+    func unloadModel() {}
+
+    func waitUntilStarted() async {
+        await started.wait()
+    }
+
+    func waitUntilTerminated() async {
+        await terminated.wait()
+    }
+}
+
 /// Phase 1.2.5 PR-A — coverage for the new `ConversationRuntime` send sub-flow.
 ///
 /// Send is the only sub-flow PR-A ships. Regenerate / edit / branch are
@@ -301,6 +389,51 @@ final class ConversationRuntimeTests: XCTestCase {
             let first = try await group.next()
             group.cancelAll()
             return first ?? []
+        }
+    }
+
+    private func waitForActiveTurnTaskCount(
+        _ expectedCount: Int,
+        in runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadlineInstant = clock.now + deadline
+        while runtime.activeTurnTaskCount != expectedCount {
+            if clock.now >= deadlineInstant {
+                throw TestError.deadlineElapsed
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private func waitForBackendStart(
+        _ backend: HangingRuntimeBackend,
+        deadline: Duration = .seconds(5)
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { await backend.waitUntilStarted() }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                throw TestError.deadlineElapsed
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    private func waitForBackendTermination(
+        _ backend: HangingRuntimeBackend,
+        deadline: Duration = .seconds(5)
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { await backend.waitUntilTerminated() }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                throw TestError.deadlineElapsed
+            }
+            try await group.next()
+            group.cancelAll()
         }
     }
 
@@ -1046,6 +1179,45 @@ final class ConversationRuntimeTests: XCTestCase {
         // hang. (Sabotaging this would mean making `cancel(_:)` force-
         // unwrap or throw — the test asserts the no-op behaviour.)
         await runtime.cancel(bogus)
+    }
+
+    func test_cancel_hangingBackend_cancelsTurnTaskAndUnregisters() async throws {
+        let backend = HangingRuntimeBackend()
+        let inference = InferenceService(backend: backend, name: "Hanging")
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        let drain = drainUntilStreamFinished(from: runtime)
+
+        let handle = try await runtime.send(SendInput(sessionID: UUID(), userText: "hang"))
+        try await waitForBackendStart(backend)
+        XCTAssertEqual(runtime.activeTurnTaskCount, 1, "The launched turn should be tracked while the backend stream is hanging")
+
+        await runtime.cancel(handle)
+        let events = try await waitForEvents(from: drain)
+        try await waitForActiveTurnTaskCount(0, in: runtime)
+        try await waitForBackendTermination(backend)
+
+        XCTAssertEqual(streamFinishedReasons(in: events), [.cancelled])
+        XCTAssertEqual(backend.stopCallCount, 1, "Handle cancellation must propagate to the active backend request")
+        XCTAssertEqual(runtime.activeTurnTaskCount, 0, "Completed cancelled turns must unregister their task handle")
+    }
+
+    func test_deinit_cancelsActiveTurnTasks() async throws {
+        let backend = HangingRuntimeBackend()
+        let inference = InferenceService(backend: backend, name: "Hanging")
+        let store = RuntimeMessageStore()
+        var runtime: ConversationRuntime? = ConversationRuntime(messageStore: store, inferenceService: inference)
+        weak var weakRuntime = runtime
+
+        _ = try await runtime?.send(SendInput(sessionID: UUID(), userText: "hang"))
+        try await waitForBackendStart(backend)
+        XCTAssertEqual(runtime?.activeTurnTaskCount, 1)
+
+        runtime = nil
+
+        XCTAssertNil(weakRuntime, "Turn tasks must not retain the owning runtime after teardown")
+        try await waitForBackendTermination(backend)
+        XCTAssertGreaterThanOrEqual(backend.stopCallCount, 1, "Runtime teardown must cancel active backend requests")
     }
 
     // MARK: - Context pipeline integration


### PR DESCRIPTION
## Summary
- Adds a runtime-owned turn task registry for launched generation tasks.
- Wires send/regenerate/edit/branch flows through the registry and cancels active turn tasks during cancellation/deinit.
- Adds runtime tests covering task cleanup and cancellation lifecycle.

## Validation
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all scripts/test.sh --profile spike --spike-module ManifoldRuntimeTests`