### PR TITLE
fix(cloud): make ClaudeBackend error-body catch observable and UTF-8-safe

### DIFF
--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -498,18 +498,24 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
         }
     }
 
-    /// Reads up to 1000 characters from the byte stream for error diagnostics.
+    /// Reads up to 1000 bytes from the byte stream for error diagnostics.
     private static func readErrorBody(from bytes: URLSession.AsyncBytes) async -> String {
-        var body = ""
+        // Accumulate raw bytes and decode as UTF-8 once at the end. Decoding
+        // each byte as an individual Latin-1 scalar mangles any multi-byte
+        // UTF-8 sequence (non-ASCII upstream/proxy error messages) into
+        // mojibake before sanitization ever sees it.
+        var data = Data()
         do {
             for try await byte in bytes {
-                body.append(Character(UnicodeScalar(byte)))
-                if body.count > 1000 { break }
+                data.append(byte)
+                if data.count > 1000 { break }
             }
         } catch {
-            // Best-effort — partial body is fine for error messages.
+            // Best-effort — a partial body is still useful for error messages,
+            // but log the interruption so the swallow stays observable.
+            Log.network.debug("Claude error-body read interrupted: \(error.localizedDescription, privacy: .private)")
         }
-        return body
+        return String(decoding: data, as: UTF8.self)
     }
 
 }

--- a/Tests/ManifoldBackendsTests/ClaudeBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeBackendTests.swift
@@ -508,6 +508,56 @@ extension ClaudeBackendTests {
             // thing is that 503 is not mis-classified as providerOverloaded.
         }
     }
+
+    /// A non-ASCII (multi-byte UTF-8) upstream error message must survive the
+    /// error-body read intact and reach the surfaced `serverError` message.
+    ///
+    /// Regression for the per-byte `Character(UnicodeScalar(byte))` read, which
+    /// decoded each UTF-8 byte as an independent Latin-1 scalar and turned any
+    /// multi-byte sequence into mojibake before sanitization ever saw it.
+    ///
+    /// Sabotage check: revert `readErrorBody` to the per-byte
+    /// `body.append(Character(UnicodeScalar(byte)))` accumulation. The é/中文/🚫
+    /// glyphs come back as mojibake and the substring assertions fail.
+    func test_serverError_nonASCIIBody_roundTripsAsUTF8() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let backend = ClaudeBackend(urlSession: session)
+        backend.retryStrategy = ExponentialBackoffStrategy(maxRetries: 0)
+        let url = URL(string: "https://claude-utf8-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        // Mix 2-byte (é), 3-byte (中文), and 4-byte (🚫) UTF-8 sequences.
+        let upstreamMessage = "Réseau indisponible 中文 🚫"
+        let body = Data(#"{"type":"error","error":{"type":"api_error","message":"\#(upstreamMessage)"}}"#.utf8)
+        MockURLProtocol.stub(url: url, response: .immediate(data: body, statusCode: 500))
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        do {
+            for try await _ in stream.events {}
+            XCTFail("Expected serverError for HTTP 500")
+        } catch {
+            guard let cloudError = extractCloudError(error) else {
+                XCTFail("Expected CloudBackendError, got \(error)")
+                return
+            }
+            guard case .serverError(let code, let message) = cloudError else {
+                XCTFail("Expected .serverError, got \(cloudError)")
+                return
+            }
+            XCTAssertEqual(code, 500)
+            let surfaced = try XCTUnwrap(message, "serverError must carry the upstream message")
+            XCTAssertTrue(surfaced.contains("Réseau"),
+                          "2-byte UTF-8 (é) must survive the error-body read; got: \(surfaced)")
+            XCTAssertTrue(surfaced.contains("中文"),
+                          "3-byte UTF-8 must survive the error-body read; got: \(surfaced)")
+            XCTAssertTrue(surfaced.contains("🚫"),
+                          "4-byte UTF-8 must survive the error-body read; got: \(surfaced)")
+        }
+    }
 }
 
 #endif

--- a/Tests/ManifoldInferenceTests/silent_catch_allowlist.txt
+++ b/Tests/ManifoldInferenceTests/silent_catch_allowlist.txt
@@ -57,7 +57,6 @@ ManifoldServer/ChatCompletionsAdapter.swift:if let string = try? decoder.singleV
 
 # Stream cancellation cleanup paths — already-cancelled errors are the
 # only failure mode and would be redundant to log.
-ManifoldCloud/ClaudeBackend.swift:} catch {
 ManifoldTools/TranscriptLogger.swift:} catch {
 ManifoldTools/ReferenceTools/NowTool.swift:} catch {
 


### PR DESCRIPTION
Two fixes in the same method, `ClaudeBackend.readErrorBody` (`Sources/ManifoldCloud/ClaudeBackend.swift`).

## 1. Unobservable error-body catch (latent CI exposure)

The `catch` block in `readErrorBody` had a **comment-only body** (`// Best-effort — partial body is fine for error messages.`). `SilentCatchAuditTest` skips comment lines during its multi-line look-ahead, so a catch whose only body is a comment is classified as an **empty catch**. The fingerprint was being held alive by `silent_catch_allowlist.txt`, which papered over a genuinely unobservable swallow rather than fixing it. The audit scans raw text under `Sources/` regardless of traits, and local `--disable-default-traits` runs skip it — so the only thing standing between this and a red audit was the allowlist entry.

Fix: put a real (non-comment) statement in the catch so the swallow is observable, and remove the now-stale allowlist entry:

```swift
} catch {
    Log.network.debug("Claude error-body read interrupted: \(error.localizedDescription, privacy: .private)")
}
```

This matches the existing `Log.network.debug(...)` logger/category already used a few lines up in the same status-code path.

## 2. Multi-byte UTF-8 corruption in the error body

The body was accumulated with `body.append(Character(UnicodeScalar(byte)))`, treating each byte as an independent Latin-1 scalar. Any non-ASCII upstream/proxy error message (accented text, CJK, emoji) turned into mojibake **before** `CloudErrorSanitizer` ever saw it. Fixed by mirroring `OllamaBackend`: accumulate raw bytes into `Data` under the existing 1000-byte cap, then decode once with `String(decoding: data, as: UTF8.self)`. Sanitization (`CloudErrorSanitizer`) and the thrown `serverError` are unchanged.

## Tests

- `SilentCatchAuditTest` passes (`--traits CloudSaaS`).
- All ClaudeBackend tests pass (46 XCTest + 6 Swift Testing).
- New CloudSaaS-gated regression `test_serverError_nonASCIIBody_roundTripsAsUTF8` asserts a 500 body containing 2-byte (é), 3-byte (中文) and 4-byte (🚫) UTF-8 sequences round-trips into the surfaced `serverError` message intact. Includes a sabotage note (revert to the per-byte read → mojibake → assertions fail).

## Scope

Scoped to ClaudeBackend's own method. The broader cross-backend consolidation (base class + Ollama + a single shared error-body reader) is tracked in #1497; this PR deliberately does not touch that surface, so there is partial overlap but no duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)