### PR TITLE
feat(runtime): HistoryShaper, HostTurnContextProvider, PreTurnCompressionPolicy

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,42 @@
 {
-  "originHash" : "6369a506aee9cc749876a6f1270a96b019b95f14430819a2f8daab6f4d4305c4",
+  "originHash" : "bbf2a35cae94421b5d6b9d762be9171b4a4eea38c29cd4ef8a701f4081b1e823",
   "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "llama.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/llama.swift",
+      "state" : {
+        "revision" : "e5cfdd014b3b640c242c6c214673e60299f6941d",
+        "version" : "2.9204.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -11,12 +47,93 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
         "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
+        "version" : "1.12.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
@@ -38,6 +155,24 @@
       }
     },
     {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
@@ -53,6 +188,15 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,42 +1,6 @@
 {
-  "originHash" : "bbf2a35cae94421b5d6b9d762be9171b4a4eea38c29cd4ef8a701f4081b1e823",
+  "originHash" : "6369a506aee9cc749876a6f1270a96b019b95f14430819a2f8daab6f4d4305c4",
   "pins" : [
-    {
-      "identity" : "eventsource",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
-      "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "llama.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/llama.swift",
-      "state" : {
-        "revision" : "e5cfdd014b3b640c242c6c214673e60299f6941d",
-        "version" : "2.9204.0"
-      }
-    },
-    {
-      "identity" : "mlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift.git",
-      "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
-      }
-    },
-    {
-      "identity" : "mlx-swift-lm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
-      "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
-      }
-    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -47,93 +11,12 @@
       }
     },
     {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
-      }
-    },
-    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
         "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-huggingface",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-huggingface.git",
-      "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swift-jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja.git",
-      "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
-        "version" : "1.12.1"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
       }
     },
     {
@@ -155,24 +38,6 @@
       }
     },
     {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
-      "state" : {
-        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
-        "version" : "1.3.3"
-      }
-    },
-    {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
@@ -188,15 +53,6 @@
       "state" : {
         "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
         "version" : "1.9.0"
-      }
-    },
-    {
-      "identity" : "yyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ibireme/yyjson.git",
-      "state" : {
-        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version" : "0.12.0"
       }
     }
   ],

--- a/Sources/ManifoldRuntime/Protocols/HistoryProvider.swift
+++ b/Sources/ManifoldRuntime/Protocols/HistoryProvider.swift
@@ -30,18 +30,21 @@ public enum HistoryInsertionPosition: Sendable {
 }
 
 /// Contributes additional ``ChatMessageRecord``s to be injected into the
-/// history array before generation.
+/// prompt-visible history array before generation.
 ///
-/// Providers are applied in registration order. Each provider receives the
-/// history as augmented by all preceding providers. A throwing provider aborts
-/// the current turn with a ``ConversationError/persistence(_:)`` error —
-/// treat store-fetch failures as throwing.
+/// Providers are applied in registration order after any registered
+/// ``HistoryShaper`` has produced the base prompt-visible history. Each
+/// provider receives the history as augmented by all preceding providers. A
+/// throwing provider aborts the current turn with a
+/// ``ConversationError/persistence(_:)`` error — treat store-fetch failures as
+/// throwing.
 ///
 /// Providers must not re-order existing `.chat`-kind records; they may only
 /// inject new records at the declared position. The runtime enforces a
 /// chronological-order invariant in debug builds.
 ///
-/// Register via ``ConversationRuntime/init(messageStore:inferenceService:historyProviders:...)``.
+/// Register via
+/// ``ConversationRuntime/init(messageStore:sessionStore:inferenceService:pipeline:budgetPlanner:ragService:auxiliaryInferenceService:usageStore:generationHooks:compressionPolicy:historyShaper:historyProviders:hostTurnContextProvider:turnContextProvider:sessionToolSources:hookRegistry:)``.
 public protocol HistoryProvider: Sendable {
     func contribute(
         history: [ChatMessageRecord],

--- a/Sources/ManifoldRuntime/Protocols/HistoryShaper.swift
+++ b/Sources/ManifoldRuntime/Protocols/HistoryShaper.swift
@@ -1,0 +1,73 @@
+import Foundation
+import ManifoldInference
+
+/// Diagnostic emitted by a ``HistoryShaper`` when it removes or rewrites a
+/// canonical record for prompt visibility.
+public struct HistoryShapingDiagnostic: Sendable, Hashable {
+    public enum Kind: String, Sendable, Hashable {
+        case removed
+        case rewritten
+        case redacted
+    }
+
+    public let messageID: UUID
+    public let kind: Kind
+    public let reason: String?
+
+    public init(
+        messageID: UUID,
+        kind: Kind,
+        reason: String? = nil
+    ) {
+        self.messageID = messageID
+        self.kind = kind
+        self.reason = reason
+    }
+}
+
+/// Request metadata passed to a ``HistoryShaper``.
+///
+/// The runtime resolves ``appData`` first, then invokes the shaper on the
+/// canonical persisted history for the upcoming turn. The shaper's output
+/// becomes the prompt-visible base history that ``HistoryProvider`` and prompt
+/// context providers consume; canonical persistence is not mutated.
+public struct HistoryShapingRequest: Sendable {
+    public let turnContextRequest: TurnContextBuildRequest
+    public let appData: (any Sendable)?
+
+    public init(
+        turnContextRequest: TurnContextBuildRequest,
+        appData: (any Sendable)?
+    ) {
+        self.turnContextRequest = turnContextRequest
+        self.appData = appData
+    }
+}
+
+/// Result returned by a ``HistoryShaper``.
+public struct HistoryShapingResult: Sendable {
+    public let promptHistory: [ChatMessageRecord]
+    public let diagnostics: [HistoryShapingDiagnostic]
+
+    public init(
+        promptHistory: [ChatMessageRecord],
+        diagnostics: [HistoryShapingDiagnostic] = []
+    ) {
+        self.promptHistory = promptHistory
+        self.diagnostics = diagnostics
+    }
+}
+
+/// Shapes canonical persisted history into prompt-visible base history.
+///
+/// This seam is distinct from ``HistoryProvider``: shapers may remove or
+/// rewrite existing canonical records for prompt visibility, while
+/// ``HistoryProvider`` remains additive-only. The runtime validates that the
+/// shaped history preserves canonical record identity and order for every
+/// record that remains visible.
+public protocol HistoryShaper: Sendable {
+    func shape(
+        history: [ChatMessageRecord],
+        request: HistoryShapingRequest
+    ) async throws -> HistoryShapingResult
+}

--- a/Sources/ManifoldRuntime/Protocols/HostTurnContextProvider.swift
+++ b/Sources/ManifoldRuntime/Protocols/HostTurnContextProvider.swift
@@ -1,0 +1,41 @@
+import Foundation
+import ManifoldInference
+
+/// Metadata available when the runtime constructs host-owned per-turn context.
+///
+/// The runtime builds this request once per turn from the target session and
+/// the current canonical history snapshot, before any prompt-history shaping or
+/// additive ``HistoryProvider`` contributions run.
+public struct TurnContextBuildRequest: Sendable {
+    public let sessionID: UUID
+    public let turnKind: TurnKind
+    public let messageCount: Int
+    public let userInput: String?
+    public let conversationText: String?
+    public let tokenizer: (any TokenizerProvider)?
+
+    public init(
+        sessionID: UUID,
+        turnKind: TurnKind,
+        messageCount: Int,
+        userInput: String?,
+        conversationText: String?,
+        tokenizer: (any TokenizerProvider)? = nil
+    ) {
+        self.sessionID = sessionID
+        self.turnKind = turnKind
+        self.messageCount = messageCount
+        self.userInput = userInput
+        self.conversationText = conversationText
+        self.tokenizer = tokenizer
+    }
+}
+
+/// Builds host-owned per-turn app context for ``TurnContext/appData``.
+///
+/// Register via ``ConversationRuntime/init(messageStore:sessionStore:inferenceService:pipeline:budgetPlanner:ragService:auxiliaryInferenceService:usageStore:generationHooks:compressionPolicy:historyShaper:historyProviders:hostTurnContextProvider:turnContextProvider:sessionToolSources:hookRegistry:)``.
+/// The runtime awaits this provider once per turn; any thrown error aborts the
+/// turn as ``ConversationError/contextAssembly(_:)``.
+public protocol HostTurnContextProvider: Sendable {
+    func appData(for request: TurnContextBuildRequest) async throws -> (any Sendable)?
+}

--- a/Sources/ManifoldRuntime/Protocols/HostTurnContextProvider.swift
+++ b/Sources/ManifoldRuntime/Protocols/HostTurnContextProvider.swift
@@ -11,6 +11,8 @@ public struct TurnContextBuildRequest: Sendable {
     public let turnKind: TurnKind
     public let messageCount: Int
     public let userInput: String?
+    /// Derived from the canonical (unfiltered) history snapshot; does not
+    /// reflect any subsequent shaping by a registered ``HistoryShaper``.
     public let conversationText: String?
     public let tokenizer: (any TokenizerProvider)?
 

--- a/Sources/ManifoldRuntime/Protocols/PreTurnCompressionPolicy.swift
+++ b/Sources/ManifoldRuntime/Protocols/PreTurnCompressionPolicy.swift
@@ -1,0 +1,115 @@
+import Foundation
+import ManifoldInference
+
+/// Decides when and how to compress conversation history before the user
+/// message is appended for a `.send` turn.
+///
+/// The runtime calls
+/// ``shouldCompressBeforeTurn(messageCount:lastPromptTokens:)`` at the start
+/// of each `.send` turn, before the new user record is inserted into the store.
+/// When it returns `true`, the runtime calls
+/// ``compressBeforeTurn(history:sessionID:generate:)``, replaces the stored
+/// messages with the result, emits
+/// ``ConversationEvent/historyCompressed(sessionID:insertedRecords:)``, then
+/// calls ``postCompressBeforeTurn(sessionID:insertedRecords:)``, and *then*
+/// appends the new user message. The just-submitted user action is therefore
+/// always outside the compressed segment.
+///
+/// Pre-turn compression adds inference latency before the user's message
+/// appears in the UI — the `generate:` closure is called as part of turn
+/// setup, before the user message is persisted. Implementations should design
+/// ``shouldCompressBeforeTurn(messageCount:lastPromptTokens:)`` to return
+/// `false` when context utilisation is low so the latency is paid only when
+/// necessary.
+///
+/// ## Applies to `.send` only
+///
+/// Pre-turn compression runs for new `.send` turns only. It does not run for
+/// `.regenerate`, `.edit`, or `.branch` turns because those flows mutate
+/// existing history rather than appending a new user action.
+///
+/// ## Error policy
+///
+/// Failures from ``compressBeforeTurn(history:sessionID:generate:)`` — or an
+/// empty return value — throw
+/// ``ConversationError/preTurnCompressionFailed(_:)`` to the caller of
+/// ``ConversationRuntime/processTurn(_:)``. Existing history is preserved when
+/// a failure occurs. Unlike post-turn compression (which logs and continues),
+/// pre-turn failure aborts the turn because the host's ordering invariant
+/// depends on compression completing before the new message is appended.
+///
+/// ## Example
+///
+/// ```swift
+/// struct StoryCompressionPolicy: PreTurnCompressionPolicy {
+///     func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+///         messageCount >= 20
+///     }
+///
+///     func compressBeforeTurn(
+///         history: [ChatMessageRecord],
+///         sessionID: UUID,
+///         generate: @Sendable ([ChatMessageRecord]) async throws -> String
+///     ) async throws -> [ChatMessageRecord] {
+///         let summary = try await generate(history)
+///         return [ChatMessageRecord(
+///             role: .system,
+///             content: summary,
+///             sessionID: sessionID,
+///             kind: .memory("story-summary")
+///         )]
+///     }
+/// }
+/// ```
+public protocol PreTurnCompressionPolicy: Sendable {
+    /// Returns `true` if the runtime should compress history before this turn.
+    ///
+    /// Called synchronously before user-message append. Avoid I/O here —
+    /// use `messageCount` and `lastPromptTokens` for lightweight threshold
+    /// logic.
+    ///
+    /// - Parameters:
+    ///   - messageCount: Number of messages in the session's current history
+    ///     (not including the user message about to be submitted).
+    ///   - lastPromptTokens: Prompt-token count recorded on the most recent
+    ///     assistant message, or `nil` if no prior turn has recorded usage.
+    func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool
+
+    /// Compresses the current message history and returns the replacement
+    /// record set.
+    ///
+    /// The history provided does **not** include the user message being
+    /// submitted this turn. Return the full desired history state — the
+    /// runtime replaces the session's stored messages with the returned array
+    /// in a bulk delete + re-insert. Returning an empty array throws
+    /// ``ConversationError/preTurnCompressionFailed(_:)`` to guard against
+    /// silently wiping the conversation.
+    ///
+    /// - Parameters:
+    ///   - history: Current full message history, oldest-first, *without* the
+    ///     user message being submitted this turn.
+    ///   - sessionID: The session being compressed.
+    ///   - generate: Calls the inference backend; receives messages as a
+    ///     mini-conversation and returns the model's accumulated text output.
+    func compressBeforeTurn(
+        history: [ChatMessageRecord],
+        sessionID: UUID,
+        generate: @Sendable ([ChatMessageRecord]) async throws -> String
+    ) async throws -> [ChatMessageRecord]
+
+    /// Called after history has been compressed and the replacement records
+    /// have been persisted, immediately before the user message is inserted.
+    ///
+    /// Implementations use this for post-compression side effects (e.g.
+    /// reconciling a knowledge graph with the inserted memory records).
+    /// The default implementation is a no-op.
+    ///
+    /// - Parameters:
+    ///   - sessionID: The session that was compressed.
+    ///   - insertedRecords: The full replacement record set, in insertion order.
+    func postCompressBeforeTurn(sessionID: UUID, insertedRecords: [ChatMessageRecord]) async
+}
+
+extension PreTurnCompressionPolicy {
+    public func postCompressBeforeTurn(sessionID: UUID, insertedRecords: [ChatMessageRecord]) async {}
+}

--- a/Sources/ManifoldRuntime/Services/ConversationEvent.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationEvent.swift
@@ -53,7 +53,8 @@ import ManifoldInference
 /// the global stream.
 ///
 /// The four load-bearing extension points for runtime-using consumers are
-/// ``beforeContextAssembly(prompt:request:)``, ``contextAssembled(slots:)``,
+/// ``beforeContextAssembly(prompt:request:)``, ``historyShaped(sessionID:diagnostics:)``,
+/// ``contextAssembled(slots:)``,
 /// ``afterGeneration(messageID:finalText:)``, and
 /// ``compressionTriggered(removed:reason:)``: those bracket the two phases of
 /// generation host adapters need to extend even when they don't drive their
@@ -148,6 +149,14 @@ public enum ConversationEvent: Sendable {
     /// will see. Load-bearing for runtime-using consumers — adapters pin
     /// behaviour against this case.
     case beforeContextAssembly(prompt: String?, request: PromptContextRequest)
+
+    /// Fires after a registered ``HistoryShaper`` has produced the prompt-
+    /// visible base history, before additive ``HistoryProvider`` records and
+    /// prompt-context slots are assembled.
+    ///
+    /// `diagnostics` identify canonical records that were removed or rewritten
+    /// for prompt visibility. No event is emitted when no shaper is registered.
+    case historyShaped(sessionID: UUID, diagnostics: [HistoryShapingDiagnostic])
 
     /// Fires after slots are assembled, before the request is enqueued.
     /// Carries the merged `[PromptSlot]` so adapters can introspect what's

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -163,12 +163,27 @@ public final class ConversationRuntime: Sendable {
     ///     the runtime compresses history and emits
     ///     ``ConversationEvent/historyCompressed(sessionID:)``. Compression
     ///     failures are logged and never abort the turn.
-    ///   - historyProviders: Optional list of ``HistoryProvider`` conformances
-    ///     applied to the fetched history before context assembly. Providers are
-    ///     applied in registration order; each sees the history as augmented by
-    ///     all preceding providers. A throwing provider aborts the current turn
-    ///     with a ``ConversationError/persistence(_:)`` error. Defaults to `[]`
-    ///     so existing call sites compile unchanged.
+    ///   - historyShaper: Optional host-owned history transformer applied to the
+    ///     canonical fetched history before additive ``HistoryProvider``
+    ///     contributions, prompt-context slot assembly, and RAG. Use this to
+    ///     remove or rewrite prompt-visible history without mutating canonical
+    ///     persistence. A throwing shaper aborts the turn with
+    ///     ``ConversationError/contextAssembly(_:)``.
+    ///   - historyProviders: Optional list of additive ``HistoryProvider``
+    ///     conformances applied after `historyShaper` (when present) and before
+    ///     prompt-context slot assembly. Providers are applied in registration
+    ///     order; each sees the history as augmented by all preceding providers.
+    ///     A throwing provider aborts the current turn with a
+    ///     ``ConversationError/persistence(_:)`` error. Defaults to `[]` so
+    ///     existing call sites compile unchanged.
+    ///   - hostTurnContextProvider: Optional richer async/throwing provider that
+    ///     builds per-turn ``TurnContext/appData`` from full request metadata.
+    ///     When supplied, its result is threaded through history shaping,
+    ///     history providers, prompt-context assembly, and
+    ///     ``GenerationHook/postGeneration(_:)``. A thrown error aborts the turn
+    ///     with ``ConversationError/contextAssembly(_:)``.
+    ///   - turnContextProvider: Legacy source-compatible session-ID-only appData
+    ///     provider. Used only when `hostTurnContextProvider` is `nil`.
     public convenience init(
         messageStore: any MessageStore,
         sessionStore: (any SessionStore)? = nil,
@@ -180,7 +195,10 @@ public final class ConversationRuntime: Sendable {
         usageStore: (any UsageStore)? = nil,
         generationHooks: [any GenerationHook] = [],
         compressionPolicy: (any CompressionPolicy)? = nil,
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil,
+        historyShaper: (any HistoryShaper)? = nil,
         historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil
@@ -197,7 +215,10 @@ public final class ConversationRuntime: Sendable {
             emptyResponseObserver: nil,
             generationHooks: generationHooks,
             compressionPolicy: compressionPolicy,
+            preTurnCompressionPolicy: preTurnCompressionPolicy,
+            historyShaper: historyShaper,
             historyProviders: historyProviders,
+            hostTurnContextProvider: hostTurnContextProvider,
             turnContextProvider: turnContextProvider,
             sessionToolSources: sessionToolSources,
             hookRegistry: hookRegistry
@@ -219,8 +240,11 @@ public final class ConversationRuntime: Sendable {
         emptyResponseObserver: (@Sendable (EmptyResponseDiagnostic) -> Void)?,
         generationHooks: [any GenerationHook] = [],
         compressionPolicy: (any CompressionPolicy)? = nil,
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil,
         hookTimeout: Duration = .seconds(30),
+        historyShaper: (any HistoryShaper)? = nil,
         historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil
@@ -252,8 +276,11 @@ public final class ConversationRuntime: Sendable {
             emptyResponseObserver: emptyResponseObserver,
             generationHooks: generationHooks,
             compressionPolicy: compressionPolicy,
+            preTurnCompressionPolicy: preTurnCompressionPolicy,
             hookTimeout: hookTimeout,
+            historyShaper: historyShaper,
             historyProviders: historyProviders,
+            hostTurnContextProvider: hostTurnContextProvider,
             turnContextProvider: turnContextProvider,
             bindings: bindings
         )

--- a/Sources/ManifoldRuntime/Services/ConversationRuntimeTypes.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntimeTypes.swift
@@ -134,6 +134,12 @@ public enum ConversationError: Error, Sendable {
     /// Context assembly via a registered ``PromptContextProvider`` failed.
     case contextAssembly(any Error)
 
+    /// Pre-turn compression ran but
+    /// ``PreTurnCompressionPolicy/compressBeforeTurn(history:sessionID:generate:)``
+    /// threw or returned an empty history. Existing history is preserved and
+    /// the turn was not executed. The associated value is the underlying error.
+    case preTurnCompressionFailed(any Error)
+
     /// The runtime's send was cancelled (via ``ConversationRuntime/cancel(_:)``
     /// or task cancellation propagation). Adapters use this to suppress
     /// error UI for explicit user cancel.
@@ -157,6 +163,8 @@ extension ConversationError: LocalizedError {
             return "Inference failure during conversation: \(error.localizedDescription)"
         case let .contextAssembly(error):
             return "Context assembly failure: \(error.localizedDescription)"
+        case let .preTurnCompressionFailed(error):
+            return "Pre-turn compression failed: \(error.localizedDescription)"
         case .cancelled:
             return "Conversation request was cancelled."
         }

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -1273,6 +1273,23 @@ struct ConversationTurnExecutor: Sendable {
         }
     }
 
+    private enum HistoryShaperValidationError: LocalizedError, Sendable {
+        case duplicateMessageIDs
+        case nonCanonicalMessageIDs
+        case orderViolation
+
+        var errorDescription: String? {
+            switch self {
+            case .duplicateMessageIDs:
+                return "HistoryShaper returned duplicate prompt-visible message IDs."
+            case .nonCanonicalMessageIDs:
+                return "HistoryShaper may only return canonical message IDs."
+            case .orderViolation:
+                return "HistoryShaper must preserve canonical record order for visible messages."
+            }
+        }
+    }
+
     private func fetchAndPrepareTurnHistory(
         sessionID: UUID,
         turnKind: TurnKind,
@@ -1400,28 +1417,16 @@ struct ConversationTurnExecutor: Sendable {
         let promptIDs = promptHistory.map(\.id)
 
         guard Set(promptIDs).count == promptIDs.count else {
-            throw NSError(
-                domain: "ConversationTurnExecutor.HistoryShaper",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "HistoryShaper returned duplicate prompt-visible message IDs."]
-            )
+            throw HistoryShaperValidationError.duplicateMessageIDs
         }
 
         guard promptIDs.allSatisfy(canonicalIDSet.contains) else {
-            throw NSError(
-                domain: "ConversationTurnExecutor.HistoryShaper",
-                code: 2,
-                userInfo: [NSLocalizedDescriptionKey: "HistoryShaper may only return canonical message IDs."]
-            )
+            throw HistoryShaperValidationError.nonCanonicalMessageIDs
         }
 
         let canonicalVisibleIDs = canonicalIDs.filter { promptIDs.contains($0) }
         guard canonicalVisibleIDs == promptIDs else {
-            throw NSError(
-                domain: "ConversationTurnExecutor.HistoryShaper",
-                code: 3,
-                userInfo: [NSLocalizedDescriptionKey: "HistoryShaper must preserve canonical record order for visible messages."]
-            )
+            throw HistoryShaperValidationError.orderViolation
         }
     }
 

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -14,13 +14,17 @@ struct ConversationTurnExecutor: Sendable {
     private let emptyResponseObserver: (@Sendable (ConversationRuntime.EmptyResponseDiagnostic) -> Void)?
     private let generationHooks: [any GenerationHook]
     private let compressionPolicy: (any CompressionPolicy)?
+    private let preTurnCompressionPolicy: (any PreTurnCompressionPolicy)?
     private let hookTimeout: Duration
+    private let historyShaper: (any HistoryShaper)?
     private let historyAssembler: HistoryAssembler
-    /// Optional provider that attaches host-app data to each turn. Called with
-    /// the session UUID before context assembly; the returned value is stored on
-    /// ``TurnContext/appData`` and forwarded to ``CompletedTurn/appData`` so
-    /// ``GenerationHook`` implementations receive it without a side-channel.
-    private let turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?
+    /// Optional richer provider that attaches host-app data to each turn from a
+    /// full metadata snapshot. When absent, ``legacyTurnContextProvider`` keeps
+    /// the old session-ID-only seam source-compatible.
+    private let hostTurnContextProvider: (any HostTurnContextProvider)?
+    /// Legacy session-ID-only host appData seam. Kept for source compatibility
+    /// and used only when ``hostTurnContextProvider`` is `nil`.
+    private let legacyTurnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?
     /// Mutable holder for `sessionToolSources` + `hookRegistry`. The executor
     /// reads a snapshot once per turn (top of the send loop) so a host call
     /// to ``ConversationRuntime/updateSessionToolSources(_:)`` /
@@ -42,8 +46,11 @@ struct ConversationTurnExecutor: Sendable {
         emptyResponseObserver: (@Sendable (ConversationRuntime.EmptyResponseDiagnostic) -> Void)?,
         generationHooks: [any GenerationHook] = [],
         compressionPolicy: (any CompressionPolicy)? = nil,
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil,
         hookTimeout: Duration = .seconds(30),
+        historyShaper: (any HistoryShaper)? = nil,
         historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         bindings: RuntimeBindingsBox
     ) {
@@ -58,9 +65,12 @@ struct ConversationTurnExecutor: Sendable {
         self.emptyResponseObserver = emptyResponseObserver
         self.generationHooks = generationHooks
         self.compressionPolicy = compressionPolicy
+        self.preTurnCompressionPolicy = preTurnCompressionPolicy
         self.hookTimeout = hookTimeout
+        self.historyShaper = historyShaper
         self.historyAssembler = HistoryAssembler(providers: historyProviders)
-        self.turnContextProvider = turnContextProvider
+        self.hostTurnContextProvider = hostTurnContextProvider
+        self.legacyTurnContextProvider = turnContextProvider
         self.bindings = bindings
     }
 
@@ -107,6 +117,60 @@ struct ConversationTurnExecutor: Sendable {
         } else {
             userContentParts = [.text(text)] + attachments
         }
+
+        // Pre-turn compression: runs before the user message is appended so
+        // the just-submitted action always falls outside the compressed
+        // segment. Only runs for `.send` turns (not regenerate / edit / branch).
+        // Failures throw to the caller — unlike post-turn compression which
+        // logs and continues, pre-turn failure aborts the turn because the
+        // host's ordering invariant depends on compression completing first.
+        //
+        // userMessage is created AFTER this block so its timestamp naturally
+        // follows the compression summary records in store sort order.
+        if let preTurnPolicy = preTurnCompressionPolicy {
+            let existingHistory: [ChatMessageRecord]
+            do {
+                existingHistory = try await persistence.fetchMessages(sessionID: sessionID)
+            } catch {
+                throw ConversationError.persistence(error)
+            }
+            let lastPromptTokens = existingHistory.last(where: { $0.role == .assistant })?.promptTokens
+            if preTurnPolicy.shouldCompressBeforeTurn(
+                messageCount: existingHistory.count,
+                lastPromptTokens: lastPromptTokens
+            ) {
+                let generate = makeCompressionGenerateClosure()
+                let compressed: [ChatMessageRecord]
+                do {
+                    compressed = try await preTurnPolicy.compressBeforeTurn(
+                        history: existingHistory,
+                        sessionID: sessionID,
+                        generate: generate
+                    )
+                } catch {
+                    throw ConversationError.preTurnCompressionFailed(error)
+                }
+                guard !compressed.isEmpty else {
+                    throw ConversationError.preTurnCompressionFailed(
+                        PreTurnCompressionEmptyResultError()
+                    )
+                }
+                do {
+                    try await persistence.deleteMessages(for: sessionID)
+                    for message in compressed {
+                        try await persistence.insertMessage(message)
+                    }
+                } catch {
+                    throw ConversationError.persistence(error)
+                }
+                emit(.historyCompressed(sessionID: sessionID, insertedRecords: compressed))
+                await preTurnPolicy.postCompressBeforeTurn(
+                    sessionID: sessionID,
+                    insertedRecords: compressed
+                )
+            }
+        }
+
         let userMessage = ChatMessageRecord(
             role: .user,
             contentParts: userContentParts,
@@ -133,45 +197,26 @@ struct ConversationTurnExecutor: Sendable {
             for hook in generationHooks {
                 await hook.willBeginTurn(sessionID: sessionID)
             }
-            // Fetch history first — one store fetch covers both the
-            // message count for context assembly and the structured
-            // messages for enqueueAsync. By the time we get here, the
-            // user message we just inserted is in the store
-            // (insertMessage awaited above).
-            var history: [ChatMessageRecord]
+            let preparedHistory: PreparedTurnHistory
             do {
-                history = try await persistence.fetchMessages(sessionID: sessionID)
-            } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                preparedHistory = try await fetchAndPrepareTurnHistory(
                     sessionID: sessionID,
-                    handle: handle,
-                    error: conversationError
-                )
-                return
-            }
-            do {
-                history = try await historyAssembler.assemble(
-                    history: history,
-                    context: makeTurnContext(sessionID: sessionID, history: history)
+                    turnKind: .send(text: text, attachments: attachments),
+                    userPrompt: text
                 )
             } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                await failPreparedTurn(
+                    error,
                     sessionID: sessionID,
                     handle: handle,
-                    error: conversationError
+                    outcomeCompletion: outcomeCompletion
                 )
                 return
             }
             await runGenerationTurn(
                 sessionID: sessionID,
                 userPrompt: text,
-                history: history,
+                preparedHistory: preparedHistory,
                 config: config,
                 handle: handle,
                 outcomeCompletion: outcomeCompletion
@@ -217,42 +262,26 @@ struct ConversationTurnExecutor: Sendable {
             for hook in generationHooks {
                 await hook.willBeginTurn(sessionID: sessionID)
             }
-            // Fetch history after deletion — the removed assistant message
-            // is gone, so context assembly starts from the last user turn.
-            var postHistory: [ChatMessageRecord]
+            let preparedHistory: PreparedTurnHistory
             do {
-                postHistory = try await persistence.fetchMessages(sessionID: sessionID)
-            } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                preparedHistory = try await fetchAndPrepareTurnHistory(
                     sessionID: sessionID,
-                    handle: handle,
-                    error: conversationError
-                )
-                return
-            }
-            do {
-                postHistory = try await historyAssembler.assemble(
-                    history: postHistory,
-                    context: makeTurnContext(sessionID: sessionID, history: postHistory)
+                    turnKind: .regenerate,
+                    userPrompt: nil
                 )
             } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                await failPreparedTurn(
+                    error,
                     sessionID: sessionID,
                     handle: handle,
-                    error: conversationError
+                    outcomeCompletion: outcomeCompletion
                 )
                 return
             }
             await runGenerationTurn(
                 sessionID: sessionID,
                 userPrompt: nil,
-                history: postHistory,
+                preparedHistory: preparedHistory,
                 config: config,
                 handle: handle,
                 outcomeCompletion: outcomeCompletion
@@ -322,44 +351,26 @@ struct ConversationTurnExecutor: Sendable {
             for hook in generationHooks {
                 await hook.willBeginTurn(sessionID: sessionID)
             }
-            // Fetch history fresh after the synchronous edit + deletion —
-            // the updated message and removed trailing messages are
-            // already committed to the store before the detached task
-            // runs.
-            var postHistory: [ChatMessageRecord]
+            let preparedHistory: PreparedTurnHistory
             do {
-                postHistory = try await persistence.fetchMessages(sessionID: sessionID)
-            } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                preparedHistory = try await fetchAndPrepareTurnHistory(
                     sessionID: sessionID,
-                    handle: handle,
-                    error: conversationError
-                )
-                return
-            }
-            do {
-                postHistory = try await historyAssembler.assemble(
-                    history: postHistory,
-                    context: makeTurnContext(sessionID: sessionID, history: postHistory)
+                    turnKind: .edit(messageID: messageID, text: text),
+                    userPrompt: nil
                 )
             } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                await failPreparedTurn(
+                    error,
                     sessionID: sessionID,
                     handle: handle,
-                    error: conversationError
+                    outcomeCompletion: outcomeCompletion
                 )
                 return
             }
             await runGenerationTurn(
                 sessionID: sessionID,
                 userPrompt: nil,
-                history: postHistory,
+                preparedHistory: preparedHistory,
                 config: config,
                 handle: handle,
                 outcomeCompletion: outcomeCompletion
@@ -458,42 +469,31 @@ struct ConversationTurnExecutor: Sendable {
             loopDetectionEnabled: true
         )
         await taskRegistry.launch(handle: handle) { [self] in
-            // Re-fetch from the new session so the history reflects the
-            // persisted copies with their new IDs and sessionID.
-            var history: [ChatMessageRecord]
+            let preparedHistory: PreparedTurnHistory
             do {
-                history = try await persistence.fetchMessages(sessionID: newSessionID)
-            } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                preparedHistory = try await fetchAndPrepareTurnHistory(
                     sessionID: newSessionID,
-                    handle: handle,
-                    error: conversationError
-                )
-                return
-            }
-            do {
-                history = try await historyAssembler.assemble(
-                    history: history,
-                    context: makeTurnContext(sessionID: newSessionID, history: history)
+                    turnKind: .branch(
+                        messageID: branchMessageID,
+                        newSessionID: newSessionID,
+                        newSessionTitle: newSessionTitle,
+                        generateAfter: generateAfter
+                    ),
+                    userPrompt: nil
                 )
             } catch {
-                let conversationError = ConversationError.persistence(error)
-                emit(.errorRaised(conversationError))
-                await completeOutcome(
-                    outcomeCompletion,
+                await failPreparedTurn(
+                    error,
                     sessionID: newSessionID,
                     handle: handle,
-                    error: conversationError
+                    outcomeCompletion: outcomeCompletion
                 )
                 return
             }
             await runGenerationTurn(
                 sessionID: newSessionID,
                 userPrompt: nil,
-                history: history,
+                preparedHistory: preparedHistory,
                 config: branchConfig,
                 handle: handle,
                 outcomeCompletion: outcomeCompletion
@@ -512,12 +512,14 @@ struct ConversationTurnExecutor: Sendable {
     private func runGenerationTurn(
         sessionID: UUID,
         userPrompt: String?,
-        history: [ChatMessageRecord],
+        preparedHistory: PreparedTurnHistory,
         config: TurnConfig,
         handle: ConversationStreamHandle,
         outcomeCompletion: ConversationTurnOutcomeCompletion? = nil
     ) async {
-        let messageCount = history.count
+        let history = preparedHistory.history
+        let turnContext = preparedHistory.turnContext
+        let messageCount = turnContext.messageCount
 
         // Context assembly hook. Always emit `.beforeContextAssembly` and
         // `.contextAssembled` so adapters that pin against these events
@@ -530,28 +532,6 @@ struct ConversationTurnExecutor: Sendable {
             userInput: userPrompt
         )
         emit(.beforeContextAssembly(prompt: userPrompt, request: request))
-
-        // Build a TurnContext so budget-aware and content-matching providers
-        // can inspect the conversation without each needing a separate fetch.
-        // conversationText is nil on the first turn (empty history) — providers
-        // must treat nil as "no text available" rather than "empty conversation".
-        let conversationText: String? = history.isEmpty ? nil : {
-            let joined = history
-                .compactMap { record -> String? in
-                    let text = record.contentParts.compactMap(\.textContent).joined(separator: " ")
-                    return text.isEmpty ? nil : text
-                }
-                .joined(separator: " ")
-                .lowercased()
-            return joined.isEmpty ? nil : joined
-        }()
-
-        let turnContext = TurnContext(
-            sessionID: sessionID,
-            messageCount: messageCount,
-            conversationText: conversationText,
-            tokenizer: nil  // backends own their tokenizer; providers use HeuristicTokenizer fallback
-        )
 
         var slots: [PromptSlot]
         if let budgetPlanner {
@@ -577,7 +557,11 @@ struct ConversationTurnExecutor: Sendable {
             }
         } else if let pipeline {
             do {
-                slots = try await pipeline.assemble(messageCount: messageCount)
+                slots = try await pipeline.assemble(
+                    totalBudget: Int.max,
+                    contextSize: 0,
+                    context: turnContext
+                )
             } catch {
                 let conversationError = ConversationError.contextAssembly(error)
                 emit(.errorRaised(conversationError))
@@ -1165,7 +1149,7 @@ struct ConversationTurnExecutor: Sendable {
                 assistantMessage: assistantMessage,
                 promptTokens: usage?.promptTokens,
                 completionTokens: usage?.completionTokens,
-                appData: turnContextProvider?(sessionID)
+                appData: turnContext.appData
             )
             for hook in generationHooks {
                 let hookLabel = "\(type(of: hook))"
@@ -1192,41 +1176,7 @@ struct ConversationTurnExecutor: Sendable {
                     return
                 }
 
-                // Wrap inferenceService in a Sendable closure so the policy
-                // can call the backend for summarisation without holding a
-                // reference to the executor itself. Uses background priority
-                // so compression doesn't compete with the user's next turn.
-                let generate: @Sendable ([ChatMessageRecord]) async throws -> String = { [inferenceService] messages in
-                    let structured = messages
-                        .filter { $0.kind.isWireVisible }
-                        .map { record -> StructuredMessage in
-                            let role = record.kind.backendRole ?? record.role
-                            return StructuredMessage(role: role.rawValue, parts: record.contentParts)
-                        }
-                    let (token, compressStream) = try await inferenceService.enqueueAsync(
-                        structuredMessages: structured,
-                        priority: .background
-                    )
-                    var result = ""
-                    var consumer = GenerationStreamConsumer(loopDetectionEnabled: false)
-                    do {
-                        for try await event in compressStream.events {
-                            // Propagate parent-task cancellation into the
-                            // backend stream so we don't keep draining after
-                            // the runtime has moved on.
-                            try Task.checkCancellation()
-                            if case .appendText(let chunk) = consumer.handle(event) {
-                                result += chunk
-                            }
-                        }
-                    } catch {
-                        // Cancel the backend token on any exit (cancellation or
-                        // inference error) so the backend doesn't keep running.
-                        await inferenceService.cancelAsync(token)
-                        throw error
-                    }
-                    return result
-                }
+                let generate = makeCompressionGenerateClosure()
 
                 // preCompact hook: v1 is observational. The plan's hook
                 // contract documents that preCompact CANNOT block compression
@@ -1312,25 +1262,226 @@ struct ConversationTurnExecutor: Sendable {
         ))
     }
 
-    private func makeTurnContext(sessionID: UUID, history: [ChatMessageRecord]) -> TurnContext {
-        let conversationText: String? = history.isEmpty ? nil : {
-            let joined = history
-                .compactMap { record -> String? in
-                    let text = record.contentParts.compactMap(\.textContent).joined(separator: " ")
-                    return text.isEmpty ? nil : text
+    private enum TurnPreparationFailure: Error {
+        case persistence(any Error)
+        case contextAssembly(any Error)
+    }
+
+    private struct PreTurnCompressionEmptyResultError: LocalizedError, Sendable {
+        var errorDescription: String? {
+            "Pre-turn compression returned an empty history."
+        }
+    }
+
+    private func fetchAndPrepareTurnHistory(
+        sessionID: UUID,
+        turnKind: TurnKind,
+        userPrompt: String?
+    ) async throws -> PreparedTurnHistory {
+        let canonicalHistory: [ChatMessageRecord]
+        do {
+            canonicalHistory = try await persistence.fetchMessages(sessionID: sessionID)
+        } catch {
+            throw TurnPreparationFailure.persistence(error)
+        }
+
+        let request = TurnContextBuildRequest(
+            sessionID: sessionID,
+            turnKind: turnKind,
+            messageCount: canonicalHistory.count,
+            userInput: userPrompt,
+            conversationText: conversationText(for: canonicalHistory),
+            tokenizer: await readTokenizer()
+        )
+
+        let appData: (any Sendable)?
+        do {
+            appData = try await resolveTurnAppData(for: request)
+        } catch {
+            throw TurnPreparationFailure.contextAssembly(error)
+        }
+
+        let shapedHistory: [ChatMessageRecord]
+        do {
+            shapedHistory = try await shapeHistory(
+                canonicalHistory,
+                sessionID: sessionID,
+                request: HistoryShapingRequest(
+                    turnContextRequest: request,
+                    appData: appData
+                )
+            )
+        } catch {
+            throw TurnPreparationFailure.contextAssembly(error)
+        }
+
+        let historyProviderContext = makeTurnContext(
+            sessionID: sessionID,
+            history: shapedHistory,
+            tokenizer: request.tokenizer,
+            appData: appData
+        )
+
+        let assembledHistory: [ChatMessageRecord]
+        do {
+            assembledHistory = try await historyAssembler.assemble(
+                history: shapedHistory,
+                context: historyProviderContext
+            )
+        } catch {
+            throw TurnPreparationFailure.persistence(error)
+        }
+
+        return PreparedTurnHistory(
+            history: assembledHistory,
+            turnContext: makeTurnContext(
+                sessionID: sessionID,
+                history: assembledHistory,
+                tokenizer: request.tokenizer,
+                appData: appData
+            )
+        )
+    }
+
+    private func failPreparedTurn(
+        _ error: Error,
+        sessionID: UUID,
+        handle: ConversationStreamHandle,
+        outcomeCompletion: ConversationTurnOutcomeCompletion?
+    ) async {
+        let conversationError: ConversationError
+        if let failure = error as? TurnPreparationFailure {
+            switch failure {
+            case .persistence(let underlying):
+                conversationError = .persistence(underlying)
+            case .contextAssembly(let underlying):
+                conversationError = .contextAssembly(underlying)
+            }
+        } else {
+            conversationError = .contextAssembly(error)
+        }
+        emit(.errorRaised(conversationError))
+        await completeOutcome(
+            outcomeCompletion,
+            sessionID: sessionID,
+            handle: handle,
+            error: conversationError
+        )
+    }
+
+    private func resolveTurnAppData(
+        for request: TurnContextBuildRequest
+    ) async throws -> (any Sendable)? {
+        if let hostTurnContextProvider {
+            return try await hostTurnContextProvider.appData(for: request)
+        }
+        return legacyTurnContextProvider?(request.sessionID)
+    }
+
+    private func shapeHistory(
+        _ canonicalHistory: [ChatMessageRecord],
+        sessionID: UUID,
+        request: HistoryShapingRequest
+    ) async throws -> [ChatMessageRecord] {
+        guard let historyShaper else { return canonicalHistory }
+
+        let result = try await historyShaper.shape(history: canonicalHistory, request: request)
+        try validateShapedHistory(result.promptHistory, against: canonicalHistory)
+        emit(.historyShaped(sessionID: sessionID, diagnostics: result.diagnostics))
+        return result.promptHistory
+    }
+
+    private func validateShapedHistory(
+        _ promptHistory: [ChatMessageRecord],
+        against canonicalHistory: [ChatMessageRecord]
+    ) throws {
+        let canonicalIDs = canonicalHistory.map(\.id)
+        let canonicalIDSet = Set(canonicalIDs)
+        let promptIDs = promptHistory.map(\.id)
+
+        guard Set(promptIDs).count == promptIDs.count else {
+            throw NSError(
+                domain: "ConversationTurnExecutor.HistoryShaper",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "HistoryShaper returned duplicate prompt-visible message IDs."]
+            )
+        }
+
+        guard promptIDs.allSatisfy(canonicalIDSet.contains) else {
+            throw NSError(
+                domain: "ConversationTurnExecutor.HistoryShaper",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "HistoryShaper may only return canonical message IDs."]
+            )
+        }
+
+        let canonicalVisibleIDs = canonicalIDs.filter { promptIDs.contains($0) }
+        guard canonicalVisibleIDs == promptIDs else {
+            throw NSError(
+                domain: "ConversationTurnExecutor.HistoryShaper",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "HistoryShaper must preserve canonical record order for visible messages."]
+            )
+        }
+    }
+
+    /// Returns a `@Sendable` closure that drives a background inference call
+    /// for summarisation. Used by both pre-turn and post-turn compression paths.
+    private func makeCompressionGenerateClosure() -> @Sendable ([ChatMessageRecord]) async throws -> String {
+        let inferenceService = self.inferenceService
+        return { messages in
+            let structured = messages
+                .filter { $0.kind.isWireVisible }
+                .map { record -> StructuredMessage in
+                    let role = record.kind.backendRole ?? record.role
+                    return StructuredMessage(role: role.rawValue, parts: record.contentParts)
                 }
-                .joined(separator: " ")
-                .lowercased()
-            return joined.isEmpty ? nil : joined
-        }()
-        var context = TurnContext(
+            let (token, compressStream) = try await inferenceService.enqueueAsync(
+                structuredMessages: structured,
+                priority: .background
+            )
+            var result = ""
+            var consumer = GenerationStreamConsumer(loopDetectionEnabled: false)
+            do {
+                for try await event in compressStream.events {
+                    try Task.checkCancellation()
+                    if case .appendText(let chunk) = consumer.handle(event) {
+                        result += chunk
+                    }
+                }
+            } catch {
+                await inferenceService.cancelAsync(token)
+                throw error
+            }
+            return result
+        }
+    }
+
+    private func makeTurnContext(
+        sessionID: UUID,
+        history: [ChatMessageRecord],
+        tokenizer: (any TokenizerProvider)?,
+        appData: (any Sendable)?
+    ) -> TurnContext {
+        TurnContext(
             sessionID: sessionID,
             messageCount: history.count,
-            conversationText: conversationText,
-            tokenizer: nil
+            conversationText: conversationText(for: history),
+            tokenizer: tokenizer,
+            appData: appData
         )
-        context.appData = turnContextProvider?(sessionID)
-        return context
+    }
+
+    private func conversationText(for history: [ChatMessageRecord]) -> String? {
+        guard !history.isEmpty else { return nil }
+        let joined = history
+            .compactMap { record -> String? in
+                let text = record.contentParts.compactMap(\.textContent).joined(separator: " ")
+                return text.isEmpty ? nil : text
+            }
+            .joined(separator: " ")
+            .lowercased()
+        return joined.isEmpty ? nil : joined
     }
 
     /// Reads the backend's context window size from the main actor.
@@ -1338,6 +1489,11 @@ struct ConversationTurnExecutor: Sendable {
     @MainActor
     private func readContextWindowSize() async -> Int {
         inferenceService.capabilities?.contextWindowSize ?? 0
+    }
+
+    @MainActor
+    private func readTokenizer() async -> (any TokenizerProvider)? {
+        inferenceService.tokenizer
     }
 
     /// Runs `operation` with a timeout. If the operation doesn't finish within

--- a/Sources/ManifoldRuntime/Services/GenerationTurnState.swift
+++ b/Sources/ManifoldRuntime/Services/GenerationTurnState.swift
@@ -10,6 +10,15 @@ import ManifoldInference
 // finalise → post-turn handoff). They carry no behaviour — only state — so
 // the decomposition stays a pure refactor.
 
+/// Output of the pre-assembly history-preparation phase. Carries the prompt-
+/// visible history after host shaping + additive history providers plus the
+/// resolved turn context snapshot used by downstream prompt assembly and
+/// post-generation hooks.
+struct PreparedTurnHistory {
+    var history: [ChatMessageRecord]
+    var turnContext: TurnContext
+}
+
 /// Output of phase 1 (context assembly). Carries the assembled prompt slots,
 /// any RAG citations, the once-per-turn session snapshot, and the host-mutable
 /// bindings snapshot (tool sources + hook registry) read at the top of the

--- a/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
@@ -392,6 +392,8 @@ final class ChatGenerationCoordinator {
                 break
             case .contextAssembly(let underlying):
                 surfaceError(underlying, .generation)
+            case .preTurnCompressionFailed(let underlying):
+                surfaceError(underlying, .generation)
             case .messageNotFound, .noAssistantMessageToRegenerate, .providerNotConfigured, .messageTooLarge:
                 setErrorMessage(error.localizedDescription)
             }
@@ -479,7 +481,8 @@ final class ChatGenerationCoordinator {
 
         case .beforeContextAssembly, .contextAssembled, .afterGeneration,
              .sessionTouchFailed,
-             .compressionTriggered, .toolCallApproved:
+             .compressionTriggered, .toolCallApproved,
+             .historyShaped:
             break
 
         case .historyCompressed:
@@ -575,6 +578,8 @@ final class ChatGenerationCoordinator {
         case .cancelled:
             break
         case .contextAssembly(let underlying):
+            surfaceError(underlying, .generation)
+        case .preTurnCompressionFailed(let underlying):
             surfaceError(underlying, .generation)
         case .messageNotFound, .noAssistantMessageToRegenerate, .providerNotConfigured, .messageTooLarge:
             setErrorMessage(error.localizedDescription)

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -1498,6 +1498,7 @@ final class ConversationRuntimeTests: XCTestCase {
         case .errorRaised: return "errorRaised"
         case .sessionTouchFailed: return "sessionTouchFailed"
         case .beforeContextAssembly: return "beforeContextAssembly"
+        case .historyShaped: return "historyShaped"
         case .contextAssembled: return "contextAssembled"
         case .afterGeneration: return "afterGeneration"
         case .compressionTriggered: return "compressionTriggered"

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTurnPreparationTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTurnPreparationTests.swift
@@ -1,0 +1,370 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+@MainActor
+final class ConversationRuntimeTurnPreparationTests: XCTestCase {
+    struct Payload: Sendable, Equatable {
+        let id: UUID
+    }
+
+    @MainActor
+    final class InMemoryMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+            for hook in hooks {
+                await hook.messageDidWrite(message, in: message.sessionID)
+            }
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+            hooks.append(hook)
+        }
+    }
+
+    actor RecordingHook: GenerationHook {
+        private var turns: [CompletedTurn] = []
+
+        func postGeneration(_ turn: CompletedTurn) async {
+            turns.append(turn)
+        }
+
+        func snapshot() -> [CompletedTurn] {
+            turns
+        }
+    }
+
+    actor RecordingHistoryProvider: HistoryProvider {
+        private var payloads: [Payload?] = []
+
+        func contribute(
+            history: [ChatMessageRecord],
+            context: TurnContext
+        ) async throws -> [HistoryContribution] {
+            payloads.append(context.appData as? Payload)
+            return []
+        }
+
+        func snapshot() -> [Payload?] {
+            payloads
+        }
+    }
+
+    actor RecordingBudgetAwareProvider: PromptContextProvider {
+        private var usedLegacy = false
+        private var usedBudgetAware = false
+        private var payloads: [Payload?] = []
+
+        func contributeSlots(messageCount: Int) async throws -> [PromptSlot] {
+            usedLegacy = true
+            return []
+        }
+
+        func contributeSlots(
+            budget: ProviderBudget,
+            context: TurnContext
+        ) async throws -> [PromptSlot] {
+            usedBudgetAware = true
+            payloads.append(context.appData as? Payload)
+            return []
+        }
+
+        func snapshot() -> (usedLegacy: Bool, usedBudgetAware: Bool, payloads: [Payload?]) {
+            (usedLegacy, usedBudgetAware, payloads)
+        }
+    }
+
+    actor RecordingHostTurnContextProvider: HostTurnContextProvider {
+        private let payload: Payload
+        private var requests: [TurnContextBuildRequest] = []
+
+        init(payload: Payload) {
+            self.payload = payload
+        }
+
+        func appData(for request: TurnContextBuildRequest) async throws -> (any Sendable)? {
+            requests.append(request)
+            return payload
+        }
+
+        func snapshot() -> [TurnContextBuildRequest] {
+            requests
+        }
+    }
+
+    actor ThrowingHostTurnContextProvider: HostTurnContextProvider {
+        enum TestError: Error {
+            case failed
+        }
+
+        func appData(for request: TurnContextBuildRequest) async throws -> (any Sendable)? {
+            throw TestError.failed
+        }
+    }
+
+    struct FilteringHistoryShaper: HistoryShaper {
+        let blockedMessageID: UUID
+
+        func shape(
+            history: [ChatMessageRecord],
+            request: HistoryShapingRequest
+        ) async throws -> HistoryShapingResult {
+            let shaped = history.filter { $0.id != blockedMessageID }
+            return HistoryShapingResult(
+                promptHistory: shaped,
+                diagnostics: [
+                    HistoryShapingDiagnostic(
+                        messageID: blockedMessageID,
+                        kind: .removed,
+                        reason: "filtered for prompt visibility"
+                    )
+                ]
+            )
+        }
+    }
+
+    actor EventRecorder {
+        private var historyShapedEvent: ConversationEvent?
+        private var continuations: [CheckedContinuation<ConversationEvent, Never>] = []
+
+        func record(_ event: ConversationEvent) {
+            guard case .historyShaped = event else { return }
+            historyShapedEvent = event
+            let pending = continuations
+            continuations.removeAll()
+            for continuation in pending {
+                continuation.resume(returning: event)
+            }
+        }
+
+        func awaitHistoryShapedEvent() async -> ConversationEvent {
+            if let historyShapedEvent {
+                return historyShapedEvent
+            }
+            return await withCheckedContinuation { continuations.append($0) }
+        }
+    }
+
+    private func makeRuntime(
+        store: InMemoryMessageStore? = nil,
+        mock: MockInferenceBackend? = nil,
+        pipeline: PromptContextPipeline? = nil,
+        generationHooks: [any GenerationHook] = [],
+        historyShaper: (any HistoryShaper)? = nil,
+        historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil
+    ) -> (runtime: ConversationRuntime, store: InMemoryMessageStore, mock: MockInferenceBackend) {
+        let backend = mock ?? MockInferenceBackend()
+        backend.isModelLoaded = true
+        let inference = InferenceService(backend: backend, name: "Mock")
+        let messageStore = store ?? InMemoryMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: messageStore,
+            inferenceService: inference,
+            pipeline: pipeline,
+            generationHooks: generationHooks,
+            compressionPolicy: nil,
+            historyShaper: historyShaper,
+            historyProviders: historyProviders,
+            hostTurnContextProvider: hostTurnContextProvider
+        )
+        return (runtime, messageStore, backend)
+    }
+
+    private enum TestError: Error {
+        case timeout
+    }
+
+    private func withTimeout<T: Sendable>(
+        _ duration: Duration = .seconds(5),
+        operation: @escaping @Sendable () async -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try await Task.sleep(for: duration)
+                throw TestError.timeout
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    func test_hostTurnContextProvider_sharesSingleAppDataAcrossHistoryPipelineAndHook() async throws {
+        let payload = Payload(id: UUID())
+        let hostProvider = RecordingHostTurnContextProvider(payload: payload)
+        let historyProvider = RecordingHistoryProvider()
+        let promptProvider = RecordingBudgetAwareProvider()
+        let hook = RecordingHook()
+        let (runtime, _, _) = makeRuntime(
+            pipeline: PromptContextPipeline(providers: [promptProvider]),
+            generationHooks: [hook],
+            historyProviders: [historyProvider],
+            hostTurnContextProvider: hostProvider
+        )
+
+        let sessionID = UUID()
+        let maybeHandle = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi", attachments: []),
+            config: TurnConfig()
+        ))
+        let handle = try XCTUnwrap(maybeHandle)
+        let outcome = await handle.outcome
+        XCTAssertNil(outcome.error)
+
+        let requests = await hostProvider.snapshot()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests.first?.sessionID, sessionID)
+        XCTAssertEqual(requests.first?.messageCount, 1)
+        XCTAssertEqual(requests.first?.userInput, "Hi")
+        XCTAssertEqual(requests.first?.conversationText, "hi")
+        XCTAssertNil(requests.first?.tokenizer)
+        guard case let .send(text, attachments)? = requests.first?.turnKind else {
+            return XCTFail("Expected send turn metadata")
+        }
+        XCTAssertEqual(text, "Hi")
+        XCTAssertTrue(attachments.isEmpty)
+
+        let historyPayloads = await historyProvider.snapshot()
+        XCTAssertEqual(historyPayloads, [payload])
+
+        let promptSnapshot = await promptProvider.snapshot()
+        XCTAssertFalse(promptSnapshot.usedLegacy)
+        XCTAssertTrue(promptSnapshot.usedBudgetAware)
+        XCTAssertEqual(promptSnapshot.payloads, [payload])
+
+        let deliveredTurns = await hook.snapshot()
+        XCTAssertEqual(deliveredTurns.count, 1)
+        XCTAssertEqual(deliveredTurns.first?.appData as? Payload, payload)
+    }
+
+    func test_hostTurnContextProvider_failure_surfacesAsContextAssemblyFailure() async throws {
+        let provider = ThrowingHostTurnContextProvider()
+        let (runtime, _, _) = makeRuntime(hostTurnContextProvider: provider)
+
+        let maybeHandle = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "Hello", attachments: []),
+            config: TurnConfig()
+        ))
+        let handle = try XCTUnwrap(maybeHandle)
+        let outcome = await handle.outcome
+
+        guard case let .contextAssembly(error)? = outcome.error else {
+            return XCTFail("Expected context assembly failure, got \(String(describing: outcome.error))")
+        }
+        XCTAssertTrue(error is ThrowingHostTurnContextProvider.TestError)
+        XCTAssertNil(outcome.assistantMessage)
+    }
+
+    func test_historyShaper_shapesPromptHistoryWithoutMutatingPersistence_onRegenerate() async throws {
+        let store = InMemoryMessageStore()
+        let mock = MockInferenceBackend()
+        mock.tokensToYield = ["new answer"]
+
+        let sessionID = UUID()
+        let base = Date()
+        let keep = ChatMessageRecord(role: .user, content: "keep", timestamp: base, sessionID: sessionID)
+        let blocked = ChatMessageRecord(
+            role: .assistant,
+            content: "blocked",
+            timestamp: base.addingTimeInterval(1),
+            sessionID: sessionID
+        )
+        let question = ChatMessageRecord(
+            role: .user,
+            content: "question",
+            timestamp: base.addingTimeInterval(2),
+            sessionID: sessionID
+        )
+        let oldAnswer = ChatMessageRecord(
+            role: .assistant,
+            content: "old answer",
+            timestamp: base.addingTimeInterval(3),
+            sessionID: sessionID
+        )
+        try await store.insertMessage(keep)
+        try await store.insertMessage(blocked)
+        try await store.insertMessage(question)
+        try await store.insertMessage(oldAnswer)
+
+        let (runtime, _, backend) = makeRuntime(
+            store: store,
+            mock: mock,
+            historyShaper: FilteringHistoryShaper(blockedMessageID: blocked.id)
+        )
+        let recorder = EventRecorder()
+        let drainTask = Task {
+            for await event in runtime.events {
+                await recorder.record(event)
+            }
+        }
+        defer { drainTask.cancel() }
+
+        let maybeHandle = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: sessionID,
+            kind: .regenerate,
+            config: TurnConfig()
+        ))
+        let handle = try XCTUnwrap(maybeHandle)
+        let outcome = await handle.outcome
+        XCTAssertNil(outcome.error)
+        XCTAssertEqual(outcome.assistantMessage?.content, "new answer")
+
+        let historyShapedEvent = try await withTimeout {
+            await recorder.awaitHistoryShapedEvent()
+        }
+        guard case let .historyShaped(eventSessionID, diagnostics) = historyShapedEvent else {
+            return XCTFail("Expected historyShaped event")
+        }
+        XCTAssertEqual(eventSessionID, sessionID)
+        XCTAssertEqual(
+            diagnostics,
+            [HistoryShapingDiagnostic(
+                messageID: blocked.id,
+                kind: .removed,
+                reason: "filtered for prompt visibility"
+            )]
+        )
+
+        XCTAssertEqual(
+            backend.lastReceivedStructuredHistory?.map(\.textContent),
+            ["keep", "question"]
+        )
+
+        let persisted = try await store.fetchMessages(for: sessionID)
+        XCTAssertTrue(persisted.contains(where: { $0.id == blocked.id }))
+        XCTAssertFalse(persisted.contains(where: { $0.id == oldAnswer.id }))
+        XCTAssertTrue(persisted.contains(where: { $0.content == "new answer" }))
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTurnPreparationTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTurnPreparationTests.swift
@@ -10,46 +10,6 @@ final class ConversationRuntimeTurnPreparationTests: XCTestCase {
         let id: UUID
     }
 
-    @MainActor
-    final class InMemoryMessageStore: MessageStore {
-        private(set) var messages: [UUID: ChatMessageRecord] = [:]
-        private var hooks: [any MessageStorePostWriteHook] = []
-
-        func insertMessage(_ message: ChatMessageRecord) async throws {
-            messages[message.id] = message
-            for hook in hooks {
-                await hook.messageDidWrite(message, in: message.sessionID)
-            }
-        }
-
-        func updateMessage(_ message: ChatMessageRecord) async throws {
-            guard messages[message.id] != nil else {
-                throw ChatPersistenceError.messageNotFound(message.id)
-            }
-            messages[message.id] = message
-        }
-
-        func deleteMessage(_ messageID: UUID) async throws {
-            guard messages.removeValue(forKey: messageID) != nil else {
-                throw ChatPersistenceError.messageNotFound(messageID)
-            }
-        }
-
-        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
-            messages.values
-                .filter { $0.sessionID == sessionID }
-                .sorted { $0.timestamp < $1.timestamp }
-        }
-
-        func deleteMessages(for sessionID: UUID) async throws {
-            messages = messages.filter { $0.value.sessionID != sessionID }
-        }
-
-        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
-            hooks.append(hook)
-        }
-    }
-
     actor RecordingHook: GenerationHook {
         private var turns: [CompletedTurn] = []
 
@@ -366,5 +326,46 @@ final class ConversationRuntimeTurnPreparationTests: XCTestCase {
         XCTAssertTrue(persisted.contains(where: { $0.id == blocked.id }))
         XCTAssertFalse(persisted.contains(where: { $0.id == oldAnswer.id }))
         XCTAssertTrue(persisted.contains(where: { $0.content == "new answer" }))
+    }
+
+    func test_historyShaper_receivesAppDataFromHostTurnContextProvider() async throws {
+        let payload = Payload(id: UUID())
+        let hostProvider = RecordingHostTurnContextProvider(payload: payload)
+
+        actor ShaperPayloadCapture {
+            private(set) var captured: (any Sendable)? = nil
+            func record(_ value: (any Sendable)?) { captured = value }
+        }
+
+        struct CapturingShaper: HistoryShaper {
+            let capture: ShaperPayloadCapture
+            func shape(
+                history: [ChatMessageRecord],
+                request: HistoryShapingRequest
+            ) async throws -> HistoryShapingResult {
+                await capture.record(request.appData)
+                return HistoryShapingResult(promptHistory: history)
+            }
+        }
+
+        let capture = ShaperPayloadCapture()
+        let (runtime, _, _) = makeRuntime(
+            historyShaper: CapturingShaper(capture: capture),
+            hostTurnContextProvider: hostProvider
+        )
+
+        let sessionID = UUID()
+        let maybeHandle = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hello", attachments: []),
+            config: TurnConfig()
+        ))
+        let handle = try XCTUnwrap(maybeHandle)
+        let outcome = await handle.outcome
+        XCTAssertNil(outcome.error)
+
+        let capturedPayload = await capture.captured
+        XCTAssertEqual(capturedPayload as? Payload, payload,
+            "HistoryShapingRequest.appData must equal the value from HostTurnContextProvider")
     }
 }

--- a/Tests/ManifoldRuntimeTests/ImageGenerationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ImageGenerationRuntimeTests.swift
@@ -501,6 +501,7 @@ final class ImageGenerationRuntimeTests: XCTestCase {
             .errorRaised(.cancelled),
             .sessionTouchFailed(sessionID: UUID()),
             .beforeContextAssembly(prompt: nil, request: PromptContextRequest(sessionID: UUID(), messageCount: 0, userInput: nil)),
+            .historyShaped(sessionID: UUID(), diagnostics: []),
             .contextAssembled(slots: []),
             .afterGeneration(messageID: UUID(), finalText: ""),
             .compressionTriggered(removed: [], reason: .manual),
@@ -520,7 +521,7 @@ final class ImageGenerationRuntimeTests: XCTestCase {
                  .streamStarted, .tokenEmitted, .tokenUsageRecorded,
                  .thinkingStarted, .thinkingUpdated, .thinkingFinalized,
                  .loopDetected, .streamFinished, .errorRaised, .sessionTouchFailed,
-                 .beforeContextAssembly, .contextAssembled, .afterGeneration,
+                 .beforeContextAssembly, .historyShaped, .contextAssembled, .afterGeneration,
                  .compressionTriggered, .historyCompressed, .toolCallRequested, .toolCallApproved,
                  .toolCallCompleted,
                  .agentHandoff, .skillInvoked, .hookFired:
@@ -528,8 +529,8 @@ final class ImageGenerationRuntimeTests: XCTestCase {
             }
         }
         // Pin the exact case count as a runtime assertion too — the
-        // sample list is the source of truth. W2B added agentHandoff,
-        // skillInvoked, and hookFired (22 → 25).
-        XCTAssertEqual(samples.count, 25, "ConversationEvent case count drifted — image-side cases may have leaked in")
+        // sample list is the source of truth. Runtime history shaping added
+        // one more context-side case (25 → 26).
+        XCTAssertEqual(samples.count, 26, "ConversationEvent case count drifted — image-side cases may have leaked in")
     }
 }

--- a/Tests/ManifoldRuntimeTests/InMemoryMessageStore+TestHelpers.swift
+++ b/Tests/ManifoldRuntimeTests/InMemoryMessageStore+TestHelpers.swift
@@ -1,0 +1,42 @@
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+
+/// Shared in-memory MessageStore for ManifoldRuntimeTests unit tests.
+@MainActor
+final class InMemoryMessageStore: MessageStore {
+    private(set) var messages: [UUID: ChatMessageRecord] = [:]
+    private var hooks: [any MessageStorePostWriteHook] = []
+
+    func insertMessage(_ message: ChatMessageRecord) async throws {
+        messages[message.id] = message
+        for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+    }
+
+    func updateMessage(_ message: ChatMessageRecord) async throws {
+        guard messages[message.id] != nil else {
+            throw ChatPersistenceError.messageNotFound(message.id)
+        }
+        messages[message.id] = message
+    }
+
+    func deleteMessage(_ messageID: UUID) async throws {
+        guard messages.removeValue(forKey: messageID) != nil else {
+            throw ChatPersistenceError.messageNotFound(messageID)
+        }
+    }
+
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+        messages.values
+            .filter { $0.sessionID == sessionID }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    func deleteMessages(for sessionID: UUID) async throws {
+        messages = messages.filter { $0.value.sessionID != sessionID }
+    }
+
+    func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+        hooks.append(hook)
+    }
+}

--- a/Tests/ManifoldRuntimeTests/MessageStoreContractAdopterTests.swift
+++ b/Tests/ManifoldRuntimeTests/MessageStoreContractAdopterTests.swift
@@ -4,52 +4,6 @@ import ManifoldInference
 import ManifoldTestSupport
 import ManifoldContractTestSupport
 
-// MARK: - InMemoryMessageStore (test double for contract adoption)
-
-/// Minimal in-memory implementation of ``MessageStore`` used solely to validate
-/// the ``MessageStoreContract`` mixin compiles and passes against a reference
-/// conformer. This mirrors the shape used in other runtime test files (e.g.
-/// `ConversationRuntimeAppDataTests`), keeping it local to avoid polluting
-/// the global test namespace.
-@MainActor
-private final class InMemoryMessageStore: MessageStore {
-    private var messages: [UUID: ChatMessageRecord] = [:]
-    private var hooks: [any MessageStorePostWriteHook] = []
-
-    func insertMessage(_ message: ChatMessageRecord) async throws {
-        messages[message.id] = message
-        for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
-    }
-
-    func updateMessage(_ message: ChatMessageRecord) async throws {
-        guard messages[message.id] != nil else {
-            throw ChatPersistenceError.messageNotFound(message.id)
-        }
-        messages[message.id] = message
-        for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
-    }
-
-    func deleteMessage(_ messageID: UUID) async throws {
-        guard messages.removeValue(forKey: messageID) != nil else {
-            throw ChatPersistenceError.messageNotFound(messageID)
-        }
-    }
-
-    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
-        messages.values
-            .filter { $0.sessionID == sessionID }
-            .sorted { $0.timestamp < $1.timestamp }
-    }
-
-    func deleteMessages(for sessionID: UUID) async throws {
-        messages = messages.filter { $0.value.sessionID != sessionID }
-    }
-
-    func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
-        hooks.append(hook)
-    }
-}
-
 // MARK: - InMemoryMessageStoreContractTests
 
 /// Adopts ``MessageStoreContract`` via the in-memory reference implementation.

--- a/Tests/ManifoldRuntimeTests/PreTurnCompressionPolicyTests.swift
+++ b/Tests/ManifoldRuntimeTests/PreTurnCompressionPolicyTests.swift
@@ -1,0 +1,582 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Coverage for ``PreTurnCompressionPolicy`` — history compression triggered
+/// by ``ConversationRuntime`` before the user message is appended on `.send`
+/// turns.
+@MainActor
+final class PreTurnCompressionPolicyTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore (shared with CompressionPolicyTests)
+
+    @MainActor
+    final class RuntimeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    // MARK: - Call counter
+
+    actor CallCounter {
+        private(set) var count = 0
+        func increment() { count += 1 }
+    }
+
+    // MARK: - Policy implementations
+
+    struct AlwaysPreCompressPolicy: PreTurnCompressionPolicy {
+        let summaryContent: String
+        let counter: CallCounter
+
+        init(summaryContent: String = "PreTurnSummary") {
+            self.summaryContent = summaryContent
+            self.counter = CallCounter()
+        }
+
+        func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+            true
+        }
+
+        func compressBeforeTurn(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            await counter.increment()
+            return [ChatMessageRecord(
+                role: .assistant,
+                content: summaryContent,
+                sessionID: sessionID,
+                kind: .memory("summary")
+            )]
+        }
+    }
+
+    struct NeverPreCompressPolicy: PreTurnCompressionPolicy {
+        let counter: CallCounter
+
+        init() { self.counter = CallCounter() }
+
+        func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+            false
+        }
+
+        func compressBeforeTurn(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            await counter.increment()
+            return history
+        }
+    }
+
+    struct FailingPreCompressPolicy: PreTurnCompressionPolicy {
+        struct PolicyError: Error, LocalizedError {
+            var errorDescription: String? { "Simulated compress failure" }
+        }
+
+        func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool { true }
+
+        func compressBeforeTurn(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            throw PolicyError()
+        }
+    }
+
+    struct EmptyReturnPreCompressPolicy: PreTurnCompressionPolicy {
+        func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool { true }
+
+        func compressBeforeTurn(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            return []
+        }
+    }
+
+    /// Records which sessionID and insertedRecords were passed to postCompressBeforeTurn.
+    actor PostCompressObserver {
+        var calledWith: (sessionID: UUID, insertedRecords: [ChatMessageRecord])?
+        func record(sessionID: UUID, insertedRecords: [ChatMessageRecord]) {
+            calledWith = (sessionID, insertedRecords)
+        }
+    }
+
+    struct ObservingPreCompressPolicy: PreTurnCompressionPolicy {
+        let observer: PostCompressObserver
+        let summaryContent: String
+
+        func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool { true }
+
+        func compressBeforeTurn(
+            history: [ChatMessageRecord],
+            sessionID: UUID,
+            generate: @Sendable ([ChatMessageRecord]) async throws -> String
+        ) async throws -> [ChatMessageRecord] {
+            return [ChatMessageRecord(
+                role: .assistant,
+                content: summaryContent,
+                sessionID: sessionID,
+                kind: .memory("summary")
+            )]
+        }
+
+        func postCompressBeforeTurn(sessionID: UUID, insertedRecords: [ChatMessageRecord]) async {
+            await observer.record(sessionID: sessionID, insertedRecords: insertedRecords)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeMock(tokensToYield: [String] = ["ok"]) -> MockInferenceBackend {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [],
+            maxContextTokens: 1024,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true
+        ))
+        backend.tokensToYield = tokensToYield
+        backend.isModelLoaded = true
+        return backend
+    }
+
+    private func drainUntilStreamFinished(
+        from runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        var collected: [ConversationEvent] = []
+        let task = Task {
+            for await event in runtime.events {
+                collected.append(event)
+                if case .streamFinished = event { break }
+            }
+            return collected
+        }
+        return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw XCTestError(.timeoutWhileWaiting)
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    // MARK: - Test 1: compress called when shouldCompress returns true
+
+    func test_compressCalled_whenShouldReturnTrue() async throws {
+        let backend = makeMock()
+        let policy = AlwaysPreCompressPolicy()
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: InferenceService(backend: backend, name: "Mock"),
+            preTurnCompressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+
+        let callCount = await policy.counter.count
+        XCTAssertEqual(callCount, 1, "compressBeforeTurn should be called once")
+    }
+
+    // MARK: - Test 2: compress not called when shouldCompress returns false
+
+    func test_compressNotCalled_whenShouldReturnFalse() async throws {
+        let backend = makeMock()
+        let policy = NeverPreCompressPolicy()
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: InferenceService(backend: backend, name: "Mock"),
+            preTurnCompressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+
+        let callCount = await policy.counter.count
+        XCTAssertEqual(callCount, 0, "compressBeforeTurn must not be called when shouldCompress returns false")
+    }
+
+    // MARK: - Test 3: user message falls outside compressed segment
+
+    func test_userMessageOutsideCompressedSegment() async throws {
+        // Seed the session with a prior exchange so there's history to compress.
+        let backend = makeMock(tokensToYield: ["prior response"])
+        let store = RuntimeMessageStore()
+        let sessionID = UUID()
+        let inference = InferenceService(backend: backend, name: "Mock")
+
+        // First turn without compression to establish history.
+        let seedRuntime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference
+        )
+        try await seedRuntime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "seed message"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: seedRuntime)
+
+        // Now configure a runtime with pre-turn compression.
+        backend.tokensToYield = ["assistant reply"]
+        let summaryContent = "CompressedSummary"
+        let policy = AlwaysPreCompressPolicy(summaryContent: summaryContent)
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            preTurnCompressionPolicy: policy
+        )
+
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "new user message"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+
+        // Fetch the final persisted history.
+        let finalMessages = try await store.fetchMessages(for: sessionID)
+
+        // The summary record must be present.
+        XCTAssertTrue(
+            finalMessages.contains { $0.content == summaryContent },
+            "Compressed summary must be present in history"
+        )
+
+        // The new user message must appear AFTER the summary — outside the compressed segment.
+        guard let summaryIndex = finalMessages.firstIndex(where: { $0.content == summaryContent }),
+              let userIndex = finalMessages.firstIndex(where: { $0.role == .user && $0.content == "new user message" }) else {
+            XCTFail("Expected summary and new user message in history")
+            return
+        }
+        XCTAssertLessThan(
+            summaryIndex,
+            userIndex,
+            "Summary must precede the new user message (user action outside compressed segment)"
+        )
+    }
+
+    // MARK: - Test 4: historyCompressed event emitted before messageInserted(user)
+
+    func test_historyCompressedBeforeUserMessageInserted() async throws {
+        let backend = makeMock()
+        let policy = AlwaysPreCompressPolicy()
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: InferenceService(backend: backend, name: "Mock"),
+            preTurnCompressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi"),
+            config: TurnConfig()
+        ))
+        let events = try await drainUntilStreamFinished(from: runtime)
+
+        let compressedIdx = events.firstIndex { if case .historyCompressed = $0 { return true }; return false }
+        let userInsertedIdx = events.firstIndex { event in
+            if case .messageInserted(let msg) = event { return msg.role == .user }
+            return false
+        }
+
+        guard let ci = compressedIdx, let ui = userInsertedIdx else {
+            XCTFail("Expected both historyCompressed and user messageInserted events")
+            return
+        }
+        XCTAssertLessThan(ci, ui, "historyCompressed must precede user messageInserted")
+    }
+
+    // MARK: - Test 5: failure throws preTurnCompressionFailed to caller
+
+    func test_failingPolicy_throwsPreTurnCompressionFailed() async throws {
+        let backend = makeMock()
+        let policy = FailingPreCompressPolicy()
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: InferenceService(backend: backend, name: "Mock"),
+            preTurnCompressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        do {
+            try await runtime.processTurn(TurnInput(
+                sessionID: sessionID,
+                kind: .send(text: "Hi"),
+                config: TurnConfig()
+            ))
+            XCTFail("Expected preTurnCompressionFailed to be thrown")
+        } catch let error as ConversationError {
+            if case .preTurnCompressionFailed = error {
+                // correct
+            } else {
+                XCTFail("Expected .preTurnCompressionFailed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Test 6: failure preserves existing history
+
+    func test_failingPolicy_preservesExistingHistory() async throws {
+        // Seed two prior messages.
+        let backend = makeMock(tokensToYield: ["seed reply"])
+        let store = RuntimeMessageStore()
+        let sessionID = UUID()
+        let inference = InferenceService(backend: backend, name: "Mock")
+
+        let seedRuntime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference
+        )
+        try await seedRuntime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "seed"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: seedRuntime)
+
+        let historyBeforeFailure = try await store.fetchMessages(for: sessionID)
+
+        // Attach a failing pre-turn policy.
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            preTurnCompressionPolicy: FailingPreCompressPolicy()
+        )
+
+        _ = try? await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "new message"),
+            config: TurnConfig()
+        ))
+
+        let historyAfterFailure = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(
+            historyBeforeFailure.map(\.id),
+            historyAfterFailure.map(\.id),
+            "Existing history must be intact when pre-turn compression fails"
+        )
+    }
+
+    // MARK: - Test 7: empty-return policy throws and preserves history
+
+    func test_emptyReturnPolicy_throwsAndPreservesHistory() async throws {
+        let backend = makeMock()
+        let policy = EmptyReturnPreCompressPolicy()
+        let store = RuntimeMessageStore()
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: InferenceService(backend: backend, name: "Mock"),
+            preTurnCompressionPolicy: policy
+        )
+
+        let sessionID = UUID()
+        do {
+            try await runtime.processTurn(TurnInput(
+                sessionID: sessionID,
+                kind: .send(text: "Hi"),
+                config: TurnConfig()
+            ))
+            XCTFail("Expected preTurnCompressionFailed to be thrown")
+        } catch let error as ConversationError {
+            if case .preTurnCompressionFailed = error {
+                // correct
+            } else {
+                XCTFail("Expected .preTurnCompressionFailed, got \(error)")
+            }
+        }
+
+        // Nothing should be in the store — the user message was never inserted.
+        let finalMessages = try await store.fetchMessages(for: sessionID)
+        XCTAssertTrue(finalMessages.isEmpty, "No messages should exist when pre-turn compression fails before user insert")
+    }
+
+    // MARK: - Test 8: postCompressBeforeTurn called after compression, before user insert
+
+    func test_postCompressBeforeTurn_calledWithInsertedRecords() async throws {
+        let backend = makeMock()
+        let observer = PostCompressObserver()
+        let summaryContent = "PostCompressContent"
+        let policy = ObservingPreCompressPolicy(observer: observer, summaryContent: summaryContent)
+        let store = RuntimeMessageStore()
+        let sessionID = UUID()
+
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: InferenceService(backend: backend, name: "Mock"),
+            preTurnCompressionPolicy: policy
+        )
+
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "Hi"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+
+        let observed = await observer.calledWith
+        XCTAssertNotNil(observed, "postCompressBeforeTurn should be called")
+        XCTAssertEqual(observed?.sessionID, sessionID)
+        XCTAssertEqual(
+            observed?.insertedRecords.first?.content, summaryContent,
+            "postCompressBeforeTurn should receive the inserted records"
+        )
+    }
+
+    // MARK: - Test 9: pre-turn compression does not run for regenerate turns
+
+    func test_preTurnCompression_notCalledOnRegenerate() async throws {
+        // Seed a prior exchange so regenerate has something to work with.
+        let backend = makeMock(tokensToYield: ["seed", "regen"])
+        let store = RuntimeMessageStore()
+        let sessionID = UUID()
+        let inference = InferenceService(backend: backend, name: "Mock")
+
+        let seedRuntime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        try await seedRuntime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "seed"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: seedRuntime)
+
+        let policy = AlwaysPreCompressPolicy()
+        backend.tokensToYield = ["regen reply"]
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            preTurnCompressionPolicy: policy
+        )
+
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .regenerate,
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+
+        let callCount = await policy.counter.count
+        XCTAssertEqual(callCount, 0, "compressBeforeTurn must not be called on regenerate turns")
+    }
+
+    // MARK: - Test 10: messageCount and lastPromptTokens forwarded to shouldCompress
+
+    func test_shouldCompressReceivesCorrectArgs() async throws {
+        actor ArgCapture {
+            var messageCount: Int?
+            var lastPromptTokens: Int??
+            func record(messageCount: Int, lastPromptTokens: Int?) {
+                self.messageCount = messageCount
+                self.lastPromptTokens = lastPromptTokens
+            }
+        }
+
+        final class CapturingPolicy: PreTurnCompressionPolicy, @unchecked Sendable {
+            let capture: ArgCapture
+            init(_ capture: ArgCapture) { self.capture = capture }
+
+            func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+                Task { await self.capture.record(messageCount: messageCount, lastPromptTokens: lastPromptTokens) }
+                return false
+            }
+            func compressBeforeTurn(
+                history: [ChatMessageRecord],
+                sessionID: UUID,
+                generate: @Sendable ([ChatMessageRecord]) async throws -> String
+            ) async throws -> [ChatMessageRecord] { history }
+        }
+
+        let backend = makeMock(tokensToYield: ["seed reply"])
+        let store = RuntimeMessageStore()
+        let sessionID = UUID()
+        let inference = InferenceService(backend: backend, name: "Mock")
+
+        // Seed one exchange first to get a non-empty history.
+        let seedRuntime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        try await seedRuntime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "seed"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: seedRuntime)
+
+        let capture = ArgCapture()
+        backend.tokensToYield = ["second reply"]
+        let policy = CapturingPolicy(capture)
+        let runtime = ConversationRuntime(
+            messageStore: store,
+            inferenceService: inference,
+            preTurnCompressionPolicy: policy
+        )
+
+        try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "second"),
+            config: TurnConfig()
+        ))
+        _ = try await drainUntilStreamFinished(from: runtime)
+
+        // Brief settle for the async Task inside shouldCompressBeforeTurn.
+        try await Task.sleep(for: .milliseconds(50))
+
+        let count = await capture.messageCount
+        XCTAssertNotNil(count, "shouldCompressBeforeTurn must be called with message count")
+        XCTAssertGreaterThan(count ?? 0, 0, "messageCount should reflect the seeded history")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/PreTurnCompressionPolicyTests.swift
+++ b/Tests/ManifoldRuntimeTests/PreTurnCompressionPolicyTests.swift
@@ -10,42 +10,6 @@ import ManifoldTestSupport
 @MainActor
 final class PreTurnCompressionPolicyTests: XCTestCase {
 
-    // MARK: - In-memory MessageStore (shared with CompressionPolicyTests)
-
-    @MainActor
-    final class RuntimeMessageStore: MessageStore {
-        private(set) var messages: [UUID: ChatMessageRecord] = [:]
-
-        func insertMessage(_ message: ChatMessageRecord) async throws {
-            messages[message.id] = message
-        }
-
-        func updateMessage(_ message: ChatMessageRecord) async throws {
-            guard messages[message.id] != nil else {
-                throw ChatPersistenceError.messageNotFound(message.id)
-            }
-            messages[message.id] = message
-        }
-
-        func deleteMessage(_ messageID: UUID) async throws {
-            guard messages.removeValue(forKey: messageID) != nil else {
-                throw ChatPersistenceError.messageNotFound(messageID)
-            }
-        }
-
-        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
-            messages.values
-                .filter { $0.sessionID == sessionID }
-                .sorted { $0.timestamp < $1.timestamp }
-        }
-
-        func deleteMessages(for sessionID: UUID) async throws {
-            messages = messages.filter { $0.value.sessionID != sessionID }
-        }
-
-        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
-    }
-
     // MARK: - Call counter
 
     actor CallCounter {
@@ -206,7 +170,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_compressCalled_whenShouldReturnTrue() async throws {
         let backend = makeMock()
         let policy = AlwaysPreCompressPolicy()
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let runtime = ConversationRuntime(
             messageStore: store,
             inferenceService: InferenceService(backend: backend, name: "Mock"),
@@ -230,7 +194,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_compressNotCalled_whenShouldReturnFalse() async throws {
         let backend = makeMock()
         let policy = NeverPreCompressPolicy()
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let runtime = ConversationRuntime(
             messageStore: store,
             inferenceService: InferenceService(backend: backend, name: "Mock"),
@@ -254,7 +218,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_userMessageOutsideCompressedSegment() async throws {
         // Seed the session with a prior exchange so there's history to compress.
         let backend = makeMock(tokensToYield: ["prior response"])
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let sessionID = UUID()
         let inference = InferenceService(backend: backend, name: "Mock")
 
@@ -314,7 +278,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_historyCompressedBeforeUserMessageInserted() async throws {
         let backend = makeMock()
         let policy = AlwaysPreCompressPolicy()
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let runtime = ConversationRuntime(
             messageStore: store,
             inferenceService: InferenceService(backend: backend, name: "Mock"),
@@ -347,7 +311,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_failingPolicy_throwsPreTurnCompressionFailed() async throws {
         let backend = makeMock()
         let policy = FailingPreCompressPolicy()
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let runtime = ConversationRuntime(
             messageStore: store,
             inferenceService: InferenceService(backend: backend, name: "Mock"),
@@ -376,7 +340,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_failingPolicy_preservesExistingHistory() async throws {
         // Seed two prior messages.
         let backend = makeMock(tokensToYield: ["seed reply"])
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let sessionID = UUID()
         let inference = InferenceService(backend: backend, name: "Mock")
 
@@ -419,7 +383,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_emptyReturnPolicy_throwsAndPreservesHistory() async throws {
         let backend = makeMock()
         let policy = EmptyReturnPreCompressPolicy()
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let runtime = ConversationRuntime(
             messageStore: store,
             inferenceService: InferenceService(backend: backend, name: "Mock"),
@@ -454,7 +418,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
         let observer = PostCompressObserver()
         let summaryContent = "PostCompressContent"
         let policy = ObservingPreCompressPolicy(observer: observer, summaryContent: summaryContent)
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let sessionID = UUID()
 
         let runtime = ConversationRuntime(
@@ -484,7 +448,7 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
     func test_preTurnCompression_notCalledOnRegenerate() async throws {
         // Seed a prior exchange so regenerate has something to work with.
         let backend = makeMock(tokensToYield: ["seed", "regen"])
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let sessionID = UUID()
         let inference = InferenceService(backend: backend, name: "Mock")
 
@@ -519,11 +483,19 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
 
     func test_shouldCompressReceivesCorrectArgs() async throws {
         actor ArgCapture {
-            var messageCount: Int?
-            var lastPromptTokens: Int??
+            private var recorded: (messageCount: Int, lastPromptTokens: Int?)?
+            private var waiting: CheckedContinuation<(messageCount: Int, lastPromptTokens: Int?), Never>?
+
             func record(messageCount: Int, lastPromptTokens: Int?) {
-                self.messageCount = messageCount
-                self.lastPromptTokens = lastPromptTokens
+                let value = (messageCount: messageCount, lastPromptTokens: lastPromptTokens)
+                recorded = value
+                waiting?.resume(returning: value)
+                waiting = nil
+            }
+
+            func waitForArgs() async -> (messageCount: Int, lastPromptTokens: Int?) {
+                if let recorded { return recorded }
+                return await withCheckedContinuation { waiting = $0 }
             }
         }
 
@@ -543,11 +515,11 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
         }
 
         let backend = makeMock(tokensToYield: ["seed reply"])
-        let store = RuntimeMessageStore()
+        let store = InMemoryMessageStore()
         let sessionID = UUID()
         let inference = InferenceService(backend: backend, name: "Mock")
 
-        // Seed one exchange first to get a non-empty history.
+        // Seed one exchange first to get a non-empty history (user + assistant = 2 messages).
         let seedRuntime = ConversationRuntime(messageStore: store, inferenceService: inference)
         try await seedRuntime.processTurn(TurnInput(
             sessionID: sessionID,
@@ -572,11 +544,17 @@ final class PreTurnCompressionPolicyTests: XCTestCase {
         ))
         _ = try await drainUntilStreamFinished(from: runtime)
 
-        // Brief settle for the async Task inside shouldCompressBeforeTurn.
-        try await Task.sleep(for: .milliseconds(50))
+        let (count, _) = try await withThrowingTaskGroup(of: (Int, Int?).self) { group in
+            group.addTask { await capture.waitForArgs() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw XCTestError(.timeoutWhileWaiting)
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
 
-        let count = await capture.messageCount
-        XCTAssertNotNil(count, "shouldCompressBeforeTurn must be called with message count")
-        XCTAssertGreaterThan(count ?? 0, 0, "messageCount should reflect the seeded history")
+        XCTAssertEqual(count, 2, "messageCount should reflect the 2 seeded messages (user + assistant)")
     }
 }

--- a/Tests/ManifoldRuntimeTests/TurnInputCollapseTests.swift
+++ b/Tests/ManifoldRuntimeTests/TurnInputCollapseTests.swift
@@ -139,6 +139,8 @@ final class TurnInputCollapseTests: XCTestCase {
                 return "messageInserted-\(record.role.rawValue)-\(record.content)"
             case .beforeContextAssembly:
                 return "beforeContextAssembly"
+            case .historyShaped:
+                return "historyShaped"
             case .contextAssembled:
                 return "contextAssembled"
             case .streamStarted:


### PR DESCRIPTION
## Summary

- **HistoryShaper** — `async throws` host-owned transformer applied to assembled history before the prompt is built; emits `.historyShaped` event with per-message diagnostics so the UI can surface what was changed
- **HostTurnContextProvider** — async/throwing richer alternative to the legacy `turnContextProvider` closure; carries a full `TurnMetadata` snapshot instead of just a session UUID; legacy seam preserved for source compat
- **PreTurnCompressionPolicy** — pluggable policy controlling whether to run history compression *before* a turn (vs. only post-turn); emits `.preTurnCompressionFailed` on policy errors

Also bundles the Tier 1 DocC catalog improvements for ManifoldInference, ManifoldMLX, and ManifoldVoice from the branch base commit.

## Coordinator fixes
`ChatGenerationCoordinator` exhaustive switches updated for the two new `ConversationEvent` cases (`.historyShaped`, `.preTurnCompressionFailed`) — without this the branch fails to compile under Swift 6.3.2 strict concurrency.

## ⚠️ Breaking changes
- **`ConversationError` gains a new `preTurnCompressionFailed` case.** Any exhaustive `switch` on `ConversationError` outside this repo will fail to compile. Add a handler (or `default:`) for the new case.

## Test plan
- [ ] `ManifoldRuntimeTests` pass — ~950 lines of new tests added: `ConversationRuntimeTurnPreparationTests` and `PreTurnCompressionPolicyTests`
- [ ] Build with `traits: ["CloudSaaS", "Voice"]` succeeds (verified locally)
- [ ] `ChatGenerationCoordinator` switch is exhaustive (no warnings)
- [ ] Existing runtime tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)