### PR TITLE
test: make model-discovery E2E suites hermetic (isolate from ~/Documents/Models)

### DIFF
--- a/Tests/ManifoldE2ETests/ModelSelectionE2ETests.swift
+++ b/Tests/ManifoldE2ETests/ModelSelectionE2ETests.swift
@@ -41,7 +41,14 @@ final class ModelSelectionE2ETests {
         service.registerBackendFactory { _ in mockRef }
 
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
-        let storage = ModelStorageService(baseDirectory: modelsDir)
+        // Disable the `~/Documents/Models` fallback scan so discovery is
+        // hermetic: counts must reflect only fixtures this suite writes to
+        // `modelsDir`, never whatever models the developer keeps in their real
+        // home directory. The public init defaults the fallback on (#1468).
+        let storage = ModelStorageService(
+            baseDirectory: modelsDir,
+            includeUserDocumentsFallback: false
+        )
         vm = ChatViewModel(inferenceService: service, modelStorage: storage)
         vm.configure(persistence: persistence)
 
@@ -188,7 +195,10 @@ final class ModelSelectionE2ETests {
     @Test("Model too large for device sets an error and skips load")
     func modelTooLarge_setsError() async throws {
         let mockRef = mock
-        let storage = ModelStorageService(baseDirectory: modelsDir)
+        let storage = ModelStorageService(
+            baseDirectory: modelsDir,
+            includeUserDocumentsFallback: false
+        )
 
         // Stage 2: fit checks route through `ModelLoadPlan`, which consults
         // `availableMemoryBytes` from an injected environment. The legacy

--- a/Tests/ManifoldE2ETests/UserJourneyE2ETests.swift
+++ b/Tests/ManifoldE2ETests/UserJourneyE2ETests.swift
@@ -4,7 +4,7 @@ import SwiftData
 @testable import ManifoldUI
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
-import ManifoldInference
+@testable import ManifoldInference
 import ManifoldTestSupport
 
 /// Day-one user journey E2E — exercises a full first-session experience end to
@@ -51,7 +51,14 @@ final class UserJourneyE2ETests {
         service.registerBackendFactory { _ in backendRef }
 
         persistence = SwiftDataPersistenceProvider(modelContext: context)
-        let storage = ModelStorageService(baseDirectory: modelsDir)
+        // Disable the `~/Documents/Models` fallback scan so discovery is
+        // hermetic: the exact-count assertions in this journey must reflect
+        // only fixtures written to `modelsDir`, never the developer's real
+        // home-directory models. The public init defaults the fallback on (#1468).
+        let storage = ModelStorageService(
+            baseDirectory: modelsDir,
+            includeUserDocumentsFallback: false
+        )
         vm = ChatViewModel(inferenceService: service, modelStorage: storage)
         vm.configure(persistence: persistence)
 


### PR DESCRIPTION
## The bug

`ModelSelectionE2ETests` and `UserJourneyE2ETests` build their `ChatViewModel` with `ModelStorageService(baseDirectory: tempDir)` — the **public** init, which defaults `includeUserDocumentsFallback` to `true` (#1468). `discoverModels()` therefore scanned **both** the per-test temp directory **and** the developer's real `~/Documents/Models`. Both suites then assert *exact* model counts (`availableModels.count == 1`, `== 2`).

Any model a developer keeps in `~/Documents/Models` inflated every count and failed the suite. Surfaced by a **live-model test run**: with a real `llama3.1-8b.gguf` present, both suites failed with `count → 2) == 1` and `→ 3) == 2`, the extra `ModelInfo` being literally that file. Remove it and they pass. This is the leaked-artifact class `scripts/clean-leaked-test-artifacts.sh` exists for — the tests should be hermetic, not depend on the home directory.

## The fix

No production change was needed — the injection seam already existed. `ModelStorageService` has an internal init taking `includeUserDocumentsFallback:`. Both suites now construct storage with `includeUserDocumentsFallback: false`, so discovery scans only the isolated temp dir.

- `Tests/ManifoldE2ETests/ModelSelectionE2ETests.swift` — discovery `ModelStorageService` + the memory-guard one switched to `includeUserDocumentsFallback: false`.
- `Tests/ManifoldE2ETests/UserJourneyE2ETests.swift` — same; also switched `import ManifoldInference` → `@testable import ManifoldInference` to reach the internal init (ModelSelectionE2ETests already used `@testable`).

## Hermeticity verification

Planted a stub `~/Documents/Models/__isolation_probe__.gguf` (with a shell `trap` guaranteeing removal even on failure), ran both suites, then deleted the probe:

```
✔ Test run with 10 tests in 2 suites passed after 0.510 seconds.
OK: probe removed
```

10 tests, 0 failures with a stray model present — counts unaffected. Before this fix the same run failed. No stray file left in `~/Documents/Models`.

## Other suites checked

Swept `Tests/` for `availableModels.count` / `discoverModels().count` + public `ModelStorageService(baseDirectory:)`:
- `ConsumerRuntimeHarness` (drives `ConsumerRuntimeHarnessTests`' `count == 1` assertion) **already** passes `includeUserDocumentsFallback: false` — hermetic.
- `ModelRegistryTests` uses `contains(where:)`, not exact counts — unaffected.
- Other ManifoldUITests using the public init assert against explicit `ModelInfo`s, not disk discovery counts.

Only the two in-scope E2E suites were exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)