### PR TITLE
feat(ui): ImageGenerationToolSource + VideoGenerationToolSource

### DIFF
--- a/Sources/ManifoldUI/Tools/ImageGenerationToolSource.swift
+++ b/Sources/ManifoldUI/Tools/ImageGenerationToolSource.swift
@@ -1,0 +1,66 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+/// A ``SessionToolSource`` that advertises a ``generate_image`` tool to the
+/// language model. Install it via
+/// ``ConversationRuntime/updateSessionToolSources(_:)`` after wiring an
+/// ``ImageGenerationRuntime`` into the chat view model.
+///
+/// When the model calls ``generate_image``, this source forwards the request
+/// to ``ChatViewModel/generateImage(prompt:config:)`` so the generated image
+/// appears inline as a chat message without any user interaction.
+@MainActor
+public final class ImageGenerationToolSource: SessionToolSource {
+
+    private let viewModel: ChatViewModel
+
+    public init(viewModel: ChatViewModel) {
+        self.viewModel = viewModel
+    }
+
+    nonisolated public func toolDefinitions(
+        for session: ChatSessionRecord
+    ) async -> [ToolDefinition] {
+        [
+            ToolDefinition(
+                name: "generate_image",
+                description: "Generate an image from a text description and insert it into the conversation. Use this when the user asks you to create, draw, make, or show them an image.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "prompt": .object([
+                            "type": .string("string"),
+                            "description": .string("A detailed description of the image to generate")
+                        ])
+                    ]),
+                    "required": .array([.string("prompt")])
+                ])
+            )
+        ]
+    }
+
+    nonisolated public func resolve(
+        toolName: String,
+        arguments: String,
+        session: ChatSessionRecord
+    ) async throws -> ToolResult {
+        guard toolName == "generate_image" else {
+            return ToolResult(callId: toolName, content: "Unknown tool: \(toolName)", errorKind: .unknownTool)
+        }
+        guard
+            let data = arguments.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let prompt = json["prompt"] as? String,
+            !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return ToolResult(callId: toolName, content: "Expected a non-empty \"prompt\" string.", errorKind: .invalidArguments)
+        }
+        do {
+            let messageID = try await viewModel.generateImage(prompt: prompt, config: ImageGenerationConfig())
+            return ToolResult(callId: toolName, content: "Image generation started (id: \(messageID)). It will appear in the conversation shortly.")
+        } catch {
+            return ToolResult(callId: toolName, content: "Image generation failed: \(error.localizedDescription)", errorKind: .transient)
+        }
+    }
+}

--- a/Sources/ManifoldUI/Tools/VideoGenerationToolSource.swift
+++ b/Sources/ManifoldUI/Tools/VideoGenerationToolSource.swift
@@ -1,0 +1,71 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+/// A ``SessionToolSource`` that advertises a ``generate_video`` tool to the
+/// language model. Install it via
+/// ``ConversationRuntime/updateSessionToolSources(_:)`` after wiring a
+/// ``VideoGenerationRuntime`` into the chat view model.
+///
+/// When the model calls ``generate_video``, this source fires-and-forgets the
+/// generation via a detached `Task` so ``resolve(toolName:arguments:session:)``
+/// returns immediately — video generation is long-running (~30–60 s) and must
+/// not block the conversation turn executor. Progress and the completed video
+/// surface through ``ChatViewModel/videoGenerationProgress`` exactly as if the
+/// user had triggered generation directly.
+@MainActor
+public final class VideoGenerationToolSource: SessionToolSource {
+
+    private let viewModel: ChatViewModel
+
+    public init(viewModel: ChatViewModel) {
+        self.viewModel = viewModel
+    }
+
+    nonisolated public func toolDefinitions(
+        for session: ChatSessionRecord
+    ) async -> [ToolDefinition] {
+        [
+            ToolDefinition(
+                name: "generate_video",
+                description: "Generate a short video clip from a text description and insert it into the conversation. Use this when the user asks you to create, make, animate, or show them a video.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "prompt": .object([
+                            "type": .string("string"),
+                            "description": .string("A detailed description of the video to generate")
+                        ])
+                    ]),
+                    "required": .array([.string("prompt")])
+                ])
+            )
+        ]
+    }
+
+    nonisolated public func resolve(
+        toolName: String,
+        arguments: String,
+        session: ChatSessionRecord
+    ) async throws -> ToolResult {
+        guard toolName == "generate_video" else {
+            return ToolResult(callId: toolName, content: "Unknown tool: \(toolName)", errorKind: .unknownTool)
+        }
+        guard
+            let data = arguments.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let prompt = json["prompt"] as? String,
+            !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return ToolResult(callId: toolName, content: "Expected a non-empty \"prompt\" string.", errorKind: .invalidArguments)
+        }
+        // Fire-and-forget: video generation is long-running; resolve returns
+        // immediately so the conversation turn is not blocked while the backend
+        // processes the request. The generated video and progress updates surface
+        // through ChatViewModel.videoGenerationProgress.
+        Task { @MainActor in
+            try? await viewModel.generateVideo(prompt: prompt, config: VideoGenerationConfig(duration: 5))
+        }
+        return ToolResult(callId: toolName, content: "Video generation started. It will appear in approximately 30–60 seconds.")
+    }
+}


### PR DESCRIPTION
## Summary

Adds two built-in `SessionToolSource` implementations that any ManifoldKit app with generation wired in can use to expose those capabilities to the language model — no boilerplate needed.

### `ImageGenerationToolSource`

Advertises a `generate_image` tool. When the model calls it, forwards to `ChatViewModel.generateImage(prompt:config:)` so the image appears inline as a chat message.

### `VideoGenerationToolSource`

Advertises a `generate_video` tool. Fires-and-forgets the generation via a detached `Task` so `resolve()` returns immediately while the video generates in the background (~30–60 s). Progress surfaces through `ChatViewModel.videoGenerationProgress` exactly as if the user triggered it directly.

### Usage

```swift
let imageToolSource = ImageGenerationToolSource(viewModel: kit.viewModel)
let videoToolSource = VideoGenerationToolSource(viewModel: kit.viewModel)
await kit.bootstrap.conversationRuntime.updateSessionToolSources([imageToolSource, videoToolSource])
```

## Test plan
- [ ] `ImageGenerationToolSource.toolDefinitions` returns a single `generate_image` definition
- [ ] `resolve` with valid JSON arguments calls `viewModel.generateImage` and returns a success message containing the placeholder UUID
- [ ] `resolve` with missing or blank `prompt` returns `.invalidArguments`
- [ ] `VideoGenerationToolSource.toolDefinitions` returns a single `generate_video` definition
- [ ] `resolve` for video fires-and-forgets and returns immediately without awaiting generation
- [ ] `resolve` for video with missing `prompt` returns `.invalidArguments`
- [ ] Build clean under `CloudSaaS` + `Voice` traits ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)