### PR TITLE
fix(mlx): serialize arbiter teardown and cancel generation on any stream termination

### DIFF
--- a/Sources/ManifoldMLX/MLXBackend.swift
+++ b/Sources/ManifoldMLX/MLXBackend.swift
@@ -97,6 +97,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
     private var _modelContainer: (any MLXModelContainerProtocol)?
     /// Access only under `stateLock`.
     private var _generationTask: Task<Void, Never>?
+    /// Chained arbiter-teardown task. Each `unloadModel`/`secureWipe` appends
+    /// its `release`/`clearAll` to this chain (`await previousCleanup?.value`)
+    /// so teardown is serialized, and `loadModel` awaits it before issuing a
+    /// new `claim`. Without this barrier the actor could process a fresh
+    /// `claim` *before* the prior `release` for the same `backendID`,
+    /// silently dropping the new claim (the actor runs in scheduling order,
+    /// not call order). Mirrors `LlamaBackend.cleanupTask`. Access only under
+    /// `stateLock`.
+    private var _cleanupTask: Task<Void, Never>?
     /// Access only under `stateLock`.
     private var _conversationHistory: [(role: String, content: String)] = []
     /// The tool-call dialect detected for the currently loaded model.
@@ -311,6 +320,13 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             // accumulate per-instance claims rather than overwriting each
             // other's `cacheLimit`.
             let cacheBytes = cachePolicy.resolvedBytes()
+            // Barrier: the `unloadModel()` issued at the top of this method
+            // spawned a chained teardown task that calls `release`/`clearAll`
+            // on the arbiter. Await it before claiming so a stale release from
+            // the prior lineage cannot land *after* this fresh claim and drop
+            // it (the arbiter is an actor; it runs enqueued ops in scheduling
+            // order, not call order). See `_cleanupTask`.
+            await pendingCleanupTask()?.value
             await MLXResourceArbiter.shared.claim(
                 backendID: backendID,
                 requestedCacheBytes: cacheBytes
@@ -431,10 +447,15 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
 
         withStateLock { self._generationTask = task }
 
-        continuation.onTermination = { @Sendable termination in
-            if case .cancelled = termination {
-                task.cancel()
-            }
+        // Cancel on ANY termination, not just `.cancelled`. A consumer that
+        // abandons the stream early (stops iterating, or the `GenerationStream`
+        // deinits) terminates it with `.finished`; without cancelling here the
+        // `@MainActor` generation task keeps running, occupying the MLX GPU
+        // scheduler until it completes naturally. The driver already treats
+        // `Task.isCancelled` as clean completion. Matches Llama / Foundation /
+        // the SSE runner.
+        continuation.onTermination = { @Sendable _ in
+            task.cancel()
         }
 
         return generationStream
@@ -560,16 +581,50 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             return had
         }
         if hadInitializedRuntime {
-            // Fire-and-forget: the protocol contract for `unloadModel()` is
-            // synchronous, but cache eviction does not need to block teardown.
-            // The arbiter clears `MLX.Memory` only on the last release; while
-            // sibling MLX backends are still loaded, this preserves their
-            // pooled buffers — that's the whole point of routing through the
-            // arbiter rather than calling `Memory.clearCache()` directly.
+            // The protocol contract for `unloadModel()` is synchronous, but
+            // cache eviction does not need to block teardown — so we still
+            // spawn a task rather than awaiting. The arbiter clears
+            // `MLX.Memory` only on the last release; while sibling MLX backends
+            // are still loaded, this preserves their pooled buffers — that's
+            // the whole point of routing through the arbiter rather than
+            // calling `Memory.clearCache()` directly.
+            //
+            // Chain onto the prior cleanup (`await previousCleanup?.value`) and
+            // store the result so the next `loadModel` can await it before
+            // claiming. This serializes teardown vs a following load and stops
+            // a stale `release` from dropping a fresh `claim`.
             let id = backendID
-            Task { await MLXResourceArbiter.shared.release(backendID: id) }
+            let previousCleanup = withStateLock { () -> Task<Void, Never>? in
+                let prior = _cleanupTask
+                _cleanupTask = nil
+                return prior
+            }
+            let cleanup = Task {
+                await previousCleanup?.value
+                await MLXResourceArbiter.shared.release(backendID: id)
+            }
+            withStateLock { _cleanupTask = cleanup }
         }
         Self.logger.info("MLX backend unloaded")
+    }
+
+    /// Schedules the same arbiter teardown as ``unloadModel()`` and awaits the
+    /// chained cleanup task that releases this backend's cache claim.
+    ///
+    /// Production code that drops the backend can keep calling fire-and-forget
+    /// ``unloadModel()`` — but the reload loop, programmatic back-to-back load
+    /// cycles, and tests should await this so the prior `release` is guaranteed
+    /// to have completed before the next `claim`. Mirrors
+    /// `LlamaBackend.unloadAndWait()`.
+    public func unloadAndWait() async {
+        unloadModel()
+        await pendingCleanupTask()?.value
+    }
+
+    /// Snapshots the pending arbiter-cleanup task under `stateLock`. Callers
+    /// await its `.value` to barrier against an in-flight `release`/`clearAll`.
+    private func pendingCleanupTask() -> Task<Void, Never>? {
+        withStateLock { _cleanupTask }
     }
 }
 
@@ -621,8 +676,19 @@ extension MLXBackend {
             // pool is process-global, partial scrubbing isn't possible: route
             // through `clearAll` so the arbiter drops accounting state too,
             // and surviving sibling backends will re-claim on their next
-            // load.
-            Task { await MLXResourceArbiter.shared.clearAll() }
+            // load. Chain it through `_cleanupTask` (same barrier as
+            // `unloadModel`) so a following `loadModel`'s `claim` can't be
+            // dropped by this `clearAll`.
+            let previousCleanup = withStateLock { () -> Task<Void, Never>? in
+                let prior = _cleanupTask
+                _cleanupTask = nil
+                return prior
+            }
+            let cleanup = Task {
+                await previousCleanup?.value
+                await MLXResourceArbiter.shared.clearAll()
+            }
+            withStateLock { _cleanupTask = cleanup }
         }
         #endif
     }

--- a/Tests/ManifoldBackendsTests/MLXResourceArbiterTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXResourceArbiterTests.swift
@@ -207,6 +207,56 @@ final class MLXResourceArbiterTests: XCTestCase {
 
     // MARK: - clearAll
 
+    // MARK: - Teardown-vs-load ordering (issue #1498)
+
+    /// The motivating bug for the chained-cleanup barrier: the reload loop is
+    /// `unloadModel()` (spawns a `release` task) immediately followed by
+    /// `loadModel()` (issues a `claim`). Because the arbiter is an actor that
+    /// runs enqueued ops in *scheduling* order rather than call order, a fresh
+    /// `claim` enqueued before the prior `release` runs would be dropped by
+    /// that release — leaving the reloaded model with a zero cache budget and
+    /// an empty claim table.
+    ///
+    /// `MLXBackend` fixes this by chaining the `release` into `_cleanupTask`
+    /// and having `loadModel` `await` that task before claiming. This test
+    /// reproduces the barrier at the task-chain level (no Metal, no model
+    /// load): the `claim` only runs *after* `await release.value`, so the
+    /// final claim survives.
+    func test_releaseBeforeClaim_barrierPreservesFreshClaim() async {
+        let (arbiter, recorder) = makeArbiter()
+        let id = UUID()
+
+        // Prior lineage holds a claim.
+        await arbiter.claim(backendID: id, requestedCacheBytes: 100)
+
+        // unloadModel(): chained teardown task releasing the prior claim.
+        let releaseTask = Task { await arbiter.release(backendID: id) }
+
+        // loadModel(): the barrier — await the pending cleanup BEFORE claiming.
+        await releaseTask.value
+        await arbiter.claim(backendID: id, requestedCacheBytes: 250)
+
+        // The fresh claim must be live: one active claim of 250 bytes.
+        let active = await arbiter._activeClaimCountForTesting()
+        XCTAssertEqual(active, 1, "fresh claim must survive the reload barrier")
+        let total = await arbiter._totalClaimedBytesForTesting()
+        XCTAssertEqual(total, 250, "claim table must hold the new claim, not be emptied by the stale release")
+
+        // Sabotage check (mirrors the pre-fix interleave): if the claim is
+        // enqueued WITHOUT awaiting the release, the release can run last and
+        // drop it. We can't reorder actor scheduling deterministically here,
+        // but we can prove the inverse ordering empties the table — which is
+        // exactly what the barrier prevents.
+        let (arbiter2, _) = makeArbiter()
+        let id2 = UUID()
+        await arbiter2.claim(backendID: id2, requestedCacheBytes: 100)
+        await arbiter2.claim(backendID: id2, requestedCacheBytes: 250) // fresh claim
+        await arbiter2.release(backendID: id2)                          // stale release runs last
+        let activeSabotage = await arbiter2._activeClaimCountForTesting()
+        XCTAssertEqual(activeSabotage, 0,
+                       "control: release-after-claim drops the claim — this is the race the barrier averts")
+    }
+
     func test_clearAll_dropsAllClaimsAndInvokesClear() async {
         let (arbiter, recorder) = makeArbiter()
         let a = UUID()


### PR DESCRIPTION
Fixes two MLX lifecycle issues from a deep code review (#1498).

## 1. Arbiter teardown ordering vs a following load

`unloadModel()` (`MLXBackend.swift:570`) and `secureWipe()` (`:625`) spawned unstructured `Task { await MLXResourceArbiter.shared.release/clearAll(...) }` with no ordering guarantee. In the reload loop (`unloadModel()` → `loadModel()`), the new load's `arbiter.claim` (`:314`) could be enqueued on the arbiter **actor** *before* the prior `release` for the same `backendID` ran — the actor processes in scheduling order, not call order — silently dropping the fresh claim and leaving the reloaded model with a zero cache budget.

**Fix (chosen approach: chained `cleanupTask`, mirroring `LlamaBackend`):**
- Added a stored `_cleanupTask` (guarded by `stateLock`). Each `unloadModel`/`secureWipe` chains its `release`/`clearAll` onto the previous cleanup (`await previousCleanup?.value`) and stores the result back.
- `loadModel` awaits the pending cleanup (`await pendingCleanupTask()?.value`) *before* issuing its `claim`, so a stale teardown can never land after a fresh claim.
- Added `public func unloadAndWait() async` for the reload-loop / test path, mirroring `LlamaBackend.unloadAndWait()`.

The chained-task approach was chosen over a generation-token scheme because it exactly matches the established, proven `LlamaBackend.cleanupTask` pattern already in this codebase.

## 2. Stream `onTermination` only cancelled on `.cancelled`

`MLXBackend.swift:434-438` cancelled the generation task only on `.cancelled`. A consumer abandoning the stream early (deinit → `.finished`) left the `@MainActor` generation task running, occupying the GPU scheduler. Changed to `{ @Sendable _ in task.cancel() }` — cancel on **any** termination, matching Llama / Foundation / the SSE runner. The driver already treats `Task.isCancelled` as clean completion.

## Tests
Added `test_releaseBeforeClaim_barrierPreservesFreshClaim` to `MLXResourceArbiterTests` — a **Metal-free** regression test at the arbiter task-chain level. It proves that awaiting the chained `release` before `claim` preserves the fresh claim, and includes a control showing release-after-claim empties the table (the race the barrier averts).

## Test results
- `swift build --build-tests --traits MLX` — succeeds (Metal shader compile, ~107s).
- `swift test --traits MLX --filter MLXResourceArbiter` — 10/10 pass (incl. new test).
- `swift test --traits MLX --filter MLXBackend` — 87 executed, 13 skipped (Metal-gated via `XCTSkipIf`), 0 failures.

Closes #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)