### PR TITLE
feat(runtime): VideoGenerationService, VideoGenerationRuntime, and chat integration

### DIFF
--- a/Sources/ManifoldInference/Models/MessagePart.swift
+++ b/Sources/ManifoldInference/Models/MessagePart.swift
@@ -61,6 +61,13 @@ public enum MessagePart: Hashable, Sendable {
     /// from ``textContent`` (the payload's prompt is metadata, not visible chat
     /// text).
     case generatedImage(ImageMessagePayload)
+    /// A video produced by a ``VideoGenerationBackend`` and attached to
+    /// a saved message.
+    ///
+    /// References a local file URL whose binary is the backend's *output*.
+    /// Excluded from ``textContent`` (the payload's prompt is metadata, not
+    /// visible chat text).
+    case generatedVideo(VideoMessagePayload)
 }
 
 // MARK: - Codable
@@ -72,7 +79,7 @@ extension MessagePart: Codable {
     // assertions in MessagePartToolCasesTests / MessagePartThinkingTests are
     // the sentries that catch such drift.
     private enum CodingKeys: String, CodingKey {
-        case text, image, audio, thinking, toolCall, toolResult, generatedImage
+        case text, image, audio, thinking, toolCall, toolResult, generatedImage, generatedVideo
     }
 
     private enum ImageKeys: String, CodingKey {
@@ -151,6 +158,8 @@ extension MessagePart: Codable {
             self = .toolResult(try container.decode(ToolResult.self, forKey: .toolResult))
         case .generatedImage:
             self = .generatedImage(try container.decode(ImageMessagePayload.self, forKey: .generatedImage))
+        case .generatedVideo:
+            self = .generatedVideo(try container.decode(VideoMessagePayload.self, forKey: .generatedVideo))
         }
     }
 
@@ -181,6 +190,8 @@ extension MessagePart: Codable {
             try container.encode(result, forKey: .toolResult)
         case .generatedImage(let payload):
             try container.encode(payload, forKey: .generatedImage)
+        case .generatedVideo(let payload):
+            try container.encode(payload, forKey: .generatedVideo)
         }
     }
 }
@@ -230,6 +241,13 @@ extension MessagePart {
     /// for any other case.
     public var generatedImageContent: ImageMessagePayload? {
         if case .generatedImage(let p) = self { return p }
+        return nil
+    }
+
+    /// The ``VideoMessagePayload`` of a `.generatedVideo` part, or `nil`
+    /// for any other case.
+    public var generatedVideoContent: VideoMessagePayload? {
+        if case .generatedVideo(let p) = self { return p }
         return nil
     }
 

--- a/Sources/ManifoldInference/Models/VideoGenerationConfigSnapshot.swift
+++ b/Sources/ManifoldInference/Models/VideoGenerationConfigSnapshot.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Persistence-layer mirror of ``VideoGenerationConfig``.
+///
+/// Held by ``VideoMessagePayload`` so saved conversation history can render —
+/// or regenerate — a video with the exact parameters that produced it.
+///
+/// ## Why a separate type?
+///
+/// ``VideoGenerationConfig`` is the *runtime* shape. Backends read fields
+/// from it and may grow new ones over time. Decoupling persistence from
+/// runtime keeps two concerns from drifting into each other:
+///
+/// - Adding a new runtime knob does not silently change the on-disk wire
+///   format of every persisted video message.
+/// - Renaming or restructuring a runtime field does not strand persisted
+///   rows; the snapshot type stays stable and adopts changes deliberately
+///   via an explicit Codable migration.
+///
+/// Mirrors the field shape exactly today; future divergence is allowed
+/// without touching ``VideoGenerationConfig``.
+public struct VideoGenerationConfigSnapshot: Sendable, Hashable {
+
+    /// Duration in seconds, as recorded at generation time.
+    public var duration: Int
+
+    /// Raw value of ``VideoGenerationConfig/AspectRatio`` (e.g. `"16:9"`).
+    public var aspectRatio: String
+
+    /// Raw value of ``VideoGenerationConfig/Resolution`` (e.g. `"720p"`).
+    public var resolution: String
+
+    /// Local file URL of the source image used for image-to-video mode, if any.
+    public var sourceImageURL: URL?
+
+    public init(
+        duration: Int,
+        aspectRatio: String,
+        resolution: String,
+        sourceImageURL: URL? = nil
+    ) {
+        self.duration = duration
+        self.aspectRatio = aspectRatio
+        self.resolution = resolution
+        self.sourceImageURL = sourceImageURL
+    }
+
+    /// Captures the current runtime configuration into a persistable
+    /// snapshot. Used by the persistence layer at the moment a
+    /// ``VideoMessagePayload`` is created.
+    public init(from config: VideoGenerationConfig) {
+        self.duration = config.duration
+        self.aspectRatio = config.aspectRatio.rawValue
+        self.resolution = config.resolution.rawValue
+        self.sourceImageURL = config.sourceImageURL
+    }
+
+    /// Rehydrates a runtime ``VideoGenerationConfig`` from this snapshot.
+    /// Used when replaying a generation from history (e.g. a "regenerate
+    /// with the same settings" affordance).
+    ///
+    /// Falls back to ``VideoGenerationConfig`` defaults when the stored raw
+    /// values do not match any current enum case — tolerates enum additions
+    /// across app versions.
+    public func toConfig() -> VideoGenerationConfig {
+        VideoGenerationConfig(
+            duration: duration,
+            aspectRatio: VideoGenerationConfig.AspectRatio(rawValue: aspectRatio) ?? .landscape,
+            resolution: VideoGenerationConfig.Resolution(rawValue: resolution) ?? .hd,
+            sourceImageURL: sourceImageURL
+        )
+    }
+}
+
+// MARK: - Codable
+
+extension VideoGenerationConfigSnapshot: Codable {
+
+    // Custom Codable so older persisted rows that pre-date `sourceImageURL`
+    // decode to `nil` rather than failing the whole row, and so absent
+    // fields never get force-encoded as `null`.
+    private enum CodingKeys: String, CodingKey {
+        case duration, aspectRatio, resolution, sourceImageURL
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.duration = try c.decode(Int.self, forKey: .duration)
+        self.aspectRatio = try c.decode(String.self, forKey: .aspectRatio)
+        self.resolution = try c.decode(String.self, forKey: .resolution)
+        self.sourceImageURL = try c.decodeIfPresent(URL.self, forKey: .sourceImageURL)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(duration, forKey: .duration)
+        try c.encode(aspectRatio, forKey: .aspectRatio)
+        try c.encode(resolution, forKey: .resolution)
+        try c.encodeIfPresent(sourceImageURL, forKey: .sourceImageURL)
+    }
+}

--- a/Sources/ManifoldInference/Models/VideoMessagePayload.swift
+++ b/Sources/ManifoldInference/Models/VideoMessagePayload.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Persisted record of a single backend-generated video, attached to a
+/// ``MessagePart/generatedVideo(_:)``.
+///
+/// Distinct from ``ImageMessagePayload`` — this type carries a
+/// *backend-produced video output*, referenced by file URL (the binary lives
+/// on disk in the app container) and tagged with the parameters that produced
+/// it.
+///
+/// ## Why URL instead of inline bytes?
+///
+/// Generated videos are typically 10–100 MB files. Storing the bytes in
+/// ``ManifoldSchemaV4/ChatMessage/contentPartsJSON`` would balloon the
+/// JSON payload size for every saved row and make pagination expensive.
+/// The video binary is owned by the host app's storage strategy; this
+/// payload only references it.
+public struct VideoMessagePayload: Sendable, Codable, Hashable {
+
+    /// The prompt the user submitted to produce this video.
+    public var prompt: String
+
+    /// File URL (in the app container) of the produced video binary.
+    public var videoURL: URL
+
+    /// Identifier of the backend service that produced this video. Free-form
+    /// because service identifiers vary by provider.
+    public var modelIdentifier: String
+
+    /// Snapshot of the generation parameters used to produce this video.
+    /// Captured at generation time so a "regenerate with same settings"
+    /// affordance remains meaningful even after the runtime config evolves.
+    public var generationConfig: VideoGenerationConfigSnapshot
+
+    /// When the video was produced.
+    public var generatedAt: Date
+
+    public init(
+        prompt: String,
+        videoURL: URL,
+        modelIdentifier: String,
+        generationConfig: VideoGenerationConfigSnapshot,
+        generatedAt: Date = Date()
+    ) {
+        self.prompt = prompt
+        self.videoURL = videoURL
+        self.modelIdentifier = modelIdentifier
+        self.generationConfig = generationConfig
+        self.generatedAt = generatedAt
+    }
+}

--- a/Sources/ManifoldInference/Services/VideoGenerationService.swift
+++ b/Sources/ManifoldInference/Services/VideoGenerationService.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Observation
+
+/// Errors thrown by ``VideoGenerationService`` for caller-observable conditions.
+public enum VideoGenerationServiceError: Error, Equatable, Sendable {
+    /// `generate` was called while another generation is already in progress.
+    case alreadyGenerating
+}
+
+/// Orchestrates a video-generation backend's lifecycle.
+///
+/// Sibling to ``ImageGenerationService`` for the video path. Unlike image
+/// generation, video is inherently cloud-only — there is no `loadModel`
+/// concept. The service is always "ready" and holds a backend directly from
+/// construction time. State machine: `idle → generating → idle`.
+///
+/// ## Concurrency
+///
+/// `@MainActor`-isolated; all state transitions happen on the main actor.
+/// The backend's `generate(prompt:config:)` is `async throws`, so the
+/// service's own `generate` is also `async throws` — the submission
+/// handshake (which may do a network round-trip) happens before the stream
+/// is returned, so callers `await` the initial `generate` call and then
+/// iterate the returned stream.
+@MainActor
+@Observable
+public final class VideoGenerationService {
+
+    // MARK: - State
+
+    /// High-level lifecycle state. Transitions:
+    ///
+    /// `idle → generating → idle`
+    ///
+    /// Errors thrown from `generate` surface to the caller; the service
+    /// itself does not enter a long-lived `.error` state — a failed
+    /// generate returns to `.idle`.
+    public enum State: Sendable, Equatable {
+        case idle
+        case generating
+    }
+
+    public private(set) var state: State = .idle
+
+    // MARK: - Private
+
+    private let backend: any VideoGenerationBackend
+
+    // MARK: - Init
+
+    /// Creates a service that drives the supplied backend directly.
+    ///
+    /// - Parameter backend: The cloud video-generation backend to use.
+    ///   The backend is retained for the lifetime of the service.
+    public init(backend: any VideoGenerationBackend) {
+        self.backend = backend
+    }
+
+    // MARK: - Generate
+
+    /// Submits a video-generation request to the backend and returns a
+    /// stream of progress events.
+    ///
+    /// The state transitions to `.generating` before this method returns
+    /// so a follow-up call from the same actor observes `.generating`
+    /// deterministically. The submission handshake (which may involve a
+    /// network round-trip to the cloud backend) happens inside this `async
+    /// throws` call — callers `await` the initial submit, then iterate
+    /// the returned stream for progress and the final `.completed` URL.
+    ///
+    /// - Parameters:
+    ///   - prompt: User-supplied text prompt.
+    ///   - config: Generation parameters (duration, aspect ratio, resolution,
+    ///     optional source image for image-to-video).
+    /// - Returns: A stream of ``VideoGenerationEvent`` values, finishing with
+    ///   `.completed(URL)` on success or a thrown error on failure.
+    /// - Throws: ``VideoGenerationServiceError/alreadyGenerating`` when a
+    ///   generation is already in progress. Backend submission errors
+    ///   (authentication, rate limit, network) are rethrown directly.
+    public func generate(
+        prompt: String,
+        config: VideoGenerationConfig
+    ) async throws -> AsyncThrowingStream<VideoGenerationEvent, Error> {
+        guard state == .idle else {
+            throw VideoGenerationServiceError.alreadyGenerating
+        }
+
+        state = .generating
+
+        do {
+            let upstream = try await backend.generate(prompt: prompt, config: config)
+
+            return AsyncThrowingStream { continuation in
+                let task = Task.detached(priority: .userInitiated) { [weak self] in
+                    do {
+                        for try await event in upstream {
+                            if Task.isCancelled {
+                                await self?.restoreIdleState()
+                                continuation.finish()
+                                return
+                            }
+                            continuation.yield(event)
+                        }
+                        await self?.restoreIdleState()
+                        continuation.finish()
+                    } catch is CancellationError {
+                        await self?.restoreIdleState()
+                        continuation.finish()
+                    } catch {
+                        if Task.isCancelled {
+                            await self?.restoreIdleState()
+                            continuation.finish()
+                        } else {
+                            await self?.restoreIdleState()
+                            continuation.finish(throwing: error)
+                        }
+                    }
+                }
+
+                continuation.onTermination = { [weak self] termination in
+                    task.cancel()
+                    if case .cancelled = termination {
+                        Task { @MainActor [weak self] in
+                            await self?.backend.cancel()
+                        }
+                    }
+                }
+            }
+        } catch {
+            state = .idle
+            throw error
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    /// Returns the service to `.idle` after a generation finishes, but only
+    /// if the currently-observed state is still `.generating`. If the caller
+    /// somehow drove the service off `.generating`, the state has already
+    /// moved on and we must not overwrite it.
+    private func restoreIdleState() {
+        if state == .generating {
+            state = .idle
+        }
+    }
+}

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -139,6 +139,7 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
+        runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
         makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
@@ -176,14 +177,24 @@ public final class ManifoldBootstrap {
             // ManifoldPersistenceSwiftData does not depend on ManifoldFoundation,
             // so FoundationBackend cannot be instantiated here directly. Host apps
             // that run on iOS 26+ / macOS 26+ can wire their own auxiliary service
-            // via the `auxiliaryInferenceService:` parameter on ConversationRuntime.
+            // via `runtimeOptions.auxiliaryInferenceService`.
             // See ManifoldFoundation.FoundationBackend for the recommended setup.
             self.conversationRuntime = ConversationRuntime(
                 messageStore: resolvedPersistence,
                 sessionStore: resolvedPersistence,
                 inferenceService: resolvedInferenceService,
+                pipeline: runtimeOptions.pipeline,
+                budgetPlanner: runtimeOptions.budgetPlanner,
                 ragService: resolvedRAGService,
+                auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
                 usageStore: resolvedUsageStore,
+                generationHooks: runtimeOptions.generationHooks,
+                compressionPolicy: runtimeOptions.compressionPolicy,
+                preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
+                historyShaper: runtimeOptions.historyShaper,
+                historyProviders: runtimeOptions.historyProviders,
+                hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
+                turnContextProvider: runtimeOptions.turnContextProvider,
                 sessionToolSources: sessionToolSources,
                 hookRegistry: hookRegistry
             )
@@ -213,6 +224,7 @@ public final class ManifoldBootstrap {
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
         ragService: RAGService? = nil,
+        runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil
     ) {
@@ -229,8 +241,18 @@ public final class ManifoldBootstrap {
             messageStore: persistence,
             sessionStore: persistence,
             inferenceService: inferenceService,
+            pipeline: runtimeOptions.pipeline,
+            budgetPlanner: runtimeOptions.budgetPlanner,
             ragService: ragService,
+            auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
             usageStore: usageStore,
+            generationHooks: runtimeOptions.generationHooks,
+            compressionPolicy: runtimeOptions.compressionPolicy,
+            preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
+            historyShaper: runtimeOptions.historyShaper,
+            historyProviders: runtimeOptions.historyProviders,
+            hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
+            turnContextProvider: runtimeOptions.turnContextProvider,
             sessionToolSources: sessionToolSources,
             hookRegistry: hookRegistry
         )
@@ -294,6 +316,7 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
+        runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
         makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
@@ -346,6 +369,7 @@ public final class ManifoldBootstrap {
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
                     ragService: ragService,
+                    runtimeOptions: runtimeOptions,
                     sessionToolSources: sessionToolSources,
                     hookRegistry: hookRegistry
                 )

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -458,4 +458,5 @@ extension ManifoldBootstrap: ChatRuntimeBootstrap {
     public var apiEndpointStore: any EndpointStore { endpointStore }
     public var diagnosticsService: DiagnosticsService { diagnostics }
     public var imageGenerationRuntime: ImageGenerationRuntime? { imageRuntime }
+    public var videoGenerationRuntime: VideoGenerationRuntime? { videoRuntime }
 }

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -7,7 +7,7 @@ import ManifoldInference
 
 /// Configuration for the RAG knowledge base.
 ///
-/// Pass to ``ManifoldBootstrap/init(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
+/// Pass to ``ManifoldBootstrap/init(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:makeModelContainer:)``
 /// to enable on-device RAG. When `nil`, the runtime runs without retrieval.
 ///
 /// ```swift
@@ -68,7 +68,7 @@ public struct RAGConfiguration: Sendable {
 ///
 /// ### Splash-screen progress
 ///
-/// Call ``build(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:sessionToolSources:hookRegistry:makeModelContainer:)``
+/// Call ``build(configuration:ragConfiguration:inferenceService:imageGenerationService:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:makeModelContainer:)``
 /// instead of `init` when you want to drive a launch progress UI. That factory
 /// returns an `AsyncStream<RuntimeBootstrapMilestone>` you can iterate on the
 /// main actor while bootstrap runs concurrently in a sibling task:
@@ -112,6 +112,17 @@ public final class ManifoldBootstrap {
     /// `nil` when ``imageGenerationService`` is `nil`.
     public let imageRuntime: ImageGenerationRuntime?
 
+    /// The video-generation service, when the host opted in to video generation.
+    /// `nil` when ``ManifoldBootstrap`` was constructed without a
+    /// `videoGenerationService` parameter.
+    public let videoGenerationService: VideoGenerationService?
+
+    /// The video-generation runtime, pre-wired against ``videoGenerationService``
+    /// and ``persistence``. Pass to ``ChatViewModel/configure(videoRuntime:)``
+    /// to enable video generation in the chat view model.
+    /// `nil` when ``videoGenerationService`` is `nil`.
+    public let videoRuntime: VideoGenerationRuntime?
+
     /// The RAG knowledge-base service, when the host opted in via
     /// ``RAGConfiguration``. `nil` when bootstrapped without RAG.
     ///
@@ -138,6 +149,7 @@ public final class ManifoldBootstrap {
         ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
+        videoGenerationService: VideoGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -207,6 +219,15 @@ public final class ManifoldBootstrap {
             } else {
                 self.imageRuntime = nil
             }
+            self.videoGenerationService = videoGenerationService
+            if let videoGenerationService {
+                self.videoRuntime = VideoGenerationRuntime(
+                    service: videoGenerationService,
+                    messageStore: resolvedPersistence
+                )
+            } else {
+                self.videoRuntime = nil
+            }
         } catch {
             ManifoldConfiguration.shared = previousConfiguration
             throw error
@@ -223,6 +244,7 @@ public final class ManifoldBootstrap {
         endpointStore: SwiftDataEndpointStore,
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
+        videoGenerationService: VideoGenerationService? = nil,
         ragService: RAGService? = nil,
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -264,6 +286,15 @@ public final class ManifoldBootstrap {
             )
         } else {
             self.imageRuntime = nil
+        }
+        self.videoGenerationService = videoGenerationService
+        if let videoGenerationService {
+            self.videoRuntime = VideoGenerationRuntime(
+                service: videoGenerationService,
+                messageStore: persistence
+            )
+        } else {
+            self.videoRuntime = nil
         }
     }
 
@@ -315,6 +346,7 @@ public final class ManifoldBootstrap {
         ragConfiguration: RAGConfiguration? = nil,
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
+        videoGenerationService: VideoGenerationService? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
@@ -368,6 +400,7 @@ public final class ManifoldBootstrap {
                     endpointStore: endpointStore,
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
+                    videoGenerationService: videoGenerationService,
                     ragService: ragService,
                     runtimeOptions: runtimeOptions,
                     sessionToolSources: sessionToolSources,

--- a/Sources/ManifoldRuntime/Services/ChatRuntimeBootstrap.swift
+++ b/Sources/ManifoldRuntime/Services/ChatRuntimeBootstrap.swift
@@ -10,4 +10,5 @@ public protocol ChatRuntimeBootstrap: AnyObject {
     var apiEndpointStore: any EndpointStore { get }
     var diagnosticsService: DiagnosticsService { get }
     var imageGenerationRuntime: ImageGenerationRuntime? { get }
+    var videoGenerationRuntime: VideoGenerationRuntime? { get }
 }

--- a/Sources/ManifoldRuntime/Services/ConversationRuntimeOptions.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntimeOptions.swift
@@ -1,0 +1,90 @@
+import Foundation
+import ManifoldInference
+
+/// Optional ``ConversationRuntime`` extension points threaded through
+/// ``ManifoldBootstrap`` to the runtime it constructs.
+///
+/// All properties default to `nil` / empty, which reproduces the behaviour of
+/// a bootstrap with no options specified. Set only what your host app needs:
+///
+/// ```swift
+/// var options = ConversationRuntimeOptions()
+/// options.historyShaper = StoryHistoryShaper()
+/// options.compressionPolicy = SummarisationPolicy()
+/// options.generationHooks = [TitleGenerationHook()]
+///
+/// let bootstrap = try ManifoldBootstrap(
+///     configuration: config,
+///     runtimeOptions: options,
+///     makeModelContainer: { try ModelContainerFactory.makeContainer() }
+/// )
+/// ```
+///
+/// Passing an `auxiliaryInferenceService` lets the runtime use a separate, cheap
+/// model for internal tasks like session-title generation and compression routing,
+/// keeping those off your primary model:
+///
+/// ```swift
+/// var options = ConversationRuntimeOptions()
+/// options.auxiliaryInferenceService = InferenceService(backend: FoundationBackend())
+/// ```
+public struct ConversationRuntimeOptions {
+
+    /// Custom prompt-context assembly pipeline replacing the default slot-merge.
+    public var pipeline: PromptContextPipeline?
+
+    /// Custom token-budget planner used during context trimming.
+    public var budgetPlanner: ContextBudgetPlanner?
+
+    /// Hooks called after each completed generation turn.
+    public var generationHooks: [any GenerationHook]
+
+    /// Post-turn history-compression policy.
+    public var compressionPolicy: (any CompressionPolicy)?
+
+    /// Pre-turn history-compression policy applied before each new turn.
+    public var preTurnCompressionPolicy: (any PreTurnCompressionPolicy)?
+
+    /// Host-owned transformer applied to assembled history before each turn.
+    public var historyShaper: (any HistoryShaper)?
+
+    /// History augmentation providers injected before context assembly.
+    public var historyProviders: [any HistoryProvider]
+
+    /// Async/throwing richer per-turn context provider. Supersedes
+    /// ``turnContextProvider`` when both are set.
+    public var hostTurnContextProvider: (any HostTurnContextProvider)?
+
+    /// Legacy synchronous per-turn context provider. Used only when
+    /// ``hostTurnContextProvider`` is `nil`.
+    public var turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)?
+
+    /// Auxiliary inference service for internal framework tasks such as
+    /// session-title generation and compression routing. When `nil` the
+    /// runtime falls back to the primary ``InferenceService``.
+    public var auxiliaryInferenceService: InferenceService?
+
+    public init(
+        pipeline: PromptContextPipeline? = nil,
+        budgetPlanner: ContextBudgetPlanner? = nil,
+        generationHooks: [any GenerationHook] = [],
+        compressionPolicy: (any CompressionPolicy)? = nil,
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil,
+        historyShaper: (any HistoryShaper)? = nil,
+        historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
+        auxiliaryInferenceService: InferenceService? = nil
+    ) {
+        self.pipeline = pipeline
+        self.budgetPlanner = budgetPlanner
+        self.generationHooks = generationHooks
+        self.compressionPolicy = compressionPolicy
+        self.preTurnCompressionPolicy = preTurnCompressionPolicy
+        self.historyShaper = historyShaper
+        self.historyProviders = historyProviders
+        self.hostTurnContextProvider = hostTurnContextProvider
+        self.turnContextProvider = turnContextProvider
+        self.auxiliaryInferenceService = auxiliaryInferenceService
+    }
+}

--- a/Sources/ManifoldRuntime/Services/VideoGenerationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/VideoGenerationRuntime.swift
@@ -1,0 +1,277 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - VideoGenerationRuntime
+//
+// Sibling to `ImageGenerationRuntime` for the video-generation path. Owns a
+// `VideoGenerationService`, drives `generate(prompt:config:)`, and persists
+// the resulting `.generatedVideo` part via the `MessageStore` port.
+//
+// Per umbrella #1002:
+//   - Video-side runtime is a sibling type, not a new method on
+//     `ImageGenerationRuntime` or `ConversationRuntime`. Video lifecycle has
+//     a different shape (cloud-only, no model loading, `async throws` submit
+//     before the stream) and squeezing it into another runtime would distort
+//     both surfaces.
+//   - Events ride `VideoRuntimeEvent` — distinct from `ImageRuntimeEvent` and
+//     `ConversationEvent` so exhaustive switches in those consumers stay closed.
+//   - Persistence uses the existing `MessageStore` port. The runtime inserts
+//     an empty placeholder on `generate` and updates it in place with the
+//     `.generatedVideo` part when the backend completes.
+//
+// Concurrency: `@MainActor` because both `MessageStore` and
+// `VideoGenerationService` are `@MainActor`-isolated. The backend's stream is
+// consumed on a `Task` per generation so `cancel(messageID:)` can locate and
+// tear it down by ID without blocking the actor.
+
+/// Drives video-generation lifecycle through ``VideoGenerationService`` and
+/// persists results via ``MessageStore``.
+///
+/// Sibling to ``ImageGenerationRuntime``. Hosts call ``generate(prompt:config:in:)``
+/// to start a generation, observe progress on ``events`` (an
+/// ``AsyncStream`` of ``VideoRuntimeEvent``), and call ``cancel(messageID:)``
+/// to tear down an in-flight job.
+///
+/// ## Persistence
+///
+/// On ``generate(prompt:config:in:)`` the runtime inserts a placeholder
+/// ``ChatMessageRecord`` (role `.assistant`, empty `contentParts`) into the
+/// message store. Backend progress events are forwarded as
+/// ``VideoRuntimeEvent/progress(messageID:fractionComplete:)`` *without*
+/// touching the store — UI subscribes to events for the in-flight indicator;
+/// persistence stays minimal until the terminal step.
+///
+/// On backend completion the runtime builds a ``VideoMessagePayload`` and
+/// updates the placeholder message via
+/// ``MessageStore/updateMessage(_:)`` so its `contentParts` becomes a single
+/// ``MessagePart/generatedVideo(_:)`` carrying the payload, then emits
+/// ``VideoRuntimeEvent/completed(messageID:payload:)``.
+///
+/// On error or cancellation the placeholder remains in the store with its
+/// original empty `contentParts`. Hosts that prefer to drop the slot can
+/// observe the terminal event and call ``MessageStore/deleteMessage(_:)``
+/// from the adapter — the runtime intentionally does not pick a UX policy.
+///
+/// ## Concurrency
+///
+/// `@MainActor`-isolated for parity with both ports. Each in-flight
+/// generation runs on a tracked `Task` keyed to its placeholder message ID;
+/// ``cancel(messageID:)`` cancels the task and stops the backend via
+/// ``VideoGenerationService``'s `AsyncThrowingStream` cancellation hook
+/// (which calls `backend.cancel()` per the service contract).
+@MainActor
+public final class VideoGenerationRuntime {
+
+    // MARK: Ports
+
+    private let service: VideoGenerationService
+    private let messageStore: any MessageStore
+    private let modelIdentifierProvider: @MainActor () -> String
+
+    // MARK: Event stream
+
+    /// Lifecycle event stream. Single-consumer by design — adapters either
+    /// iterate it directly or install an observable wrapper.
+    public let events: AsyncStream<VideoRuntimeEvent>
+    private let continuation: AsyncStream<VideoRuntimeEvent>.Continuation
+
+    // MARK: In-flight state
+    //
+    // Tracks the consumer task for each in-flight generation by the
+    // placeholder message ID. The dict is `@MainActor`-protected — every
+    // mutation happens from main-actor methods and the runtime itself is
+    // `@MainActor`.
+
+    private var inFlight: [ChatMessageRecord.ID: Task<Void, Never>] = [:]
+
+    // MARK: Init
+
+    /// Creates a runtime that composes the supplied service and message store.
+    ///
+    /// - Parameters:
+    ///   - service: The ``VideoGenerationService`` the runtime drives.
+    ///   - messageStore: Required. Persists the placeholder and final
+    ///     `.generatedVideo` part across the generation.
+    ///   - modelIdentifier: Closure returning the identifier embedded in
+    ///     ``VideoMessagePayload/modelIdentifier``. Defaults to `"cloud"`.
+    ///     Tests inject this when they want a deterministic identifier.
+    public init(
+        service: VideoGenerationService,
+        messageStore: any MessageStore,
+        modelIdentifier: (@MainActor () -> String)? = nil
+    ) {
+        self.service = service
+        self.messageStore = messageStore
+        self.modelIdentifierProvider = modelIdentifier ?? { "cloud" }
+        var cap: AsyncStream<VideoRuntimeEvent>.Continuation!
+        self.events = AsyncStream(bufferingPolicy: .unbounded) { cap = $0 }
+        self.continuation = cap
+    }
+
+    deinit {
+        continuation.finish()
+    }
+
+    // MARK: Commands
+
+    /// Begins a video generation in the supplied session.
+    ///
+    /// Persists a placeholder ``ChatMessageRecord`` (role `.assistant`,
+    /// empty `contentParts`) before returning, then submits the generation
+    /// request to the backend (which may involve a network round-trip) and
+    /// starts a detached task that forwards backend events through ``events``.
+    /// The returned message ID is stable for the lifetime of the generation —
+    /// pass it to ``cancel(messageID:)`` to tear down the job, and observe
+    /// the terminal event (`completed` / `failed` / `cancelled`) on
+    /// ``events`` to know when the placeholder has been finalised.
+    ///
+    /// - Parameters:
+    ///   - prompt: User-supplied prompt.
+    ///   - config: Video generation parameters.
+    ///   - sessionID: The session the placeholder message belongs to.
+    /// - Returns: The placeholder ``ChatMessageRecord/ID`` so the host can
+    ///   pair UI state with the in-flight generation.
+    /// - Throws: Persistence errors from the placeholder insert, or backend
+    ///   submission errors (auth, rate limit, network).
+    @discardableResult
+    public func generate(
+        prompt: String,
+        config: VideoGenerationConfig,
+        in sessionID: UUID
+    ) async throws -> ChatMessageRecord.ID {
+        // Insert placeholder synchronously so the caller observes the
+        // message ID before any event fires. Empty `contentParts` because
+        // we don't have a `.generatedVideo` payload yet — the placeholder
+        // is finalised via `updateMessage` when the backend completes.
+        let placeholder = ChatMessageRecord(
+            role: .assistant,
+            contentParts: [],
+            sessionID: sessionID
+        )
+        try await messageStore.insertMessage(placeholder)
+
+        let messageID = placeholder.id
+        emit(.started(messageID: messageID, prompt: prompt))
+
+        // Snapshot config for the persisted payload. Take it now so the
+        // payload reflects the call-site value even if a future runtime
+        // mutates the live `config` mid-flight.
+        let snapshot = VideoGenerationConfigSnapshot(from: config)
+
+        // `VideoGenerationService.generate` is `async throws` — the backend
+        // submits the cloud job here (may do a network round-trip). If the
+        // submit fails we emit `.failed` and rethrow so the caller can react.
+        let stream: AsyncThrowingStream<VideoGenerationEvent, Error>
+        do {
+            stream = try await service.generate(prompt: prompt, config: config)
+        } catch {
+            emit(.failed(messageID: messageID, error: error))
+            throw error
+        }
+
+        // Strong capture: the consumer task owns this generation's logical
+        // unit of work and must complete (emit terminal event, clean up
+        // `inFlight`) even if the host releases its last reference to the
+        // runtime mid-flight.
+        let task = Task { @MainActor [self] in
+            await self.consume(
+                stream: stream,
+                messageID: messageID,
+                prompt: prompt,
+                placeholder: placeholder,
+                snapshot: snapshot
+            )
+        }
+        inFlight[messageID] = task
+        return messageID
+    }
+
+    /// Cancels an in-flight generation by its placeholder message ID.
+    ///
+    /// Idempotent — cancelling an unknown or already-finished message is a
+    /// no-op. The terminal ``VideoRuntimeEvent/cancelled(messageID:)`` event
+    /// fires once the underlying stream observes the cancellation.
+    public func cancel(messageID: ChatMessageRecord.ID) async {
+        guard let task = inFlight[messageID] else { return }
+        task.cancel()
+        // Don't await `task.value` — the consumer task itself emits the
+        // terminal event and removes itself from `inFlight`. Awaiting here
+        // would serialise callers behind a cloud poll loop's cancellation
+        // latency.
+    }
+
+    // MARK: - Stream consumer
+
+    private func consume(
+        stream: AsyncThrowingStream<VideoGenerationEvent, Error>,
+        messageID: ChatMessageRecord.ID,
+        prompt: String,
+        placeholder: ChatMessageRecord,
+        snapshot: VideoGenerationConfigSnapshot
+    ) async {
+        defer {
+            inFlight.removeValue(forKey: messageID)
+        }
+
+        do {
+            for try await event in stream {
+                if Task.isCancelled {
+                    emit(.cancelled(messageID: messageID))
+                    return
+                }
+                switch event {
+                case .queued:
+                    // No dedicated `VideoRuntimeEvent` for queued — forward
+                    // as zero-progress so adapters can show an initial indicator.
+                    emit(.progress(messageID: messageID, fractionComplete: 0.0))
+
+                case .generating(let fraction):
+                    emit(.progress(messageID: messageID, fractionComplete: fraction))
+
+                case .completed(let url):
+                    let identifier = modelIdentifierProvider()
+                    let payload = VideoMessagePayload(
+                        prompt: prompt,
+                        videoURL: url,
+                        modelIdentifier: identifier,
+                        generationConfig: snapshot
+                    )
+                    var finalised = placeholder
+                    finalised.contentParts = [.generatedVideo(payload)]
+                    do {
+                        try await messageStore.updateMessage(finalised)
+                    } catch {
+                        emit(.failed(messageID: messageID, error: error))
+                        return
+                    }
+                    emit(.completed(messageID: messageID, payload: payload))
+                    return
+                }
+            }
+            // Stream ended without `.completed` — treat as cancellation
+            // when the task is cancelled, otherwise report as failure.
+            if Task.isCancelled {
+                emit(.cancelled(messageID: messageID))
+            } else {
+                emit(.failed(
+                    messageID: messageID,
+                    error: VideoGenerationServiceError.alreadyGenerating
+                ))
+            }
+        } catch is CancellationError {
+            emit(.cancelled(messageID: messageID))
+        } catch {
+            if Task.isCancelled {
+                emit(.cancelled(messageID: messageID))
+            } else {
+                emit(.failed(messageID: messageID, error: error))
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private func emit(_ event: VideoRuntimeEvent) {
+        continuation.yield(event)
+    }
+}

--- a/Sources/ManifoldRuntime/Services/VideoRuntimeEvent.swift
+++ b/Sources/ManifoldRuntime/Services/VideoRuntimeEvent.swift
@@ -1,0 +1,80 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - VideoRuntimeEvent
+//
+// Sibling to `ImageRuntimeEvent` for the video-generation runtime. Per the
+// umbrella-#1002 architectural call, video-side runtime events ride a
+// parallel enum rather than landing as new cases on `ImageRuntimeEvent` or
+// `ConversationEvent`.
+//
+// `VideoRuntimeEvent` is distinct from the backend-level
+// `VideoGenerationEvent` (`.queued`, `.generating(fractionComplete:)`,
+// `.completed(URL)`): the runtime translates between layers, keying every
+// event to a `ChatMessageRecord.ID` so adapters can pair UI state to the
+// right placeholder slot.
+
+/// Events emitted by ``VideoGenerationRuntime``.
+///
+/// Sibling to ``ImageRuntimeEvent`` — video-side events are deliberately a
+/// parallel enum so exhaustive switches in image and text consumers stay
+/// closed. The runtime translates the backend-level ``VideoGenerationEvent``
+/// (raw fraction + URL) into these runtime-level events keyed to a
+/// placeholder ``ChatMessageRecord/ID``.
+public enum VideoRuntimeEvent: Sendable, Equatable {
+
+    /// Generation started for the placeholder message at `messageID`. The
+    /// placeholder has been persisted via ``MessageStore`` with empty
+    /// `contentParts` — adapters render a "generating" affordance until the
+    /// terminal ``completed(messageID:payload:)`` event updates the message
+    /// in place.
+    case started(messageID: ChatMessageRecord.ID, prompt: String)
+
+    /// Generation progress. `fractionComplete` is a backend-estimated value
+    /// in 0.0–1.0. Intermediate state is **not** persisted — adapters
+    /// subscribe to events for progressive UI; persistence stays minimal
+    /// until completion.
+    case progress(messageID: ChatMessageRecord.ID, fractionComplete: Double)
+
+    /// Generation completed; the persisted message at `messageID` now
+    /// carries a single ``MessagePart/generatedVideo(_:)`` part with
+    /// `payload`. Adapters refresh their view-state for `messageID` from
+    /// the store (the runtime has already written through ``MessageStore``).
+    case completed(messageID: ChatMessageRecord.ID, payload: VideoMessagePayload)
+
+    /// Generation failed. Carries the underlying error so adapters can
+    /// surface user-facing error UI; the placeholder message at `messageID`
+    /// remains in the store with its original (empty) `contentParts` so
+    /// adapters can either render an inline failure indicator or call
+    /// ``MessageStore/deleteMessage(_:)`` to drop the slot — the runtime
+    /// emits the event, the host decides UX.
+    case failed(messageID: ChatMessageRecord.ID, error: any Error)
+
+    /// User cancelled before completion. The placeholder message at
+    /// `messageID` remains in the store with empty `contentParts`; same
+    /// host-decides-UX policy as ``failed(messageID:error:)``.
+    case cancelled(messageID: ChatMessageRecord.ID)
+
+    // MARK: - Equatable
+
+    // Custom because `any Error` is not `Equatable`. Two `.failed` events
+    // are considered equal when their message IDs match — sufficient for
+    // tests asserting event sequences without forcing every error type
+    // through `Equatable`.
+    public static func == (lhs: VideoRuntimeEvent, rhs: VideoRuntimeEvent) -> Bool {
+        switch (lhs, rhs) {
+        case let (.started(lid, lp), .started(rid, rp)):
+            return lid == rid && lp == rp
+        case let (.progress(lid, lf), .progress(rid, rf)):
+            return lid == rid && lf == rf
+        case let (.completed(lid, lp), .completed(rid, rp)):
+            return lid == rid && lp == rp
+        case let (.failed(lid, _), .failed(rid, _)):
+            return lid == rid
+        case let (.cancelled(lid), .cancelled(rid)):
+            return lid == rid
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+VideoGeneration.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+VideoGeneration.swift
@@ -1,0 +1,239 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ChatViewModel + VideoGeneration
+//
+// Host-facing entry surface for `VideoGenerationRuntime`. Mirrors the role
+// `ChatViewModel+ImageGeneration` plays for `ImageGenerationRuntime`: forwards
+// commands to the runtime and maps `VideoRuntimeEvent` back to `@Observable`
+// state on `@MainActor`.
+//
+// The runtime is **optional** — chat-only hosts never call
+// `configure(videoRuntime:)` and the video methods throw `.notConfigured`.
+// The text and image paths on `ChatViewModel` are unchanged.
+
+/// Per-message progress snapshot for in-flight or completed video generations.
+///
+/// Populated by ``ChatViewModel/videoGenerationProgress`` from
+/// ``VideoRuntimeEvent`` values. Hosts subscribe via `@Observable` to render
+/// progress UIs keyed off the placeholder message ID returned by
+/// ``ChatViewModel/generateVideo(prompt:config:)``.
+public struct VideoGenerationProgress: Sendable, Equatable {
+
+    /// The placeholder ``ChatMessageRecord/ID`` the generation is writing to.
+    public let messageID: UUID
+
+    /// User-supplied prompt the generation was started with.
+    public let prompt: String
+
+    /// Backend-estimated fraction complete, 0.0–1.0. `0` while queued or
+    /// waiting for the first progress event.
+    public let fractionComplete: Double
+
+    /// `true` once a terminal event (completed / failed / cancelled) has been
+    /// observed. UI can stop animating progress affordances at this point.
+    public let isComplete: Bool
+
+    /// Localized error description if the generation failed; `nil` otherwise.
+    /// Set independently of ``isComplete`` so cancellation surfaces as
+    /// `isComplete = true, error = nil`.
+    public let error: String?
+
+    public init(
+        messageID: UUID,
+        prompt: String,
+        fractionComplete: Double,
+        isComplete: Bool,
+        error: String?
+    ) {
+        self.messageID = messageID
+        self.prompt = prompt
+        self.fractionComplete = fractionComplete
+        self.isComplete = isComplete
+        self.error = error
+    }
+}
+
+/// Errors thrown by ``ChatViewModel`` video-generation entry methods.
+public enum ChatViewModelVideoError: Error, LocalizedError, Equatable {
+
+    /// ``ChatViewModel/configure(videoRuntime:)`` was never called.
+    case notConfigured
+
+    /// ``ChatViewModel/activeSession`` is `nil` — there is no conversation
+    /// to insert the placeholder video message into.
+    case noActiveConversation
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Video generation is not configured. Install a VideoGenerationRuntime via configure(videoRuntime:)."
+        case .noActiveConversation:
+            return "No active conversation. Create or select a session before generating a video."
+        }
+    }
+}
+
+@MainActor
+extension ChatViewModel {
+
+    // MARK: - Runtime install
+
+    /// The video-generation runtime, if the host wired one up. `nil` for
+    /// chat-only hosts; video methods throw ``ChatViewModelVideoError/notConfigured``
+    /// in that case.
+    public var videoRuntime: VideoGenerationRuntime? {
+        _videoRuntime
+    }
+
+    /// Install a ``VideoGenerationRuntime``. Typically called by
+    /// ``ManifoldBootstrap`` when the host opts in to video generation;
+    /// app code can also call it directly.
+    ///
+    /// Latest-wins: a prior runtime's event-drain task is cancelled before
+    /// the new one starts, so reconfiguring at runtime is safe. The view
+    /// model holds the runtime strongly for the rest of its lifetime — same
+    /// ownership model as ``imageRuntime``.
+    public func configure(videoRuntime: VideoGenerationRuntime) {
+        _videoRuntime = videoRuntime
+        startVideoRuntimeEventDrain(runtime: videoRuntime)
+    }
+
+    /// Cancels the existing video-runtime drain task (if any) and starts a
+    /// fresh one for `runtime`.
+    ///
+    /// Weak capture mirrors the image-runtime drain: the host owns the view
+    /// model, and the drain task must not keep old test or preview instances
+    /// alive after their bootstrap and SwiftData container tear down.
+    private func startVideoRuntimeEventDrain(runtime: VideoGenerationRuntime) {
+        videoRuntimeEventDrainTask?.cancel()
+        videoRuntimeEventDrainTask = Task { [weak self] in
+            for await event in runtime.events {
+                if Task.isCancelled { return }
+                guard let self else { return }
+                self.handle(videoRuntimeEvent: event)
+            }
+        }
+    }
+
+    // MARK: - Commands
+
+    /// Begin a video generation in the active conversation.
+    ///
+    /// Inserts a placeholder ``ChatMessageRecord`` immediately (via the
+    /// runtime's `MessageStore` port) and dispatches a consumer task that
+    /// updates ``videoGenerationProgress`` from runtime events. Returns the
+    /// placeholder message ID synchronously so the caller can pair UI state
+    /// with the in-flight generation.
+    ///
+    /// - Parameters:
+    ///   - prompt: User-supplied prompt.
+    ///   - config: Video generation parameters.
+    /// - Returns: The placeholder ``ChatMessageRecord/ID``.
+    /// - Throws: ``ChatViewModelVideoError/notConfigured`` if no runtime is
+    ///   installed, ``ChatViewModelVideoError/noActiveConversation`` if
+    ///   there is no active session, or any persistence / backend error from
+    ///   the generation submit.
+    @discardableResult
+    public func generateVideo(
+        prompt: String,
+        config: VideoGenerationConfig
+    ) async throws -> UUID {
+        guard let runtime = _videoRuntime else {
+            throw ChatViewModelVideoError.notConfigured
+        }
+        guard let sessionID = activeSessionID else {
+            throw ChatViewModelVideoError.noActiveConversation
+        }
+        return try await runtime.generate(
+            prompt: prompt,
+            config: config,
+            in: sessionID
+        )
+    }
+
+    /// Cancel an in-flight video generation by its placeholder message ID.
+    ///
+    /// Idempotent — cancelling an unknown or already-finished generation is
+    /// a no-op. The terminal ``VideoRuntimeEvent/cancelled(messageID:)``
+    /// event flips ``VideoGenerationProgress/isComplete`` to `true` once the
+    /// underlying stream observes the cancellation.
+    public func cancelVideoGeneration(messageID: UUID) async {
+        guard let runtime = _videoRuntime else { return }
+        await runtime.cancel(messageID: messageID)
+    }
+
+    // MARK: - Event drain
+
+    /// Maps an incoming ``VideoRuntimeEvent`` to mutations on
+    /// ``videoGenerationProgress``. Sibling to
+    /// ``handle(imageRuntimeEvent:)`` for ``VideoRuntimeEvent``.
+    func handle(videoRuntimeEvent event: VideoRuntimeEvent) {
+        switch event {
+        case .started(let messageID, let prompt):
+            videoGenerationProgress[messageID] = VideoGenerationProgress(
+                messageID: messageID,
+                prompt: prompt,
+                fractionComplete: 0.0,
+                isComplete: false,
+                error: nil
+            )
+            if let sessionID = activeSessionID {
+                let placeholder = ChatMessageRecord(
+                    id: messageID,
+                    role: .assistant,
+                    contentParts: [],
+                    sessionID: sessionID
+                )
+                messages.append(placeholder)
+            }
+
+        case .progress(let messageID, let fractionComplete):
+            // A `progress` for an unknown ID would mean we missed `started`;
+            // create the entry with what we know rather than dropping the
+            // event silently.
+            let prompt = videoGenerationProgress[messageID]?.prompt ?? ""
+            videoGenerationProgress[messageID] = VideoGenerationProgress(
+                messageID: messageID,
+                prompt: prompt,
+                fractionComplete: fractionComplete,
+                isComplete: false,
+                error: nil
+            )
+
+        case .completed(let messageID, let payload):
+            let existing = videoGenerationProgress[messageID]
+            videoGenerationProgress[messageID] = VideoGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? payload.prompt,
+                fractionComplete: 1.0,
+                isComplete: true,
+                error: nil
+            )
+            if let idx = messages.firstIndex(where: { $0.id == messageID }) {
+                messages[idx].contentParts = [.generatedVideo(payload)]
+            }
+
+        case .failed(let messageID, let error):
+            let existing = videoGenerationProgress[messageID]
+            videoGenerationProgress[messageID] = VideoGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? "",
+                fractionComplete: existing?.fractionComplete ?? 0.0,
+                isComplete: true,
+                error: error.localizedDescription
+            )
+
+        case .cancelled(let messageID):
+            let existing = videoGenerationProgress[messageID]
+            videoGenerationProgress[messageID] = VideoGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? "",
+                fractionComplete: existing?.fractionComplete ?? 0.0,
+                isComplete: true,
+                error: nil
+            )
+        }
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -650,6 +650,29 @@ public final class ChatViewModel {
     /// generations. Driven by the `ImageGenerationRuntime` event drain.
     public internal(set) var imageGenerationProgress: [UUID: ImageGenerationProgress] = [:]
 
+    // MARK: - VideoGenerationRuntime
+    //
+    // Optional sibling to `_imageRuntime` for the video-generation path.
+    // Hosts that opt in to video generation install one via
+    // `configure(videoRuntime:)` (typically through `ManifoldBootstrap`);
+    // chat-only hosts leave this nil and the public video-generation methods
+    // throw `.notConfigured`. Storage lives on the main type because
+    // extensions cannot add stored properties — all behavior lives in
+    // `ChatViewModel+VideoGeneration.swift`.
+
+    /// Backing storage for ``videoRuntime``. Internal so the
+    /// `ChatViewModel+VideoGeneration` extension can mutate it.
+    var _videoRuntime: VideoGenerationRuntime?
+
+    /// Drain task for the video runtime event stream. Cancelled when the
+    /// runtime is replaced (latest-wins) or the view model is torn down.
+    @ObservationIgnored
+    var videoRuntimeEventDrainTask: Task<Void, Never>?
+
+    /// Per-message-ID progress dictionary for in-flight or completed video
+    /// generations. Driven by the `VideoGenerationRuntime` event drain.
+    public internal(set) var videoGenerationProgress: [UUID: VideoGenerationProgress] = [:]
+
     // MARK: - Private State
 
     var lastPressureLevel: MemoryPressureLevel = .nominal
@@ -840,6 +863,7 @@ public final class ChatViewModel {
 
     deinit {
         imageRuntimeEventDrainTask?.cancel()
+        videoRuntimeEventDrainTask?.cancel()
         endpointRefreshTask?.cancel()
     }
 

--- a/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
@@ -19,6 +19,9 @@ extension ChatViewModel {
         if let imageRuntime = bootstrap.imageGenerationRuntime {
             configure(imageRuntime: imageRuntime)
         }
+        if let videoRuntime = bootstrap.videoGenerationRuntime {
+            configure(videoRuntime: videoRuntime)
+        }
     }
 
     /// Preferred bootstrap path for apps that assemble shared services through

--- a/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
@@ -102,6 +102,8 @@ struct MessagePartsView: View {
                 key = nextKey(for: "audio", in: &ordinals)
             case .generatedImage:
                 key = nextKey(for: "generatedImage", in: &ordinals)
+            case .generatedVideo:
+                key = nextKey(for: "generatedVideo", in: &ordinals)
             }
             return KeyedPart(key: key, part: part)
         }
@@ -155,6 +157,28 @@ struct MessagePartsView: View {
 
         case .generatedImage(let payload):
             generatedImageView(payload)
+
+        case .generatedVideo(let payload):
+            generatedVideoView(payload)
+        }
+    }
+
+    @ViewBuilder
+    private func generatedVideoView(_ payload: VideoMessagePayload) -> some View {
+        // The video binary lives on disk; surface a simple file-exists check
+        // so the UI degrades gracefully when the binary is missing (deleted,
+        // container migration, restored backup without binary).
+        if FileManager.default.fileExists(atPath: payload.videoURL.path) {
+            // Hosts that want a richer player should use the payload's
+            // `videoURL` directly. The runtime/service layer does not ship
+            // a first-party video player view — that's a host concern.
+            Text(payload.prompt)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            Text("Video file not found")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
@@ -18,7 +18,7 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
 
     actor RecordingHook: GenerationHook {
         private(set) var receivedTurns: [CompletedTurn] = []
-        private var pending: [CheckedContinuation<CompletedTurn, Never>] = []
+        private var pending: [CheckedContinuation<CompletedTurn, any Error>] = []
 
         func postGeneration(_ turn: CompletedTurn) async {
             receivedTurns.append(turn)
@@ -26,8 +26,27 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
             pending.removeAll()
         }
 
-        func awaitNextTurn() async -> CompletedTurn {
-            await withCheckedContinuation { pending.append($0) }
+        /// Suspends until the next `postGeneration` delivery and returns it.
+        ///
+        /// Returns immediately when the hook has already fired (prevents a race
+        /// where the generation task completes before this continuation is
+        /// registered). Uses a throwing continuation so task cancellation can
+        /// resume the stored continuation with `CancellationError`, avoiding a
+        /// debug-build deinit precondition trap when the caller's 5-second
+        /// deadline fires first.
+        func awaitNextTurn() async throws -> CompletedTurn {
+            if let already = receivedTurns.last { return already }
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { pending.append($0) }
+            } onCancel: {
+                Task { await self.cancelPending() }
+            }
+        }
+
+        private func cancelPending() {
+            let waiters = pending
+            pending.removeAll()
+            for cont in waiters { cont.resume(throwing: CancellationError()) }
         }
     }
 
@@ -57,7 +76,7 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
         )
         // Await the hook's own signal — deterministic, no sleep.
         try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
-            group.addTask { await hook.awaitNextTurn() }
+            group.addTask { try await hook.awaitNextTurn() }
             group.addTask {
                 try await Task.sleep(for: .seconds(5))
                 throw TestError.deadlineElapsed

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+import ManifoldRuntime
+@testable import ManifoldPersistenceSwiftData
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Verifies that ``ConversationRuntimeOptions`` is threaded through to the
+/// ``ConversationRuntime`` constructed by both ``ManifoldBootstrap/init`` and
+/// ``ManifoldBootstrap/build``.
+///
+/// Each behavioral test wires a ``GenerationHook`` through
+/// ``ConversationRuntimeOptions`` and confirms the hook fires during a real
+/// turn, proving the options aren't silently discarded.
+@MainActor
+final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
+
+    // MARK: - Recording hook
+
+    actor RecordingHook: GenerationHook {
+        private(set) var receivedTurns: [CompletedTurn] = []
+        private var pending: [CheckedContinuation<CompletedTurn, Never>] = []
+
+        func postGeneration(_ turn: CompletedTurn) async {
+            receivedTurns.append(turn)
+            for cont in pending { cont.resume(returning: turn) }
+            pending.removeAll()
+        }
+
+        func awaitNextTurn() async -> CompletedTurn {
+            await withCheckedContinuation { pending.append($0) }
+        }
+    }
+
+    enum TestError: Error { case deadlineElapsed }
+
+    // MARK: - Helpers
+
+    private func makeConfig(tag: String) -> ManifoldConfiguration {
+        ManifoldConfiguration(
+            appName: "RuntimeOptionsTests",
+            bundleIdentifier: "com.manifoldkit.runtime-options-tests.\(tag).\(UUID().uuidString)"
+        )
+    }
+
+    /// Sends one turn through `runtime` and returns once the given hook fires.
+    /// Fails if the hook doesn't fire within 5 seconds.
+    private func sendTurnAndAwaitHook(
+        through runtime: ConversationRuntime,
+        backend: MockInferenceBackend,
+        hook: RecordingHook,
+        tokens: [String] = ["ok"]
+    ) async throws {
+        backend.tokensToYield = tokens
+        backend.isModelLoaded = true
+        _ = try await runtime.processTurn(
+            TurnInput(sessionID: UUID(), kind: .send(text: "hello"))
+        )
+        // Await the hook's own signal — deterministic, no sleep.
+        try await withThrowingTaskGroup(of: CompletedTurn.self) { group in
+            group.addTask { await hook.awaitNextTurn() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw TestError.deadlineElapsed
+            }
+            _ = try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    // MARK: - Default options
+
+    func test_defaultOptions_producesValidRuntime() throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let bootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "default-options"),
+            runtimeOptions: ConversationRuntimeOptions(),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        // Runtime is live and its event stream can be iterated.
+        let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
+        _ = conversationRuntime
+    }
+
+    // MARK: - init path
+
+    func test_init_generationHookFiresAfterTurn() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let hook = RecordingHook()
+        var options = ConversationRuntimeOptions()
+        options.generationHooks = [hook]
+
+        let backend = MockInferenceBackend()
+        let bootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "hook-init"),
+            inferenceService: InferenceService(backend: backend, name: "HookInitMock"),
+            runtimeOptions: options,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        try await sendTurnAndAwaitHook(
+            through: bootstrap.conversationRuntime, backend: backend, hook: hook
+        )
+
+        let count = await hook.receivedTurns.count
+        XCTAssertEqual(count, 1,
+            "GenerationHook registered via runtimeOptions must fire once after a completed turn")
+    }
+
+    func test_init_omittingRuntimeOptions_preservesExistingBehaviour() throws {
+        // Callers that don't pass runtimeOptions must compile and produce a
+        // valid runtime — source compatibility gate.
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let bootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "no-options"),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
+        _ = conversationRuntime
+    }
+
+    // MARK: - build() async path
+
+    func test_build_generationHookFiresAfterTurn() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let hook = RecordingHook()
+        var options = ConversationRuntimeOptions()
+        options.generationHooks = [hook]
+
+        let backend = MockInferenceBackend()
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: makeConfig(tag: "hook-build"),
+            inferenceService: InferenceService(backend: backend, name: "HookBuildMock"),
+            runtimeOptions: options,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let bootstrap = try await task.value
+
+        try await sendTurnAndAwaitHook(
+            through: bootstrap.conversationRuntime, backend: backend, hook: hook
+        )
+
+        let count = await hook.receivedTurns.count
+        XCTAssertEqual(count, 1,
+            "GenerationHook registered via runtimeOptions must fire on the build() path too")
+    }
+
+    func test_build_omittingRuntimeOptions_preservesExistingBehaviour() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: makeConfig(tag: "build-no-options"),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let bootstrap = try await task.value
+
+        let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
+        _ = conversationRuntime
+    }
+}


### PR DESCRIPTION
## Summary

Completes the video-generation infrastructure as a sibling to the existing image-generation stack. The protocol layer (`VideoGenerationBackend`, `VideoGenerationConfig`, `VideoGenerationEvent`) already landed in #1526; this PR adds the orchestration and UI integration layers.

### New files (6)

| File | Role |
|------|------|
| `ManifoldInference/Models/VideoGenerationConfigSnapshot.swift` | Persistence-safe mirror of `VideoGenerationConfig` with raw-value string fields |
| `ManifoldInference/Models/VideoMessagePayload.swift` | Persisted output record: `prompt`, `videoURL`, `modelIdentifier`, `generationConfig`, `generatedAt` |
| `ManifoldInference/Services/VideoGenerationService.swift` | `@MainActor @Observable` orchestrator. Takes a backend directly (always ready — no `loadModel`). State machine: `idle → generating → idle`. `generate()` is `async throws` matching the backend protocol |
| `ManifoldRuntime/Services/VideoRuntimeEvent.swift` | `.started`, `.progress(fractionComplete:)`, `.completed(payload:)`, `.failed`, `.cancelled` with custom `Equatable` ignoring the error value |
| `ManifoldRuntime/Services/VideoGenerationRuntime.swift` | Inserts placeholder message, awaits the async submit, drains the stream, persists `.generatedVideo` on completion |
| `ManifoldUI/ViewModels/ChatViewModel+VideoGeneration.swift` | `VideoGenerationProgress`, `configure(videoRuntime:)`, `generateVideo(prompt:config:)`, `cancelVideoGeneration(messageID:)`, event drain |

### Edited files (6)

- **`MessagePart.swift`** — new `.generatedVideo(VideoMessagePayload)` case + `"generatedVideo"` Codable discriminator
- **`ManifoldBootstrap.swift`** — `videoGenerationService` param on both `init` and `build`; conditional `VideoGenerationRuntime` construction; `videoRuntime` property
- **`ChatRuntimeBootstrap.swift`** — `videoGenerationRuntime` protocol requirement
- **`ChatViewModel.swift`** — `_videoRuntime`, `videoRuntimeEventDrainTask`, `videoGenerationProgress` stored properties
- **`RuntimeConfiguration.swift`** — wires `configure(videoRuntime:)` when present
- **`MessagePartsView.swift`** — `.generatedVideo` arm with file-existence check stub

## Key design decisions vs image gen

- **No backend factory / `loadModel`** — video is cloud-only by design; the service takes a concrete backend at init and is immediately ready
- **`generate()` is `async throws`** — video submission does a network round-trip before the stream starts (unlike image gen where the backend `throws` synchronously); the service contract matches the backend protocol rather than hiding the async boundary
- **`.queued` events forward as `progress(fractionComplete: 0.0)`** — keeps the runtime event set to five cases (matching image gen shape) without a dedicated `.queued` variant

## Test plan
- [ ] `ManifoldRuntimeTests` compile and pass
- [ ] `MessagePart` Codable round-trips: `.generatedVideo` encodes as `"generatedVideo"` key; old persisted records without the key still decode
- [ ] `ChatViewModel+VideoGeneration` event handler: `.started` inserts placeholder, `.progress` updates `videoGenerationProgress`, `.completed` replaces placeholder with `.generatedVideo(payload)`, `.failed`/`.cancelled` mark complete
- [ ] `ManifoldBootstrap` with `videoGenerationService: nil` (default) sets `videoRuntime = nil`; `configure(videoRuntime:)` not called on `ChatViewModel`
- [ ] Build clean under `CloudSaaS` + `Voice` traits (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)