### PR TITLE
feat(inference): expose currentCloudBackend on InferenceService

### DIFF
--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -113,6 +113,12 @@ public final class InferenceService {
 
     public var capabilities: BackendCapabilities? { lifecycle.capabilities }
 
+    /// The currently-loaded cloud backend, if any. Host apps can use this to
+    /// call ``SSECloudBackend/configure(baseURL:tokenProvider:modelName:)``
+    /// after ``loadCloudBackend(from:)`` to inject a rotating token provider
+    /// without going through the static Keychain path.
+    public var currentCloudBackend: (any InferenceBackend)? { lifecycle.backend }
+
     // MARK: - Deny Policy
 
     /// Policy applied when a ``ModelLoadPlan`` returns a ``ModelLoadPlan/Verdict/deny``


### PR DESCRIPTION
## Summary

- Adds a public read-only `currentCloudBackend: (any InferenceBackend)?` property to `InferenceService`
- The property is a thin computed accessor over the private `lifecycle.backend` already managed by `ModelLifecycleCoordinator`
- Previously the loaded backend was inaccessible from outside the service, blocking the `TokenProvider` integration path for OAuth-backed apps

## Motivation

After calling `loadCloudBackend(from:)`, host apps need to inject a rotating `TokenProvider` without relying on the static Keychain path. This unlocks that pattern:

```swift
if let backend = inferenceService.currentCloudBackend as? SSECloudBackend {
    backend.configure(baseURL: url, tokenProvider: myProvider, modelName: "grok-4.3")
}
```

## Test plan

- [ ] Build passes with `--traits CloudSaaS,Voice` (verified: `Build complete!`)
- [ ] Cast `currentCloudBackend as? SSECloudBackend` succeeds after `loadCloudBackend(from:)` in a host app
- [ ] `currentCloudBackend` returns `nil` before any backend is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)