### PR TITLE
docs(ui): GenerationComponents — PhotoAttachmentButton, tool sources, context menus

### DIFF
--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
@@ -1,0 +1,70 @@
+# Generation Components
+
+Add image generation, video generation, and photo attachment to your chat interface.
+
+## Overview
+
+ManifoldKit ships three composable components for building generative chat experiences: ``PhotoAttachmentButton`` lets users attach photos from their library, and ``ImageGenerationToolSource`` / ``VideoGenerationToolSource`` expose generation as callable tools that the language model can invoke autonomously. Wire them together or use each independently.
+
+## Photo Attachment
+
+``PhotoAttachmentButton`` wraps a `PhotosPicker` and stages the selected image on ``ChatViewModel`` using ``ChatViewModel/stageAttachment(_:)``. The staged image is sent as a ``MessagePart/image(data:mimeType:placeholderHash:)`` part alongside the next user message.
+
+Place it in the `composerAccessory` slot of ``ChatView``:
+
+```swift,no-build
+ChatView(showModelManagement: $show, composerAccessory: {
+    PhotoAttachmentButton()
+})
+```
+
+Combine it with ``VoiceComposerAccessory`` when your app supports both modalities:
+
+```swift,no-build
+ChatView(showModelManagement: $show, composerAccessory: {
+    HStack {
+        PhotoAttachmentButton()
+        VoiceComposerAccessory(controller: controller)
+    }
+})
+```
+
+The button tint changes to ``Color/accentColor`` when an image is already staged, giving the user visual confirmation without requiring a separate indicator view. ``PhotoAttachmentButton/clearSelection()`` resets both the picker state and the staged attachment — useful when the host needs to programmatically cancel an in-progress compose operation.
+
+> Note: ``PhotoAttachmentButton`` is iOS-only. It is compiled under `#if os(iOS)` and is not available on macOS or visionOS.
+
+## Tool Sources
+
+``ImageGenerationToolSource`` and ``VideoGenerationToolSource`` conform to `SessionToolSource` and advertise `generate_image` and `generate_video` tools respectively to the language model. Register them via `ConversationRuntime.updateSessionToolSources(_:)` after the bootstrap and view model are wired:
+
+```swift,no-build
+let imageToolSource = ImageGenerationToolSource(viewModel: kit.viewModel)
+await kit.bootstrap.conversationRuntime.updateSessionToolSources([imageToolSource])
+```
+
+Register both sources to enable the full generation surface:
+
+```swift,no-build
+let imageToolSource = ImageGenerationToolSource(viewModel: chatVM)
+let videoToolSource = VideoGenerationToolSource(viewModel: chatVM)
+await bootstrap.conversationRuntime.updateSessionToolSources([imageToolSource, videoToolSource])
+```
+
+Once registered, the model will call `generate_image` or `generate_video` autonomously when the user asks it to create visual content — the result appears inline as a chat message with no additional user interaction required.
+
+### Image generation
+
+``ImageGenerationToolSource`` delegates to ``ChatViewModel/generateImage(prompt:config:)`` when the model calls `generate_image`. The generated image surfaces in the conversation the same way as one triggered directly by the user.
+
+### Video generation
+
+``VideoGenerationToolSource`` delegates to ``ChatViewModel/generateVideo(prompt:config:)`` using a fire-and-forget detached `Task`. ``VideoGenerationToolSource/resolve(toolName:arguments:session:)`` returns immediately — video generation is long-running (typically 30–60 seconds) and must not block the conversation turn executor. Progress and the completed video surface through ``ChatViewModel/videoGenerationProgress`` exactly as if the user had triggered generation directly.
+
+### Prerequisites
+
+Both tool sources require their corresponding generation runtimes to be wired into the bootstrap before installation:
+
+- ``ImageGenerationToolSource`` — requires an ``ImageGenerationRuntime`` wired via `ManifoldBootstrap.build(imageGenerationService:)`.
+- ``VideoGenerationToolSource`` — requires a ``VideoGenerationRuntime`` wired into ``ChatViewModel``.
+
+If a generation runtime is absent, the tool source is safe to register — the underlying `ChatViewModel` call will surface an error through ``ChatViewModel/backgroundTaskError`` rather than crashing.

--- a/Sources/ManifoldUI/ManifoldUI.docc/ManifoldUI.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/ManifoldUI.md
@@ -102,6 +102,7 @@ For a sidebar-based layout with multiple sessions, combine ``ChatView`` with ``S
 ### Getting Started
 
 - <doc:BuildingAChatUI>
+- <doc:GenerationComponents>
 
 ### View Models
 
@@ -113,6 +114,12 @@ For a sidebar-based layout with multiple sessions, combine ``ChatView`` with ``S
 - ``ChatView``
 - ``ChatInputBar``
 - ``MessageBubbleView``
+
+### Generation
+
+- ``PhotoAttachmentButton``
+- ``ImageGenerationToolSource``
+- ``VideoGenerationToolSource``
 
 ### Settings
 


### PR DESCRIPTION
Adds a DocC article covering the three new generation-related UI components added in #1535, #1536, #1537.

## Changes

- New article `Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md` covering:
  - `PhotoAttachmentButton` — iOS-only `PhotosPicker` wrapper; placement in `composerAccessory`, combining with `VoiceComposerAccessory`, `clearSelection()`, and the iOS-only platform note
  - `ImageGenerationToolSource` — `generate_image` tool registration, delegation to `ChatViewModel.generateImage(prompt:config:)`, and `ImageGenerationRuntime` prerequisite
  - `VideoGenerationToolSource` — `generate_video` tool registration, fire-and-forget async design rationale, `videoGenerationProgress` surface, and `VideoGenerationRuntime` prerequisite
- `ManifoldUI.md` catalog updated: `GenerationComponents` added to Getting Started; new `### Generation` topic group listing all three types

## Build

`swift build --traits CloudSaaS,Voice` — Build complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)