### PR TITLE
feat(inference): add aspectRatio field to ImageGenerationConfig

### DIFF
--- a/Sources/ManifoldInference/Models/ImageGenerationConfig.swift
+++ b/Sources/ManifoldInference/Models/ImageGenerationConfig.swift
@@ -68,6 +68,14 @@ public struct ImageGenerationConfig: Sendable, Codable, Equatable {
     /// default.
     public var guidanceScale: Float?
 
+    /// Aspect ratio hint for backends that accept ratio strings rather than
+    /// pixel dimensions (e.g. `"16:9"`, `"1:1"`, `"4:3"`).
+    ///
+    /// When non-nil, backends that support named ratios should use this value
+    /// directly. `nil` means the backend uses its own default or derives the
+    /// ratio from ``width`` / ``height``.
+    public var aspectRatio: String?
+
     /// Destination directory the backend should write the produced image
     /// into.
     ///
@@ -86,6 +94,7 @@ public struct ImageGenerationConfig: Sendable, Codable, Equatable {
         height: Int = 1024,
         seed: UInt64? = nil,
         guidanceScale: Float? = nil,
+        aspectRatio: String? = nil,
         outputDirectory: URL? = nil
     ) {
         self.steps = steps
@@ -93,6 +102,7 @@ public struct ImageGenerationConfig: Sendable, Codable, Equatable {
         self.height = height
         self.seed = seed
         self.guidanceScale = guidanceScale
+        self.aspectRatio = aspectRatio
         self.outputDirectory = outputDirectory
     }
 
@@ -121,7 +131,7 @@ public struct ImageGenerationConfig: Sendable, Codable, Equatable {
     // Custom Codable so `outputDirectory` rides as `encodeIfPresent` and an
     // older payload that omits it decodes to `nil` rather than failing.
     private enum CodingKeys: String, CodingKey {
-        case steps, width, height, seed, guidanceScale, outputDirectory
+        case steps, width, height, seed, guidanceScale, aspectRatio, outputDirectory
     }
 
     public init(from decoder: any Decoder) throws {
@@ -131,6 +141,7 @@ public struct ImageGenerationConfig: Sendable, Codable, Equatable {
         self.height = try c.decode(Int.self, forKey: .height)
         self.seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
         self.guidanceScale = try c.decodeIfPresent(Float.self, forKey: .guidanceScale)
+        self.aspectRatio = try c.decodeIfPresent(String.self, forKey: .aspectRatio)
         self.outputDirectory = try c.decodeIfPresent(URL.self, forKey: .outputDirectory)
     }
 
@@ -141,6 +152,7 @@ public struct ImageGenerationConfig: Sendable, Codable, Equatable {
         try c.encode(height, forKey: .height)
         try c.encodeIfPresent(seed, forKey: .seed)
         try c.encodeIfPresent(guidanceScale, forKey: .guidanceScale)
+        try c.encodeIfPresent(aspectRatio, forKey: .aspectRatio)
         try c.encodeIfPresent(outputDirectory, forKey: .outputDirectory)
     }
 }

--- a/Sources/ManifoldInference/Models/ImageGenerationConfigSnapshot.swift
+++ b/Sources/ManifoldInference/Models/ImageGenerationConfigSnapshot.swift
@@ -30,6 +30,9 @@ public struct ImageGenerationConfigSnapshot: Sendable, Hashable {
     public var height: Int
     public var seed: UInt64?
     public var guidanceScale: Float?
+    /// Mirrors ``ImageGenerationConfig/aspectRatio``. `nil` means the backend
+    /// derives the ratio from ``width``/``height`` or uses its own default.
+    public var aspectRatio: String?
 
     /// Mirrors ``ImageGenerationConfig/outputDirectory``. Persisted so a
     /// "regenerate from history" affordance can re-target the same storage
@@ -57,6 +60,7 @@ public struct ImageGenerationConfigSnapshot: Sendable, Hashable {
         height: Int,
         seed: UInt64? = nil,
         guidanceScale: Float? = nil,
+        aspectRatio: String? = nil,
         outputDirectory: URL? = nil
     ) {
         self.steps = steps
@@ -64,6 +68,7 @@ public struct ImageGenerationConfigSnapshot: Sendable, Hashable {
         self.height = height
         self.seed = seed
         self.guidanceScale = guidanceScale
+        self.aspectRatio = aspectRatio
         self.outputDirectory = outputDirectory
     }
 
@@ -76,6 +81,7 @@ public struct ImageGenerationConfigSnapshot: Sendable, Hashable {
         self.height = config.height
         self.seed = config.seed
         self.guidanceScale = config.guidanceScale
+        self.aspectRatio = config.aspectRatio
         self.outputDirectory = config.outputDirectory
     }
 
@@ -89,6 +95,7 @@ public struct ImageGenerationConfigSnapshot: Sendable, Hashable {
             height: height,
             seed: seed,
             guidanceScale: guidanceScale,
+            aspectRatio: aspectRatio,
             outputDirectory: outputDirectory
         )
     }
@@ -102,7 +109,7 @@ extension ImageGenerationConfigSnapshot: Codable {
     // decode to `nil` rather than failing the whole row, and so absent
     // fields never get force-encoded as `null`.
     private enum CodingKeys: String, CodingKey {
-        case steps, width, height, seed, guidanceScale, outputDirectory
+        case steps, width, height, seed, guidanceScale, aspectRatio, outputDirectory
     }
 
     public init(from decoder: any Decoder) throws {
@@ -112,6 +119,7 @@ extension ImageGenerationConfigSnapshot: Codable {
         self.height = try c.decode(Int.self, forKey: .height)
         self.seed = try c.decodeIfPresent(UInt64.self, forKey: .seed)
         self.guidanceScale = try c.decodeIfPresent(Float.self, forKey: .guidanceScale)
+        self.aspectRatio = try c.decodeIfPresent(String.self, forKey: .aspectRatio)
         self.outputDirectory = try c.decodeIfPresent(URL.self, forKey: .outputDirectory)
     }
 


### PR DESCRIPTION
Closes #1532.

## Summary

Adds `aspectRatio: String?` to `ImageGenerationConfig` and `ImageGenerationConfigSnapshot`.

Cloud image backends (xAI Grok Imagine, DALL-E 3, Stability AI) accept explicit aspect-ratio strings rather than pixel dimensions. Without this field, consumers guess the ratio from `width`/`height` — lossy: 768×512 gets sent as `"16:9"` when it's actually 3:2.

```swift
var config = ImageGenerationConfig()
config.aspectRatio = "16:9"   // passed directly to the backend
config.width = 1280            // still used as pixel hint when ratio is nil
```

`nil` means: use `width`/`height` or let the backend choose — existing call sites are unaffected.

`ImageGenerationConfigSnapshot` uses `decodeIfPresent` so records written before this change decode cleanly with `aspectRatio == nil`.

## Test plan
- [ ] `ImageGenerationConfig(aspectRatio: "16:9")` round-trips through Codable
- [ ] Snapshot records without `aspectRatio` key decode to `nil`
- [ ] Build clean under `CloudSaaS` + `Voice` traits ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)