### PR TITLE
fix(test): opt ConsumerRuntimeHarness out of ~/Documents/Models fallback scan

### DIFF
--- a/Tests/ManifoldUITests/ConsumerRuntimeHarness.swift
+++ b/Tests/ManifoldUITests/ConsumerRuntimeHarness.swift
@@ -76,7 +76,7 @@ final class ConsumerRuntimeHarness {
 
             let chatViewModel = ChatViewModel(
                 inferenceService: runtime.inferenceService,
-                modelStorage: ModelStorageService(baseDirectory: directory),
+                modelStorage: ModelStorageService(baseDirectory: directory, includeUserDocumentsFallback: false),
                 toolApprovalGate: toolApprovalGate,
                 userDefaults: defaults,
                 conversationRuntime: runtime.conversationRuntime


### PR DESCRIPTION
## Summary

- `ConsumerRuntimeHarness` constructed `ModelStorageService(baseDirectory: directory)` without `includeUserDocumentsFallback: false`
- With `MANIFOLD_DISCOVER_LOCAL_MODELS=1` set in the local environment, the harness scanned `~/Documents/Models/` and found the Ollama GGUF symlink added in PR #1491
- This injected a second model entry alongside the built-in Foundation model, causing `test_refreshModels_includesBuiltInFoundationWhenAvailable` to assert count 2 ≠ 1
- Fix mirrors the same opt-out already applied to `ModelCatalogTests` in PR #1490

## Test plan

- [ ] `MANIFOLD_DISCOVER_LOCAL_MODELS=1 swift test --disable-default-traits --filter ConsumerRuntimeHarnessTests` passes (verified locally)
- [ ] Full local suite (`scripts/test.sh --profile local --skip-update`) shows 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)