### PR TITLE
refactor(inference): collapse generation parameter lists onto GenerationConfig

### DIFF
--- a/Sources/ManifoldFuzz/SessionScriptRunner.swift
+++ b/Sources/ManifoldFuzz/SessionScriptRunner.swift
@@ -213,13 +213,22 @@ public actor SessionScriptRunner {
         // Enqueue on MainActor (InferenceService is MainActor-isolated).
         let enqueueResult: Result<(GenerationRequestToken, GenerationStream), Error> = await MainActor.run { [service, options] in
             do {
+                let messageValues: [Message] = tuples.map { tuple in
+                    switch tuple.role {
+                    case "system": return .system(tuple.content)
+                    case "assistant": return .assistant(tuple.content)
+                    default: return .user(tuple.content)
+                    }
+                }
                 let r = try service.enqueue(
-                    messages: tuples,
+                    messages: messageValues,
                     systemPrompt: systemPrompt,
-                    temperature: options.temperature,
-                    topP: options.topP,
-                    repeatPenalty: options.repeatPenalty,
-                    maxOutputTokens: options.maxOutputTokens,
+                    config: GenerationConfig(
+                        temperature: options.temperature,
+                        topP: options.topP,
+                        repeatPenalty: options.repeatPenalty,
+                        maxOutputTokens: options.maxOutputTokens
+                    ),
                     priority: .normal,
                     sessionID: sessionID
                 )

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -439,6 +439,114 @@ final class GenerationQueue {
 
     // MARK: - Generation Queue
 
+    /// The single value-typed enqueue entry point.
+    ///
+    /// Takes a pre-built ``GenerationConfig`` plus the small non-config triple
+    /// (`priority`, `sessionID`, and the structured `messages`/`systemPrompt`).
+    /// Every parameterized convenience overload funnels here after assembling a
+    /// config, so the capability gates, queue-depth check, token/stream
+    /// construction, and FIFO+priority insertion live in exactly one place.
+    func enqueue(
+        structuredMessages messages: [StructuredMessage],
+        systemPrompt: String? = nil,
+        config: GenerationConfig,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        guard let backend = currentBackend, isBackendLoaded else {
+            throw InferenceError.inferenceFailure("No model loaded")
+        }
+        guard requestQueue.count < maxQueueDepth else {
+            throw InferenceError.inferenceFailure("Generation queue is full")
+        }
+
+        // Capability gate for tool calling. A backend that reports
+        // `supportsToolCalling == false` has no wire path for tool definitions
+        // — they are silently dropped, and the model loops on "I cannot access
+        // tools" while the host's registry never sees the call. Reject the
+        // request up front with a clear error so the failure is diagnosable
+        // at the call site rather than manifesting as a silent no-op.
+        if !config.tools.isEmpty && !backend.capabilities.supportsToolCalling {
+            let backendType = String(describing: type(of: backend))
+            let toolWord = config.tools.count == 1 ? "tool" : "tools"
+            let message = "GenerationQueue: \(config.tools.count) \(toolWord) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
+            Log.inference.warning("\(message, privacy: .public)")
+            Self.toolsUnsupportedWarningHook?(backendType, message)
+            throw InferenceError.inferenceFailure("Tools passed to a backend that does not support tool calling (\(backendType)); set capabilities.supportsToolCalling = true or remove tools from the request.")
+        }
+
+        let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)
+        nextGenerationToken = token
+
+        var continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation!
+        let rawStream = AsyncThrowingStream<GenerationEvent, Error> { continuation = $0 }
+        let stream = GenerationStream(rawStream)
+        stream.setPhase(.queued)
+        continuations[token] = continuation
+
+        Self.warnIfThinkingUnsupported(backend: backend, config: config)
+
+        let request = QueuedRequest(
+            token: token,
+            priority: priority,
+            sessionID: sessionID,
+            messages: messages,
+            systemPrompt: systemPrompt,
+            config: config,
+            stream: stream
+        )
+
+        if let insertIdx = requestQueue.firstIndex(where: { $0.priority < priority }) {
+            requestQueue.insert(request, at: insertIdx)
+        } else {
+            requestQueue.append(request)
+        }
+
+        drainQueue()
+        return (token: token, stream: stream)
+    }
+
+    /// Assembles a ``GenerationConfig`` from the individual sampling parameters
+    /// in the exact shape the parameterized `enqueue` overloads have always
+    /// produced. Centralised so both the tuple and structured builders match
+    /// field-for-field.
+    static func makeEnqueueConfig(
+        temperature: Float,
+        topP: Float,
+        repeatPenalty: Float,
+        topK: Int32?,
+        minP: Float?,
+        presencePenalty: Float?,
+        frequencyPenalty: Float?,
+        seed: UInt64?,
+        maxOutputTokens: Int?,
+        maxThinkingTokens: Int?,
+        jsonMode: Bool,
+        grammar: String?,
+        tools: [ToolDefinition],
+        toolChoice: ToolChoice,
+        maxToolIterations: Int
+    ) -> GenerationConfig {
+        var config = GenerationConfig(
+            temperature: temperature,
+            topP: topP,
+            repeatPenalty: repeatPenalty,
+            topK: topK,
+            minP: minP,
+            presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty,
+            seed: seed,
+            maxOutputTokens: maxOutputTokens,
+            tools: tools,
+            toolChoice: toolChoice,
+            jsonMode: jsonMode,
+            maxToolIterations: maxToolIterations
+        )
+        config.maxThinkingTokens = maxThinkingTokens
+        config.grammar = grammar
+        return config
+    }
+
     func enqueue(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -463,21 +571,23 @@ final class GenerationQueue {
         try enqueue(
             structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
             systemPrompt: systemPrompt,
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            topK: topK,
-            minP: minP,
-            presencePenalty: presencePenalty,
-            frequencyPenalty: frequencyPenalty,
-            seed: seed,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            jsonMode: jsonMode,
-            grammar: grammar,
-            tools: tools,
-            toolChoice: toolChoice,
-            maxToolIterations: maxToolIterations,
+            config: Self.makeEnqueueConfig(
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                topK: topK,
+                minP: minP,
+                presencePenalty: presencePenalty,
+                frequencyPenalty: frequencyPenalty,
+                seed: seed,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                jsonMode: jsonMode,
+                grammar: grammar,
+                tools: tools,
+                toolChoice: toolChoice,
+                maxToolIterations: maxToolIterations
+            ),
             priority: priority,
             sessionID: sessionID
         )
@@ -510,75 +620,29 @@ final class GenerationQueue {
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
-        guard let backend = currentBackend, isBackendLoaded else {
-            throw InferenceError.inferenceFailure("No model loaded")
-        }
-        guard requestQueue.count < maxQueueDepth else {
-            throw InferenceError.inferenceFailure("Generation queue is full")
-        }
-
-        // Capability gate for tool calling. A backend that reports
-        // `supportsToolCalling == false` has no wire path for tool definitions
-        // — they are silently dropped, and the model loops on "I cannot access
-        // tools" while the host's registry never sees the call. Reject the
-        // request up front with a clear error so the failure is diagnosable
-        // at the call site rather than manifesting as a silent no-op.
-        if !tools.isEmpty && !backend.capabilities.supportsToolCalling {
-            let backendType = String(describing: type(of: backend))
-            let toolWord = tools.count == 1 ? "tool" : "tools"
-            let message = "GenerationQueue: \(tools.count) \(toolWord) passed to enqueue() but \(backendType) reports capabilities.supportsToolCalling == false; tools will be ignored on the wire and tool calls will never be dispatched. Check `backend.capabilities.supportsToolCalling` before passing tools, or load a tool-capable backend."
-            Log.inference.warning("\(message, privacy: .public)")
-            Self.toolsUnsupportedWarningHook?(backendType, message)
-            throw InferenceError.inferenceFailure("Tools passed to a backend that does not support tool calling (\(backendType)); set capabilities.supportsToolCalling = true or remove tools from the request.")
-        }
-
-        let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)
-        nextGenerationToken = token
-
-        var continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation!
-        let rawStream = AsyncThrowingStream<GenerationEvent, Error> { continuation = $0 }
-        let stream = GenerationStream(rawStream)
-        stream.setPhase(.queued)
-        continuations[token] = continuation
-
-        var config = GenerationConfig(
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            topK: topK,
-            minP: minP,
-            presencePenalty: presencePenalty,
-            frequencyPenalty: frequencyPenalty,
-            seed: seed,
-            maxOutputTokens: maxOutputTokens,
-            tools: tools,
-            toolChoice: toolChoice,
-            jsonMode: jsonMode,
-            maxToolIterations: maxToolIterations
-        )
-        config.maxThinkingTokens = maxThinkingTokens
-        config.grammar = grammar
-
-        Self.warnIfThinkingUnsupported(backend: backend, config: config)
-
-        let request = QueuedRequest(
-            token: token,
-            priority: priority,
-            sessionID: sessionID,
-            messages: messages,
+        try enqueue(
+            structuredMessages: messages,
             systemPrompt: systemPrompt,
-            config: config,
-            stream: stream
+            config: Self.makeEnqueueConfig(
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                topK: topK,
+                minP: minP,
+                presencePenalty: presencePenalty,
+                frequencyPenalty: frequencyPenalty,
+                seed: seed,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                jsonMode: jsonMode,
+                grammar: grammar,
+                tools: tools,
+                toolChoice: toolChoice,
+                maxToolIterations: maxToolIterations
+            ),
+            priority: priority,
+            sessionID: sessionID
         )
-
-        if let insertIdx = requestQueue.firstIndex(where: { $0.priority < priority }) {
-            requestQueue.insert(request, at: insertIdx)
-        } else {
-            requestQueue.append(request)
-        }
-
-        drainQueue()
-        return (token: token, stream: stream)
     }
 
     /// Processes the next queued request if no generation is active.

--- a/Sources/ManifoldInference/Services/InferenceService+Nonisolated.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+Nonisolated.swift
@@ -73,16 +73,23 @@ extension InferenceService {
             try self.enqueue(
                 structuredMessages: messages,
                 systemPrompt: systemPrompt,
-                temperature: temperature,
-                topP: topP,
-                repeatPenalty: repeatPenalty,
-                maxOutputTokens: maxOutputTokens,
-                maxThinkingTokens: maxThinkingTokens,
-                jsonMode: jsonMode,
-                grammar: grammar,
-                tools: tools,
-                toolChoice: toolChoice,
-                maxToolIterations: maxToolIterations,
+                config: GenerationQueue.makeEnqueueConfig(
+                    temperature: temperature,
+                    topP: topP,
+                    repeatPenalty: repeatPenalty,
+                    topK: nil,
+                    minP: nil,
+                    presencePenalty: nil,
+                    frequencyPenalty: nil,
+                    seed: nil,
+                    maxOutputTokens: maxOutputTokens,
+                    maxThinkingTokens: maxThinkingTokens,
+                    jsonMode: jsonMode,
+                    grammar: grammar,
+                    tools: tools,
+                    toolChoice: toolChoice,
+                    maxToolIterations: maxToolIterations
+                ),
                 priority: priority,
                 sessionID: sessionID
             )

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -378,16 +378,67 @@ public final class InferenceService {
 
     // MARK: - Generation Queue
 
-    /// Enqueues a generation request from a typed ``Message`` slice and
-    /// returns a token + stream pair.
+    /// Enqueues a generation request from a typed ``Message`` slice using a
+    /// pre-built ``GenerationConfig``, returning a token + stream pair.
+    ///
+    /// This is the value-typed entry point. Every sampling knob now lives on
+    /// ``GenerationConfig`` rather than being spread across a ~18-parameter
+    /// argument list, so adding a new knob is a one-line change on the config
+    /// type instead of a thread-through across every enqueue signature. The
+    /// parameterized overloads below remain as deprecated source-compatible
+    /// builders that assemble a config and forward here.
     ///
     /// The stream starts in `.queued` phase and transitions to `.connecting`
     /// when the request reaches the front of the queue.
     ///
-    /// Prefer this overload over the tuple-shaped `enqueue(messages: [(role:content:)])`
-    /// — `Message.system(_:)` / `.user(_:)` / `.assistant(_:)` cannot be
-    /// misspelled, while raw `"systme"` typos in the tuple variant pass
-    /// the type checker and surface as silent backend errors.
+    /// Prefer ``Message`` literals over raw role/content tuples —
+    /// `Message.system(_:)` / `.user(_:)` / `.assistant(_:)` cannot be
+    /// misspelled, while raw `"systme"` typos pass the type checker and
+    /// surface as silent backend errors.
+    public func enqueue(
+        messages: [Message],
+        systemPrompt: String? = nil,
+        config: GenerationConfig,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        ensureProviderWired()
+        return try generation.enqueue(
+            structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
+            systemPrompt: systemPrompt,
+            config: config,
+            priority: priority,
+            sessionID: sessionID
+        )
+    }
+
+    /// Structured-message variant of ``enqueue(messages:config:priority:sessionID:)``.
+    ///
+    /// Threads ``StructuredMessage`` through the queue so cloud backends
+    /// with structured wire formats (Anthropic) can replay prior assistant
+    /// turns including their thinking blocks and signatures verbatim.
+    public func enqueue(
+        structuredMessages messages: [StructuredMessage],
+        systemPrompt: String? = nil,
+        config: GenerationConfig,
+        priority: GenerationPriority = .normal,
+        sessionID: UUID? = nil
+    ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
+        ensureProviderWired()
+        return try generation.enqueue(
+            structuredMessages: messages,
+            systemPrompt: systemPrompt,
+            config: config,
+            priority: priority,
+            sessionID: sessionID
+        )
+    }
+
+    /// Parameterized enqueue retained as a source-compatible builder.
+    ///
+    /// Assembles a ``GenerationConfig`` from the individual sampling
+    /// parameters and forwards to ``enqueue(messages:config:priority:sessionID:)``.
+    @available(*, deprecated, message: "Build a GenerationConfig and call enqueue(messages:config:priority:sessionID:).")
     public func enqueue(
         messages: [Message],
         systemPrompt: String? = nil,
@@ -409,33 +460,34 @@ public final class InferenceService {
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
-        ensureProviderWired()
-        return try generation.enqueue(
-            messages: messages.asRoleContentTuples,
+        try enqueue(
+            messages: messages,
             systemPrompt: systemPrompt,
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            topK: topK,
-            minP: minP,
-            presencePenalty: presencePenalty,
-            frequencyPenalty: frequencyPenalty,
-            seed: seed,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            jsonMode: jsonMode,
-            grammar: grammar,
-            tools: tools,
-            toolChoice: toolChoice,
-            maxToolIterations: maxToolIterations,
+            config: GenerationQueue.makeEnqueueConfig(
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                topK: topK,
+                minP: minP,
+                presencePenalty: presencePenalty,
+                frequencyPenalty: frequencyPenalty,
+                seed: seed,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                jsonMode: jsonMode,
+                grammar: grammar,
+                tools: tools,
+                toolChoice: toolChoice,
+                maxToolIterations: maxToolIterations
+            ),
             priority: priority,
             sessionID: sessionID
         )
     }
 
     /// Tuple-shaped enqueue retained for one minor while consumers migrate
-    /// to the typed ``enqueue(messages:[Message],...)`` overload.
-    @available(*, deprecated, message: "Use [Message] with .system/.user/.assistant — raw role strings are typo-prone.")
+    /// to the typed ``enqueue(messages:config:priority:sessionID:)`` overload.
+    @available(*, deprecated, message: "Use [Message] with .system/.user/.assistant and a GenerationConfig — raw role strings are typo-prone.")
     public func enqueue(
         messages: [(role: String, content: String)],
         systemPrompt: String? = nil,
@@ -454,28 +506,32 @@ public final class InferenceService {
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         ensureProviderWired()
         return try generation.enqueue(
-            messages: messages,
+            structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
             systemPrompt: systemPrompt,
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            jsonMode: jsonMode,
-            grammar: grammar,
-            tools: tools,
-            toolChoice: toolChoice,
-            maxToolIterations: maxToolIterations,
+            config: GenerationQueue.makeEnqueueConfig(
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                topK: nil,
+                minP: nil,
+                presencePenalty: nil,
+                frequencyPenalty: nil,
+                seed: nil,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                jsonMode: jsonMode,
+                grammar: grammar,
+                tools: tools,
+                toolChoice: toolChoice,
+                maxToolIterations: maxToolIterations
+            ),
             priority: priority,
             sessionID: sessionID
         )
     }
 
-    /// Structured-message variant of ``enqueue(messages:...)``.
-    ///
-    /// Threads ``StructuredMessage`` through the queue so cloud backends
-    /// with structured wire formats (Anthropic) can replay prior assistant
-    /// turns including their thinking blocks and signatures verbatim.
+    /// Parameterized structured-message enqueue retained as a source-compatible builder.
+    @available(*, deprecated, message: "Build a GenerationConfig and call enqueue(structuredMessages:config:priority:sessionID:).")
     public func enqueue(
         structuredMessages messages: [StructuredMessage],
         systemPrompt: String? = nil,
@@ -497,25 +553,26 @@ public final class InferenceService {
         priority: GenerationPriority = .normal,
         sessionID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
-        ensureProviderWired()
-        return try generation.enqueue(
+        try enqueue(
             structuredMessages: messages,
             systemPrompt: systemPrompt,
-            temperature: temperature,
-            topP: topP,
-            repeatPenalty: repeatPenalty,
-            topK: topK,
-            minP: minP,
-            presencePenalty: presencePenalty,
-            frequencyPenalty: frequencyPenalty,
-            seed: seed,
-            maxOutputTokens: maxOutputTokens,
-            maxThinkingTokens: maxThinkingTokens,
-            jsonMode: jsonMode,
-            grammar: grammar,
-            tools: tools,
-            toolChoice: toolChoice,
-            maxToolIterations: maxToolIterations,
+            config: GenerationQueue.makeEnqueueConfig(
+                temperature: temperature,
+                topP: topP,
+                repeatPenalty: repeatPenalty,
+                topK: topK,
+                minP: minP,
+                presencePenalty: presencePenalty,
+                frequencyPenalty: frequencyPenalty,
+                seed: seed,
+                maxOutputTokens: maxOutputTokens,
+                maxThinkingTokens: maxThinkingTokens,
+                jsonMode: jsonMode,
+                grammar: grammar,
+                tools: tools,
+                toolChoice: toolChoice,
+                maxToolIterations: maxToolIterations
+            ),
             priority: priority,
             sessionID: sessionID
         )

--- a/Sources/ManifoldRuntime/Services/SessionListService.swift
+++ b/Sources/ManifoldRuntime/Services/SessionListService.swift
@@ -383,9 +383,7 @@ package final class SessionListService: Sendable {
         let (_, stream) = try inferenceService.enqueue(
             messages: messages,
             systemPrompt: systemPrompt,
-            temperature: 0.3,
-            topP: 0.9,
-            repeatPenalty: 1.0,
+            config: GenerationConfig(temperature: 0.3, topP: 0.9, repeatPenalty: 1.0),
             priority: .background,
             sessionID: nil
         )

--- a/Tests/ManifoldInferenceTests/MessageEnqueueTests.swift
+++ b/Tests/ManifoldInferenceTests/MessageEnqueueTests.swift
@@ -22,6 +22,7 @@ final class MessageEnqueueTests: XCTestCase {
         )
         var lastPrompt: String?
         var lastSystemPrompt: String?
+        var lastConfig: GenerationConfig?
 
         func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
             isModelLoaded = true
@@ -30,6 +31,7 @@ final class MessageEnqueueTests: XCTestCase {
         func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
             lastPrompt = prompt
             lastSystemPrompt = systemPrompt
+            lastConfig = config
             return GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
                 continuation.yield(.token("ok"))
                 continuation.finish()
@@ -112,6 +114,92 @@ final class MessageEnqueueTests: XCTestCase {
             ("assistant", "hello"),
             ("user", "how are you?")
         ])
+    }
+
+    // MARK: - Value-typed config entry point
+
+    /// Canonical exercise of the value-typed
+    /// ``InferenceService/enqueue(messages:config:priority:sessionID:)`` entry
+    /// point introduced when the ~18-parameter sampling list was collapsed onto
+    /// ``GenerationConfig``. Pins that a caller-built config reaches the backend
+    /// verbatim, with every field preserved.
+    func test_enqueue_valueTypedConfig_reachesBackendVerbatim() async throws {
+        let backend = CapturingBackend()
+        let service = InferenceService(backend: backend, name: "Capture")
+
+        var config = GenerationConfig(
+            temperature: 0.42,
+            topP: 0.81,
+            repeatPenalty: 1.23,
+            topK: 7,
+            seed: 99,
+            maxOutputTokens: 333
+        )
+        config.maxThinkingTokens = 64
+
+        let (_, stream) = try service.enqueue(
+            messages: [.user("hello")],
+            config: config,
+            priority: .normal,
+            sessionID: nil
+        )
+        for try await _ in stream.events {}
+
+        let received = try XCTUnwrap(backend.lastConfig)
+        XCTAssertEqual(received.temperature, 0.42)
+        XCTAssertEqual(received.topP, 0.81)
+        XCTAssertEqual(received.repeatPenalty, 1.23)
+        XCTAssertEqual(received.topK, 7)
+        XCTAssertEqual(received.seed, 99)
+        XCTAssertEqual(received.maxOutputTokens, 333)
+        XCTAssertEqual(received.maxThinkingTokens, 64)
+    }
+
+    /// The deprecated parameterized builder must produce the same config the
+    /// new value-typed path would — proves the shim is a pure forwarder.
+    @available(*, deprecated)
+    func test_parameterizedBuilder_matchesValueTypedConfig() async throws {
+        let paramBackend = CapturingBackend()
+        let paramService = InferenceService(backend: paramBackend, name: "Param")
+        let (_, paramStream) = try paramService.enqueue(
+            messages: [.user("hello")],
+            temperature: 0.42,
+            topP: 0.81,
+            repeatPenalty: 1.23,
+            topK: 7,
+            seed: 99,
+            maxOutputTokens: 333,
+            maxThinkingTokens: 64
+        )
+        for try await _ in paramStream.events {}
+
+        let configBackend = CapturingBackend()
+        let configService = InferenceService(backend: configBackend, name: "Config")
+        var config = GenerationConfig(
+            temperature: 0.42,
+            topP: 0.81,
+            repeatPenalty: 1.23,
+            topK: 7,
+            seed: 99,
+            maxOutputTokens: 333
+        )
+        config.maxThinkingTokens = 64
+        let (_, configStream) = try configService.enqueue(
+            messages: [.user("hello")],
+            config: config
+        )
+        for try await _ in configStream.events {}
+
+        let viaParams = try XCTUnwrap(paramBackend.lastConfig)
+        let viaConfig = try XCTUnwrap(configBackend.lastConfig)
+        XCTAssertEqual(viaParams.temperature, viaConfig.temperature)
+        XCTAssertEqual(viaParams.topP, viaConfig.topP)
+        XCTAssertEqual(viaParams.repeatPenalty, viaConfig.repeatPenalty)
+        XCTAssertEqual(viaParams.topK, viaConfig.topK)
+        XCTAssertEqual(viaParams.seed, viaConfig.seed)
+        XCTAssertEqual(viaParams.maxOutputTokens, viaConfig.maxOutputTokens)
+        XCTAssertEqual(viaParams.maxThinkingTokens, viaConfig.maxThinkingTokens)
+        XCTAssertEqual(viaParams.maxToolIterations, viaConfig.maxToolIterations)
     }
 
     // MARK: - Message conformance / role mapping


### PR DESCRIPTION
## Problem

The ~18-parameter generation sampling list was re-declared and forwarded verbatim across **~8 signatures** in two files:

- `InferenceService.swift` — four entry points (`enqueue(messages:[Message])`, the tuple `enqueue`, `enqueue(structuredMessages:)`, plus the `generate` overloads) each re-declaring the full sampling list.
- `GenerationQueue.swift` — the same list re-declared again on `enqueue` / `enqueue(structuredMessages:)`.

Every new `GenerationConfig` knob had to be threaded through all of them. This was the biggest maintenance hazard in the core.

## Change

Introduce a single value-typed entry point on the queue:

```swift
func enqueue(
    structuredMessages messages: [StructuredMessage],
    systemPrompt: String? = nil,
    config: GenerationConfig,
    priority: GenerationPriority = .normal,
    sessionID: UUID? = nil
) throws -> (token: GenerationRequestToken, stream: GenerationStream)
```

with matching public overloads on `InferenceService`:

```swift
public func enqueue(messages: [Message], systemPrompt: String? = nil, config: GenerationConfig, priority: GenerationPriority = .normal, sessionID: UUID? = nil) throws -> ...
public func enqueue(structuredMessages: [StructuredMessage], systemPrompt: String? = nil, config: GenerationConfig, priority: GenerationPriority = .normal, sessionID: UUID? = nil) throws -> ...
```

The capability gates (tool-calling rejection, thinking-unsupported warning), queue-depth check, token/stream construction, and FIFO+priority insertion now live in **exactly one** implementation. A shared `GenerationQueue.makeEnqueueConfig(...)` assembles the config in the exact shape the old parameterized path produced (same defaults, `maxThinkingTokens`/`grammar` post-set).

## Compatibility

No public method removed. Every parameterized entry point remains as a `@available(*, deprecated)` source-compatible builder that assembles a `GenerationConfig` and forwards to the value-typed path:

- `enqueue(messages:[Message], temperature:...)` — deprecated builder
- `enqueue(messages:[(role:content:)], ...)` — deprecated tuple builder (kept its existing deprecation rationale)
- `enqueue(structuredMessages:, temperature:...)` — deprecated builder

Old call sites still compile (with a deprecation warning). Behavior is preserved field-for-field: same defaults, same capability/thinking warnings, same event emission and ordering.

Internal (non-test) callers migrated to the value-typed path: `InferenceService+Nonisolated.enqueueAsync`, `SessionListService.generateTitle`, and `ManifoldFuzz/SessionScriptRunner`.

## Tests

- Added two canonical tests in `MessageEnqueueTests`: one exercising the new value-typed `enqueue(messages:config:)` (config reaches the backend verbatim), one proving the deprecated parameterized builder produces an identical config.
- `swift test --disable-default-traits --filter ManifoldInferenceTests` → **1646 passed, 0 failures, 5 skipped**.
- `swift test --disable-default-traits --filter ManifoldInferenceSwiftTestingTests` (separate process) → **83 passed, 0 failures**.
- Existing tests passing unchanged is the proof of behavior preservation; none were loosened.

## All-traits build sweep

`swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace` → **Build complete**, no errors. (Only pre-existing `OllamaBackend.init(urlSession:)` deprecation warnings, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)