### PR TITLE
feat(runtime): VideoGenerationService + Runtime, provider-neutral VideoGenerationConfig, ConversationRuntimeOptions

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -112,17 +112,6 @@ public final class ManifoldBootstrap {
     /// `nil` when ``imageGenerationService`` is `nil`.
     public let imageRuntime: ImageGenerationRuntime?
 
-    /// The video-generation service, when the host opted in to video generation.
-    /// `nil` when ``ManifoldBootstrap`` was constructed without a
-    /// `videoGenerationService` parameter.
-    public let videoGenerationService: VideoGenerationService?
-
-    /// The video-generation runtime, pre-wired against ``videoGenerationService``
-    /// and ``persistence``. Pass to ``ChatViewModel/configure(videoRuntime:)``
-    /// to enable video generation in the chat view model.
-    /// `nil` when ``videoGenerationService`` is `nil`.
-    public let videoRuntime: VideoGenerationRuntime?
-
     /// The RAG knowledge-base service, when the host opted in via
     /// ``RAGConfiguration``. `nil` when bootstrapped without RAG.
     ///
@@ -149,7 +138,6 @@ public final class ManifoldBootstrap {
         ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
-        videoGenerationService: VideoGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -219,15 +207,6 @@ public final class ManifoldBootstrap {
             } else {
                 self.imageRuntime = nil
             }
-            self.videoGenerationService = videoGenerationService
-            if let videoGenerationService {
-                self.videoRuntime = VideoGenerationRuntime(
-                    service: videoGenerationService,
-                    messageStore: resolvedPersistence
-                )
-            } else {
-                self.videoRuntime = nil
-            }
         } catch {
             ManifoldConfiguration.shared = previousConfiguration
             throw error
@@ -244,7 +223,6 @@ public final class ManifoldBootstrap {
         endpointStore: SwiftDataEndpointStore,
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
-        videoGenerationService: VideoGenerationService? = nil,
         ragService: RAGService? = nil,
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -286,15 +264,6 @@ public final class ManifoldBootstrap {
             )
         } else {
             self.imageRuntime = nil
-        }
-        self.videoGenerationService = videoGenerationService
-        if let videoGenerationService {
-            self.videoRuntime = VideoGenerationRuntime(
-                service: videoGenerationService,
-                messageStore: persistence
-            )
-        } else {
-            self.videoRuntime = nil
         }
     }
 
@@ -346,7 +315,6 @@ public final class ManifoldBootstrap {
         ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
-        videoGenerationService: VideoGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -400,7 +368,6 @@ public final class ManifoldBootstrap {
                     endpointStore: endpointStore,
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
-                    videoGenerationService: videoGenerationService,
                     ragService: ragService,
                     runtimeOptions: runtimeOptions,
                     sessionToolSources: sessionToolSources,

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -139,6 +139,7 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
+        runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
         makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
@@ -176,14 +177,24 @@ public final class ManifoldBootstrap {
             // ManifoldPersistenceSwiftData does not depend on ManifoldFoundation,
             // so FoundationBackend cannot be instantiated here directly. Host apps
             // that run on iOS 26+ / macOS 26+ can wire their own auxiliary service
-            // via the `auxiliaryInferenceService:` parameter on ConversationRuntime.
+            // via `runtimeOptions.auxiliaryInferenceService`.
             // See ManifoldFoundation.FoundationBackend for the recommended setup.
             self.conversationRuntime = ConversationRuntime(
                 messageStore: resolvedPersistence,
                 sessionStore: resolvedPersistence,
                 inferenceService: resolvedInferenceService,
+                pipeline: runtimeOptions.pipeline,
+                budgetPlanner: runtimeOptions.budgetPlanner,
                 ragService: resolvedRAGService,
+                auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
                 usageStore: resolvedUsageStore,
+                generationHooks: runtimeOptions.generationHooks,
+                compressionPolicy: runtimeOptions.compressionPolicy,
+                preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
+                historyShaper: runtimeOptions.historyShaper,
+                historyProviders: runtimeOptions.historyProviders,
+                hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
+                turnContextProvider: runtimeOptions.turnContextProvider,
                 sessionToolSources: sessionToolSources,
                 hookRegistry: hookRegistry
             )
@@ -213,6 +224,7 @@ public final class ManifoldBootstrap {
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
         ragService: RAGService? = nil,
+        runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil
     ) {
@@ -229,8 +241,18 @@ public final class ManifoldBootstrap {
             messageStore: persistence,
             sessionStore: persistence,
             inferenceService: inferenceService,
+            pipeline: runtimeOptions.pipeline,
+            budgetPlanner: runtimeOptions.budgetPlanner,
             ragService: ragService,
+            auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
             usageStore: usageStore,
+            generationHooks: runtimeOptions.generationHooks,
+            compressionPolicy: runtimeOptions.compressionPolicy,
+            preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
+            historyShaper: runtimeOptions.historyShaper,
+            historyProviders: runtimeOptions.historyProviders,
+            hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
+            turnContextProvider: runtimeOptions.turnContextProvider,
             sessionToolSources: sessionToolSources,
             hookRegistry: hookRegistry
         )
@@ -294,6 +316,7 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
+        runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
         makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
@@ -346,6 +369,7 @@ public final class ManifoldBootstrap {
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
                     ragService: ragService,
+                    runtimeOptions: runtimeOptions,
                     sessionToolSources: sessionToolSources,
                     hookRegistry: hookRegistry
                 )

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -7,7 +7,7 @@ import ManifoldInference
 
 /// Configuration for the RAG knowledge base.
 ///
-/// Pass to ``ManifoldBootstrap/init(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
+/// Pass to ``ManifoldBootstrap/init(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:makeModelContainer:)``
 /// to enable on-device RAG. When `nil`, the runtime runs without retrieval.
 ///
 /// ```swift
@@ -68,7 +68,7 @@ public struct RAGConfiguration: Sendable {
 ///
 /// ### Splash-screen progress
 ///
-/// Call ``build(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:sessionToolSources:hookRegistry:makeModelContainer:)``
+/// Call ``build(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:makeModelContainer:)``
 /// instead of `init` when you want to drive a launch progress UI. That factory
 /// returns an `AsyncStream<RuntimeBootstrapMilestone>` you can iterate on the
 /// main actor while bootstrap runs concurrently in a sibling task:
@@ -112,6 +112,17 @@ public final class ManifoldBootstrap {
     /// `nil` when ``imageGenerationService`` is `nil`.
     public let imageRuntime: ImageGenerationRuntime?
 
+    /// The video-generation service, when the host opted in to video generation.
+    /// `nil` when ``ManifoldBootstrap`` was constructed without a
+    /// `videoGenerationService` parameter.
+    public let videoGenerationService: VideoGenerationService?
+
+    /// The video-generation runtime, pre-wired against ``videoGenerationService``
+    /// and ``persistence``. Pass to ``ChatViewModel/configure(videoRuntime:)``
+    /// to enable video generation in the chat view model.
+    /// `nil` when ``videoGenerationService`` is `nil`.
+    public let videoRuntime: VideoGenerationRuntime?
+
     /// The RAG knowledge-base service, when the host opted in via
     /// ``RAGConfiguration``. `nil` when bootstrapped without RAG.
     ///
@@ -138,6 +149,7 @@ public final class ManifoldBootstrap {
         ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
+        videoGenerationService: VideoGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -207,6 +219,15 @@ public final class ManifoldBootstrap {
             } else {
                 self.imageRuntime = nil
             }
+            self.videoGenerationService = videoGenerationService
+            if let videoGenerationService {
+                self.videoRuntime = VideoGenerationRuntime(
+                    service: videoGenerationService,
+                    messageStore: resolvedPersistence
+                )
+            } else {
+                self.videoRuntime = nil
+            }
         } catch {
             ManifoldConfiguration.shared = previousConfiguration
             throw error
@@ -223,6 +244,7 @@ public final class ManifoldBootstrap {
         endpointStore: SwiftDataEndpointStore,
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
+        videoGenerationService: VideoGenerationService? = nil,
         ragService: RAGService? = nil,
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -264,6 +286,15 @@ public final class ManifoldBootstrap {
             )
         } else {
             self.imageRuntime = nil
+        }
+        self.videoGenerationService = videoGenerationService
+        if let videoGenerationService {
+            self.videoRuntime = VideoGenerationRuntime(
+                service: videoGenerationService,
+                messageStore: persistence
+            )
+        } else {
+            self.videoRuntime = nil
         }
     }
 
@@ -315,6 +346,7 @@ public final class ManifoldBootstrap {
         ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
+        videoGenerationService: VideoGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -368,6 +400,7 @@ public final class ManifoldBootstrap {
                     endpointStore: endpointStore,
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
+                    videoGenerationService: videoGenerationService,
                     ragService: ragService,
                     runtimeOptions: runtimeOptions,
                     sessionToolSources: sessionToolSources,

--- a/Sources/ManifoldRuntime/Services/ConversationRuntimeOptions.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntimeOptions.swift
@@ -1,0 +1,90 @@
+import Foundation
+import ManifoldInference
+
+/// Optional ``ConversationRuntime`` extension points threaded through
+/// ``ManifoldBootstrap`` to the runtime it constructs.
+///
+/// All properties default to `nil` / empty, which reproduces the behaviour of
+/// a bootstrap with no options specified. Set only what your host app needs:
+///
+/// ```swift
+/// var options = ConversationRuntimeOptions()
+/// options.historyShaper = StoryHistoryShaper()
+/// options.compressionPolicy = SummarisationPolicy()
+/// options.generationHooks = [TitleGenerationHook()]
+///
+/// let bootstrap = try ManifoldBootstrap(
+///     configuration: config,
+///     runtimeOptions: options,
+///     makeModelContainer: { try ModelContainerFactory.makeContainer() }
+/// )
+/// ```
+///
+/// Passing an `auxiliaryInferenceService` lets the runtime use a separate, cheap
+/// model for internal tasks like session-title generation and compression routing,
+/// keeping those off your primary model:
+///
+/// ```swift
+/// var options = ConversationRuntimeOptions()
+/// options.auxiliaryInferenceService = InferenceService(backend: FoundationBackend())
+/// ```
+public struct ConversationRuntimeOptions {
+
+    /// Custom prompt-context assembly pipeline replacing the default slot-merge.
+    public var pipeline: PromptContextPipeline?
+
+    /// Custom token-budget planner used during context trimming.
+    public var budgetPlanner: ContextBudgetPlanner?
+
+    /// Hooks called after each completed generation turn.
+    public var generationHooks: [any GenerationHook]
+
+    /// Post-turn history-compression policy.
+    public var compressionPolicy: (any CompressionPolicy)?
+
+    /// Pre-turn history-compression policy applied before each new turn.
+    public var preTurnCompressionPolicy: (any PreTurnCompressionPolicy)?
+
+    /// Host-owned transformer applied to assembled history before each turn.
+    public var historyShaper: (any HistoryShaper)?
+
+    /// History augmentation providers injected before context assembly.
+    public var historyProviders: [any HistoryProvider]
+
+    /// Async/throwing richer per-turn context provider. Supersedes
+    /// ``turnContextProvider`` when both are set.
+    public var hostTurnContextProvider: (any HostTurnContextProvider)?
+
+    /// Legacy synchronous per-turn context provider. Used only when
+    /// ``hostTurnContextProvider`` is `nil`.
+    public var turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?
+
+    /// Auxiliary inference service for internal framework tasks such as
+    /// session-title generation and compression routing. When `nil` the
+    /// runtime falls back to the primary ``InferenceService``.
+    public var auxiliaryInferenceService: InferenceService?
+
+    public init(
+        pipeline: PromptContextPipeline? = nil,
+        budgetPlanner: ContextBudgetPlanner? = nil,
+        generationHooks: [any GenerationHook] = [],
+        compressionPolicy: (any CompressionPolicy)? = nil,
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil,
+        historyShaper: (any HistoryShaper)? = nil,
+        historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
+        auxiliaryInferenceService: InferenceService? = nil
+    ) {
+        self.pipeline = pipeline
+        self.budgetPlanner = budgetPlanner
+        self.generationHooks = generationHooks
+        self.compressionPolicy = compressionPolicy
+        self.preTurnCompressionPolicy = preTurnCompressionPolicy
+        self.historyShaper = historyShaper
+        self.historyProviders = historyProviders
+        self.hostTurnContextProvider = hostTurnContextProvider
+        self.turnContextProvider = turnContextProvider
+        self.auxiliaryInferenceService = auxiliaryInferenceService
+    }
+}

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
@@ -18,7 +18,7 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
 
     actor RecordingHook: GenerationHook {
         private(set) var receivedTurns: [CompletedTurn] = []
-        private var pending: [CheckedContinuation<CompletedTurn, Never>] = []
+        private var pending: [CheckedContinuation<CompletedTurn, any Error>] = []
 
         func postGeneration(_ turn: CompletedTurn) async {
             receivedTurns.append(turn)
@@ -26,8 +26,27 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
             pending.removeAll()
         }
 
-        func awaitNextTurn() async -> CompletedTurn {
-            await withCheckedContinuation { pending.append($0) }
+        /// Suspends until the next `postGeneration` delivery and returns it.
+        ///
+        /// Returns immediately when the hook has already fired (prevents a race
+        /// where the generation task completes before this continuation is
+        /// registered). Uses a throwing continuation so task cancellation can
+        /// resume the stored continuation with `CancellationError`, avoiding a
+        /// debug-build deinit precondition trap when the caller's 5-second
+        /// deadline fires first.
+        func awaitNextTurn() async throws -> CompletedTurn {
+            if let already = receivedTurns.last { return already }
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { pending.append($0) }
+            } onCancel: {
+                Task { await self.cancelPending() }
+            }
+        }
+
+        private func cancelPending() {
+            let waiters = pending
+            pending.removeAll()
+            for cont in waiters { cont.resume(throwing: CancellationError()) }
         }
     }
 
@@ -57,7 +76,7 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
         )
         // Await the hook's own signal — deterministic, no sleep.
         try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
-            group.addTask { await hook.awaitNextTurn() }
+            group.addTask { try await hook.awaitNextTurn() }
             group.addTask {
                 try await Task.sleep(for: .seconds(5))
                 throw TestError.deadlineElapsed

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+import ManifoldRuntime
+@testable import ManifoldPersistenceSwiftData
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Verifies that ``ConversationRuntimeOptions`` is threaded through to the
+/// ``ConversationRuntime`` constructed by both ``ManifoldBootstrap/init`` and
+/// ``ManifoldBootstrap/build``.
+///
+/// Each behavioral test wires a ``GenerationHook`` through
+/// ``ConversationRuntimeOptions`` and confirms the hook fires during a real
+/// turn, proving the options aren't silently discarded.
+@MainActor
+final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
+
+    // MARK: - Recording hook
+
+    actor RecordingHook: GenerationHook {
+        private(set) var receivedTurns: [CompletedTurn] = []
+        private var pending: [CheckedContinuation<CompletedTurn, Never>] = []
+
+        func postGeneration(_ turn: CompletedTurn) async {
+            receivedTurns.append(turn)
+            for cont in pending { cont.resume(returning: turn) }
+            pending.removeAll()
+        }
+
+        func awaitNextTurn() async -> CompletedTurn {
+            await withCheckedContinuation { pending.append($0) }
+        }
+    }
+
+    enum TestError: Error { case deadlineElapsed }
+
+    // MARK: - Helpers
+
+    private func makeConfig(tag: String) -> ManifoldConfiguration {
+        ManifoldConfiguration(
+            appName: "RuntimeOptionsTests",
+            bundleIdentifier: "com.manifoldkit.runtime-options-tests.\(tag).\(UUID().uuidString)"
+        )
+    }
+
+    /// Sends one turn through `runtime` and returns once the given hook fires.
+    /// Fails if the hook doesn't fire within 5 seconds.
+    private func sendTurnAndAwaitHook(
+        through runtime: ConversationRuntime,
+        backend: MockInferenceBackend,
+        hook: RecordingHook,
+        tokens: [String] = ["ok"]
+    ) async throws {
+        backend.tokensToYield = tokens
+        backend.isModelLoaded = true
+        _ = try await runtime.processTurn(
+            TurnInput(sessionID: UUID(), kind: .send(text: "hello"))
+        )
+        // Await the hook's own signal — deterministic, no sleep.
+        try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
+            group.addTask { await hook.awaitNextTurn() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw TestError.deadlineElapsed
+            }
+            _ = try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    // MARK: - Default options
+
+    func test_defaultOptions_producesValidRuntime() throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let bootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "default-options"),
+            runtimeOptions: ConversationRuntimeOptions(),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        // Runtime is live and its event stream can be iterated.
+        let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
+        _ = conversationRuntime
+    }
+
+    // MARK: - init path
+
+    func test_init_generationHookFiresAfterTurn() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let hook = RecordingHook()
+        var options = ConversationRuntimeOptions()
+        options.generationHooks = [hook]
+
+        let backend = MockInferenceBackend()
+        let bootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "hook-init"),
+            inferenceService: InferenceService(backend: backend, name: "HookInitMock"),
+            runtimeOptions: options,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        try await sendTurnAndAwaitHook(
+            through: bootstrap.conversationRuntime, backend: backend, hook: hook
+        )
+
+        let count = await hook.receivedTurns.count
+        XCTAssertEqual(count, 1,
+            "GenerationHook registered via runtimeOptions must fire once after a completed turn")
+    }
+
+    func test_init_omittingRuntimeOptions_preservesExistingBehaviour() throws {
+        // Callers that don't pass runtimeOptions must compile and produce a
+        // valid runtime — source compatibility gate.
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let bootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "no-options"),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
+        _ = conversationRuntime
+    }
+
+    // MARK: - build() async path
+
+    func test_build_generationHookFiresAfterTurn() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let hook = RecordingHook()
+        var options = ConversationRuntimeOptions()
+        options.generationHooks = [hook]
+
+        let backend = MockInferenceBackend()
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: makeConfig(tag: "hook-build"),
+            inferenceService: InferenceService(backend: backend, name: "HookBuildMock"),
+            runtimeOptions: options,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let bootstrap = try await task.value
+
+        try await sendTurnAndAwaitHook(
+            through: bootstrap.conversationRuntime, backend: backend, hook: hook
+        )
+
+        let count = await hook.receivedTurns.count
+        XCTAssertEqual(count, 1,
+            "GenerationHook registered via runtimeOptions must fire on the build() path too")
+    }
+
+    func test_build_omittingRuntimeOptions_preservesExistingBehaviour() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: makeConfig(tag: "build-no-options"),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let bootstrap = try await task.value
+
+        let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
+        _ = conversationRuntime
+    }
+}


### PR DESCRIPTION
## Summary

Three related additions to the runtime layer, now combined on this branch:

### 1. VideoGenerationService + VideoGenerationRuntime (main focus)

Full video-generation orchestration as a sibling to the existing image-generation stack. Protocol surface (`VideoGenerationBackend`, `VideoGenerationConfig`, `VideoGenerationEvent`) already landed in #1526.

**New files (6):**

| File | Role |
|------|------|
| `ManifoldInference/Models/VideoGenerationConfigSnapshot.swift` | Persistence mirror with `width/height` (not a resolution enum) |
| `ManifoldInference/Models/VideoMessagePayload.swift` | Persisted output record |
| `ManifoldInference/Services/VideoGenerationService.swift` | `@MainActor @Observable` orchestrator; always ready (no `loadModel`); `generate()` is `async throws` |
| `ManifoldRuntime/Services/VideoRuntimeEvent.swift` | `.started / .progress / .completed / .failed / .cancelled` |
| `ManifoldRuntime/Services/VideoGenerationRuntime.swift` | Placeholder → stream drain → `.generatedVideo` in-place update |
| `ManifoldUI/ViewModels/ChatViewModel+VideoGeneration.swift` | `configure(videoRuntime:)`, `generateVideo`, `cancelVideoGeneration`, event handler |

**Edited files:** `MessagePart.swift` (`.generatedVideo` case), `ManifoldBootstrap.swift` (service/runtime params + construction), `ChatRuntimeBootstrap.swift`, `ChatViewModel.swift`, `RuntimeConfiguration.swift`, `MessagePartsView.swift`

### 2. Provider-neutral VideoGenerationConfig

`AspectRatio` → namespace with `static let` String constants (not an enum). `Resolution` → `width: Int?` + `height: Int?`. Duration clamping removed (backends enforce their own limits). Snapshot Codable migrates legacy `resolution` rows silently.

### 3. ConversationRuntimeOptions (original scope)

Exposes `ConversationRuntime` extension points — `historyShaper`, `hostTurnContextProvider`, `preTurnCompressionPolicy`, `auxiliaryInferenceService`, etc. — via a single options struct so `ManifoldBootstrap` and `build(...)` don't need to grow a new parameter for each knob.

## Key design decisions (video gen)

- No backend factory / `loadModel` — video is cloud-only; the service holds a concrete backend at init
- `generate()` is `async throws` — matches the backend protocol (submission does a network round-trip before the stream)
- `.queued` → `progress(fractionComplete: 0.0)` — five-event runtime shape matching image gen

## Test plan
- [ ] `MessagePart` Codable: `generatedVideo` encodes/decodes; legacy rows without the key still decode
- [ ] `ChatViewModel+VideoGeneration`: `.started` inserts placeholder, `.progress` updates, `.completed` replaces with `.generatedVideo`, `.failed`/`.cancelled` mark complete
- [ ] `ManifoldBootstrap` with `videoGenerationService: nil` → `videoRuntime = nil`
- [ ] Build clean under `CloudSaaS` + `Voice` traits ✅ verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)