### PR TITLE
docs(docc): flesh out Tier 1 DocC catalogs (ManifoldInference, ManifoldMLX, ManifoldVoice)

### DIFF
--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -28,6 +28,218 @@ to integrate a custom backend or drive a custom chat surface.
 
 For the source-backed operational contract around loading, streaming, memory handling, cancellation, and pinning, see [`docs/RELIABILITY.md`](../../../docs/RELIABILITY.md).
 
+## When to use this module
+
+Import `ManifoldInference` directly when:
+
+- You are writing a custom ``InferenceBackend`` conformer and need the protocol
+  shape, ``GenerationConfig``, and ``GenerationStream`` without pulling in any
+  backend family or ML dependency.
+- You are building a host shell that drives generation directly — enqueue
+  messages through ``InferenceService``, drain the ``GenerationStream``, and
+  handle ``GenerationEvent`` values in your own turn loop.
+- You need the image-generation value types (``ImageGenerationConfig``,
+  ``ImageGenerationEvent``, ``ImageModelInfo``) in a non-MLX target — for
+  example a catalog UI, a persistence adapter, or a cloud image service.
+- You want the conversation record types (``ChatMessageRecord``,
+  ``ChatSessionRecord``) without dragging in SwiftData or any UI layer.
+- You are writing a backend test and need ``BackendCapabilities`` or the
+  ``BackendContractChecks`` conformance harness.
+
+## When not to use this module
+
+- **You want a turn loop with persistence.** ``ConversationRuntime`` in
+  `ManifoldRuntime` adds session scoping, message store writes, hooks, and the
+  reliable ``ConversationTurnHandle/outcome`` handle on top. Use `ManifoldRuntime`
+  when you need any of those.
+- **You want the full chat shell.** ``ManifoldBootstrap`` and ``ChatView``/
+  ``ChatViewModel`` in `ManifoldUI` configure everything for you. Touch
+  `ManifoldInference` only when building outside that shell.
+- **You want a concrete backend.** MLX, llama.cpp, Foundation, and cloud
+  backends live in their own family targets. This module only declares the
+  protocols they conform to.
+
+## Beyond chat
+
+``InferenceService`` is named for its most common use case but is more
+general: it is a backend-agnostic request queue that serialises streaming
+generation calls through a priority-ordered FIFO, routes them to the loaded
+backend, and emits ``GenerationEvent`` values. Any pipeline that fits that
+shape — tool-call orchestrators, classification workers, document summarisers,
+image-generation runs (``ImageGenerationService``), voice prompt assembly —
+can drive ``InferenceService`` directly without touching chat UI.
+
+The same is true of ``InferenceBackend``: backend authors implement this
+protocol to add new inference engines (local or remote) without touching any
+persistence or UI layer.
+
+## The 3–5 most-used types
+
+### `InferenceBackend` — write a custom backend
+
+Adopt ``InferenceBackend`` to plug a new engine into the framework. The
+minimum conformance is four methods; the rest have no-op defaults:
+
+```swift,no-build
+import ManifoldInference
+
+final class MyBackend: InferenceBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = false
+    var isGenerating: Bool = false
+    var capabilities: BackendCapabilities {
+        BackendCapabilities(
+            maxContextTokens: 4096,
+            supportsSystemPrompt: true
+        )
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        // Load weights, initialise runtime.
+        isModelLoaded = true
+    }
+
+    func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        GenerationStream { continuation in
+            isGenerating = true
+            continuation.yield(.token("Hello "))
+            continuation.yield(.token("world"))
+            continuation.finish()
+            isGenerating = false
+        }
+    }
+
+    func stopGeneration() { /* signal the loop */ }
+    func unloadModel() { isModelLoaded = false }
+}
+```
+
+Register the conformer via `InferenceService.registerBackendFactory` at app
+start, or pass it directly to `InferenceService(backend:)` in tests.
+
+### `GenerationConfig` — tune sampling parameters
+
+``GenerationConfig`` is the single value type handed to every generation call.
+Most fields default to sensible values and non-honoured fields are silently
+ignored by each backend:
+
+```swift,no-build
+import ManifoldInference
+
+let config = GenerationConfig(
+    temperature: 0.8,
+    topP: 0.95,
+    maxOutputTokens: 1024,
+    // Disable chain-of-thought for a backend that loads a thinking model.
+    maxThinkingTokens: 0
+)
+
+let (token, stream) = try inferenceService.enqueue(
+    messages: [.system("You are a concise assistant."), .user("Summarise this.")],
+    config: config
+)
+
+for try await event in stream {
+    if case .token(let chunk) = event {
+        print(chunk, terminator: "")
+    }
+}
+```
+
+The `llamaDRY`, `llamaXTC`, and `llamaMirostatV2` fields are llama.cpp-only;
+all other backends silently ignore them.
+
+### `GenerationEvent` — consume the token stream
+
+``GenerationEvent`` is the typed event emitted by every backend. The most
+commonly handled cases are:
+
+```swift,no-build
+import ManifoldInference
+
+for try await event in stream {
+    switch event {
+    case .token(let chunk):
+        responseText += chunk
+    case .thinkingToken(let chunk):
+        thinkingText += chunk
+    case .thinkingComplete:
+        showThinkingBubble(thinkingText)
+    case .toolCall(let call):
+        let result = try await myToolRegistry.dispatch(call)
+        // The queue re-prompts automatically; you only need to observe.
+    case .usage(let prompt, let completion):
+        updateTokenCounter(prompt: prompt, completion: completion)
+    default:
+        break
+    }
+}
+```
+
+Pattern-match consumers must handle or default-case every case — the enum is
+exhaustive and new cases are source-breaking. Use `default:` when you only care
+about a subset.
+
+### `ImageGenerationConfig` and `ImageGenerationEvent` — image pipelines
+
+The image-generation value types live in `ManifoldInference` (not in
+`ManifoldMLX`) so any module — catalog UI, persistence, cloud image service —
+can reference them without pulling in ML dependencies:
+
+```swift,no-build
+import ManifoldInference
+import ManifoldMLX
+
+let backend = FluxDiffusionBackend()
+try await backend.loadModel(from: weightsURL)
+
+let config = ImageGenerationConfig(
+    steps: 4,           // distilled model — 4 steps is enough
+    width: 1024,
+    height: 1024,
+    seed: 42,
+    outputDirectory: FileManager.default.temporaryDirectory
+)
+
+let stream = try await backend.generate(prompt: "a red fox in the snow", config: config)
+for try await event in stream {
+    switch event {
+    case .progress(let step, let total):
+        progressView.update(step: step, total: total)
+    case .completed(let url):
+        imageView.image = NSImage(contentsOf: url)
+    }
+}
+```
+
+For apps that swap models at runtime, use ``ImageGenerationService`` instead —
+it manages backend lifecycle and arbitrates against the text-inference resource
+pool.
+
+### `ChatMessageRecord` — cross-boundary message snapshot
+
+``ChatMessageRecord`` is a plain `Sendable` value type that crosses persistence
+boundaries. It carries no SwiftData, no CoreData, and no UI. Use it to pass
+message data between layers without coupling them:
+
+```swift,no-build
+import ManifoldInference
+
+// Construct a record the persistence layer can store.
+let record = ChatMessageRecord(
+    sessionID: sessionID,
+    role: .assistant,
+    content: [.text(responseText)],
+    modelName: "llama-3.2-3b"
+)
+
+// Persistence adapters receive this type — no SwiftData import needed here.
+try await myMessageStore.insertMessage(record)
+```
+
 ## Topics
 
 ### Configuration
@@ -51,6 +263,7 @@ For the source-backed operational contract around loading, streaming, memory han
 
 - ``GenerationEvent``
 - ``GenerationStream``
+- ``GenerationConfig``
 
 ### Image generation
 

--- a/Sources/ManifoldMLX/ManifoldMLX.docc/ManifoldMLX.md
+++ b/Sources/ManifoldMLX/ManifoldMLX.docc/ManifoldMLX.md
@@ -18,7 +18,7 @@ distinct surfaces:
 The module is trait-gated behind the `MLX` package trait; apps that don't
 need MLX can build without it. Image generation backends additionally need
 diffusion weights on disk — see ``ImageModelInfo`` for the on-disk shape and
-``ManifoldHuggingFace`` for the downloader.
+`ManifoldHuggingFace` for the downloader.
 
 > Note: `ImageGenerationConfig`, `ImageGenerationEvent`, and `ImageModelInfo`
 > are declared in `ManifoldInference`, not here — they have to sit below the
@@ -30,6 +30,193 @@ diffusion weights on disk — see ``ImageModelInfo`` for the on-disk shape and
 > import ManifoldInference
 > import ManifoldMLX
 > ```
+
+## When to use this module
+
+Import `ManifoldMLX` directly when:
+
+- You are loading safetensors / MLX-format model weights from a local directory
+  or a HuggingFace Hub snapshot for **text inference** on Apple Silicon.
+- You are running **on-device diffusion** — either SDXL/SD 2.1 via
+  ``MLXDiffusionBackend`` or FLUX.1 Schnell via ``FluxDiffusionBackend``.
+- You want to tune the Metal GPU buffer cache size with ``MLXCachePolicy``
+  (for example to maximise throughput on a Mac Studio with 192 GB RAM, or to
+  minimise peak footprint on an older iPhone).
+- You are writing backend-level tests that need ``MLXBackend`` directly rather
+  than going through ``InferenceService``.
+
+## When not to use this module
+
+- **Your app never runs on Apple Silicon.** The entire module is conditionally
+  compiled behind the `MLX` package trait. Cloud-only apps should omit the
+  `MLX` trait so the MLX XCFramework is never linked.
+- **You only need the image-generation value types** (``ImageGenerationConfig``,
+  ``ImageGenerationEvent``). Those are in `ManifoldInference` so you can
+  reference them without pulling in the MLX dependency.
+- **You want the framework to manage model lifecycle.** For text inference,
+  register ``MLXBackend`` via
+  `InferenceService.registerBackendFactory` and let ``InferenceService``
+  own loading. For image generation, use ``ImageGenerationService`` when you
+  want automatic load/unload-on-switch and resource arbitration against the
+  text-inference pool.
+
+## Beyond chat
+
+``MLXDiffusionBackend`` and ``FluxDiffusionBackend`` are fully independent of
+the chat runtime. Use them from any Swift context — a command-line tool, a
+photo-editing extension, a SwiftUI image-generation view — without importing
+`ManifoldRuntime` or `ManifoldUI`. The shared ``ImageGenerationEvent`` stream
+and file-URL–based output mean finished images slot directly into any
+persistence layer that stores file references.
+
+The text backend (``MLXBackend``) is also usable outside chat: classification
+pipelines, document summarisers, and structured-output extractors that need a
+fast local LLM on Mac can drive it through ``InferenceService`` without
+wiring up sessions or a message store.
+
+## When to use which image-gen entry point
+
+| Need | Use |
+|---|---|
+| Multi-model app, user can switch models, want framework to load/unload | ``ImageGenerationService`` |
+| Single-model app, you own the model URL, want minimum surface area | ``FluxDiffusionBackend`` or ``MLXDiffusionBackend`` directly |
+| Persist generated images alongside chat turns | ``ImageGenerationService`` + `ConversationRuntime` |
+| FLUX.1 Schnell (distilled, 4-step) | ``FluxDiffusionBackend`` |
+| Stable Diffusion 2.1 Base or SDXL Turbo | ``MLXDiffusionBackend`` |
+| Headless / CLI generation, no persistence | Direct backend |
+
+Both paths emit the same ``ImageGenerationEvent`` stream and write the
+finished image to a file URL on disk (see the type's "Why URL, not CGImage?"
+section). The service path additionally arbitrates against the
+text-inference resource pool so loading a diffusion model evicts an LLM
+that's currently resident, and vice versa.
+
+## The 3–5 most-used types
+
+### `MLXBackend` — text inference on Apple Silicon
+
+``MLXBackend`` is the primary text backend for safetensors/MLX models. Register
+it at app start so ``InferenceService`` can select it when the loaded model
+is in MLX format:
+
+```swift,no-build
+import ManifoldInference
+import ManifoldMLX
+
+@MainActor
+func wireBackends(service: InferenceService) {
+    service.registerBackendFactory { modelType in
+        guard modelType == .mlx else { return nil }
+        return MLXBackend()
+    }
+}
+
+// Later: load a model directory containing config.json + .safetensors weights.
+let plan = try ModelLoadPlan.compute(for: modelInfo)
+try await inferenceService.loadModel(from: modelInfo, plan: plan)
+
+let (_, stream) = try inferenceService.enqueue(
+    messages: [.user("Explain diffusion models in one paragraph.")],
+    config: GenerationConfig(temperature: 0.7, maxOutputTokens: 256)
+)
+
+for try await event in stream {
+    if case .token(let chunk) = event { print(chunk, terminator: "") }
+}
+```
+
+``MLXBackend`` requires real Apple Silicon hardware — it will not function in
+the iOS Simulator. Gate Metal-dependent paths with `#if !targetEnvironment(simulator)`.
+
+### `MLXCachePolicy` — tune the Metal buffer pool
+
+MLX maintains a process-global pool of freed Metal buffers. The default
+``MLXCachePolicy/auto`` picks a sensible size based on device RAM, but you
+can override it when you have measured a specific workload:
+
+```swift,no-build
+import ManifoldMLX
+
+// Auto (recommended) — picks 64 MB on older iPhones, up to 1 GB on 36+ GB Macs.
+let policy: MLXCachePolicy = .auto
+
+// Generous — ~25% of physical RAM, capped at 4 GB.
+// Use when throughput matters more than peak footprint.
+let policy: MLXCachePolicy = .generous
+
+// Explicit — you have benchmarked 768 MB for your specific model + workload.
+let policy: MLXCachePolicy = .explicit(bytes: 768 * 1024 * 1024)
+
+// Apply the policy (call after loadModel succeeds, not before).
+MLX.Memory.cacheLimit = policy.resolvedBytes()
+```
+
+> Warning: Never call `MLX.Memory.cacheLimit` or `MLX.Memory.clearCache()`
+> before a successful `loadModel` — doing so requires the metallib to be
+> initialised and will abort the process in the Simulator. Use container
+> presence as the guard.
+
+### `FluxDiffusionBackend` — FLUX.1 Schnell on device
+
+``FluxDiffusionBackend`` drives FLUX.1 Schnell via `mzbac/flux.swift`. It
+accepts both quantized weights (4-bit, written by `flux.swift`'s own
+`saveQuantizedWeights`) and standard FP16 safetensors in diffusers layout:
+
+```swift,no-build
+import ManifoldInference
+import ManifoldMLX
+
+let backend = FluxDiffusionBackend()
+try await backend.loadModel(from: weightsURL)  // URL to the model directory
+
+let config = ImageGenerationConfig(
+    steps: 4,           // FLUX Schnell is distilled — 4 steps is enough
+    width: 1024,
+    height: 1024,
+    seed: 42,
+    outputDirectory: FileManager.default.temporaryDirectory
+)
+
+let stream = try await backend.generate(prompt: "a red fox in the snow", config: config)
+for try await event in stream {
+    switch event {
+    case .progress(let step, let total):
+        print("Step \(step)/\(total)")
+    case .completed(let url):
+        // `url` points to a fully-written PNG on disk.
+        displayImage(at: url)
+    }
+}
+```
+
+### `MLXDiffusionBackend` — Stable Diffusion on device
+
+``MLXDiffusionBackend`` auto-detects the model layout from the directory
+structure — SD 2.1 Base (512×512) or SDXL Turbo (1024×1024). The init
+takes no parameters; all tuning goes through ``ImageGenerationConfig``:
+
+```swift,no-build
+import ManifoldInference
+import ManifoldMLX
+
+let backend = MLXDiffusionBackend()
+try await backend.loadModel(from: sdxlTurboURL)
+
+let config = ImageGenerationConfig(
+    steps: 1,           // SDXL Turbo is distilled — 1 step works well
+    width: 1024,
+    height: 1024,
+    guidanceScale: 0.0  // distilled models ignore CFG; set to 0 to be explicit
+)
+
+let stream = try await backend.generate(
+    prompt: "a watercolour painting of Kyoto in autumn",
+    config: config
+)
+for try await event in stream {
+    if case .completed(let url) = event { displayImage(at: url) }
+}
+```
 
 ## Topics
 
@@ -57,18 +244,3 @@ or a CLI that does one generation and exits. Both backends conform to
 
 - ``MLXBackend``
 - ``MLXCachePolicy``
-
-## When to use which image-gen entry point
-
-| Need | Use |
-|---|---|
-| Multi-model app, user can switch models, want framework to load/unload | ``ImageGenerationService`` |
-| Single-model app, you own the model URL, want minimum surface area | ``FluxDiffusionBackend`` or ``MLXDiffusionBackend`` directly |
-| Persist generated images alongside chat turns | ``ImageGenerationService`` + `ConversationRuntime` |
-| Headless / CLI generation, no persistence | Direct backend |
-
-Both paths emit the same ``ImageGenerationEvent`` stream and write the
-finished image to a file URL on disk (see the type's "Why URL, not CGImage?"
-section). The service path additionally arbitrates against the
-text-inference resource pool so loading a diffusion model evicts an LLM
-that's currently resident, and vice versa.

--- a/Sources/ManifoldVoice/ManifoldVoice.docc/ManifoldVoice.md
+++ b/Sources/ManifoldVoice/ManifoldVoice.docc/ManifoldVoice.md
@@ -48,6 +48,195 @@ with a localized message when either authorization is denied.
 - Inject your own ``SpeechTranscribing`` / ``SpeechSynthesizing`` implementations
   in tests to avoid touching the audio session.
 
+## When to use this module
+
+Import `ManifoldVoice` directly when:
+
+- You want **streaming STT in any SwiftUI view** — a search bar, image-generation
+  prompt field, note-taking surface, or accessibility aid — without building
+  a chat session.
+- You need **TTS readback** of model output or any other text, with start/stop
+  control and an `isSpeaking` observable property to drive UI.
+- You want **wake-word triggering** — a passive phrase (e.g. "Hey Manifold")
+  that starts a recording session hands-free without a tap target.
+- You are building an accessibility-first UI and need `VoiceCaptureState`
+  changes to drive button labels and progress indicators.
+- You want to replace `SFSpeechRecognizer` with a different STT engine (e.g. a
+  local Whisper model) without changing the rest of your UI — inject your own
+  ``SpeechTranscribing`` conformer.
+
+## When not to use this module
+
+- **You only need text input.** If push-to-talk is an optional enhancement, you
+  can ship the text path first and add `ManifoldVoice` later. The module adds
+  `Speech` and `AVFoundation` link-time cost even when the user never taps the
+  mic button.
+- **You need server-side or Whisper-based STT.** The shipped ``AppleSpeechTranscriber``
+  uses `SFSpeechRecognizer` — inject a custom ``SpeechTranscribing`` conformer
+  instead of using this module as-is.
+- **You are testing on a simulator.** Recording always fails with
+  ``VoiceError/simulatorUnsupported``. Inject a ``SpeechTranscribing`` mock
+  that yields scripted updates instead of touching the audio session.
+
+## Beyond chat
+
+``VoiceConversationController`` has no dependency on chat types. Common
+non-chat patterns:
+
+- **Dictation field** — observe `liveTranscript` to mirror the in-flight
+  transcript into a `TextField`; commit `stopRecording()` to the field's binding.
+  See <doc:StandaloneSpeechRecognition> for a full worked example.
+- **Image-generation prompt** — drive `startRecording()` / `stopRecording()`
+  from a mic button next to the diffusion prompt field; feed the committed
+  transcript directly to `ImageGenerationService`.
+- **Accessibility readback** — call `speak(_:)` on ``AppleSpeechSynthesizer``
+  (or any ``SpeechSynthesizing`` conformer) to read assistant replies aloud in
+  a hands-free context. The controller tracks `isSpeaking` so a stop button
+  can be shown only while TTS is active.
+
+## The 3–5 most-used types
+
+### `VoiceConversationController` — the top-level coordinator
+
+``VoiceConversationController`` is a `@MainActor @Observable` class that
+coordinates the full voice lifecycle. Zero-argument init uses Apple's built-in
+speech recognition and synthesis:
+
+```swift,no-build
+import SwiftUI
+import ManifoldVoice
+
+@MainActor
+struct PromptBar: View {
+    @State private var voice = VoiceConversationController()
+    @Binding var prompt: String
+
+    var body: some View {
+        HStack {
+            TextField("Describe an image", text: $prompt)
+            Button {
+                Task { await toggleRecording() }
+            } label: {
+                Image(systemName: voice.isRecording ? "mic.fill" : "mic")
+                    .foregroundStyle(voice.isRecording ? .red : .secondary)
+            }
+        }
+        // Mirror the live transcript into the field while recording.
+        .onChange(of: voice.liveTranscript) { _, text in
+            if voice.isRecording { prompt = text }
+        }
+    }
+
+    private func toggleRecording() async {
+        if voice.isRecording {
+            if let committed = await voice.stopRecording() {
+                prompt = committed   // replace live preview with final result
+            }
+        } else {
+            await voice.startRecording()
+        }
+    }
+}
+```
+
+### `VoiceCaptureState` — drive your UI
+
+``VoiceCaptureState`` is an `Equatable` enum that tracks the controller's
+lifecycle. Observe it to show permission-request spinners, recording indicators,
+and error messages:
+
+```swift,no-build
+import ManifoldVoice
+
+switch voice.captureState {
+case .idle:
+    micButton.isEnabled = true
+case .requestingPermission:
+    micButton.isEnabled = false
+    statusLabel.text = "Requesting access…"
+case .recording:
+    micButton.tintColor = .systemRed
+    statusLabel.text = voice.liveTranscript.isEmpty ? "Listening…" : voice.liveTranscript
+case .processing:
+    micButton.isEnabled = false
+    statusLabel.text = "Finishing transcript…"
+case .failed(let message):
+    micButton.isEnabled = true
+    statusLabel.text = message
+}
+```
+
+``VoiceConversationController/statusText`` provides a pre-computed human-readable
+string that covers the same cases, including the `isSpeaking` TTS state.
+
+### `SpeechTranscribing` — inject a custom STT backend
+
+Conform to ``SpeechTranscribing`` to swap out `SFSpeechRecognizer` — for
+example to route audio through a local Whisper model or a server-side STT
+service. The protocol is four `@MainActor` methods:
+
+```swift,no-build
+import ManifoldVoice
+
+final class WhisperTranscriber: SpeechTranscribing {
+    @MainActor
+    func requestAuthorization() async -> VoiceAuthorizationStatus { .authorized }
+
+    @MainActor
+    func startTranscribing(
+        onUpdate: @escaping @MainActor (SpeechTranscriptionUpdate) -> Void
+    ) async throws {
+        // Start your audio pipeline; call onUpdate as partials arrive.
+        onUpdate(SpeechTranscriptionUpdate(text: "partial…", isFinal: false))
+    }
+
+    @MainActor
+    func stopTranscribing() async throws -> String? {
+        // Flush the final result; return nil to let the controller use liveTranscript.
+        return nil
+    }
+
+    @MainActor func cancelTranscribing() { /* stop audio pipeline */ }
+}
+
+// Inject at construction time.
+let controller = VoiceConversationController(transcriber: WhisperTranscriber())
+```
+
+In unit tests, inject a scripted conformer that feeds canned ``SpeechTranscriptionUpdate``
+values synchronously — no audio session needed.
+
+### Wake-word detection
+
+``WakeWordDetector`` intercepts in-flight transcription updates and fires when a
+configured phrase is heard. Implement the two-method protocol and pass it to the
+controller. ``VoiceConversationController/recentWakeWordDetection`` holds the
+last detection for UI toast display:
+
+```swift,no-build
+import ManifoldVoice
+
+final class PhraseDetector: WakeWordDetector {
+    private let trigger: String
+
+    init(phrase: String) { self.trigger = phrase.lowercased() }
+
+    @MainActor
+    func ingest(_ update: SpeechTranscriptionUpdate) -> WakeWordDetection? {
+        guard update.text.lowercased().contains(trigger) else { return nil }
+        return WakeWordDetection(phrase: trigger, transcript: update.text)
+    }
+
+    @MainActor func reset() {}
+}
+
+let controller = VoiceConversationController(
+    wakeWordDetector: PhraseDetector(phrase: "hey manifold")
+)
+
+// Observe recentWakeWordDetection to show a toast and start a new turn.
+```
+
 ## Topics
 
 ### Standalone usage


### PR DESCRIPTION
## Summary

- Adds "When to use", "When not to use", "Beyond chat", and "The 3–5 most-used types" sections to all three Tier 1 DocC catalog landing pages, matching the structure and depth of the `ManifoldRuntime.md` exemplar
- `ManifoldInference.md`: covers `InferenceBackend` (custom conformer example), `GenerationConfig` (enqueue pattern), `GenerationEvent` (switch-case drain), `ImageGenerationConfig`/`ImageGenerationEvent` (FLUX pipeline), and `ChatMessageRecord` (cross-boundary snapshot)
- `ManifoldMLX.md`: expands the entry-point chooser table (now 6 rows), adds `MLXBackend` registration + enqueue example, `MLXCachePolicy` with `.auto`/`.generous`/`.explicit` forms and the metallib guard warning, `FluxDiffusionBackend` 4-step generation, and `MLXDiffusionBackend` 1-step SDXL Turbo example
- `ManifoldVoice.md`: covers `VoiceConversationController` (PromptBar SwiftUI example), `VoiceCaptureState` (switch-case UI mapping), `SpeechTranscribing` (custom Whisper conformer injection), and `WakeWordDetector` (phrase-match implementation)
- All code examples use `swift,no-build` fences and mirror actual public API shapes verified from source

Closes #1463 (Tier 1 — ManifoldInference, ManifoldMLX, ManifoldVoice)

## Test plan

- [ ] Verify DocC renders the three landing pages without warnings in Xcode (Product → Build Documentation)
- [ ] Confirm all `swift,no-build` code blocks display correctly (no "build" button shown)
- [ ] Check that symbol links (e.g. `\`\`MLXBackend\`\``, `\`\`VoiceConversationController\`\``) resolve in the rendered catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)