### PR TITLE
fix(persistence): persist ChatSessionRecord.agents on the write path

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -63,6 +63,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         session.activeAgentID = record.activeAgentID
         session.activeSkillName = record.activeSkillName
         modelContext.insert(session)
+        reconcileAgents(on: session, with: record.agents)
         try modelContext.save()
         await fireSessionHooks(record)
     }
@@ -87,8 +88,53 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         session.pinnedSortKey = record.pinnedAt ?? .distantPast
         session.activeAgentID = record.activeAgentID
         session.activeSkillName = record.activeSkillName
+        reconcileAgents(on: session, with: record.agents)
         try modelContext.save()
         await fireSessionHooks(record)
+    }
+
+    /// Reconciles the session's owned `Agent` `@Model` rows against the
+    /// storage-agnostic `agents` carried on the record, so a write→read
+    /// round-trip is lossless (#1495). Diffs by `Agent.id`:
+    ///   - rows whose id is absent from the record are deleted (cascade-owned,
+    ///     so removal is safe);
+    ///   - rows present in both are updated in place (mutating the live row
+    ///     rather than replacing it preserves SwiftData object identity and
+    ///     avoids churning the `@Relationship` set);
+    ///   - record agents with no matching row are inserted and appended.
+    ///
+    /// `activeAgentID` is written separately on the parent row (and via
+    /// ``setActiveAgent(sessionID:agentID:)``), so handoff state is untouched
+    /// here — this only owns the agent registry membership.
+    private func reconcileAgents(on session: ChatSession, with agents: [ManifoldInference.Agent]) {
+        let desiredByID = Dictionary(agents.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
+        var existingByID: [UUID: Agent] = [:]
+
+        // Remove rows no longer present in the record. Iterate a snapshot so we
+        // can mutate `session.agents` while walking it.
+        for row in session.agents {
+            if let desired = desiredByID[row.id] {
+                row.name = desired.name
+                row.systemPrompt = desired.systemPrompt
+                row.descriptionText = desired.description
+                row.allowedToolNames = desired.allowedToolNames
+                existingByID[row.id] = row
+            } else {
+                modelContext.delete(row)
+            }
+        }
+
+        // Insert rows for agents the session does not yet have.
+        for agent in agents where existingByID[agent.id] == nil {
+            let row = Agent(
+                id: agent.id,
+                name: agent.name,
+                systemPrompt: agent.systemPrompt,
+                descriptionText: agent.description,
+                allowedToolNames: agent.allowedToolNames
+            )
+            session.agents.append(row)
+        }
     }
 
     /// Narrow in-place write of `updatedAt` only — mutates the live `@Model`

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession+Record.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession+Record.swift
@@ -13,6 +13,11 @@ extension ChatSession {
         // ManifoldInference.Agent value type so consumers downstream of
         // ChatSessionRecord (HandoffToolSource, ConversationTurnExecutor)
         // don't need to import the persistence module.
+        //
+        // The inverse — persisting `agents` back into Agent rows — lives in
+        // SwiftDataPersistenceProvider.reconcileAgents(on:with:), invoked from
+        // insertSession/updateSession so this read mapping has a lossless write
+        // counterpart (#1495).
         let agentRecords: [ManifoldInference.Agent] = agents.map { row in
             ManifoldInference.Agent(
                 id: row.id,

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataAgentRoundTripTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataAgentRoundTripTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import SwiftData
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldTestSupport
+
+/// Integration tests for the multi-agent write path (#1495): the
+/// `ChatSessionRecord.agents` registry must survive an insert→fetch and an
+/// update→fetch round-trip losslessly, and `activeAgentID` must still resolve
+/// against a fetched agent afterwards.
+///
+/// Classified integration (not unit) per CLAUDE.md: drives a real in-memory
+/// SwiftData `ModelContainer` via ``InMemoryPersistenceHarness`` — no mocks.
+@MainActor
+final class SwiftDataAgentRoundTripTests: XCTestCase {
+
+    private var stack: InMemoryPersistenceHarness.Stack!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        stack = try InMemoryPersistenceHarness.make()
+    }
+
+    override func tearDown() async throws {
+        stack = nil
+        try await super.tearDown()
+    }
+
+    private var provider: SwiftDataPersistenceProvider { stack.provider }
+
+    private func makeAgent(
+        id: UUID = UUID(),
+        name: String,
+        prompt: String,
+        description: String = "",
+        tools: [String]? = nil
+    ) -> ManifoldInference.Agent {
+        ManifoldInference.Agent(
+            id: id,
+            name: name,
+            systemPrompt: prompt,
+            description: description,
+            allowedToolNames: tools
+        )
+    }
+
+    // MARK: - Insert
+
+    func test_insertSession_persistsAgents() async throws {
+        let researcher = makeAgent(name: "Researcher", prompt: "find facts", description: "research role", tools: ["search"])
+        let writer = makeAgent(name: "Writer", prompt: "compose prose")
+        let record = ChatSessionRecord(
+            title: "Multi-agent",
+            agents: [researcher, writer],
+            activeAgentID: researcher.id
+        )
+
+        try await provider.insertSession(record)
+
+        let sessions = try await provider.fetchSessions()
+        let fetched = try XCTUnwrap(sessions.first)
+        XCTAssertEqual(Set(fetched.agents.map(\.id)), [researcher.id, writer.id])
+        let fetchedResearcher = try XCTUnwrap(fetched.agents.first { $0.id == researcher.id })
+        XCTAssertEqual(fetchedResearcher.name, "Researcher")
+        XCTAssertEqual(fetchedResearcher.systemPrompt, "find facts")
+        XCTAssertEqual(fetchedResearcher.description, "research role")
+        XCTAssertEqual(fetchedResearcher.allowedToolNames, ["search"])
+
+        // activeAgentID must still resolve to a fetched agent.
+        XCTAssertEqual(fetched.activeAgentID, researcher.id)
+        XCTAssertTrue(fetched.agents.contains { $0.id == fetched.activeAgentID })
+    }
+
+    // MARK: - Update (add / modify / remove)
+
+    func test_updateSession_reconcilesAgents_add_modify_remove() async throws {
+        let keep = makeAgent(name: "Keep", prompt: "v1", tools: ["a"])
+        let drop = makeAgent(name: "Drop", prompt: "remove me")
+        var record = ChatSessionRecord(
+            title: "Reconcile",
+            agents: [keep, drop],
+            activeAgentID: keep.id
+        )
+        try await provider.insertSession(record)
+
+        // Mutate the registry: modify `keep`, remove `drop`, add `added`.
+        let modifiedKeep = makeAgent(id: keep.id, name: "Keep v2", prompt: "v2", description: "edited", tools: ["a", "b"])
+        let added = makeAgent(name: "Added", prompt: "new agent")
+        record.agents = [modifiedKeep, added]
+        record.activeAgentID = added.id
+        try await provider.updateSession(record)
+
+        let sessions = try await provider.fetchSessions()
+        let fetched = try XCTUnwrap(sessions.first)
+        XCTAssertEqual(Set(fetched.agents.map(\.id)), [keep.id, added.id], "drop must be deleted, added must be inserted")
+
+        let fetchedKeep = try XCTUnwrap(fetched.agents.first { $0.id == keep.id })
+        XCTAssertEqual(fetchedKeep.name, "Keep v2", "modified fields must round-trip")
+        XCTAssertEqual(fetchedKeep.systemPrompt, "v2")
+        XCTAssertEqual(fetchedKeep.description, "edited")
+        XCTAssertEqual(fetchedKeep.allowedToolNames, ["a", "b"])
+
+        // Handoff still resolves after the round-trip.
+        XCTAssertEqual(fetched.activeAgentID, added.id)
+        XCTAssertTrue(fetched.agents.contains { $0.id == fetched.activeAgentID })
+    }
+
+    func test_updateSession_clearingAgents_removesAllRows() async throws {
+        let a = makeAgent(name: "A", prompt: "a")
+        let b = makeAgent(name: "B", prompt: "b")
+        var record = ChatSessionRecord(title: "Clearable", agents: [a, b])
+        try await provider.insertSession(record)
+
+        record.agents = []
+        try await provider.updateSession(record)
+
+        let sessions = try await provider.fetchSessions()
+        let fetched = try XCTUnwrap(sessions.first)
+        XCTAssertTrue(fetched.agents.isEmpty, "emptying the registry must delete every owned Agent row")
+    }
+}


### PR DESCRIPTION
## Problem

`SwiftDataPersistenceProvider.insertSession`/`updateSession` copied every record field **except** `agents`, and there was no agent-write API anywhere. Net effect: multi-agent sessions could only be created by writing SwiftData `Agent` `@Model` rows directly (bypassing the port), and any `updateSession(record)` round-trip silently dropped the `agents` array. Handoff worked only because `activeAgentID` *is* persisted — an asymmetric footgun (#1495).

## Approach: (A) persist `agents` in insert/update

I chose **A** (reconcile `Agent` rows in the write path) over **B** (a separate `AgentStore` port), because:

- `agents` is already a **cascade-owned** `@Relationship` on `ChatSession` — agents have no independent lifecycle, so a separate CRUD port would be an asymmetric abstraction over an owned child collection.
- The read path (`ChatSession+Record.swift`) already **projects `agents` out** of the session; the natural symmetric fix is to make the write path lossless too.
- **No new protocol surface, no breaking change** — purely an adapter-internal fix.

`reconcileAgents(on:with:)` diffs by `Agent.id`: inserts new agents, updates changed ones **in place** (preserving SwiftData object identity rather than churning the relationship set), and deletes removed ones. `activeAgentID` is still written separately on the parent row and via `setActiveAgent(...)`, so handoff state is untouched and #1506's `setActiveAgent` is not conflicted.

## Files changed

- `Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift` — `reconcileAgents` helper + call sites in `insertSession`/`updateSession`
- `Sources/ManifoldPersistenceSwiftData/Schema/ChatSession+Record.swift` — doc cross-reference to the write counterpart
- `Tests/ManifoldPersistenceSwiftDataTests/SwiftDataAgentRoundTripTests.swift` — new integration tests (real in-memory SwiftData)

## Tests

Real in-memory SwiftData round-trips (no mocks):
- `test_insertSession_persistsAgents` — insert→fetch preserves all agent fields; `activeAgentID` resolves to a fetched agent.
- `test_updateSession_reconcilesAgents_add_modify_remove` — add/modify/remove in one update→fetch; modified fields round-trip; handoff still resolves.
- `test_updateSession_clearingAgents_removesAllRows` — emptying the registry deletes every owned row.

Spike gate `ManifoldPersistenceSwiftDataTests`: **202 passed, 0 failed, 6 skipped** (env-gated). `swift build --build-tests --disable-default-traits` succeeds.

## Stacking

Stacked on **#1506** (`fix/1494-turn-path-concurrency`) because both touch the persistence adapter. **Base is `fix/1494-turn-path-concurrency`, not `main`** — rebase onto `main` after #1506 merges.

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)