### PR TITLE
docs: add TODO.md tracking Glass Box P0 trigger

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+Cross-session notes. Not a tracker — real work lives in GitHub issues.
+
+## Next up
+
+- **Start Glass Box P0 after v0.38 ships.** Umbrella: [#1531](https://github.com/roryford/ManifoldKit/issues/1531).
+  P0 = productionize the multicast event tap + public `ConversationEventRecorder`
+  (`ManifoldRuntime`) + Swift-6 tests + "Observing a turn" DocC article.
+  Keystone already spiked on branch `spike/conversation-event-tap` (c8d654fc) —
+  reproduce properly, that branch is throwaway validation, not for merge.
+  When P0 lands, update the `feedback_mock_backend_and_events_test_patterns` note
+  (the single-consumer `runtime.events` workaround is what the tap retires).


### PR DESCRIPTION
Adds a `TODO.md` cross-session note to start **Glass Box P0** once v0.38 ships.

- Points at umbrella **#1531** (observable runtime + scenario-as-contract).
- Records that the P0 keystone is already spiked on `spike/conversation-event-tap` (`c8d654fc`) — reproduce properly, that branch is throwaway validation.
- Per CLAUDE.md issue-hygiene: cross-session notes live in `TODO.md`, not new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)