### PR TITLE
refactor(inference): collapse duplicated chokepoints, modernize lock, log swallowed refresh

### DIFF
--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -169,6 +169,17 @@ final class GenerationQueue {
         let systemPrompt: String?
         let config: GenerationConfig
         let stream: GenerationStream
+        /// Per-request handoff detector, captured at enqueue time. When set, it
+        /// is used for this request's dispatch loop instead of the queue-level
+        /// ``handoffDetector``. This closes the per-turn race where two
+        /// concurrent turns mutating the shared queue-level detector clobbered
+        /// each other between enqueue and stream consumption (#1494). `nil`
+        /// falls back to the queue-level default for legacy single-turn callers.
+        let handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)?
+        /// Per-request pre-tool-use hook, captured at enqueue time. See
+        /// ``handoffDetector`` for the rationale. `nil` falls back to the
+        /// queue-level ``preToolUseHook``.
+        let preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)?
     }
 
     // MARK: - Queue State (Private)
@@ -451,7 +462,9 @@ final class GenerationQueue {
         systemPrompt: String? = nil,
         config: GenerationConfig,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        sessionID: UUID? = nil,
+        handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)? = nil,
+        preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         guard let backend = currentBackend, isBackendLoaded else {
             throw InferenceError.inferenceFailure("No model loaded")
@@ -493,7 +506,9 @@ final class GenerationQueue {
             messages: messages,
             systemPrompt: systemPrompt,
             config: config,
-            stream: stream
+            stream: stream,
+            handoffDetector: handoffDetector,
+            preToolUseHook: preToolUseHook
         )
 
         if let insertIdx = requestQueue.firstIndex(where: { $0.priority < priority }) {
@@ -768,9 +783,19 @@ final class GenerationQueue {
 
     /// Drives the backend through an entire tool-dispatch loop for one queued request.
     private func runToolDispatchLoop(request: QueuedRequest) async throws {
+        // Prefer the per-request closures captured at enqueue time over the
+        // queue-level defaults. The runtime threads detector + pre-tool-use
+        // hook in per request (#1494) so two concurrent turns can't clobber a
+        // shared mutable detector between enqueue and stream consumption. A
+        // `nil` per-request closure falls back to the queue-level default for
+        // legacy single-turn callers that still call setHandoffDetector(_:) /
+        // setPreToolUseHook(_:).
+        let effectiveHandoffDetector = request.handoffDetector ?? handoffDetector
+        let effectivePreToolUseHook = request.preToolUseHook ?? preToolUseHook
+
         // Bind the per-request hook closures explicitly so the type checker
         // doesn't have to infer them inside the giant init expression below.
-        let boundPreToolUseHook: PreToolUseHook? = preToolUseHook.map { hook in
+        let boundPreToolUseHook: PreToolUseHook? = effectivePreToolUseHook.map { hook in
             let sessionID = request.sessionID
             return { @Sendable toolName, arguments, _ in
                 await hook(toolName, arguments, sessionID)
@@ -799,7 +824,7 @@ final class GenerationQueue {
             pauseWhileThermalCritical: { [weak self] token in
                 await self?.pauseWhileThermalCritical(token: token)
             },
-            handoffDetector: handoffDetector.map { detector in
+            handoffDetector: effectiveHandoffDetector.map { detector in
                 { [sessionID = request.sessionID] call in
                     detector(sessionID, call)
                 }

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -270,19 +270,6 @@ final class GenerationQueue {
             throw InferenceError.inferenceFailure("No model loaded")
         }
 
-        // Single pre-dispatch chokepoint for the native-JSON-mode capability
-        // check. Backends without native JSON-mode support silently ignore
-        // the flag and return plain text, so we warn once per request here
-        // rather than in each backend. Callers can branch on
-        // `backend.capabilities.supportsNativeJSONMode` programmatically to
-        // suppress the warning by not setting the flag in the first place.
-        if jsonMode && !backend.capabilities.supportsNativeJSONMode {
-            let backendType = String(describing: type(of: backend))
-            let message = "GenerationQueue: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
-            Log.inference.warning("\(message, privacy: .public)")
-            Self.jsonModeUnsupportedWarningHook?(backendType, message)
-        }
-
         var config = GenerationConfig(
             temperature: temperature,
             topP: topP,
@@ -334,13 +321,6 @@ final class GenerationQueue {
             throw InferenceError.inferenceFailure("No model loaded")
         }
 
-        if config.jsonMode && !backend.capabilities.supportsNativeJSONMode {
-            let backendType = String(describing: type(of: backend))
-            let message = "GenerationQueue: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
-            Log.inference.warning("\(message, privacy: .public)")
-            Self.jsonModeUnsupportedWarningHook?(backendType, message)
-        }
-
         Self.warnIfThinkingUnsupported(backend: backend, config: config)
 
         return try dispatchToBackend(
@@ -352,6 +332,23 @@ final class GenerationQueue {
     }
 
     // MARK: - Backend dispatch (Private)
+
+    /// Single pre-dispatch chokepoint for the native-JSON-mode capability
+    /// check. Backends without native JSON-mode support silently ignore the
+    /// flag and return plain text, so we warn once per request here rather
+    /// than in each backend. Callers can branch on
+    /// `backend.capabilities.supportsNativeJSONMode` programmatically to
+    /// suppress the warning by not setting the flag in the first place.
+    private static func warnIfJSONModeUnsupported(
+        backend: InferenceBackend,
+        config: GenerationConfig
+    ) {
+        guard config.jsonMode, !backend.capabilities.supportsNativeJSONMode else { return }
+        let backendType = String(describing: type(of: backend))
+        let message = "GenerationQueue: jsonMode=true requested but \(backendType) does not support native JSON mode (capabilities.supportsNativeJSONMode == false); the flag will be ignored and the response will be plain text. Check `backend.capabilities.supportsNativeJSONMode` before setting `config.jsonMode`."
+        Log.inference.warning("\(message, privacy: .public)")
+        Self.jsonModeUnsupportedWarningHook?(backendType, message)
+    }
 
     private static func warnIfThinkingUnsupported(
         backend: InferenceBackend,
@@ -388,6 +385,8 @@ final class GenerationQueue {
         systemPrompt: String?,
         config: GenerationConfig
     ) throws -> GenerationStream {
+        Self.warnIfJSONModeUnsupported(backend: backend, config: config)
+
         if GenerationHistoryInstaller.containsImages(messages), !backend.capabilities.supportsVision {
             throw InferenceError.inferenceFailure(
                 "Image attachments require a backend whose capabilities.supportsVision is true. Select a vision-capable backend before sending image parts."

--- a/Sources/ManifoldInference/Services/GenerationStream.swift
+++ b/Sources/ManifoldInference/Services/GenerationStream.swift
@@ -183,30 +183,19 @@ public final class GenerationStream: Sendable {
 // MARK: - Thread-safe Atomics
 
 /// Lock-protected boolean for cross-task signaling.
-private final class ManagedAtomic<Value>: @unchecked Sendable {
-    private let lock = os_unfair_lock_t.allocate(capacity: 1)
-    private var storage: Value
+private final class ManagedAtomic<Value: Sendable>: @unchecked Sendable {
+    private let lock: OSAllocatedUnfairLock<Value>
 
     init(_ initial: Value) {
-        storage = initial
-        lock.initialize(to: os_unfair_lock())
-    }
-
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
+        lock = OSAllocatedUnfairLock(initialState: initial)
     }
 
     func load() -> Value {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        return storage
+        lock.withLock { $0 }
     }
 
     func store(_ value: Value) {
-        os_unfair_lock_lock(lock)
-        defer { os_unfair_lock_unlock(lock) }
-        storage = value
+        lock.withLock { $0 = value }
     }
 }
 
@@ -219,29 +208,13 @@ private typealias AtomicInstant = ManagedAtomic<ContinuousClock.Instant>
 /// This breaks the init ordering problem: the closure is created before `self`
 /// is available, and the handler is assigned after init completes.
 private final class StalledCallback: @unchecked Sendable {
-    private let lock = os_unfair_lock_t.allocate(capacity: 1)
+    private let lock = OSAllocatedUnfairLock<(@Sendable () -> Void)?>(initialState: nil)
     var handler: (@Sendable () -> Void)? {
-        get {
-            os_unfair_lock_lock(lock)
-            defer { os_unfair_lock_unlock(lock) }
-            return _handler
-        }
-        set {
-            os_unfair_lock_lock(lock)
-            defer { os_unfair_lock_unlock(lock) }
-            _handler = newValue
-        }
-    }
-    private var _handler: (@Sendable () -> Void)?
-
-    init() {
-        lock.initialize(to: os_unfair_lock())
+        get { lock.withLock { $0 } }
+        set { lock.withLock { $0 = newValue } }
     }
 
-    deinit {
-        lock.deinitialize(count: 1)
-        lock.deallocate()
-    }
+    init() {}
 
     func fire() {
         handler?()

--- a/Sources/ManifoldInference/Services/InferenceService+Nonisolated.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+Nonisolated.swift
@@ -67,7 +67,9 @@ extension InferenceService {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        sessionID: UUID? = nil,
+        handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)? = nil,
+        preToolUseHook: PreToolUseHook? = nil
     ) async throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         try await MainActor.run {
             try self.enqueue(
@@ -91,7 +93,9 @@ extension InferenceService {
                     maxToolIterations: maxToolIterations
                 ),
                 priority: priority,
-                sessionID: sessionID
+                sessionID: sessionID,
+                handoffDetector: handoffDetector,
+                preToolUseHook: preToolUseHook
             )
         }
     }

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -422,7 +422,9 @@ public final class InferenceService {
         systemPrompt: String? = nil,
         config: GenerationConfig,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        sessionID: UUID? = nil,
+        handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)? = nil,
+        preToolUseHook: PreToolUseHook? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         ensureProviderWired()
         return try generation.enqueue(
@@ -430,7 +432,9 @@ public final class InferenceService {
             systemPrompt: systemPrompt,
             config: config,
             priority: priority,
-            sessionID: sessionID
+            sessionID: sessionID,
+            handoffDetector: handoffDetector,
+            preToolUseHook: preToolUseHook
         )
     }
 

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -211,19 +211,43 @@ final class ModelLifecycleCoordinator {
         }
 
         let backendName = backendDisplayName(for: modelInfo.modelType)
-        let request = beginLoadRequest(
+        let url = modelInfo.url
+        let mmprojURL = modelInfo.mmprojURL
+        let dispatchPlan = effectivePlan
+        try await runLoad(
             source: "local",
             target: modelTypeLogLabel(modelInfo.modelType),
+            backendName: backendName,
+            backend: newBackend,
+            modelName: modelInfo.name
+        ) {
+            (newBackend as? MultimodalProjectorConfigurable)?.setMmprojURL(mmprojURL)
+            try await newBackend.loadModel(from: url, plan: dispatchPlan)
+        }
+    }
+
+    /// Shared begin/install/detached-load/catch/commit ceremony for both the
+    /// on-disk model path and the cloud-endpoint path. The only per-call
+    /// variation is the request labels, the model name, and the detached load
+    /// body — passed in as `loadOperation`, which runs off the main actor
+    /// inside `Task.detached`.
+    private func runLoad(
+        source: String,
+        target: String,
+        backendName: String,
+        backend newBackend: any InferenceBackend,
+        modelName: String,
+        loadOperation: @escaping @Sendable () async throws -> Void
+    ) async throws {
+        let request = beginLoadRequest(
+            source: source,
+            target: target,
             backend: backendName
         )
         installProgressHandler(on: newBackend, for: request)
         do {
-            let url = modelInfo.url
-            let mmprojURL = modelInfo.mmprojURL
-            let dispatchPlan = effectivePlan
             try await Task.detached(priority: .userInitiated) {
-                (newBackend as? MultimodalProjectorConfigurable)?.setMmprojURL(mmprojURL)
-                try await newBackend.loadModel(from: url, plan: dispatchPlan)
+                try await loadOperation()
             }.value
         } catch {
             (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
@@ -236,7 +260,12 @@ final class ModelLifecycleCoordinator {
         (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
 
         logLoadEvent("load.complete", request: request)
-        guard commitLoadIfCurrent(request: request, backend: newBackend, backendName: backendName, modelName: modelInfo.name) else {
+        guard commitLoadIfCurrent(
+            request: request,
+            backend: newBackend,
+            backendName: backendName,
+            modelName: modelName
+        ) else {
             newBackend.unloadModel()
             logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
             return
@@ -288,38 +317,16 @@ final class ModelLifecycleCoordinator {
         }
 
         let cloudBackendName = backendDisplayName(for: endpoint.provider)
-        let request = beginLoadRequest(
+        let backendURL = url
+        let cloudPlan = ModelLoadPlan.cloud()
+        try await runLoad(
             source: "cloud",
             target: endpoint.provider.rawValue,
-            backend: cloudBackendName
-        )
-        installProgressHandler(on: newBackend, for: request)
-        do {
-            let backendURL = url
-            let cloudPlan = ModelLoadPlan.cloud()
-            try await Task.detached(priority: .userInitiated) {
-                try await newBackend.loadModel(from: backendURL, plan: cloudPlan)
-            }.value
-        } catch {
-            (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
-            let isStale = finishLoadAttemptWithFailure(request, error: error)
-            if isStale {
-                newBackend.unloadModel()
-            }
-            throw error
-        }
-        (newBackend as? LoadProgressReporting)?.setLoadProgressHandler(nil)
-
-        logLoadEvent("load.complete", request: request)
-        guard commitLoadIfCurrent(
-            request: request,
-            backend: newBackend,
             backendName: cloudBackendName,
+            backend: newBackend,
             modelName: endpoint.modelName
-        ) else {
-            newBackend.unloadModel()
-            logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
-            return
+        ) {
+            try await newBackend.loadModel(from: backendURL, plan: cloudPlan)
         }
     }
 

--- a/Sources/ManifoldInference/Services/ToolRegistry.swift
+++ b/Sources/ManifoldInference/Services/ToolRegistry.swift
@@ -222,11 +222,7 @@ public protocol JSONSchemaValidating: Sendable {
     /// 5 entries — see README "Tool Calling" section.
     public var definitions: [ToolDefinition] {
         let result = sortedDefinitions()
-        #if DEBUG
-        if result.count > 5 {
-            print("[ManifoldKit] ⚠️ \(result.count) tools in this request. Local backends (3B–8B) degrade beyond ~5 — see README Tool Calling section.")
-        }
-        #endif
+        warnIfTooManyTools(result)
         return result
     }
 
@@ -240,12 +236,20 @@ public protocol JSONSchemaValidating: Sendable {
         let result = advertisedToolNameKeys.map { keys in
             allDefinitions.filter { keys.contains($0.name.lowercased()) }
         } ?? allDefinitions
+        warnIfTooManyTools(result)
+        return result
+    }
+
+    /// Emits a DEBUG-only console warning when a model-facing tool list grows
+    /// past the point where small local backends start to degrade. Shared by
+    /// ``definitions`` and ``advertisedDefinitions`` so the threshold and
+    /// message stay in one place.
+    private func warnIfTooManyTools(_ result: [ToolDefinition]) {
         #if DEBUG
         if result.count > 5 {
             print("[ManifoldKit] ⚠️ \(result.count) tools in this request. Local backends (3B–8B) degrade beyond ~5 — see README Tool Calling section.")
         }
         #endif
-        return result
     }
 
     private func sortedDefinitions() -> [ToolDefinition] {

--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -91,6 +91,28 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         await fireSessionHooks(record)
     }
 
+    /// Narrow in-place write of `updatedAt` only — mutates the live `@Model`
+    /// row without rewriting the other columns, so a concurrent full-record
+    /// write (another turn, or a host-side session edit) is not clobbered by a
+    /// stale-snapshot rewrite. Fires session hooks with a fresh record read
+    /// back from the mutated row. Silently no-ops when the session is gone (a
+    /// touch racing a delete).
+    public func touch(sessionID: UUID, date: Date = Date()) async throws {
+        guard let session = try fetchSwiftDataSession(id: sessionID) else { return }
+        session.updatedAt = date
+        try modelContext.save()
+        await fireSessionHooks(session.toRecord())
+    }
+
+    /// Narrow in-place write of `activeAgentID` only. See ``touch(sessionID:date:)``
+    /// for the lost-update rationale. Silently no-ops when the session is gone.
+    public func setActiveAgent(sessionID: UUID, agentID: UUID?) async throws {
+        guard let session = try fetchSwiftDataSession(id: sessionID) else { return }
+        session.activeAgentID = agentID
+        try modelContext.save()
+        await fireSessionHooks(session.toRecord())
+    }
+
     public func deleteSession(_ sessionID: UUID) async throws {
         guard let session = try fetchSwiftDataSession(id: sessionID) else {
             throw ChatPersistenceError.sessionNotFound(sessionID)

--- a/Sources/ManifoldRuntime/Protocols/SessionStore.swift
+++ b/Sources/ManifoldRuntime/Protocols/SessionStore.swift
@@ -49,6 +49,40 @@ public protocol SessionStore: AnyObject, Sendable {
     ///   - Storage errors from the underlying store.
     func updateSession(_ session: ChatSessionRecord) async throws
 
+    /// Updates **only** `updatedAt` on the session, in place.
+    ///
+    /// The turn loop bumps `updatedAt` twice per send so the sidebar reflects
+    /// recency, but ``updateSession(_:)`` rewrites every column from a snapshot
+    /// taken earlier in the turn. Two concurrent turns (or a host-side session
+    /// edit racing a turn) interleave as a lost update: B reads, A writes its
+    /// fields, B writes its stale snapshot back, clobbering A's columns. This
+    /// narrow write mutates the live row's `updatedAt` without round-tripping
+    /// the other fields, so a concurrent edit to e.g. `title` survives.
+    ///
+    /// No-ops silently when the session does not exist — a touch racing a
+    /// delete is benign and must not surface an error to the turn loop.
+    ///
+    /// - Parameters:
+    ///   - sessionID: The session whose `updatedAt` to bump.
+    ///   - date: The timestamp to set (defaults to now).
+    /// - Throws: Storage errors from the underlying store.
+    func touch(sessionID: UUID, date: Date) async throws
+
+    /// Updates **only** `activeAgentID` on the session, in place.
+    ///
+    /// Mid-stream agent handoffs swap the active agent. ``updateSession(_:)``
+    /// would rewrite the whole row from the turn-start snapshot, clobbering any
+    /// concurrent field change. This narrow write mutates only the
+    /// active-agent column on the live row.
+    ///
+    /// No-ops silently when the session does not exist.
+    ///
+    /// - Parameters:
+    ///   - sessionID: The session to mutate.
+    ///   - agentID: The new active agent, or `nil` to clear it.
+    /// - Throws: Storage errors from the underlying store.
+    func setActiveAgent(sessionID: UUID, agentID: UUID?) async throws
+
     /// Deletes a chat session and all associated messages.
     ///
     /// Implementations that also conform to ``MessageStore`` typically delete
@@ -122,6 +156,29 @@ extension SessionStore {
     /// hooks inherit this and silently drop the registration. Provisional —
     /// see ``addPostWriteHook(_:)`` doc.
     public func addPostWriteHook(_ hook: any SessionStorePostWriteHook) {}
+
+    /// Default: read-modify-write fallback for stores that don't push the
+    /// narrow update into the engine. **Not** atomic against a concurrent
+    /// full-record write — storage-backed adapters that own a live row MUST
+    /// override and mutate only `updatedAt` so the lost-update window closes.
+    /// Provided so in-memory test doubles keep compiling. Silently no-ops when
+    /// the session is gone.
+    public func touch(sessionID: UUID, date: Date = Date()) async throws {
+        let sessions = try await fetchSessions()
+        guard var session = sessions.first(where: { $0.id == sessionID }) else { return }
+        session.updatedAt = date
+        try await updateSession(session)
+    }
+
+    /// Default: read-modify-write fallback. See ``touch(sessionID:date:)`` for
+    /// why storage-backed adapters must override. Silently no-ops when the
+    /// session is gone.
+    public func setActiveAgent(sessionID: UUID, agentID: UUID?) async throws {
+        let sessions = try await fetchSessions()
+        guard var session = sessions.first(where: { $0.id == sessionID }) else { return }
+        session.activeAgentID = agentID
+        try await updateSession(session)
+    }
 
     /// Default: iterates ``fetchSessions()`` and calls ``deleteSession(_:)``
     /// per id. **Not** atomic — provided so existing custom in-memory

--- a/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationPersistencePort.swift
@@ -132,18 +132,37 @@ struct ConversationPersistencePort: Sendable {
         }
     }
 
+    /// Bumps the session's `updatedAt` via the store's narrow single-column
+    /// write so a concurrent turn or host-side session edit isn't clobbered by
+    /// a stale-snapshot rewrite (see ``SessionStore/touch(sessionID:date:)``).
+    /// Best-effort: returns `false` and logs on failure.
     @MainActor
     func touchSession(sessionID: UUID) async -> Bool {
         guard let sessionStore else { return true }
         do {
-            let sessions = try await sessionStore.fetchSessions()
-            guard var session = sessions.first(where: { $0.id == sessionID }) else { return true }
-            session.updatedAt = Date()
-            try await sessionStore.updateSession(session)
+            try await sessionStore.touch(sessionID: sessionID, date: Date())
             return true
         } catch {
             Log.persistence.warning(
                 "ConversationRuntime: touchSession failed: \(error.localizedDescription)"
+            )
+            return false
+        }
+    }
+
+    /// Swaps the session's active agent via the store's narrow single-column
+    /// write so a mid-stream handoff doesn't clobber concurrent edits to other
+    /// session columns (see ``SessionStore/setActiveAgent(sessionID:agentID:)``).
+    /// Best-effort: returns `false` and logs on failure.
+    @MainActor
+    func setActiveAgent(sessionID: UUID, agentID: UUID?) async -> Bool {
+        guard let sessionStore else { return true }
+        do {
+            try await sessionStore.setActiveAgent(sessionID: sessionID, agentID: agentID)
+            return true
+        } catch {
+            Log.persistence.warning(
+                "ConversationRuntime: setActiveAgent failed: \(error.localizedDescription)"
             )
             return false
         }

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -653,39 +653,42 @@ struct ConversationTurnExecutor: Sendable {
             return sessionRecord.agents.filter { $0.id != activeID }
         }()
 
-        // Configure the handoff detector for this turn. The closure is
-        // captured by the GenerationQueue's loop construction; we always
-        // (re)set it so a host that mutates session.agents between turns
-        // sees the new registry on the next call without a clear/reset
-        // dance.
+        // Build the handoff detector for this turn as a per-request closure
+        // threaded into `enqueueAsync` (#1494) rather than mutated onto the
+        // shared `InferenceService`. The old per-turn `setHandoffDetector`
+        // raced: turn B's set between turn A's set and A's stream consumption
+        // clobbered A's detector because the queue keyed the detector on the
+        // service, not the request. Capturing the session snapshot in the
+        // closure keeps each in-flight turn's detector independent.
+        let turnHandoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)?
         if let sessionRecord {
-            await inferenceService.setHandoffDetector { @Sendable callSessionID, call in
+            turnHandoffDetector = { @Sendable callSessionID, call in
                 guard callSessionID == sessionRecord.id else {
-                    // Detector closures live on the queue but loop captures
-                    // a per-request sessionID; mismatches are defensive —
-                    // route through the regular dispatch path.
+                    // The queue passes the per-request sessionID; mismatches
+                    // are defensive — route through the regular dispatch path.
                     return .regular(call)
                 }
                 return HandoffDetector.classify(call, in: sessionRecord)
             }
         } else {
-            await inferenceService.setHandoffDetector(nil)
+            turnHandoffDetector = nil
         }
 
-        // Pre-tool-use hook plumbing. The runtime owns the HookRegistry
-        // (Runtime can import Inference, not the other way round) so we
-        // adapt the registry into the closure shape the dispatch loop
-        // accepts. The adapter enforces the sanitize-only invariant and
-        // emits `.hookFired(event: "preToolUse", ...)` on every call.
+        // Build the pre-tool-use hook for this turn. The runtime owns the
+        // HookRegistry (Runtime can import Inference, not the other way round)
+        // so we adapt the registry into the closure shape the dispatch loop
+        // accepts. The adapter enforces the sanitize-only invariant and emits
+        // `.hookFired(event: "preToolUse", ...)` on every call. Threaded per
+        // request alongside the detector (#1494).
+        let turnPreToolUseHook: PreToolUseHook?
         if let turnHookRegistry = assembled.turnHookRegistry {
             let emit = self.eventSink
-            let adapter = PreToolUseHookAdapter.make(
+            turnPreToolUseHook = PreToolUseHookAdapter.make(
                 registry: turnHookRegistry,
                 eventEmitter: { event in emit(event) }
             )
-            await inferenceService.setPreToolUseHook(adapter)
         } else {
-            await inferenceService.setPreToolUseHook(nil)
+            turnPreToolUseHook = nil
         }
 
         // Build the assistant message slot up front so token deltas can
@@ -767,7 +770,9 @@ struct ConversationTurnExecutor: Sendable {
             composedSystemPrompt: composedSystemPrompt,
             structuredHistory: structuredHistory,
             advertisedTools: advertisedTools,
-            assistantMessage: assistantMessage
+            assistantMessage: assistantMessage,
+            handoffDetector: turnHandoffDetector,
+            preToolUseHook: turnPreToolUseHook
         )
     }
 
@@ -793,7 +798,9 @@ struct ConversationTurnExecutor: Sendable {
                 maxThinkingTokens: config.maxThinkingTokens,
                 tools: plan.advertisedTools,
                 priority: .userInitiated,
-                sessionID: sessionID
+                sessionID: sessionID,
+                handoffDetector: plan.handoffDetector,
+                preToolUseHook: plan.preToolUseHook
             )
         } catch {
             emit(.errorRaised(.inference(error)))
@@ -928,7 +935,11 @@ struct ConversationTurnExecutor: Sendable {
                     if var current = state.sessionRecord {
                         let previousID = current.activeAgentID
                         current.activeAgentID = handoff.targetAgentID
-                        _ = await persistence.updateSession(current)
+                        // Narrow single-column write: bump only `activeAgentID`
+                        // on the live row so a concurrent turn or host-side
+                        // session edit isn't clobbered by a stale full-record
+                        // rewrite (#1494).
+                        _ = await persistence.setActiveAgent(sessionID: current.id, agentID: handoff.targetAgentID)
                         state.sessionRecord = current
                         emit(.agentHandoff(from: previousID, to: handoff.targetAgentID))
                     } else {

--- a/Sources/ManifoldRuntime/Services/GenerationTurnState.swift
+++ b/Sources/ManifoldRuntime/Services/GenerationTurnState.swift
@@ -30,6 +30,15 @@ struct GenerationPlan {
     var structuredHistory: [StructuredMessage]
     var advertisedTools: [ToolDefinition]
     var assistantMessage: ChatMessageRecord
+    /// Per-request handoff detector for this turn, passed into `enqueueAsync`
+    /// rather than mutated onto the shared `InferenceService`. Threading it per
+    /// request closes the race where two concurrent turns clobbered the
+    /// service-global detector between set and stream consumption (#1494).
+    /// `nil` for sessionless / single-agent turns.
+    var handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)?
+    /// Per-request pre-tool-use hook for this turn. See ``handoffDetector`` for
+    /// the rationale. `nil` when no host hook registry is wired.
+    var preToolUseHook: PreToolUseHook?
 }
 
 /// The enqueued backend request: the cancellation token and the event stream

--- a/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
@@ -46,7 +46,11 @@ struct HuggingFaceBrowserView: View {
     /// invoked only after the directory is already populated, so the error
     /// path is unreachable in practice).
     private func refreshModels() {
-        try? modelRegistry.refresh()
+        do {
+            try modelRegistry.refresh()
+        } catch {
+            Log.download.warning("HuggingFaceBrowserView: registry refresh failed: \(error)")
+        }
     }
 
     var body: some View {

--- a/Sources/ManifoldUIModelManagement/Views/Models/LocalModelStorageView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/LocalModelStorageView.swift
@@ -137,7 +137,11 @@ struct LocalModelStorageView: View {
     private func deleteModel(_ model: ModelInfo) {
         do {
             try managementViewModel.deleteModel(model)
-            try? modelRegistry.refresh()
+            do {
+                try modelRegistry.refresh()
+            } catch {
+                Log.download.warning("LocalModelStorageView: registry refresh after delete failed: \(error)")
+            }
         } catch {
             Log.download.error("Failed to delete model: \(error)")
             deleteErrorMessage = error.localizedDescription

--- a/Sources/ManifoldUIModelManagement/Views/Models/ModelManagementSheet.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/ModelManagementSheet.swift
@@ -137,7 +137,11 @@ public struct ModelManagementSheet: View {
             } else if selectedTab != initialTab {
                 selectedTab = initialTab
             }
-            try? modelRegistry.refresh()
+            do {
+                try modelRegistry.refresh()
+            } catch {
+                Log.download.warning("ModelManagementSheet: registry refresh on appear failed: \(error)")
+            }
             managementViewModel.invalidateModelCache()
         }
     }

--- a/Sources/ManifoldUIModelManagement/Views/Models/StorageManagementView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/StorageManagementView.swift
@@ -181,7 +181,11 @@ public struct StorageManagementView: View {
     private func deleteModel(_ model: ModelInfo, modelRegistry: ModelRegistry) {
         do {
             try managementViewModel.deleteModel(model)
-            try? modelRegistry.refresh()
+            do {
+                try modelRegistry.refresh()
+            } catch {
+                Log.download.warning("StorageManagementView: registry refresh after delete failed: \(error)")
+            }
         } catch {
             Log.download.error("Failed to delete model: \(error)")
         }

--- a/Tests/ManifoldInferenceTests/GenerationQueuePerRequestDetectorTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueuePerRequestDetectorTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Concurrency regression coverage for #1494: the handoff detector and
+/// pre-tool-use hook must be captured **per request** at enqueue time rather
+/// than read from shared mutable `GenerationQueue` state at drain time.
+///
+/// The old shape set `handoffDetector` / `preToolUseHook` on the shared
+/// service before each `enqueue`. With concurrent in-flight turns the second
+/// turn's set clobbered the first's between enqueue and stream consumption.
+/// Capturing the closures on the `QueuedRequest` makes each request's routing
+/// independent of any later mutation.
+@MainActor
+final class GenerationQueuePerRequestDetectorTests: XCTestCase {
+
+    private var provider: FakeGenerationContextProvider!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        provider = FakeGenerationContextProvider()
+    }
+
+    override func tearDown() async throws {
+        provider = nil
+        try await super.tearDown()
+    }
+
+    private func makeQueue() -> GenerationQueue {
+        let queue = GenerationQueue()
+        provider.bind(to: queue)
+        return queue
+    }
+
+    private func collectEvents(_ stream: GenerationStream) async throws -> [GenerationEvent] {
+        var events: [GenerationEvent] = []
+        for try await event in stream.events {
+            events.append(event)
+        }
+        return events
+    }
+
+    private func handoffTargets(in events: [GenerationEvent]) -> [UUID] {
+        events.compactMap { event -> UUID? in
+            if case let .handoffRequested(handoff) = event { return handoff.targetAgentID }
+            return nil
+        }
+    }
+
+    /// Two requests enqueued back-to-back, each carrying its own per-request
+    /// handoff detector that maps the identical scripted `transfer` tool call
+    /// to a *different* target agent. Each request's stream must surface the
+    /// handoff its own detector produced — proving the detector is pinned to
+    /// the request, not to shared queue state that the second enqueue would
+    /// otherwise clobber.
+    func test_perRequestHandoffDetector_eachRequestUsesItsOwnDetector() async throws {
+        let targetA = UUID()
+        let targetB = UUID()
+
+        // A deliberately "wrong" queue-level detector. If the dispatch loop
+        // fell back to shared state instead of the per-request closure, both
+        // streams would route here and the per-target assertions would fail.
+        let wrongTarget = UUID()
+        // The handoff short-circuits each request's dispatch loop after one
+        // turn (the runtime re-derives the prompt next turn), so each request
+        // consumes exactly one scripted turn. Requests drain FIFO: the first
+        // transfer turn belongs to request A, the second to request B.
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "t-A", toolName: "transfer", arguments: "{}")],
+            [ToolCall(id: "t-B", toolName: "transfer", arguments: "{}")],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], []]
+
+        let queue = makeQueue()
+        queue.handoffDetector = { @Sendable _, call in .handoff(AgentHandoff(targetAgentID: wrongTarget)) }
+
+        let detectorA: @Sendable (UUID?, ToolCall) -> HandoffDetectionResult = { _, _ in
+            .handoff(AgentHandoff(targetAgentID: targetA))
+        }
+        let detectorB: @Sendable (UUID?, ToolCall) -> HandoffDetectionResult = { _, _ in
+            .handoff(AgentHandoff(targetAgentID: targetB))
+        }
+
+        // Enqueue both before draining either: request B's detector is set on
+        // the request that comes after A's enqueue, mirroring the concurrent
+        // turn interleave the issue describes.
+        let (_, streamA) = try queue.enqueue(
+            structuredMessages: [StructuredMessage(role: "user", content: "go A")],
+            config: GenerationQueue.makeEnqueueConfig(
+                temperature: 0.7, topP: 0.9, repeatPenalty: 1.1,
+                topK: nil, minP: nil, presencePenalty: nil, frequencyPenalty: nil,
+                seed: nil, maxOutputTokens: 32, maxThinkingTokens: nil,
+                jsonMode: false, grammar: nil, tools: [], toolChoice: .auto,
+                maxToolIterations: 4
+            ),
+            handoffDetector: detectorA
+        )
+        let (_, streamB) = try queue.enqueue(
+            structuredMessages: [StructuredMessage(role: "user", content: "go B")],
+            config: GenerationQueue.makeEnqueueConfig(
+                temperature: 0.7, topP: 0.9, repeatPenalty: 1.1,
+                topK: nil, minP: nil, presencePenalty: nil, frequencyPenalty: nil,
+                seed: nil, maxOutputTokens: 32, maxThinkingTokens: nil,
+                jsonMode: false, grammar: nil, tools: [], toolChoice: .auto,
+                maxToolIterations: 4
+            ),
+            handoffDetector: detectorB
+        )
+
+        let eventsA = try await collectEvents(streamA)
+        let eventsB = try await collectEvents(streamB)
+
+        XCTAssertEqual(handoffTargets(in: eventsA), [targetA],
+                       "request A's stream must route through detector A's target")
+        XCTAssertEqual(handoffTargets(in: eventsB), [targetB],
+                       "request B's stream must route through detector B's target")
+
+        // Sabotage check: reverting `runToolDispatchLoop` to read `self.handoffDetector`
+        // instead of `request.handoffDetector ?? handoffDetector` routes both
+        // streams to `wrongTarget`, failing both assertions above.
+    }
+
+    /// A `nil` per-request detector falls back to the queue-level detector so
+    /// legacy single-turn callers that still call `setHandoffDetector(_:)`
+    /// keep working.
+    func test_nilPerRequestDetector_fallsBackToQueueLevel() async throws {
+        let fallbackTarget = UUID()
+        provider.backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "t-1", toolName: "transfer", arguments: "{}")],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[]]
+
+        let queue = makeQueue()
+        queue.handoffDetector = { @Sendable _, _ in .handoff(AgentHandoff(targetAgentID: fallbackTarget)) }
+
+        let (_, stream) = try queue.enqueue(
+            structuredMessages: [StructuredMessage(role: "user", content: "go")],
+            config: GenerationQueue.makeEnqueueConfig(
+                temperature: 0.7, topP: 0.9, repeatPenalty: 1.1,
+                topK: nil, minP: nil, presencePenalty: nil, frequencyPenalty: nil,
+                seed: nil, maxOutputTokens: 32, maxThinkingTokens: nil,
+                jsonMode: false, grammar: nil, tools: [], toolChoice: .auto,
+                maxToolIterations: 4
+            )
+            // No per-request detector — must fall back to the queue-level one.
+        )
+
+        let events = try await collectEvents(stream)
+        XCTAssertEqual(handoffTargets(in: events), [fallbackTarget],
+                       "nil per-request detector must fall back to the queue-level detector")
+    }
+}

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
@@ -66,6 +66,76 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         XCTAssertEqual(first.pinnedMessageIDs, pinned)
     }
 
+    // MARK: - Narrow single-column writes (#1494 lost-update)
+
+    /// `touch(sessionID:)` bumps `updatedAt` on the live row without rewriting
+    /// the other columns. A concurrent edit to an unrelated column (here:
+    /// `title`) committed between a turn-start snapshot and the touch must
+    /// survive — the narrow write reads the live row, not the stale snapshot.
+    func test_touch_doesNotClobberConcurrentTitleEdit() async throws {
+        let original = ChatSessionRecord(title: "Original")
+        try await provider.insertSession(original)
+
+        // A turn captured this snapshot at its start (mimics the old
+        // read-modify-write `touchSession`).
+        let staleSnapshot = original
+
+        // Meanwhile a host-side edit renames the session on the live row.
+        var renamed = original
+        renamed.title = "Renamed"
+        try await provider.updateSession(renamed)
+
+        // The narrow touch must NOT carry the stale snapshot's title back.
+        let before = try await provider.fetchSessions().first!.updatedAt
+        try await provider.touch(sessionID: staleSnapshot.id, date: before.addingTimeInterval(10))
+
+        let after = try await provider.fetchSessions().first!
+        XCTAssertEqual(after.title, "Renamed",
+                       "touch must not clobber the concurrent title edit")
+        XCTAssertEqual(after.updatedAt, before.addingTimeInterval(10),
+                       "touch must bump updatedAt")
+
+        // Sabotage check: a read-modify-write touch off `staleSnapshot` would
+        // write title back to "Original", failing the first assertion.
+    }
+
+    /// `setActiveAgent(sessionID:agentID:)` swaps only the active agent on the
+    /// live row. A concurrent edit to another column committed after a
+    /// turn-start snapshot must survive.
+    func test_setActiveAgent_doesNotClobberConcurrentEdit() async throws {
+        let agentA = UUID()
+        let agentB = UUID()
+        let original = ChatSessionRecord(title: "Original", activeAgentID: agentA)
+        try await provider.insertSession(original)
+
+        let staleSnapshot = original
+
+        var renamed = original
+        renamed.title = "Renamed"
+        try await provider.updateSession(renamed)
+
+        try await provider.setActiveAgent(sessionID: staleSnapshot.id, agentID: agentB)
+
+        let after = try await provider.fetchSessions().first!
+        XCTAssertEqual(after.activeAgentID, agentB, "active agent must swap to B")
+        XCTAssertEqual(after.title, "Renamed",
+                       "setActiveAgent must not clobber the concurrent title edit")
+
+        // Sabotage check: a read-modify-write off `staleSnapshot` would write
+        // title back to "Original", failing the title assertion.
+    }
+
+    /// Both narrow writes silently no-op when the session is gone — a touch
+    /// racing a delete must not surface an error to the turn loop.
+    func test_narrowWrites_noOpWhenSessionMissing() async throws {
+        let missing = UUID()
+        // Neither call should throw.
+        try await provider.touch(sessionID: missing, date: Date())
+        try await provider.setActiveAgent(sessionID: missing, agentID: UUID())
+        let sessions = try await provider.fetchSessions()
+        XCTAssertTrue(sessions.isEmpty, "no session should have been created by the no-op writes")
+    }
+
     func test_fetchSessions_ordersByUpdatedAtDescending() async throws {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let older = ChatSessionRecord(title: "Older", updatedAt: now)


### PR DESCRIPTION
Behavior-preserving cleanup cluster from a deep code review. **Stacked on #1506** (`fix/1494-turn-path-concurrency`) because both touch `GenerationQueue.swift` — targets that branch until it merges, then should be rebased onto `main`.

### Three parts

1. **Modernize the hand-rolled lock.** `GenerationStream`'s `ManagedAtomic<Value>` and `StalledCallback` used raw `os_unfair_lock_t.allocate` with manual `initialize`/`deinitialize`/`deallocate` in `deinit` (a use-after-free hazard class). Replaced with `OSAllocatedUnfairLock` (available at the iOS 18 / macOS 15 floor; already used in `MemoryPressureBroadcaster`, `ManifoldConfiguration`, `CuratedModel`). `ManagedAtomic` gains a `Value: Sendable` constraint — both call sites (`Bool`, `ContinuousClock.Instant`) already satisfy it.

2. **Deduplicate capability/warn/ceremony blocks.**
   - The byte-identical jsonMode-unsupported warn block (two copies) moved into the `dispatchToBackend` chokepoint via `warnIfJSONModeUnsupported(...)`. Still fires exactly once per `generate` call (verified by existing `GenerationQueueTests`).
   - `ToolRegistry.definitions` / `advertisedDefinitions` DEBUG warn extracted to `warnIfTooManyTools(_:)`.
   - `ModelLifecycleCoordinator.loadModel(from:plan:)` and `loadCloudBackend` duplicated the begin/install/detached-load/catch/commit ceremony — extracted `runLoad(...)` taking the detached load body as an `@escaping @Sendable` closure (Swift 6 isolation respected; the closure captures only `Sendable` values and runs in `Task.detached`).

3. **Log swallowed refresh errors.** `try? modelRegistry.refresh()` in `ModelManagementSheet`, `HuggingFaceBrowserView`, `LocalModelStorageView`, `StorageManagementView` converted to `do { try ... } catch { Log.download.warning(...) }`. `ManifoldUIModelManagement` is not scanned by `SilentCatchAuditTest`, so a future regression that swallowed a more serious error would otherwise slip through.

### Verification
- Behavior-preserving: no public API/behavior change intended.
- `swift build --build-tests --disable-default-traits` — passes.
- All-traits sweep `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace` — passes.
- `swift test --disable-default-traits --filter ManifoldInferenceTests` — 1650 passed, 5 skipped, 0 failures (unchanged).
- `swift test --disable-default-traits --filter ManifoldUIModelManagementTests` — 110 passed, 0 failures (unchanged).

Closes #1499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)