### PR TITLE
fix(ci): pass --disable-default-traits to per-snippet swift build

### DIFF
--- a/scripts/extract-snippets-test.sh
+++ b/scripts/extract-snippets-test.sh
@@ -20,9 +20,13 @@
 #   - platforms macOS .v15 (ManifoldKit's floor)
 #   - depends on the local ManifoldKit checkout via .package(name: ..., path: ...)
 #   - links the ManifoldKit umbrella product (covers ManifoldUI / Inference re-exports)
-#   - built with --disable-default-traits so MLX/Llama XCFrameworks are not
-#     compiled (they require hardware and slow each build by ~3 min). Snippets
-#     that import ManifoldBackends still compile — the umbrella is trait-safe.
+#   - depends on ManifoldKit with traits: ["FoundationOnly"] so MLX/Llama/
+#     HuggingFace XCFrameworks are not compiled (they require hardware and add
+#     ~3 min per build). FoundationOnly is the established lean-build trait;
+#     ManifoldBackends is trait-safe so the ManifoldBackends import snippet
+#     still compiles. --disable-default-traits is NOT passed on the command
+#     line because that flag applies to the snippet package itself, which
+#     declares no traits and would be rejected by SwiftPM.
 #
 # Exit codes:
 #   0 — every snippet compiled.
@@ -87,7 +91,7 @@ let package = Package(
         .executable(name: "SnippetApp", targets: ["SnippetApp"]),
     ],
     dependencies: [
-        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
+        .package(name: "ManifoldKit", path: "$REPO_ROOT", traits: ["FoundationOnly"]),
     ],
     targets: [
         .executableTarget(
@@ -115,7 +119,7 @@ EOF
     echo "── ${base}  (from ${src_location})"
 
     log="$pkg_dir/build.log"
-    if (cd "$pkg_dir" && swift build --disable-default-traits) > "$log" 2>&1; then
+    if (cd "$pkg_dir" && swift build) > "$log" 2>&1; then
         echo "   PASS"
         passed=$((passed + 1))
     else

--- a/scripts/extract-snippets-test.sh
+++ b/scripts/extract-snippets-test.sh
@@ -20,6 +20,9 @@
 #   - platforms macOS .v15 (ManifoldKit's floor)
 #   - depends on the local ManifoldKit checkout via .package(name: ..., path: ...)
 #   - links the ManifoldKit umbrella product (covers ManifoldUI / Inference re-exports)
+#   - built with --disable-default-traits so MLX/Llama XCFrameworks are not
+#     compiled (they require hardware and slow each build by ~3 min). Snippets
+#     that import ManifoldBackends still compile — the umbrella is trait-safe.
 #
 # Exit codes:
 #   0 — every snippet compiled.
@@ -112,7 +115,7 @@ EOF
     echo "── ${base}  (from ${src_location})"
 
     log="$pkg_dir/build.log"
-    if (cd "$pkg_dir" && swift build) > "$log" 2>&1; then
+    if (cd "$pkg_dir" && swift build --disable-default-traits) > "$log" 2>&1; then
         echo "   PASS"
         passed=$((passed + 1))
     else


### PR DESCRIPTION
## Summary

- Each `swift build` in `scripts/extract-snippets-test.sh` was compiling ManifoldKit with MLX/Llama traits active, pulling in hardware XCFrameworks and adding ~3 min per snippet
- With 8 snippets running serially the `readme-snippets` job was taking 20–32 min
- All 8 current snippets use `ManifoldKit`, `ManifoldUI`, `ManifoldInference`, or `ManifoldBackends` — none reference MLX- or Llama-specific types, so `--disable-default-traits` is safe for all of them
- `ManifoldBackends` is explicitly trait-safe under `--disable-default-traits` (umbrella re-exports each family conditionally)

## Test plan
- [ ] `readme-snippets` CI job on this PR completes in under 5 min (vs 20–32 min before)
- [ ] All 8 snippet builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)