### PR TITLE
fix(ui): give MessagePartsView stable per-part identity during streaming

### DIFF
--- a/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
@@ -49,9 +49,68 @@ struct MessagePartsView: View {
     }
 
     var body: some View {
-        ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
-            partView(for: part)
+        // Identity must survive non-terminal insertions. The streaming
+        // coordinator inserts `.thinking` *before* the first text part
+        // (ChatGenerationCoordinator's `.thinkingStarted` handler), so an
+        // offset-based id would renumber every following part on insert,
+        // tearing down `AssistantMarkdownView`/`ToolInvocationView` state
+        // instead of moving the views. `keyedParts` derives a stable id from
+        // each part's kind + ordinal-within-kind (tools use their call id), so
+        // inserting a thinking block ahead of text leaves the text parts'
+        // identities untouched.
+        ForEach(Self.keyedParts(parts), id: \.key) { keyed in
+            partView(for: keyed.part)
         }
+    }
+
+    /// A `MessagePart` paired with a stable identity for `ForEach`.
+    struct KeyedPart: Identifiable {
+        let key: String
+        let part: MessagePart
+        var id: String { key }
+    }
+
+    /// Derives a stable, unique-within-message key for each part.
+    ///
+    /// - Tool calls/results key on their `ToolCall.id` / `ToolResult.callId`,
+    ///   which are stable across the streaming lifecycle (the call id is
+    ///   minted once and the result references it).
+    /// - All other parts key on `"<kind>-<ordinal>"` where the ordinal counts
+    ///   only occurrences of that same kind. Counting per-kind (rather than
+    ///   across all parts) is what makes the scheme insertion-stable: inserting
+    ///   a `.thinking` part ahead of existing `.text` parts does not change any
+    ///   text part's ordinal, so `"text-0"` keeps pointing at the same view.
+    ///
+    /// Tool ids are prefixed (`tool:`) so they can never collide with a
+    /// synthesized `"toolCall-<n>"`/`"toolResult-<n>"` fallback key.
+    static func keyedParts(_ parts: [MessagePart]) -> [KeyedPart] {
+        var ordinals: [String: Int] = [:]
+        return parts.map { part in
+            let key: String
+            switch part {
+            case .toolCall(let call):
+                key = "tool:call:\(call.id)"
+            case .toolResult(let result):
+                key = "tool:result:\(result.callId)"
+            case .text:
+                key = nextKey(for: "text", in: &ordinals)
+            case .thinking:
+                key = nextKey(for: "thinking", in: &ordinals)
+            case .image:
+                key = nextKey(for: "image", in: &ordinals)
+            case .audio:
+                key = nextKey(for: "audio", in: &ordinals)
+            case .generatedImage:
+                key = nextKey(for: "generatedImage", in: &ordinals)
+            }
+            return KeyedPart(key: key, part: part)
+        }
+    }
+
+    private static func nextKey(for kind: String, in ordinals: inout [String: Int]) -> String {
+        let ordinal = ordinals[kind, default: 0]
+        ordinals[kind] = ordinal + 1
+        return "\(kind)-\(ordinal)"
     }
 
     @ViewBuilder

--- a/Tests/ManifoldUITests/MessagePartsKeyTests.swift
+++ b/Tests/ManifoldUITests/MessagePartsKeyTests.swift
@@ -1,0 +1,96 @@
+@preconcurrency import XCTest
+@testable import ManifoldUI
+@testable import ManifoldInference
+
+/// Verifies `MessagePartsView.keyedParts` produces stable, unique per-part
+/// identities for `ForEach`.
+///
+/// Regression target: #1496. The view previously keyed `ForEach` on the array
+/// offset. Because the streaming coordinator inserts `.thinking` *before* the
+/// first text part, an offset key renumbered every following part's identity on
+/// insert — tearing down and rebuilding `AssistantMarkdownView` /
+/// `ToolInvocationView` instead of moving them. The kind+ordinal scheme keeps
+/// the existing parts' keys fixed across that insertion.
+@MainActor
+final class MessagePartsKeyTests: XCTestCase {
+
+    private func call(_ id: String) -> MessagePart {
+        .toolCall(ToolCall(id: id, toolName: "search", arguments: "{}"))
+    }
+
+    private func result(_ callId: String) -> MessagePart {
+        .toolResult(ToolResult(callId: callId, content: "ok"))
+    }
+
+    // MARK: - Uniqueness
+
+    func test_keys_areUnique_acrossMixedParts() {
+        let parts: [MessagePart] = [
+            .thinking("reasoning"),
+            .text("first"),
+            .text("second"),
+            call("c1"),
+            result("c1"),
+            .text("third"),
+        ]
+
+        let keys = MessagePartsView.keyedParts(parts).map(\.key)
+
+        XCTAssertEqual(keys.count, parts.count)
+        XCTAssertEqual(Set(keys).count, keys.count, "Every part must get a distinct key")
+    }
+
+    func test_twoTextParts_getDistinctKeys() {
+        let parts: [MessagePart] = [.text("a"), .text("b")]
+        let keys = MessagePartsView.keyedParts(parts).map(\.key)
+        XCTAssertEqual(keys, ["text-0", "text-1"])
+    }
+
+    func test_toolParts_keyOnCallID() {
+        let parts: [MessagePart] = [call("abc"), result("abc")]
+        let keys = MessagePartsView.keyedParts(parts).map(\.key)
+        XCTAssertEqual(keys, ["tool:call:abc", "tool:result:abc"])
+    }
+
+    // MARK: - The #1496 regression: non-terminal thinking insert
+
+    func test_insertingThinkingAheadOfText_preservesTextKeys() {
+        // Mirrors the coordinator's `.thinkingStarted` mutation: a `.thinking`
+        // part is inserted before the first text part mid-stream.
+        let before: [MessagePart] = [
+            .text("hello"),
+            .text("world"),
+        ]
+        let after: [MessagePart] = [
+            .thinking(""),       // inserted ahead of the text parts
+            .text("hello"),
+            .text("world"),
+        ]
+
+        let beforeKeys = Dictionary(
+            uniqueKeysWithValues: MessagePartsView.keyedParts(before).enumerated().map { ($0.offset, $0.element.key) }
+        )
+        let afterKeyed = MessagePartsView.keyedParts(after)
+
+        // The two text parts keep "text-0"/"text-1" — the thinking insert does
+        // NOT renumber them (the bug an offset key would introduce).
+        XCTAssertEqual(beforeKeys[0], "text-0")
+        XCTAssertEqual(beforeKeys[1], "text-1")
+
+        XCTAssertEqual(afterKeyed[0].key, "thinking-0")
+        XCTAssertEqual(afterKeyed[1].key, "text-0", "First text part keeps its identity after a non-terminal thinking insert")
+        XCTAssertEqual(afterKeyed[2].key, "text-1", "Second text part keeps its identity after a non-terminal thinking insert")
+    }
+
+    func test_toolKeysStable_whenThinkingInsertedAhead() {
+        let before: [MessagePart] = [call("c1"), result("c1")]
+        let after: [MessagePart] = [.thinking("x"), call("c1"), result("c1")]
+
+        let beforeKeys = MessagePartsView.keyedParts(before).map(\.key)
+        let afterKeys = MessagePartsView.keyedParts(after).map(\.key)
+
+        XCTAssertEqual(beforeKeys, ["tool:call:c1", "tool:result:c1"])
+        // Tool keys are id-derived, so they are untouched regardless of position.
+        XCTAssertEqual(Array(afterKeys.dropFirst()), beforeKeys)
+    }
+}


### PR DESCRIPTION
## Problem

`MessagePartsView` keyed its `ForEach` on the array offset:

```swift
ForEach(Array(parts.enumerated()), id: \.offset) { _, part in
```

The streaming coordinator inserts a `.thinking` part at a **non-terminal** position mid-stream — `ChatGenerationCoordinator`'s `.thinkingStarted` handler inserts `.thinking("")` *before* the first text part. With offset-based identity, that insert shifts every following part's SwiftUI identity (text moves `0 → 1`, etc.), so SwiftUI tears down and rebuilds the views — losing `AssistantMarkdownView`'s `@State blocks` and `ToolInvocationView`'s disclosure state — instead of moving them. This silently degrades streaming render correctness for messages mixing thinking + text + tools.

## Fix

Derive a stable, unique-within-message key per part (`MessagePartsView.keyedParts`):

- **Tool calls/results** key on their stable `ToolCall.id` / `ToolResult.callId` (`tool:call:<id>` / `tool:result:<callId>`).
- **All other parts** (text, thinking, image, audio, generatedImage) key on `<kind>-<ordinal>` where the ordinal counts only occurrences of that *same kind*.

Per-kind counting is what makes the scheme insertion-stable: inserting a `.thinking` block ahead of existing text parts leaves the text parts at `text-0`/`text-1`, so their view identity is preserved. Tool ids are prefixed (`tool:`) so they can't collide with a synthesized fallback key.

Streaming behavior is unchanged — only the identity `ForEach` uses.

## Tests

Added `Tests/ManifoldUITests/MessagePartsKeyTests.swift` (5 tests over the pure `keyedParts` function):
- keys are unique across a mixed thinking/text/tool parts array
- two text parts get distinct keys (`text-0`, `text-1`)
- tool parts key on call id
- **regression**: inserting `.thinking` ahead of existing text parts does NOT change the text parts' keys
- tool keys stay stable when a thinking part is inserted ahead

## Test results

- `swift build --build-tests --disable-default-traits` — succeeds
- `scripts/test.sh --profile spike --spike-module ManifoldUITests --filter MessagePartsKeyTests` — 5 passed, 0 failed
- `ViewSnapshotTests/test_messageParts*` — passes (rendered output unchanged)

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)