### PR TITLE
feat(inference): VideoGenerationBackend protocol + VideoGenerationConfig/Event + cloudAPI ImageModelFormat

### DIFF
--- a/Sources/ManifoldInference/Models/ImageModelFormat.swift
+++ b/Sources/ManifoldInference/Models/ImageModelFormat.swift
@@ -19,4 +19,9 @@ public enum ImageModelFormat: String, Codable, Hashable, Sendable, CaseIterable 
     /// weights in MLX safetensors form. Loaded by `FluxDiffusionBackend` via
     /// `mzbac/flux.swift`. Supports both FP16 and flux.swift 4-bit quantized layouts.
     case fluxSchnell
+
+    /// A cloud HTTP image-generation API (e.g. xAI Grok Imagine).
+    /// The backend ignores `directoryURL` from `ImageModelInfo` and makes
+    /// HTTP requests instead of loading a local model file.
+    case cloudAPI
 }

--- a/Sources/ManifoldInference/Models/VideoGenerationConfig.swift
+++ b/Sources/ManifoldInference/Models/VideoGenerationConfig.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Configuration for a cloud video-generation request.
+public struct VideoGenerationConfig: Sendable, Hashable {
+
+    public enum AspectRatio: String, Sendable, CaseIterable, Hashable {
+        case landscape = "16:9"
+        case portrait = "9:16"
+        case square = "1:1"
+        case wide = "4:3"
+        case tall = "3:4"
+
+        public var displayName: String {
+            switch self {
+            case .landscape: "16:9"
+            case .portrait: "9:16"
+            case .square: "1:1"
+            case .wide: "4:3"
+            case .tall: "3:4"
+            }
+        }
+    }
+
+    public enum Resolution: String, Sendable, CaseIterable, Hashable {
+        case hd = "720p"
+        case sd = "480p"
+    }
+
+    /// Duration in seconds (1–15).
+    public var duration: Int
+    public var aspectRatio: AspectRatio
+    public var resolution: Resolution
+    /// Local file URL of a source image for image-to-video mode.
+    public var sourceImageURL: URL?
+
+    public init(
+        duration: Int = 5,
+        aspectRatio: AspectRatio = .landscape,
+        resolution: Resolution = .hd,
+        sourceImageURL: URL? = nil
+    ) {
+        self.duration = min(max(duration, 1), 15)
+        self.aspectRatio = aspectRatio
+        self.resolution = resolution
+        self.sourceImageURL = sourceImageURL
+    }
+}

--- a/Sources/ManifoldInference/Models/VideoGenerationConfig.swift
+++ b/Sources/ManifoldInference/Models/VideoGenerationConfig.swift
@@ -1,37 +1,27 @@
 import Foundation
 
 /// Configuration for a cloud video-generation request.
-public struct VideoGenerationConfig: Sendable, Hashable {
+public struct VideoGenerationConfig: Sendable, Hashable, Codable {
 
-    public enum AspectRatio: String, Sendable, CaseIterable, Hashable {
+    public enum AspectRatio: String, Sendable, CaseIterable, Hashable, Codable {
         case landscape = "16:9"
         case portrait = "9:16"
         case square = "1:1"
         case wide = "4:3"
         case tall = "3:4"
-
-        public var displayName: String {
-            switch self {
-            case .landscape: "16:9"
-            case .portrait: "9:16"
-            case .square: "1:1"
-            case .wide: "4:3"
-            case .tall: "3:4"
-            }
-        }
     }
 
-    public enum Resolution: String, Sendable, CaseIterable, Hashable {
+    public enum Resolution: String, Sendable, CaseIterable, Hashable, Codable {
         case hd = "720p"
         case sd = "480p"
     }
 
-    /// Duration in seconds (1–15).
-    public var duration: Int
-    public var aspectRatio: AspectRatio
-    public var resolution: Resolution
+    /// Duration in seconds, clamped to 1–15.
+    public let duration: Int
+    public let aspectRatio: AspectRatio
+    public let resolution: Resolution
     /// Local file URL of a source image for image-to-video mode.
-    public var sourceImageURL: URL?
+    public let sourceImageURL: URL?
 
     public init(
         duration: Int = 5,

--- a/Sources/ManifoldInference/Models/VideoGenerationEvent.swift
+++ b/Sources/ManifoldInference/Models/VideoGenerationEvent.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Events emitted by a ``VideoGenerationBackend`` during generation.
+public enum VideoGenerationEvent: Sendable {
+    /// Request accepted and queued; generation not yet started.
+    case queued
+    /// Generation is in progress. `fractionComplete` is an estimate (0.0–1.0).
+    case generating(fractionComplete: Double)
+    /// Generation finished. `url` is a local file URL on disk.
+    case completed(URL)
+}

--- a/Sources/ManifoldInference/Models/VideoGenerationEvent.swift
+++ b/Sources/ManifoldInference/Models/VideoGenerationEvent.swift
@@ -1,11 +1,14 @@
 import Foundation
 
 /// Events emitted by a ``VideoGenerationBackend`` during generation.
-public enum VideoGenerationEvent: Sendable {
+public enum VideoGenerationEvent: Sendable, Codable {
     /// Request accepted and queued; generation not yet started.
     case queued
-    /// Generation is in progress. `fractionComplete` is an estimate (0.0–1.0).
+    /// Generation is in progress. `fractionComplete` is a backend-estimated
+    /// value in 0.0–1.0; callers must clamp before display.
     case generating(fractionComplete: Double)
-    /// Generation finished. `url` is a local file URL on disk.
+    /// Generation finished and the video has been downloaded to disk.
+    /// `url` is a local file URL. If download fails after generation
+    /// completes, the stream terminates with a thrown error instead.
     case completed(URL)
 }

--- a/Sources/ManifoldInference/Protocols/VideoGenerationBackend.swift
+++ b/Sources/ManifoldInference/Protocols/VideoGenerationBackend.swift
@@ -3,18 +3,31 @@ import Foundation
 /// Common interface for cloud video-generation backends.
 ///
 /// Unlike ``ImageGenerationBackend``, video generation is inherently
-/// asynchronous — requests are queued and polled. The `generate` method
-/// returns a stream that yields progress events while polling and emits
-/// ``VideoGenerationEvent/completed(_:)`` with a local file URL once the
-/// video is downloaded to disk.
+/// asynchronous — requests are queued and polled. `generate` makes an
+/// initial HTTP request to submit the job (which may throw on auth or
+/// rate-limit errors), then returns a stream that yields progress events
+/// while polling and emits ``VideoGenerationEvent/completed(_:)`` with a
+/// local file URL once the video has been downloaded to disk.
 ///
-/// Conformers must be `AnyObject & Sendable` and protect mutable state
-/// with a lock or actor.
+/// Conformers must be `AnyObject` because they hold a running poll task
+/// and a URLSession — reference semantics are required for shared mutable
+/// state across the async poll loop.
 public protocol VideoGenerationBackend: AnyObject, Sendable {
+    /// Submits the video generation request and begins polling.
+    ///
+    /// Throws on submission failure (authentication, rate limit, network
+    /// error) before any stream events are emitted. If the server-side
+    /// generation succeeds but the local download fails, the stream
+    /// terminates with a thrown error.
     func generate(
         prompt: String,
         config: VideoGenerationConfig
-    ) -> AsyncThrowingStream<VideoGenerationEvent, Error>
+    ) async throws -> AsyncThrowingStream<VideoGenerationEvent, Error>
 
-    func cancel()
+    /// Cancels an in-flight generation request.
+    ///
+    /// Implementations send the backend cancellation signal (e.g. an HTTP
+    /// DELETE) and stop the poll loop. Awaiting this method ensures the
+    /// poll task has exited before the caller proceeds.
+    func cancel() async
 }

--- a/Sources/ManifoldInference/Protocols/VideoGenerationBackend.swift
+++ b/Sources/ManifoldInference/Protocols/VideoGenerationBackend.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Common interface for cloud video-generation backends.
+///
+/// Unlike ``ImageGenerationBackend``, video generation is inherently
+/// asynchronous — requests are queued and polled. The `generate` method
+/// returns a stream that yields progress events while polling and emits
+/// ``VideoGenerationEvent/completed(_:)`` with a local file URL once the
+/// video is downloaded to disk.
+///
+/// Conformers must be `AnyObject & Sendable` and protect mutable state
+/// with a lock or actor.
+public protocol VideoGenerationBackend: AnyObject, Sendable {
+    func generate(
+        prompt: String,
+        config: VideoGenerationConfig
+    ) -> AsyncThrowingStream<VideoGenerationEvent, Error>
+
+    func cancel()
+}

--- a/Tests/ManifoldInferenceTests/VideoGenerationTests.swift
+++ b/Tests/ManifoldInferenceTests/VideoGenerationTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import ManifoldInference
+
+final class VideoGenerationTests: XCTestCase {
+
+    // MARK: - ImageModelFormat
+
+    func test_imageModelFormat_includesCloudAPI() {
+        XCTAssertTrue(
+            ImageModelFormat.allCases.contains(.cloudAPI),
+            "ImageModelFormat.cloudAPI must be present in allCases"
+        )
+    }
+
+    func test_imageModelFormat_cloudAPI_codableRoundTrip() throws {
+        let encoded = try JSONEncoder().encode(ImageModelFormat.cloudAPI)
+        let decoded = try JSONDecoder().decode(ImageModelFormat.self, from: encoded)
+        XCTAssertEqual(decoded, .cloudAPI)
+        let rawString = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(rawString, "\"cloudAPI\"")
+    }
+
+    // MARK: - VideoGenerationConfig
+
+    func test_videoGenerationConfig_durationClampedToRange() {
+        XCTAssertEqual(VideoGenerationConfig(duration: 0).duration, 1)
+        XCTAssertEqual(VideoGenerationConfig(duration: -10).duration, 1)
+        XCTAssertEqual(VideoGenerationConfig(duration: 16).duration, 15)
+        XCTAssertEqual(VideoGenerationConfig(duration: 100).duration, 15)
+        XCTAssertEqual(VideoGenerationConfig(duration: 7).duration, 7)
+    }
+
+    func test_videoGenerationConfig_codableRoundTrip() throws {
+        let config = VideoGenerationConfig(
+            duration: 8,
+            aspectRatio: .portrait,
+            resolution: .sd,
+            sourceImageURL: URL(fileURLWithPath: "/tmp/source.jpg")
+        )
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(VideoGenerationConfig.self, from: data)
+        XCTAssertEqual(decoded.duration, config.duration)
+        XCTAssertEqual(decoded.aspectRatio, config.aspectRatio)
+        XCTAssertEqual(decoded.resolution, config.resolution)
+        XCTAssertEqual(decoded.sourceImageURL, config.sourceImageURL)
+    }
+
+    func test_videoGenerationConfig_defaults() {
+        let config = VideoGenerationConfig()
+        XCTAssertEqual(config.duration, 5)
+        XCTAssertEqual(config.aspectRatio, .landscape)
+        XCTAssertEqual(config.resolution, .hd)
+        XCTAssertNil(config.sourceImageURL)
+    }
+
+    // MARK: - VideoGenerationEvent
+
+    func test_videoGenerationEvent_codableRoundTrip() throws {
+        let events: [VideoGenerationEvent] = [
+            .queued,
+            .generating(fractionComplete: 0.42),
+            .completed(URL(fileURLWithPath: "/tmp/output.mp4"))
+        ]
+        for event in events {
+            let data = try JSONEncoder().encode(event)
+            let decoded = try JSONDecoder().decode(VideoGenerationEvent.self, from: data)
+            switch (event, decoded) {
+            case (.queued, .queued): break
+            case (.generating(let a), .generating(let b)):
+                XCTAssertEqual(a, b, accuracy: 0.001)
+            case (.completed(let a), .completed(let b)):
+                XCTAssertEqual(a, b)
+            default:
+                XCTFail("Round-trip mismatch: \(event) → \(decoded)")
+            }
+        }
+    }
+
+    // MARK: - AspectRatio / Resolution coverage
+
+    func test_aspectRatio_allCasesHaveRawValue() {
+        for ratio in VideoGenerationConfig.AspectRatio.allCases {
+            XCTAssertFalse(ratio.rawValue.isEmpty)
+        }
+    }
+
+    func test_resolution_allCasesHaveRawValue() {
+        for res in VideoGenerationConfig.Resolution.allCases {
+            XCTAssertFalse(res.rawValue.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the protocol surface needed by cloud video-generation backends alongside a minor `ImageModelFormat` extension:

- **`VideoGenerationBackend`** (`ManifoldInference/Protocols/`) — protocol for async/polled cloud video generation. `generate(prompt:config:)` returns an `AsyncThrowingStream<VideoGenerationEvent, Error>`; `cancel()` stops an in-flight request. Intentionally has no `loadModel` — video generation is cloud-only in this design.

- **`VideoGenerationConfig`** (`ManifoldInference/Models/`) — `duration` (1–15 s), `aspectRatio` (16:9 / 9:16 / 1:1 / 4:3 / 3:4), `resolution` (720p / 480p), optional `sourceImageURL` for image-to-video mode.

- **`VideoGenerationEvent`** (`ManifoldInference/Models/`) — `.queued`, `.generating(fractionComplete:)` (backend-estimated 0–1), `.completed(URL)` (local file URL after download).

- **`ImageModelFormat.cloudAPI`** — new case for cloud HTTP image-generation backends that ignore `directoryURL`. No exhaustive-switch changes required anywhere (no existing callers switch over this enum).

## Design notes

- Parallel in shape to `ImageGenerationBackend` / `ImageGenerationEvent` but without `loadModel` — cloud video APIs don't have a local model artifact to load.
- `fractionComplete` in `.generating` is intentionally an estimate: video generation APIs return opaque `pending` status with no progress %; backends derive fraction from poll count.
- No `VideoGenerationService` or `VideoGenerationRuntime` in this PR — those can follow once the protocol shape is validated against a real backend.

## Test plan
- [ ] `ManifoldInference` compiles with `CloudSaaS` + `Voice` traits (verified locally against `GrokApp` consumer)
- [ ] `ImageModelFormat.cloudAPI` round-trips through `Codable` (raw value `"cloudAPI"`)
- [ ] No existing switch exhaustiveness warnings (enum is `CaseIterable`; no callers switch over format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)