### PR TITLE
fix(voice): prevent dispatch_assert_queue_fail crash in AppleSpeechTranscriber.requestAuthorization()

### DIFF
--- a/Sources/ManifoldVoice/Services/AppleSpeechTranscriber.swift
+++ b/Sources/ManifoldVoice/Services/AppleSpeechTranscriber.swift
@@ -34,28 +34,45 @@ public final class AppleSpeechTranscriber: NSObject, SpeechTranscribing {
     public func requestAuthorization() async -> VoiceAuthorizationStatus {
         guard recognizer != nil else { return .unsupportedLocale }
 
-        let speechStatus = await withCheckedContinuation { continuation in
+        // Delegate TCC requests to nonisolated static helpers.
+        //
+        // Both SFSpeechRecognizer.requestAuthorization and
+        // AVCaptureDevice.requestAccess deliver their callbacks on an arbitrary
+        // background thread. In Swift 6.3, a withCheckedContinuation created
+        // inside a @MainActor-isolated function carries actor isolation; resuming
+        // such a continuation from a non-main thread triggers the runtime's
+        // dispatch_assert_queue_fail check and crashes the process.
+        //
+        // nonisolated static functions create non-actor-isolated continuations,
+        // which are safe to resume from any thread.
+        let speechStatus = await Self.requestSpeechRecognitionAuthorization()
+
+        switch speechStatus {
+        case .authorized:
+            let micGranted = await Self.requestMicrophoneAccess()
+            return micGranted ? .authorized : .microphoneDenied
+        case .denied:           return .denied
+        case .restricted:       return .restricted
+        case .notDetermined:    return .notDetermined
+        @unknown default:       return .denied
+        }
+    }
+
+    private nonisolated static func requestSpeechRecognitionAuthorization()
+        async -> SFSpeechRecognizerAuthorizationStatus
+    {
+        await withCheckedContinuation { continuation in
             SFSpeechRecognizer.requestAuthorization { status in
                 continuation.resume(returning: status)
             }
         }
+    }
 
-        switch speechStatus {
-        case .authorized:
-            let microphoneGranted = await withCheckedContinuation { continuation in
-                AVCaptureDevice.requestAccess(for: .audio) { granted in
-                    continuation.resume(returning: granted)
-                }
+    private nonisolated static func requestMicrophoneAccess() async -> Bool {
+        await withCheckedContinuation { continuation in
+            AVCaptureDevice.requestAccess(for: .audio) { granted in
+                continuation.resume(returning: granted)
             }
-            return microphoneGranted ? .authorized : .microphoneDenied
-        case .denied:
-            return .denied
-        case .restricted:
-            return .restricted
-        case .notDetermined:
-            return .notDetermined
-        @unknown default:
-            return .denied
         }
     }
 


### PR DESCRIPTION
## Problem

Tapping the voice composer button crashes the app on any ManifoldKit consumer built with Swift 6.3.2 on iOS 26.

**Crash fingerprint** (from a live crash report, `GrokApp-2026-05-31-103626.ips`):

```
SIGNAL 5 — Trace/BPT trap
_dispatch_assert_queue_fail
dispatch_assert_queue
_swift_task_checkIsolatedSwift
swift_task_isCurrentExecutorWithFlagsImpl(SerialExecutorRef, swift_task_is_current_executor_flag)
closure #1 in closure #1 in AppleSpeechTranscriber.requestAuthorization()
__TCCAccessRequest_block_invoke_8
```

**Root cause:** `SFSpeechRecognizer.requestAuthorization` and `AVCaptureDevice.requestAccess` deliver their completion blocks on an arbitrary background thread. In Swift 6.3, a `CheckedContinuation` created inside a `@MainActor`-isolated function inherits the actor's isolation. When the TCC framework resumes that continuation from a non-main thread, the Swift runtime calls `_swift_task_checkIsolatedSwift` → `dispatch_assert_queue_fail` → `SIGABRT`.

This crash is **universal** — it affects any ManifoldKit host app that enables voice, on any device/simulator running Swift 6.3.2+.

## Fix

Lift both TCC calls into `private nonisolated static` helper functions. A `nonisolated` function creates a `CheckedContinuation` that carries no actor expectation, so the TCC frameworks can safely resume it from any thread.

```swift
// Before — continuation inherits @MainActor isolation → crash on TCC callback thread
let speechStatus = await withCheckedContinuation { continuation in
    SFSpeechRecognizer.requestAuthorization { status in
        continuation.resume(returning: status)  // ← non-main thread: SIGABRT
    }
}

// After — nonisolated continuation → safe on any thread
let speechStatus = await Self.requestSpeechRecognitionAuthorization()

private nonisolated static func requestSpeechRecognitionAuthorization()
    async -> SFSpeechRecognizerAuthorizationStatus
{
    await withCheckedContinuation { continuation in
        SFSpeechRecognizer.requestAuthorization { status in
            continuation.resume(returning: status)  // ✅ no actor, no assertion
        }
    }
}
```

`requestAuthorization()` remains `@MainActor`; callers see no API change. Behaviour on the happy path is identical.

## Test plan
- [ ] Build with `Voice` trait enabled — clean ✅ (verified locally)
- [ ] Tap voice button in a consumer app → TCC dialog appears → grant permissions → no crash
- [ ] Deny mic permission → `requestAuthorization()` returns `.microphoneDenied` without crashing
- [ ] Simulator: `startTranscribing` correctly throws `VoiceError.simulatorUnsupported` after authorization passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)