### PR TITLE
feat(llama): add awaitGenerationSettled() to await in-flight generation (hardens flaky live tests)

### DIFF
--- a/Sources/ManifoldLlama/LlamaBackend.swift
+++ b/Sources/ManifoldLlama/LlamaBackend.swift
@@ -488,6 +488,25 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
 
     // MARK: - Control
 
+    /// Awaits completion of the in-flight generation task, if any.
+    ///
+    /// `isGenerating` is cleared in the generation task's `defer` block, which
+    /// runs *after* the stream's `continuation.finish()` — so a caller that has
+    /// just drained `generate(...)`'s stream has no happens-before guarantee that
+    /// the flag has flipped back to `false`. Issuing the next `generate(...)`
+    /// immediately can therefore race the defer and trip `.alreadyGenerating`.
+    ///
+    /// Await this between back-to-back generations on the same loaded model when
+    /// deterministic readiness matters (the determinism tests, programmatic
+    /// regenerate loops). It awaits the same `Task` whose `defer` releases the
+    /// guard, so on return `isGenerating == false` is guaranteed without
+    /// unloading the model — unlike ``unloadAndWait()``, the loaded context and
+    /// KV state are preserved for the next turn.
+    public func awaitGenerationSettled() async {
+        let task = withStateLock { generationTask }
+        await task?.value
+    }
+
     public func stopGeneration() {
         // Set the atomic flag first so the decode loop can break on its very next
         // iteration check — even before the lock is acquired below.

--- a/Tests/ManifoldBackendsTests/LlamaSeedDeterminismTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaSeedDeterminismTests.swift
@@ -100,6 +100,14 @@ final class LlamaSeedDeterminismTests: XCTestCase {
                 text += chunk
             }
         }
+        // The stream's last element fires from `continuation.finish()`, but
+        // `LlamaBackend` clears `isGenerating` in the generation task's `defer`,
+        // which has no happens-before relationship with the consumer loop exiting
+        // above. Without awaiting the task to settle, the *next* generate() can
+        // race the defer and throw `.alreadyGenerating` (observed under
+        // full-suite load). Awaiting the in-flight task guarantees the defer has
+        // run and `isGenerating == false` before the caller starts gen #2.
+        await backend.awaitGenerationSettled()
         return text
     }
 }

--- a/Tests/ManifoldE2ETests/MemoryPressureUnloadE2ETests.swift
+++ b/Tests/ManifoldE2ETests/MemoryPressureUnloadE2ETests.swift
@@ -148,15 +148,20 @@ struct MemoryPressureUnloadE2ETests {
             await vm.sendMessage()
         }
 
-        // Poll until generation begins with a deadline-based timeout.
-        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
-        while !vm.isGenerating && ContinuousClock.now < deadline {
+        // Poll until generation begins with a generous deadline. A cold large-model
+        // load plus first token can take well over 2s under full-suite load (this
+        // suite may run against a real backend in some lanes), so the original 2s
+        // window tripped the precondition before generation even started. 60s is a
+        // safe upper bound for a cold 8B load; the loop exits the instant
+        // `isGenerating` flips, so a fast mock startup pays no extra cost.
+        let startupDeadline = ContinuousClock.now.advanced(by: .seconds(60))
+        while !vm.isGenerating && ContinuousClock.now < startupDeadline {
             try await Task.sleep(for: .milliseconds(10))
         }
         guard vm.isGenerating else {
             genTask.cancel()
             await genTask.value
-            Issue.record("Precondition failed: generation did not start within 2s")
+            Issue.record("Precondition failed: generation did not start within 60s")
             return
         }
 


### PR DESCRIPTION
Both tests passed in isolation but failed under a **full-suite live-model run** — load-dependent timing races, not product logic bugs (one minor product seam added, see below).

## Bug 1 — `LlamaSeedDeterminismTests.test_sameSeed_producesIdenticalOutput`

Failed under load with `LlamaBackend.swift:323: caught error: "alreadyGenerating"`.

**Root cause.** `LlamaBackend` clears `isGenerating` in the generation task's `defer` block, which runs *after* the stream's `continuation.finish()`. The test's `for try await event in stream.events` loop exits on that finish, but there is **no happens-before relationship** between the consumer loop exiting and the task's `defer` executing. So the second `generate(...)` can run while `isGenerating` is still `true` and gets rejected.

This exposed a genuine (minor) product gap: a well-behaved caller that drains a stream and immediately wants to re-generate on the *same loaded model* had no awaitable "generation settled" signal. `unloadAndWait()` exists but unloads the model — wrong for a same-model determinism comparison.

**Fix.** Added a minimal seam `LlamaBackend.awaitGenerationSettled()` that awaits the in-flight `generationTask` — the *same* Task whose `defer` releases the guard — mirroring the existing `unloadAndWait()`/cleanup-task pattern. It does not unload, so the loaded context + KV state are preserved for the next turn. The determinism helper now awaits it after draining each stream.

**Why the race is eliminated (not just made rarer):** awaiting `task.value` blocks until the task body — *including its `defer`* — has fully completed. The `defer` is exactly where `isGenerating` is set back to `false`. So on return from `awaitGenerationSettled()`, `isGenerating == false` is guaranteed before gen #2 issues its guard check. There is no remaining window.

## Bug 2 — `MemoryPressureUnloadE2ETests.criticalDuringGeneration_stopsAndUnloads`

Failed under load with `Issue.record("Precondition failed: generation did not start within 2s")`.

**Root cause.** The test polls `vm.isGenerating` against a 2s deadline before simulating memory pressure. A cold large-model load + first token can exceed 2s under full-suite load, tripping the precondition before generation even begins. Pure test-deadline bug.

**Fix.** Raised the startup window to 60s (a safe upper bound for a cold 8B load). The poll loop still exits the instant `isGenerating` flips, so fast startups pay no extra cost. The actual assertion — critical pressure stops + unloads the model — is unchanged. Swept the rest of the test; the post-pressure `await genTask.value` is unbounded by design (cancellation drives it to completion).

## Verification (live `llama3.1-8b` GGUF)

Reproduction is load-dependent, so each fixed test was run multiple times back-to-back:

- `LlamaSeedDeterminism`: **5/5** runs passed (2 tests each — `sameSeed` + `differentSeeds`), zero `alreadyGenerating`.
- `MemoryPressureUnload`: **3/3** runs passed (6 tests each).
- `swift build --build-tests --traits Llama` succeeds.

## Files changed
- `Sources/ManifoldLlama/LlamaBackend.swift` — new `awaitGenerationSettled()` seam
- `Tests/ManifoldBackendsTests/LlamaSeedDeterminismTests.swift` — await settle between generations
- `Tests/ManifoldE2ETests/MemoryPressureUnloadE2ETests.swift` — startup deadline 2s → 60s