### PR TITLE
fix(persistence): thread ragConfiguration through ManifoldBootstrap.build()

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -68,7 +68,7 @@ public struct RAGConfiguration: Sendable {
 ///
 /// ### Splash-screen progress
 ///
-/// Call ``build(configuration:inferenceService:diagnostics:makeModelContainer:)``
+/// Call ``build(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:sessionToolSources:hookRegistry:makeModelContainer:)``
 /// instead of `init` when you want to drive a launch progress UI. That factory
 /// returns an `AsyncStream<RuntimeBootstrapMilestone>` you can iterate on the
 /// main actor while bootstrap runs concurrently in a sibling task:
@@ -167,29 +167,10 @@ public final class ManifoldBootstrap {
             let resolvedUsageStore = SwiftDataUsageStore(modelContext: mainContext)
             self.usageStore = resolvedUsageStore
 
-            let resolvedRAGService: RAGService?
-            if let ragConfig = ragConfiguration {
-                let vectorURL = ragConfig.vectorStoreURL
-                    ?? ModelContainerFactory.defaultStoreURL()?
-                        .deletingLastPathComponent()
-                        .appendingPathComponent("ragvectors.bin")
-                    ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-                        .first!.appendingPathComponent("ragvectors.bin")
-                let vectorStore = FlatFileVectorStore(storageURL: vectorURL)
-                let documentStore = SwiftDataDocumentStore(modelContext: mainContext)
-                let chunker = DocumentChunker(
-                    chunkSize: ragConfig.chunkSize,
-                    overlap: ragConfig.chunkOverlap
-                )
-                resolvedRAGService = RAGService(
-                    documentStore: documentStore,
-                    vectorStore: vectorStore,
-                    embeddingBackend: ragConfig.embeddingBackend,
-                    chunker: chunker
-                )
-            } else {
-                resolvedRAGService = nil
-            }
+            let resolvedRAGService = Self.makeRAGService(
+                ragConfiguration: ragConfiguration,
+                modelContext: mainContext
+            )
             self.ragService = resolvedRAGService
 
             // ManifoldPersistenceSwiftData does not depend on ManifoldFoundation,
@@ -264,8 +245,52 @@ public final class ManifoldBootstrap {
         }
     }
 
+    /// Constructs the ``RAGService`` for the given configuration, or returns
+    /// `nil` when RAG was not requested.
+    ///
+    /// Shared by both the synchronous `init` and the async ``build(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:sessionToolSources:hookRegistry:makeModelContainer:)``
+    /// factory so the two bootstrap paths wire retrieval identically. Before
+    /// this was factored out, `build()` had no RAG wiring at all and silently
+    /// produced a runtime with retrieval disabled.
+    private static func makeRAGService(
+        ragConfiguration: RAGConfiguration?,
+        modelContext: ModelContext
+    ) -> RAGService? {
+        guard let ragConfig = ragConfiguration else { return nil }
+
+        // Resolve the on-disk vector index location. Both the configured URL
+        // and the derived Application Support path can be absent (e.g. a
+        // sandbox that denies the directory), so skip RAG with a logged
+        // warning rather than trapping on a recoverable path.
+        let vectorURL = ragConfig.vectorStoreURL
+            ?? ModelContainerFactory.defaultStoreURL()?
+                .deletingLastPathComponent()
+                .appendingPathComponent("ragvectors.bin")
+            ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+                .first?.appendingPathComponent("ragvectors.bin")
+
+        guard let vectorURL else {
+            Log.persistence.warning("ManifoldBootstrap: could not resolve a vector-store URL — RAG retrieval disabled for this session.")
+            return nil
+        }
+
+        let vectorStore = FlatFileVectorStore(storageURL: vectorURL)
+        let documentStore = SwiftDataDocumentStore(modelContext: modelContext)
+        let chunker = DocumentChunker(
+            chunkSize: ragConfig.chunkSize,
+            overlap: ragConfig.chunkOverlap
+        )
+        return RAGService(
+            documentStore: documentStore,
+            vectorStore: vectorStore,
+            embeddingBackend: ragConfig.embeddingBackend,
+            chunker: chunker
+        )
+    }
+
     public static func build(
         configuration: ManifoldConfiguration,
+        ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
@@ -302,6 +327,10 @@ public final class ManifoldBootstrap {
                 let benchmarkCache = SwiftDataBenchmarkCache(modelContext: mainContext)
                 let endpointStore = SwiftDataEndpointStore(modelContext: mainContext)
                 let usageStore = SwiftDataUsageStore(modelContext: mainContext)
+                let ragService = makeRAGService(
+                    ragConfiguration: ragConfiguration,
+                    modelContext: mainContext
+                )
                 await Task.yield()
 
                 continuation.yield(.complete)
@@ -316,6 +345,7 @@ public final class ManifoldBootstrap {
                     endpointStore: endpointStore,
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
+                    ragService: ragService,
                     sessionToolSources: sessionToolSources,
                     hookRegistry: hookRegistry
                 )

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapTests.swift
@@ -162,4 +162,73 @@ final class ManifoldBootstrapTests: XCTestCase {
         let sessions = try await runtime.persistence.fetchSessions()
         XCTAssertEqual(sessions.map(\.id), [session.id])
     }
+
+    // MARK: - RAG wiring parity
+
+    /// Regression guard: a host using the async ``ManifoldBootstrap/build``
+    /// splash path with a ``RAGConfiguration`` must get a runtime with RAG
+    /// enabled, exactly like the synchronous `init`. Before this fix, `build()`
+    /// had no `ragConfiguration:` parameter and silently produced a runtime
+    /// with `ragService == nil` (retrieval disabled with no error or warning).
+    func test_buildAndInit_haveIdenticalRAGWiringParity() async throws {
+        let originalConfiguration = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = originalConfiguration }
+
+        let ragConfiguration = RAGConfiguration(chunkSize: 1200, chunkOverlap: 100, topK: 3)
+
+        // Synchronous init enables RAG.
+        let viaInit = try ManifoldBootstrap(
+            configuration: ManifoldConfiguration(
+                appName: "RAG Init",
+                bundleIdentifier: "com.manifoldkit.runtime-tests.rag-init.\(UUID().uuidString)"
+            ),
+            ragConfiguration: ragConfiguration,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        XCTAssertNotNil(viaInit.ragService,
+            "Synchronous init with a RAGConfiguration must enable RAG retrieval")
+
+        // The async build() path must reach the same state.
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: ManifoldConfiguration(
+                appName: "RAG Build",
+                bundleIdentifier: "com.manifoldkit.runtime-tests.rag-build.\(UUID().uuidString)"
+            ),
+            ragConfiguration: ragConfiguration,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let viaBuild = try await task.value
+        XCTAssertNotNil(viaBuild.ragService,
+            "build(ragConfiguration:) must enable RAG retrieval — parity with the synchronous init")
+    }
+
+    /// Existing `build()` callers that pass no `ragConfiguration:` must be
+    /// unaffected: RAG stays disabled, matching the synchronous `init` default.
+    func test_buildAndInit_defaultToRAGDisabled() async throws {
+        let originalConfiguration = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = originalConfiguration }
+
+        let viaInit = try ManifoldBootstrap(
+            configuration: ManifoldConfiguration(
+                appName: "No RAG Init",
+                bundleIdentifier: "com.manifoldkit.runtime-tests.norag-init.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        XCTAssertNil(viaInit.ragService,
+            "init without a RAGConfiguration must leave RAG disabled")
+
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: ManifoldConfiguration(
+                appName: "No RAG Build",
+                bundleIdentifier: "com.manifoldkit.runtime-tests.norag-build.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let viaBuild = try await task.value
+        XCTAssertNil(viaBuild.ragService,
+            "build() without a RAGConfiguration must leave RAG disabled")
+    }
 }


### PR DESCRIPTION
## The bug

`ManifoldBootstrap` has two public construction paths:

- The synchronous `init` accepts a `ragConfiguration:` parameter, builds a `RAGService`, and threads it into the `ConversationRuntime`.
- The async progress-stream factory `build()` (used to drive a launch/splash progress UI) had **no** `ragConfiguration:` parameter. It constructed the runtime via the internal init, which left `ragService == nil`.

Result: a host that adopted the `build()` path specifically to enable RAG got a runtime with retrieval **silently disabled** — no error, no warning, no log. Retrieval just never happened.

## The fix

- Added a `ragConfiguration: RAGConfiguration? = nil` parameter to `build()`, positioned and defaulted identically to the sync `init` — existing `build()` callers are unaffected (no source break).
- Factored the RAG-service construction (vector-store URL resolution → `FlatFileVectorStore` + `SwiftDataDocumentStore` + `DocumentChunker` → `RAGService`) out of the sync `init` into a shared `private static func makeRAGService(ragConfiguration:modelContext:)`. Both paths now call it, so the wiring is provably identical.
- `build()` constructs the service during its `wiringPersistence` milestone and passes it to the internal init's existing `ragService:` parameter.

`Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift`:
- `build()` signature + `ragConfiguration` plumbing (~`:312`, `:351`)
- shared `makeRAGService` helper (~`:267`)
- sync `init` now delegates to the helper (~`:170`)

## Force-unwrap touched (on-path)

The RAG vector-URL resolution included a force-unwrap:

```swift
?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
```

Since the helper is now shared and this is a recoverable path (an unresolvable Application Support directory should not crash app launch — per CLAUDE.md: no traps on recoverable paths), I replaced the `!` with a `Log.persistence`-logged graceful skip: if no vector-store URL can be resolved, RAG is left disabled with a warning instead of trapping.

## Tests

Added to `Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapTests.swift` (in-memory SwiftData stores):

- `test_buildAndInit_haveIdenticalRAGWiringParity` — a runtime built via `build(ragConfiguration:)` has `ragService != nil`, matching the sync `init`. This is the regression guard for the silent-disable bug.
- `test_buildAndInit_defaultToRAGDisabled` — both paths leave RAG disabled when no config is passed, defending the no-source-break default.

Result: `swift build --build-tests --disable-default-traits` succeeds; `ManifoldBootstrapTests` (8 tests) and `RuntimeBootstrapMilestoneTests` (8 tests) all pass. RAG is not trait-gated (lives in `ManifoldRuntime`/`ManifoldPersistenceSwiftData`), so no extra trait was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)