### PR TITLE
docs: correct stale guidance and setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@ shorter, recipe-shaped surface for *consumers*.
 ManifoldKit is a Swift package. Install via SwiftPM:
 
 ```swift
-.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.18.0")
+.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.36.0")
 ```
 
 > **Pre-1.0.** Minor versions can introduce breaking changes. For production,
-> pin to a specific tag (`exact: "0.18.0"`) and read [CHANGELOG.md](CHANGELOG.md)
+> pin to a specific tag (`exact: "0.36.0"`) and read [CHANGELOG.md](CHANGELOG.md)
 > before bumping. The `0.x` line stabilises pieces incrementally; `1.0.0` will
 > be the freeze point.
 
@@ -236,7 +236,7 @@ on every consumer:
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.18.0",
+    from: "0.36.0",
     traits: [.trait(name: "Macros")]
 )
 ```
@@ -314,7 +314,7 @@ Cloud backends require **`--traits CloudSaaS`** (default-off):
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.18.0",
+    from: "0.36.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -397,5 +397,7 @@ ManifoldKit is Swift-concurrency-native. The rules:
 - The `Example/Examples/MinimalExample/` app is the canonical runnable wiring.
 - DocC catalogs live alongside the modules
   (`Sources/ManifoldUI/ManifoldUI.docc/`).
+- Contributors changing ManifoldKit internals should use `scripts/test.sh --profile local`
+  as the default pre-push gate; `CLAUDE.md` documents the full contributor workflow.
 - For contributor-facing conventions (testing, traits, release process),
   see [CLAUDE.md](CLAUDE.md). For consumer-facing API, this file is enough.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,16 +101,12 @@ keeps them honest, plus DX walkthroughs and cold-start conformance gates — see
 failed push wastes ~25 billed minutes.
 
 ```bash
-swift test --filter ManifoldCoreTests --disable-default-traits \
-  && swift test --filter ManifoldInferenceTests --disable-default-traits \
-  && swift test --filter ManifoldInferenceSwiftTestingTests --disable-default-traits \
-  && swift test --filter ManifoldUITests --disable-default-traits \
-  && swift test --filter ManifoldUIModelManagementTests --disable-default-traits \
-  && swift test --filter ManifoldMCPTests --disable-default-traits \
-  && swift test --filter ManifoldBackendsTests --disable-default-traits \
-  && swift test --filter ManifoldTestSupportTests --disable-default-traits \
-  && swift test --filter ManifoldAppIntentsTests --disable-default-traits
+scripts/test.sh --profile local
 ```
+
+Use `scripts/test.sh` as the source of truth for the gate shape: it preserves the
+required two-invocation split between XCTest and Swift Testing. When you're
+reproducing a CI-only failure locally, use `scripts/test.sh --profile ci`.
 
 Never push based on a subset passing. After rebasing, always re-run the full suite —
 conflicts can silently break tests that compiled fine before.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Specialised modules (`ManifoldUIModelManagement`, `ManifoldMCP`, `ManifoldVoice`
 
 ## Requirements
 
-- **Swift 6.2+** (`swift-tools-version: 6.2` in your `Package.swift`) — required for `.macOS(.v26)` / `.iOS(.v26)` platform entries (`PackageDescription.SupportedPlatform.MacOSVersion.v26` was introduced in PackageDescription 6.2).
+- **Swift 6.1+** (`swift-tools-version: 6.1` in this package's `Package.swift`)
+- If your app's own manifest declares `.macOS(.v26)` / `.iOS(.v26)`, use **Swift 6.2+** there — those platform entries were introduced in PackageDescription 6.2.
 - iOS 18+ / macOS 15+
 - Apple Foundation Models require iOS 26+ / macOS 26+
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,9 @@ minors are end-of-life on the day a new minor ships.
 
 | Version       | Status                          |
 |---------------|---------------------------------|
-| `0.12.x`      | Supported (security + bug fix)  |
-| `0.11.x`      | Supported until `0.13.0`        |
-| `< 0.11`      | End-of-life                     |
+| `0.36.x`      | Supported (security + bug fix)  |
+| `0.35.x`      | Supported until `0.37.0`        |
+| `< 0.35`      | End-of-life                     |
 
 When ManifoldKit reaches `1.0.0`, this table will switch to a longer support window.
 
@@ -54,7 +54,7 @@ to the `offline` build profile. `Ollama` and `CloudSaaS` are both opt-in.
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.12.0",
+    from: "0.36.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -85,7 +85,7 @@ and the import-graph rule in the same audit):
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.12.0",
+    from: "0.36.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -115,7 +115,7 @@ Same `offline` guarantees, plus:
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.12.0",
+    from: "0.36.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -134,7 +134,7 @@ transport-security boundary.
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.12.0",
+    from: "0.36.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
@@ -190,7 +190,7 @@ Include:
 
 - A description of the vulnerability and impact.
 - Steps to reproduce.
-- Affected versions (the `0.12.x` baseline plus any earlier minor you've reproduced
+- Affected versions (the `0.36.x` baseline plus any earlier minor you've reproduced
   on).
 - Any potential mitigations or workarounds you've identified.
 

--- a/Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md
+++ b/Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md
@@ -104,6 +104,9 @@ whose `RawValue` is `String`. AppIntents already encourages this shape for
 because it ships alongside the on-device LLM-actuation features in the
 current AppIntents revision. Apps with older minimum-deployment targets
 should gate registration behind `if #available(iOS 26, macOS 26, *)`.
+The sample `AskManifoldIntent` and related helper/demo types have lower
+deployment targets; the iOS 26 / macOS 26 floor applies specifically to the
+executor bridge and its streaming support.
 
 ## Topics
 

--- a/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md
+++ b/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md
@@ -4,6 +4,17 @@ Define one or more MCP server descriptors, then connect them through ``MCPClient
 
 For a shortest-path setup, see <doc:MCPQuickStart>.
 
+> Important: Enable the `MCP` trait in your package dependency before importing
+> `ManifoldMCP`.
+>
+> ```swift
+> .package(
+>     url: "https://github.com/roryford/ManifoldKit.git",
+>     from: "0.36.0",
+>     traits: [.trait(name: "MCP")]
+> )
+> ```
+
 ## 1) Create a descriptor
 
 ```swift,no-build

--- a/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPQuickStart.md
+++ b/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPQuickStart.md
@@ -2,6 +2,9 @@
 
 Get a remote MCP server running in your `ToolRegistry` with explicit consent copy and tool boundaries.
 
+> Important: Enable the `MCP` trait in your package dependency first. See
+> <doc:MCPGettingStarted> for the dependency snippet.
+
 ## 1) Create a descriptor
 
 ```swift,no-build

--- a/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillsGettingStarted.md
+++ b/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillsGettingStarted.md
@@ -6,6 +6,10 @@ Wire filesystem-discovered skills into a chat session.
 
 ``SkillLoader`` walks the default Claude-Code-compatible roots and returns the parsed `Skill` values. The default search paths are resolved lazily so iOS / sandboxed builds with no `$HOME` don't crash at module init.
 
+> Warning: **macOS-only in v1.** On iOS, ``SkillLoader/discover()`` returns `[]`
+> and logs a one-time warning. Skill discovery requires entitlement / app-group
+> design that has not shipped yet.
+
 ```swift,no-build
 import ManifoldSkills
 

--- a/Sources/ManifoldTools/README.md
+++ b/Sources/ManifoldTools/README.md
@@ -51,7 +51,10 @@ Supported assertion kinds:
 |------|---------|-------------|
 | `containsLiteral` | `"value": String` | `finalAnswer.contains(value)` |
 | `equalsLiteral` | `"value": String` | `finalAnswer == value` |
-| `containsAny` | `"values": [String]` | Every entry in `values` is present |
+| `containsAll` | `"values": [String]` | Every entry in `values` is present |
+| `toolInvoked` | `"value": String` | Tool `value` was dispatched at least once |
+| `toolResultContains` | `"value": String`, `"values": [String]` | At least one result for tool `value` contains every entry in `values` |
+| `toolResultErrorKind` | `"value": String`, `"values": [String]` | At least one result for tool `value` has `errorKind` equal to the first entry in `values` |
 
 To add a scenario, drop a JSON file in `Scenarios/built-in/`. No Swift recompile needed — the loader enumerates the directory at runtime.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,21 +83,14 @@ UI automation tests that launch the real Example app in a simulator and drive it
 ### Running tests
 
 ```bash
-# CI-safe local gate (no hardware required). Two-invocation shape mirrors CI —
-# see CLAUDE.md Pre-push checklist for the rationale.
-scripts/test.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests \
-  --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests \
-  --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests \
-  --filter ManifoldBackendsTests --filter ManifoldInferenceTests \
-  --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests \
-  --filter ManifoldServerTests --disable-default-traits --skip-update
+# Default pre-push gate on Apple Silicon.
+scripts/test.sh --profile local
 
-# Swift Testing runs in a separate process to avoid mixed-runner crashes (#681).
-# Do NOT add --parallel to ManifoldInferenceTests — the UserDefaults.standard
-# race in test_autoSelectFirstRunModel_* and download-tests legacy-key reads
-# causes non-deterministic failures (issue #910).
-scripts/test.sh --filter ManifoldInferenceSwiftTestingTests \
-  --disable-default-traits --skip-update
+# CI repro when chasing a failure from the hosted lane.
+scripts/test.sh --profile ci
+
+# Narrow to a specific suite while keeping the profile's trait/worker shape.
+scripts/test.sh --profile local --filter ManifoldCoreTests
 
 # Apple Silicon only
 swift test --filter ManifoldBackendsTests --traits MLX,Llama

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -33,6 +33,8 @@ ManifoldKit's test targets are conditionally linked on Swift package traits:
 | `MLX` | yes | MLX backend, mlx-swift-lm dependency |
 | `Llama` | yes | LlamaBackend, llama.swift dependency |
 | `HuggingFace` | yes | HF model browser |
+| `Skills` | yes | `ManifoldSkills` module and SKILL.md discovery tests |
+| `AnyLanguageModel` | no | AnyLanguageModel bridge backend target |
 | `Ollama` | no | Ollama backend, requires `localhost:11434` |
 | `CloudSaaS` | no | OpenAI/Claude/Responses backends |
 | `MCP` | no | MCP client + transports |
@@ -41,7 +43,10 @@ ManifoldKit's test targets are conditionally linked on Swift package traits:
 | `Server` | no | ManifoldServer |
 | `Operational` | (planned, T4) | Nightly soak/migration/throughput |
 
-The default-traits build is what CI's per-PR matrix runs against. Use `--disable-default-traits` locally to drop MLX/Llama/HuggingFace (faster, sim-friendly).
+The default-traits build is what CI's per-PR matrix runs against. Running `swift test`
+with no explicit trait flags enables the Package.swift defaults: `MLX`, `Llama`,
+`HuggingFace`, and `Skills`. Use `--disable-default-traits` locally to drop those
+defaults when you want a faster, sim-friendly build.
 
 **When to disable default traits locally:** any iteration that doesn't exercise a hardware backend — `ManifoldRuntimeTests`, `ManifoldPersistenceSwiftDataTests`, `ManifoldUITests`, `ManifoldInferenceTests`, `ManifoldMCPTests`, `ManifoldServerTests`. Skipping MLX avoids an mlx-swift source checkout and a Metal shader compilation pass on every rebuild — the dominant cost in a default-traits cold build.
 

--- a/docs/QUICKSTART-IMAGE-GEN.md
+++ b/docs/QUICKSTART-IMAGE-GEN.md
@@ -20,7 +20,7 @@ In your consumer `Package.swift`:
 dependencies: [
     .package(
         url: "https://github.com/roryford/ManifoldKit.git",
-        from: "0.34.0", // x-release-please-version
+        from: "0.36.0", // x-release-please-version
         traits: [
             .trait(name: "MLX"),
         ]

--- a/docs/QUICKSTART-VOICE.md
+++ b/docs/QUICKSTART-VOICE.md
@@ -20,7 +20,7 @@ In your consumer `Package.swift`:
 dependencies: [
     .package(
         url: "https://github.com/roryford/ManifoldKit.git",
-        from: "0.34.0", // x-release-please-version
+        from: "0.36.0", // x-release-please-version
         traits: [
             .trait(name: "Voice"),
             // Drop the defaults if you only want voice and not the

--- a/scripts/perf-audit/README.md
+++ b/scripts/perf-audit/README.md
@@ -1,7 +1,6 @@
 # Perf Audit Harness
 
-Runs ManifoldFuzz scenarios from the perf-audit plan and aggregates
-their RunRecord JSON into a single Markdown table.
+Aggregates ManifoldFuzz RunRecord JSON into a single Markdown table.
 
 ## Usage
 
@@ -9,5 +8,5 @@ their RunRecord JSON into a single Markdown table.
     scripts/fuzz.sh --scenario kv-reuse-coverage --backend llama --duration 60
     scripts/perf-audit/summarize.sh > /tmp/audit-ground-truth.md
 
-The summarize script reads JSON from <fuzz output dir> and produces
-one section per scenario.
+The summarize script reads JSON from `MANIFOLD_PERF_AUDIT_INPUT_DIR`
+(default: `tmp/fuzz`) and produces one section per detector/scenario id.


### PR DESCRIPTION
## Summary
- update stale version, support, and Swift/toolchain guidance across user and AI-facing docs
- align testing, trait, perf-audit, and scenario docs with current scripts and source
- add small DocC setup callouts for AppIntents, Skills, and MCP prerequisites

## Validation
- git diff --check
- rg sweep for stale version/assertion strings in updated docs