### PR TITLE
fix(cloud): consolidate error-body drain in CloudCore, fix UTF-8 corruption, lock isThinkingModel

### DIFF
--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -484,38 +484,12 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
                 .flatMap { TimeInterval($0) }
             throw CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: retryAfter)
         default:
-            let errorBody = await Self.readErrorBody(from: bytes)
-            Log.network.debug("Claude upstream error body: \(errorBody, privacy: .private)")
-            let host = self.baseURL?.host()
-            let sanitized = CloudErrorSanitizer.sanitize(
-                extractErrorMessage(from: errorBody),
-                host: host
-            )
+            let sanitized = await drainAndSanitizeErrorBody(bytes)
             throw CloudBackendError.serverError(
                 statusCode: statusCode,
                 message: sanitized
             )
         }
-    }
-
-    /// Reads up to 1000 bytes from the byte stream for error diagnostics.
-    private static func readErrorBody(from bytes: URLSession.AsyncBytes) async -> String {
-        // Accumulate raw bytes and decode as UTF-8 once at the end. Decoding
-        // each byte as an individual Latin-1 scalar mangles any multi-byte
-        // UTF-8 sequence (non-ASCII upstream/proxy error messages) into
-        // mojibake before sanitization ever sees it.
-        var data = Data()
-        do {
-            for try await byte in bytes {
-                data.append(byte)
-                if data.count > 1000 { break }
-            }
-        } catch {
-            // Best-effort — a partial body is still useful for error messages,
-            // but log the interruption so the swallow stays observable.
-            Log.network.debug("Claude error-body read interrupted: \(error.localizedDescription, privacy: .private)")
-        }
-        return String(decoding: data, as: UTF8.self)
     }
 
 }

--- a/Sources/ManifoldCloud/OllamaBackend.swift
+++ b/Sources/ManifoldCloud/OllamaBackend.swift
@@ -59,7 +59,16 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     /// forward `"think": false` on the wire (thinking models only; Ollama
     /// silently ignores the flag on non-thinking models but we omit it for
     /// clean request bodies).
-    public private(set) var isThinkingModel: Bool = false
+    /// Backing storage for ``isThinkingModel``, guarded by the base class's
+    /// `stateLock` like every other load-state field. Written inside the
+    /// `withStateLock` blocks in `loadModel`/`unloadModel`; read from
+    /// `capabilities`/`buildRequest`, which run on a different actor — an
+    /// off-lock `var` here was an unsynchronized access / Swift-6 data race.
+    private var _isThinkingModel: Bool = false
+
+    public var isThinkingModel: Bool {
+        withStateLock { _isThinkingModel }
+    }
 
     /// Conservative floor for `num_ctx` when the caller did not plumb a real
     /// context budget via `ModelLoadPlan` (`.cloud()` default is `1`).
@@ -366,7 +375,6 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             probed = .empty
         }
 
-        self.isThinkingModel = probed.thinking
         let resolvedContextWindow = probed.contextLength ?? max(resolvedNumCtx, Self.defaultNumCtxFloor)
         let manifest = ModelManifest(
             contextWindow: resolvedContextWindow,
@@ -383,6 +391,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             producerKind: .lan
         )
         withStateLock {
+            _isThinkingModel = probed.thinking
             _autoDetectedThinkingMarkers = probed.thinkingMarkers
             _manifest = manifest
         }
@@ -586,17 +595,9 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
                 .flatMap { TimeInterval($0) }
             throw CloudBackendError.rateLimited(retryAfter: retryAfter)
         default:
-            var errorBodyData = Data()
-            for try await byte in bytes {
-                errorBodyData.append(byte)
-                if errorBodyData.count > 2048 { break }
-            }
-            let errorBody = String(decoding: errorBodyData, as: UTF8.self)
-            Log.network.debug("Ollama upstream error body: \(errorBody, privacy: .private)")
-            let host = self.baseURL?.host()
-            let message = CloudErrorSanitizer.sanitize(
-                OllamaModelProbe.extractErrorMessage(from: errorBody),
-                host: host
+            let message = await drainAndSanitizeErrorBody(
+                bytes,
+                extractor: { OllamaModelProbe.extractErrorMessage(from: $0) }
             )
             throw CloudBackendError.serverError(statusCode: statusCode, message: message)
         }
@@ -612,11 +613,11 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
     public override func unloadModel() {
         withStateLock {
+            _isThinkingModel = false
             _manifest = nil
             _autoDetectedThinkingMarkers = nil
             _pendingStreamConfig = nil
         }
-        isThinkingModel = false
         super.unloadModel()
     }
 }

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -701,20 +701,57 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                 .flatMap { TimeInterval($0) }
             throw CloudBackendError.rateLimited(retryAfter: retryAfter)
         default:
-            var errorBody = ""
-            for try await byte in bytes {
-                errorBody.append(Character(UnicodeScalar(byte)))
-                if errorBody.count > 2048 { break }
-            }
-            let extracted = extractErrorMessage(from: errorBody)
-            // Raw body goes to os.Logger at .private so developers can still
-            // diagnose upstream issues via the Console / log archives; it never
-            // reaches the UI.
-            Log.network.debug("\(self.backendName, privacy: .public) upstream error body: \(errorBody, privacy: .private)")
-            let host = withStateLock { _baseURL?.host() }
-            let message = CloudErrorSanitizer.sanitize(extracted, host: host)
+            let message = await drainAndSanitizeErrorBody(bytes)
             throw CloudBackendError.serverError(statusCode: statusCode, message: message)
         }
+    }
+
+    /// Maximum number of error-body bytes drained for diagnostics across all
+    /// cloud backends. A few KB is plenty to capture a JSON error envelope
+    /// while bounding memory if an upstream/proxy streams an unbounded body.
+    /// Picked over the previous inconsistent 1000/2048 mix so every backend
+    /// reports the same truncation behaviour.
+    public static let errorBodyByteCap = 2048
+
+    /// Drains a non-2xx response body, decodes it once as UTF-8, logs the raw
+    /// body privately, and returns a sanitized, host-stripped error message
+    /// suitable for surfacing in `CloudBackendError.serverError`.
+    ///
+    /// Shared by every subclass's `default:` status branch so the drain → cap →
+    /// log → extract → sanitize sequence is implemented exactly once. Decoding
+    /// is deferred until the full (capped) byte buffer is accumulated:
+    /// appending one `UnicodeScalar` per byte would mangle any multi-byte
+    /// UTF-8 sequence (non-ASCII upstream/proxy messages) into mojibake before
+    /// the sanitizer ever sees it.
+    ///
+    /// - Parameters:
+    ///   - bytes: the response byte stream (read up to ``errorBodyByteCap``).
+    ///   - extractor: maps the decoded body to a human-readable message.
+    ///     Defaults to ``extractErrorMessage(from:)`` (adapter-routing aware).
+    /// - Returns: the sanitized message to surface to callers.
+    package func drainAndSanitizeErrorBody(
+        _ bytes: URLSession.AsyncBytes,
+        extractor: ((String) -> String?)? = nil
+    ) async -> String {
+        var data = Data()
+        do {
+            for try await byte in bytes {
+                data.append(byte)
+                if data.count > Self.errorBodyByteCap { break }
+            }
+        } catch {
+            // Best-effort — a partial body still aids diagnostics, but log the
+            // interruption so the swallow stays observable.
+            Log.network.debug("\(self.backendName, privacy: .public) error-body read interrupted: \(error.localizedDescription, privacy: .private)")
+        }
+        let errorBody = String(decoding: data, as: UTF8.self)
+        // Raw body goes to os.Logger at .private so developers can still
+        // diagnose upstream issues via the Console / log archives; it never
+        // reaches the UI.
+        Log.network.debug("\(self.backendName, privacy: .public) upstream error body: \(errorBody, privacy: .private)")
+        let extracted = (extractor ?? extractErrorMessage(from:))(errorBody)
+        let host = withStateLock { _baseURL?.host() }
+        return CloudErrorSanitizer.sanitize(extracted, host: host)
     }
 
     /// Extracts an error message from a JSON error response body.

--- a/Tests/ManifoldBackendsTests/CloudBackendSSETests.swift
+++ b/Tests/ManifoldBackendsTests/CloudBackendSSETests.swift
@@ -872,4 +872,58 @@ struct SSEHazardTests {
                 "Split SSE frame must produce exactly one event; got \(tokens)")
     }
 }
+
+// MARK: - Shared error-body drain
+
+@Suite("SSECloudBackend error-body drain")
+struct SSECloudBackendErrorBodyDrainTests {
+
+    /// The drain cap is a single shared constant across every cloud backend —
+    /// the issue called out the previous inconsistent 1000-vs-2048 mix. Pin the
+    /// value so a future "just bump it for this one backend" edit trips here.
+    @Test func errorBodyByteCap_isSingleSharedValue() {
+        #expect(SSECloudBackend.errorBodyByteCap == 2048)
+    }
+
+    /// A non-ASCII (multi-byte UTF-8) body run through the shared helper end to
+    /// end must survive decode + sanitize intact. ClaudeBackend routes its 5xx
+    /// `default:` branch through `drainAndSanitizeErrorBody`, so this exercises
+    /// the consolidated path for the SaaS family.
+    ///
+    /// Sabotage check: revert the helper to per-byte
+    /// `errorBody.append(Character(UnicodeScalar(byte)))` — the glyphs mojibake
+    /// and the substring assertions fail.
+    @Test func claudeRoutesNonASCIIBodyThroughSharedHelper() async throws {
+        DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34"] }
+        let session = makeMockSession()
+        let backend = ClaudeBackend(urlSession: session)
+        backend.retryStrategy = ExponentialBackoffStrategy(maxRetries: 0)
+        let url = URL(string: "https://claude-drain-\(UUID().uuidString).test")!
+        backend.configure(baseURL: url, apiKey: "sk-ant-test", modelName: "claude-sonnet-4-20250514")
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+
+        let upstreamMessage = "Réseau indisponible 中文 🚫"
+        let body = Data(#"{"type":"error","error":{"type":"api_error","message":"\#(upstreamMessage)"}}"#.utf8)
+        MockURLProtocol.stub(url: url, response: .immediate(data: body, statusCode: 500))
+        defer { MockURLProtocol.unstub(url: url) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        do {
+            for try await _ in stream.events {}
+            Issue.record("Expected serverError for HTTP 500")
+        } catch {
+            guard let cloudError = extractCloudError(error) else {
+                Issue.record("Expected CloudBackendError, got \(error)"); return
+            }
+            guard case .serverError(let code, let message) = cloudError else {
+                Issue.record("Expected serverError, got \(cloudError)"); return
+            }
+            #expect(code == 500)
+            let surfaced = try #require(message)
+            #expect(surfaced.contains("Réseau"))
+            #expect(surfaced.contains("中文"))
+            #expect(surfaced.contains("🚫"))
+        }
+    }
+}
 #endif

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -425,6 +425,46 @@ struct OllamaBackendTests {
         }
     }
 
+    /// A non-ASCII (multi-byte UTF-8) upstream error message must survive the
+    /// shared `SSECloudBackend.drainAndSanitizeErrorBody` read intact and reach
+    /// the surfaced `serverError` message.
+    ///
+    /// Regression for the base class's per-byte `Character(UnicodeScalar(byte))`
+    /// read, which decoded each UTF-8 byte as an independent Latin-1 scalar and
+    /// turned any multi-byte sequence into mojibake before sanitization ever saw
+    /// it. Ollama routes through the same shared helper, so this also guards the
+    /// consolidation.
+    ///
+    /// Sabotage check: revert `drainAndSanitizeErrorBody` to per-byte
+    /// `errorBody.append(Character(UnicodeScalar(byte)))`. The é/中文/🚫 glyphs
+    /// come back as mojibake and the substring assertions fail.
+    @Test func serverError_nonASCIIBody_roundTripsAsUTF8() async throws {
+        let (backend, chatURL) = makeConfiguredBackend()
+        try await loadBackend(backend)
+
+        // Mix 2-byte (é), 3-byte (中文), and 4-byte (🚫) UTF-8 sequences.
+        let upstreamMessage = "Réseau indisponible 中文 🚫"
+        let body = try JSONSerialization.data(withJSONObject: ["error": upstreamMessage])
+        MockURLProtocol.stub(url: chatURL, response: .immediate(data: body, statusCode: 500))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hello", systemPrompt: nil, config: .init())
+        do {
+            for try await _ in stream.events {}
+            Issue.record("Expected server error")
+        } catch {
+            guard let error = extractCloudError(error) else { Issue.record("Expected CloudBackendError, got \(error)"); return }
+            guard case .serverError(let code, let message) = error else {
+                Issue.record("Expected serverError, got \(error)"); return
+            }
+            #expect(code == 500)
+            let surfaced = try #require(message, "serverError must carry the upstream message")
+            #expect(surfaced.contains("Réseau"), "2-byte UTF-8 (é) must survive; got: \(surfaced)")
+            #expect(surfaced.contains("中文"), "3-byte UTF-8 must survive; got: \(surfaced)")
+            #expect(surfaced.contains("🚫"), "4-byte UTF-8 must survive; got: \(surfaced)")
+        }
+    }
+
     @Test func rateLimitError_429() async throws {
         let (backend, chatURL) = makeConfiguredBackend()
         try await loadBackend(backend)


### PR DESCRIPTION
## Summary

Fixes the three cloud-backend items from issue #1497.

### 1. Multi-byte UTF-8 corruption in the base `SSECloudBackend`
`checkStatusCode`'s `default:` branch accumulated the 5xx body with
`errorBody.append(Character(UnicodeScalar(byte)))` — Latin-1-per-byte, so any
non-ASCII upstream/proxy error message became mojibake before the sanitizer
saw it. Now drains into `Data` and decodes once as UTF-8.

### 2. Consolidated the duplicated drain
The drain → cap → `Log.network.debug(privacy: .private)` → extract → `CloudErrorSanitizer.sanitize` sequence was re-implemented in three places with
inconsistent caps (1000 vs 2048). Extracted a shared helper:

```swift
package func drainAndSanitizeErrorBody(
    _ bytes: URLSession.AsyncBytes,
    extractor: ((String) -> String?)? = nil
) async -> String
```

- Accumulates into `Data`, decodes once as UTF-8.
- One documented byte cap: `public static let errorBodyByteCap = 2048`.
- `extractor` defaults to the adapter-routing-aware `extractErrorMessage(from:)`; Ollama passes its `OllamaModelProbe.extractErrorMessage`.
- Subclasses keep only their status-code branch table and call the helper in `default:`.
- **ClaudeBackend now routes through the helper** (its local `readErrorBody` is removed) — the #1502 fix is preserved and de-duplicated.

### 3. `OllamaBackend.isThinkingModel` off-lock
Was read from `capabilities`/`buildRequest` and written in `loadModel`/`unloadModel` outside the `stateLock` blocks that guard every other
load-state field. Now a `stateLock`-guarded `_isThinkingModel` with a computed
public accessor; writes moved inside the existing `withStateLock` blocks.

## Tests
- `OllamaBackendTests.serverError_nonASCIIBody_roundTripsAsUTF8` — é / 中文 / 🚫 survive end-to-end through the Ollama 5xx path.
- `SSECloudBackendErrorBodyDrainTests.claudeRoutesNonASCIIBodyThroughSharedHelper` — same glyphs through the Claude path (consolidated SaaS family).
- `SSECloudBackendErrorBodyDrainTests.errorBodyByteCap_isSingleSharedValue` — pins the one shared cap.

## Test results
- `swift build --build-tests --traits Ollama,CloudSaaS` — clean.
- All-traits `swift build --build-tests` sweep — clean.
- `--filter OllamaBackend` — 68 tests pass.
- CloudCore SSE / `CloudErrorSanitizer` / Claude suites — 48 tests pass.
- `SilentCatchAuditTest` — pass.

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)