### PR TITLE
fix(runtime): commit edit/branch/compression message writes atomically

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
@@ -64,6 +64,25 @@ struct ConversationPersistencePort: Sendable {
         try await sessionStore.insertSession(session)
     }
 
+    /// Best-effort session delete used to unwind a partially-created branch
+    /// when the message-copy batch fails. The message mutations roll back on
+    /// their own (the adapter's `performMessageMutations` calls `rollback()`),
+    /// but the session insert commits separately because the adapter's
+    /// transactional batch spans messages only — so the branch flow deletes
+    /// the orphaned session here. Logs rather than throwing so the original
+    /// copy failure is the error the caller surfaces.
+    @MainActor
+    func deleteSession(_ sessionID: UUID) async {
+        guard let sessionStore else { return }
+        do {
+            try await sessionStore.deleteSession(sessionID)
+        } catch {
+            Log.persistence.warning(
+                "ConversationRuntime.branch: rollback deleteSession failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
     /// Fetches the storage-agnostic record for a single session, or `nil`
     /// when no session matches. Used by the executor to read multi-agent
     /// state (`activeAgentID`, `agents`) per turn so handoff detection and

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -258,24 +258,23 @@ struct ConversationTurnExecutor: Sendable {
         // Update the edited message's content in the store.
         var updatedMessage = history[index]
         updatedMessage.content = text
+
+        // Commit the edit and the trailing-message deletions as ONE atomic
+        // batch. The old sequential path committed the update first, then
+        // deleted trailing messages one at a time — a mid-delete failure left
+        // the conversation truncated with the edit already persisted, which the
+        // caller's reload could not undo. Emitting events only after the batch
+        // commits keeps observers consistent with what's on disk.
+        let trailing = Array(history[(index + 1)...])
+        var mutations: [MessageStoreMutation] = [.update(updatedMessage)]
+        mutations.append(contentsOf: trailing.map { .delete($0.id) })
         do {
-            try await persistence.updateMessage(updatedMessage)
+            try await persistence.performMessageMutations(mutations)
         } catch {
             throw ConversationError.persistence(error)
         }
         emit(.messageUpdated(updatedMessage))
-
-        // Delete all messages after the edited one. On first failure stop
-        // deleting and throw — callers reload from the store on failure;
-        // the partial deletion is acknowledged, matching ChatViewModel's
-        // behaviour.
-        let trailing = Array(history[(index + 1)...])
         for msg in trailing {
-            do {
-                try await persistence.deleteMessage(msg.id)
-            } catch {
-                throw ConversationError.persistence(error)
-            }
             emit(.messageRemoved(messageID: msg.id))
         }
 
@@ -367,19 +366,25 @@ struct ConversationTurnExecutor: Sendable {
         }
 
         // Copy messages into the new session with fresh IDs and updated
-        // sessionID.
-        for original in slice {
-            let copy = ChatMessageRecord(
+        // sessionID, committed as ONE atomic batch. The old sequential path
+        // inserted copies one at a time — a mid-loop failure orphaned the
+        // freshly-inserted session with a partial message prefix. The session
+        // insert above commits separately (the adapter's transactional batch
+        // spans messages only), so on a copy failure we delete the orphaned
+        // session to leave no partial branch behind.
+        let copies = slice.map { original in
+            ChatMessageRecord(
                 role: original.role,
                 contentParts: original.contentParts,
                 timestamp: original.timestamp,
                 sessionID: newSessionID
             )
-            do {
-                try await persistence.insertMessage(copy)
-            } catch {
-                throw ConversationError.persistence(error)
-            }
+        }
+        do {
+            try await persistence.performMessageMutations(copies.map { .insert($0) })
+        } catch {
+            await persistence.deleteSession(newSessionID)
+            throw ConversationError.persistence(error)
         }
 
         emit(.sessionBranched(newSessionID: newSessionID, copiedCount: slice.count))
@@ -1123,10 +1128,13 @@ struct ConversationTurnExecutor: Sendable {
                         )
                         return
                     }
-                    try await persistence.deleteMessages(for: sessionID)
-                    for message in compressed {
-                        try await persistence.insertMessage(message)
-                    }
+                    // Replace history as ONE atomic batch: delete-then-reinsert
+                    // committed (or rolled back) together. A mid-loop failure on
+                    // the old sequential path permanently destroyed history —
+                    // the delete had already committed before the first insert.
+                    var mutations: [MessageStoreMutation] = [.deleteMessages(sessionID: sessionID)]
+                    mutations.append(contentsOf: compressed.map { .insert($0) })
+                    try await persistence.performMessageMutations(mutations)
                     emit(.historyCompressed(sessionID: sessionID, insertedRecords: compressed))
                     await compressionPolicy.postCompress(sessionID: sessionID, insertedRecords: compressed)
                 } catch {

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataTransactionalMutationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataTransactionalMutationTests.swift
@@ -92,6 +92,162 @@ final class SwiftDataTransactionalMutationTests: XCTestCase {
 
         XCTAssertEqual(hook.records.count, 0)
     }
+
+    // MARK: - Flow-shaped batches
+    //
+    // These mirror the exact mutation batches the three ConversationTurnExecutor
+    // flows now build (compression replace, edit, branch). They prove that on a
+    // mid-sequence failure the whole batch rolls back against real SwiftData —
+    // the data-loss the sequential paths used to risk.
+
+    /// Compression replace: `deleteMessages(sessionID:)` + N inserts as one
+    /// batch. A failure mid-reinsert must leave the original history intact, not
+    /// wiped (the old path committed the delete before any insert).
+    func test_compressionReplaceBatch_rollsBackPreservingOriginalHistoryOnInsertFailure() async throws {
+        let session = ChatSessionRecord(title: "Compression Rollback")
+        try await provider.insertSession(session)
+
+        let original1 = ChatMessageRecord(role: .user, content: "q1", sessionID: session.id)
+        let original2 = ChatMessageRecord(role: .assistant, content: "a1", sessionID: session.id)
+        try await provider.insertMessage(original1)
+        try await provider.insertMessage(original2)
+
+        // A valid summary insert followed by an update of a record that does not
+        // exist (no prior insert in this batch) forces a failure after the
+        // delete + first insert have been staged.
+        let summary = ChatMessageRecord(role: .assistant, content: "summary", sessionID: session.id)
+        let phantom = ChatMessageRecord(role: .user, content: "never inserted", sessionID: session.id)
+
+        do {
+            try await provider.performMessageMutations([
+                .deleteMessages(sessionID: session.id),
+                .insert(summary),
+                .update(phantom),
+            ])
+            XCTFail("Expected compression replace batch to fail on phantom update")
+        } catch {
+            XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(phantom.id))
+        }
+
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.map(\.content), ["q1", "a1"])
+    }
+
+    /// Compression replace happy path: delete-all then reinsert commits together.
+    func test_compressionReplaceBatch_commitsReplacementAtomically() async throws {
+        let session = ChatSessionRecord(title: "Compression Commit")
+        try await provider.insertSession(session)
+        try await provider.insertMessage(ChatMessageRecord(role: .user, content: "q1", sessionID: session.id))
+        try await provider.insertMessage(ChatMessageRecord(role: .assistant, content: "a1", sessionID: session.id))
+
+        let summary = ChatMessageRecord(role: .assistant, content: "summary", sessionID: session.id)
+        try await provider.performMessageMutations([
+            .deleteMessages(sessionID: session.id),
+            .insert(summary),
+        ])
+
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.map(\.content), ["summary"])
+    }
+
+    /// Edit: `update(edited)` + N trailing `delete`s. A trailing-delete failure
+    /// must not leave the edit committed with a truncated tail.
+    func test_editBatch_rollsBackEditWhenTrailingDeleteFails() async throws {
+        let session = ChatSessionRecord(title: "Edit Rollback")
+        try await provider.insertSession(session)
+
+        var edited = ChatMessageRecord(role: .user, content: "original", sessionID: session.id)
+        let trailing = ChatMessageRecord(role: .assistant, content: "reply", sessionID: session.id)
+        try await provider.insertMessage(edited)
+        try await provider.insertMessage(trailing)
+
+        edited.content = "edited text"
+        let missingTrailingID = UUID()
+
+        do {
+            try await provider.performMessageMutations([
+                .update(edited),
+                .delete(trailing.id),
+                .delete(missingTrailingID),
+            ])
+            XCTFail("Expected edit batch to fail on missing trailing delete")
+        } catch {
+            XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(missingTrailingID))
+        }
+
+        // Edit must NOT be visible and the trailing message must still be there.
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.map(\.content), ["original", "reply"])
+    }
+
+    /// Edit happy path: update + trailing deletes commit together.
+    func test_editBatch_commitsEditAndTrailingDeletesAtomically() async throws {
+        let session = ChatSessionRecord(title: "Edit Commit")
+        try await provider.insertSession(session)
+
+        var edited = ChatMessageRecord(role: .user, content: "original", sessionID: session.id)
+        let trailing1 = ChatMessageRecord(role: .assistant, content: "reply1", sessionID: session.id)
+        let trailing2 = ChatMessageRecord(role: .user, content: "reply2", sessionID: session.id)
+        try await provider.insertMessage(edited)
+        try await provider.insertMessage(trailing1)
+        try await provider.insertMessage(trailing2)
+
+        edited.content = "edited"
+        try await provider.performMessageMutations([
+            .update(edited),
+            .delete(trailing1.id),
+            .delete(trailing2.id),
+        ])
+
+        let messages = try await provider.fetchMessages(for: session.id)
+        XCTAssertEqual(messages.map(\.content), ["edited"])
+    }
+
+    /// Branch: the message-copy batch into the new session rolls back fully on a
+    /// mid-copy failure (the executor then deletes the orphaned session). Here
+    /// we verify the message half: no partial prefix survives.
+    func test_branchCopyBatch_rollsBackAllCopiesOnFailure() async throws {
+        let source = ChatSessionRecord(title: "Branch Source")
+        let target = ChatSessionRecord(title: "Branch Target")
+        try await provider.insertSession(source)
+        try await provider.insertSession(target)
+
+        let copy1 = ChatMessageRecord(role: .user, content: "copy1", sessionID: target.id)
+        let copy2 = ChatMessageRecord(role: .assistant, content: "copy2", sessionID: target.id)
+        // A trailing update of a record never inserted forces failure after the
+        // two inserts are staged.
+        let phantom = ChatMessageRecord(role: .user, content: "phantom", sessionID: target.id)
+
+        do {
+            try await provider.performMessageMutations([
+                .insert(copy1),
+                .insert(copy2),
+                .update(phantom),
+            ])
+            XCTFail("Expected branch copy batch to fail")
+        } catch {
+            XCTAssertEqual(error as? ChatPersistenceError, .messageNotFound(phantom.id))
+        }
+
+        let messages = try await provider.fetchMessages(for: target.id)
+        XCTAssertTrue(messages.isEmpty, "No partial message prefix should survive a failed branch copy")
+    }
+
+    /// Branch happy path: all copies land in the target session as one batch.
+    func test_branchCopyBatch_commitsAllCopiesAtomically() async throws {
+        let source = ChatSessionRecord(title: "Branch Source")
+        let target = ChatSessionRecord(title: "Branch Target")
+        try await provider.insertSession(source)
+        try await provider.insertSession(target)
+
+        try await provider.performMessageMutations([
+            .insert(ChatMessageRecord(role: .user, content: "c1", sessionID: target.id)),
+            .insert(ChatMessageRecord(role: .assistant, content: "c2", sessionID: target.id)),
+        ])
+
+        let messages = try await provider.fetchMessages(for: target.id)
+        XCTAssertEqual(messages.map(\.content), ["c1", "c2"])
+    }
 }
 
 private final class RecordingMessageHook: MessageStorePostWriteHook, @unchecked Sendable {

--- a/Tests/ManifoldRuntimeTests/ConversationPersistencePortTransactionalMutationTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationPersistencePortTransactionalMutationTests.swift
@@ -55,6 +55,56 @@ final class ConversationPersistencePortTransactionalMutationTests: XCTestCase {
         XCTAssertEqual(store.updateCallCount, 1)
         XCTAssertEqual(store.deleteCallCount, 1)
     }
+
+    func test_deleteSession_forwardsToSessionStore() async throws {
+        let store = LegacyMessageStore()
+        let sessionStore = RecordingSessionStore()
+        let port = ConversationPersistencePort(messageStore: store, sessionStore: sessionStore)
+
+        let sessionID = UUID()
+        await port.deleteSession(sessionID)
+
+        XCTAssertEqual(sessionStore.deletedSessionIDs, [sessionID])
+    }
+
+    func test_deleteSession_swallowsSessionStoreError() async throws {
+        let store = LegacyMessageStore()
+        let sessionStore = RecordingSessionStore()
+        sessionStore.shouldThrowOnDelete = true
+        let port = ConversationPersistencePort(messageStore: store, sessionStore: sessionStore)
+
+        // Best-effort: must not throw even when the underlying delete fails, so
+        // the branch flow surfaces the original copy error, not the cleanup error.
+        await port.deleteSession(UUID())
+        XCTAssertEqual(sessionStore.deletedSessionIDs.count, 1)
+    }
+}
+
+@MainActor
+private final class RecordingSessionStore: SessionStore {
+    private(set) var deletedSessionIDs: [UUID] = []
+    var shouldThrowOnDelete = false
+    private var sessions: [UUID: ChatSessionRecord] = [:]
+
+    enum StoreError: Error { case deleteFailed }
+
+    func insertSession(_ session: ChatSessionRecord) async throws {
+        sessions[session.id] = session
+    }
+
+    func updateSession(_ session: ChatSessionRecord) async throws {
+        sessions[session.id] = session
+    }
+
+    func deleteSession(_ sessionID: UUID) async throws {
+        deletedSessionIDs.append(sessionID)
+        if shouldThrowOnDelete { throw StoreError.deleteFailed }
+        sessions.removeValue(forKey: sessionID)
+    }
+
+    func fetchSessions() async throws -> [ChatSessionRecord] {
+        Array(sessions.values)
+    }
 }
 
 @MainActor

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -1727,16 +1727,26 @@ final class ConversationRuntimeTests: XCTestCase {
 
     // MARK: - Edit: delete failure on first trailing message
 
-    func test_edit_firstDeleteFails_throwsBeforeAnyTrailingDeletion() async throws {
-        // Sabotage check (verified manually): removing the re-throw on deleteMessage
-        // failure causes the method to continue deleting and return a handle, failing
-        // the XCTAssertThrowsError check.
+    func test_edit_trailingDeleteFails_emitsNoEventsForIncompleteBatch() async throws {
+        // The edit flow now commits the update + all trailing deletes through one
+        // `performMessageMutations` batch. The executor emits `.messageUpdated` /
+        // `.messageRemoved` only AFTER the batch succeeds, so a trailing-delete
+        // failure surfaces a `.persistence` error with NO events emitted.
         //
-        // RuntimeMessageStore.deleteError fires on the next call then self-clears.
-        // Setting it here means the first delete call (for trailing1) throws immediately,
-        // so zero trailing messages are removed. The update commits before the delete
-        // loop runs, so .messageUpdated is emitted and the store reflects the new
-        // content even though the throw follows.
+        // `RuntimeMessageStore` is non-transactional, so the port falls back to
+        // sequential per-row writes — the update may physically land before the
+        // failing delete. That fallback partial-commit is acceptable (an in-memory
+        // test fake), but the contract that observers care about — events fire only
+        // when the whole batch commits — must hold regardless. Against a real
+        // `TransactionalMessageStore` (SwiftData) the update also rolls back; that
+        // atomicity is proven in SwiftDataTransactionalMutationTests.
+        //
+        // Sabotage check (verified manually): moving the `emit(.messageUpdated)`
+        // call back above `performMessageMutations` makes the no-events assertion
+        // fail.
+        //
+        // RuntimeMessageStore.deleteError fires on the next call then self-clears,
+        // so the delete of trailing1 throws.
         let (runtime, store, _, _) = makeRuntime()
         let sessionID = UUID()
 
@@ -1747,8 +1757,6 @@ final class ConversationRuntimeTests: XCTestCase {
         try await store.insertMessage(trailing1)
         try await store.insertMessage(trailing2)
 
-        // Collect events so we can verify .messageUpdated fired before the
-        // delete failure and that no .messageRemoved events were emitted.
         var collectedEvents: [ConversationEvent] = []
         let eventCollector = Task { @MainActor [runtime] in
             for await event in runtime.events {
@@ -1756,7 +1764,7 @@ final class ConversationRuntimeTests: XCTestCase {
             }
         }
 
-        // Poison: first delete call throws, leaving both trailing messages in place.
+        // Poison: the delete of trailing1 throws, aborting the batch.
         store.deleteError = ChatPersistenceError.messageNotFound(trailing1.id)
 
         do {
@@ -1772,27 +1780,17 @@ final class ConversationRuntimeTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
 
-        // Let any queued events drain.
         try await Task.sleep(for: .milliseconds(50))
         eventCollector.cancel()
 
-        // The update committed before the delete attempt: store has user (with new
-        // content) + both trailing messages (neither was deleted).
-        XCTAssertEqual(store.messages.count, 3,
-                       "Both trailing messages still in store when first delete fails")
-        XCTAssertEqual(store.messages[userMsg.id]?.content, "edited",
-                       "User message content was updated before the delete failure")
-
-        // .messageUpdated fired — the update completed before the delete loop ran.
-        XCTAssertTrue(collectedEvents.contains(where: {
-            if case .messageUpdated(let record) = $0 { return record.id == userMsg.id } else { return false }
-        }), ".messageUpdated fired for the edited message before the delete failure")
-
-        // No .messageRemoved events — the first delete threw before anything was removed.
+        // No events for an incomplete batch — neither the edit nor the deletions.
+        XCTAssertFalse(collectedEvents.contains(where: {
+            if case .messageUpdated = $0 { return true } else { return false }
+        }), "No .messageUpdated event when the batch aborts mid-sequence")
         let removedCount = collectedEvents.filter { event in
             if case .messageRemoved = event { return true } else { return false }
         }.count
-        XCTAssertEqual(removedCount, 0, "No .messageRemoved events when first delete fails")
+        XCTAssertEqual(removedCount, 0, "No .messageRemoved events when the batch aborts")
     }
 
     // MARK: - Branch: happy path (no generation)


### PR DESCRIPTION
## The data-loss risk

Three `ConversationTurnExecutor` flows did sequential, non-atomic persistence writes. A failure partway through any of them could corrupt or truncate conversation history with no way for the caller's reload to recover:

- **Compression replace** — `deleteMessages(for:)` committed, *then* a loop of `insertMessage`. A failure mid-insert-loop permanently wiped history (the delete was already on disk before any summary landed).
- **Edit** — `updateMessage` committed, then N trailing `deleteMessage`s one at a time. A trailing-delete failure left the conversation truncated with the edit already persisted.
- **Branch** — `insertSession(newSession)` then a per-message `insertMessage(copy)` loop. A copy failure orphaned a freshly-created session holding a partial message prefix.

## The fix

PR #1485 already shipped the transactional primitive — `MessageStoreMutation` / `TransactionalMessageStore` / `ConversationPersistencePort.performMessageMutations(...)`, with the SwiftData adapter calling `modelContext.rollback()` on failure — but **nothing in production called it**. This wires all three flows through `performMessageMutations` so each commits (or rolls back) as one unit.

Call sites changed:

- `Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift` — compression replace (was ~:1126–1129): `deleteMessages(sessionID:)` + N `.insert` in one batch.
- `Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift` — edit flow (was ~:258–280): `.update(edited)` + N trailing `.delete` in one batch. `.messageUpdated` / `.messageRemoved` now emit **only after** the batch commits.
- `Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift` — branch flow (was ~:362–383): message copies folded into one `.insert` batch.
- `Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift` — added best-effort `deleteSession(_:)` (logs, never throws) used by the branch flow to unwind the orphaned session on copy failure.

### Branch: what could NOT be one batch (and why)

The SwiftData adapter's `performMessageMutations` spans **messages only** — `MessageStoreMutation` has no session case, and `insertSession` lives on `SessionStore`. So the branch session insert stays a separate commit. To preserve atomicity at the flow level, on a message-copy failure the flow now deletes the orphaned session via the new `ConversationPersistencePort.deleteSession`. The message copies themselves roll back as one unit through the adapter.

## Tests

- `Tests/ManifoldPersistenceSwiftDataTests/SwiftDataTransactionalMutationTests.swift` — six new flow-shaped tests against **real in-memory SwiftData** (per CLAUDE.md, no persistence mocks): commit + mid-sequence-rollback for each of compression replace, edit, and branch-copy. The rollback cases prove the original history / target session is left untouched.
- `Tests/ManifoldRuntimeTests/ConversationPersistencePortTransactionalMutationTests.swift` — `deleteSession` forwards to the `SessionStore` and swallows its errors (best-effort cleanup).
- `Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift` — the existing edit-trailing-delete-failure test rewritten to the new contract: no `.messageUpdated` / `.messageRemoved` events for an incomplete batch.

## Test result

`swift build --build-tests --disable-default-traits` succeeds. `ManifoldRuntimeTests` (375 tests, 2 pre-existing skips) and `ManifoldPersistenceSwiftDataTests` (200 tests, 6 pre-existing skips) both pass with 0 failures.

Closes nothing (no issue) — this was the P0 from the 2026-05-29 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)