### PR TITLE
fix(ui): replace try? with do/catch in generation action buttons

### DIFF
--- a/Sources/ManifoldUI/Tools/VideoGenerationToolSource.swift
+++ b/Sources/ManifoldUI/Tools/VideoGenerationToolSource.swift
@@ -64,7 +64,11 @@ public final class VideoGenerationToolSource: SessionToolSource {
         // processes the request. The generated video and progress updates surface
         // through ChatViewModel.videoGenerationProgress.
         Task { @MainActor in
-            try? await viewModel.generateVideo(prompt: prompt, config: VideoGenerationConfig(duration: 5))
+            do {
+                try await viewModel.generateVideo(prompt: prompt, config: VideoGenerationConfig(duration: 5))
+            } catch {
+                Log.ui.warning("VideoGenerationToolSource: video generation failed: \(error)")
+            }
         }
         return ToolResult(callId: toolName, content: "Video generation started. It will appear in approximately 30–60 seconds.")
     }

--- a/Sources/ManifoldUI/Views/Chat/GenerativeContextMenuItems.swift
+++ b/Sources/ManifoldUI/Views/Chat/GenerativeContextMenuItems.swift
@@ -51,10 +51,14 @@ public struct GenerativeContextMenuItems: View {
         if hasText && hasImageRuntime {
             Button {
                 Task {
-                    try? await viewModel.generateImage(
-                        prompt: text,
-                        config: ImageGenerationConfig()
-                    )
+                    do {
+                        try await viewModel.generateImage(
+                            prompt: text,
+                            config: ImageGenerationConfig()
+                        )
+                    } catch {
+                        Log.ui.warning("GenerativeContextMenuItems: image generation failed: \(error)")
+                    }
                 }
             } label: {
                 Label("Generate Image from This", systemImage: "photo.badge.plus")
@@ -65,10 +69,14 @@ public struct GenerativeContextMenuItems: View {
         if hasText && hasVideoRuntime {
             Button {
                 Task {
-                    try? await viewModel.generateVideo(
-                        prompt: text,
-                        config: VideoGenerationConfig()
-                    )
+                    do {
+                        try await viewModel.generateVideo(
+                            prompt: text,
+                            config: VideoGenerationConfig()
+                        )
+                    } catch {
+                        Log.ui.warning("GenerativeContextMenuItems: video generation failed: \(error)")
+                    }
                 }
             } label: {
                 Label("Generate Video from This", systemImage: "video.badge.plus")
@@ -80,10 +88,14 @@ public struct GenerativeContextMenuItems: View {
             Button {
                 let prompt = generatedImage?.prompt ?? text
                 Task {
-                    try? await viewModel.generateImage(
-                        prompt: prompt,
-                        config: ImageGenerationConfig()
-                    )
+                    do {
+                        try await viewModel.generateImage(
+                            prompt: prompt,
+                            config: ImageGenerationConfig()
+                        )
+                    } catch {
+                        Log.ui.warning("GenerativeContextMenuItems: image remix failed: \(error)")
+                    }
                 }
             } label: {
                 Label("Remix Image", systemImage: "arrow.triangle.2.circlepath")
@@ -95,10 +107,14 @@ public struct GenerativeContextMenuItems: View {
             Button {
                 let prompt = generatedImage?.prompt ?? text
                 Task {
-                    try? await viewModel.generateVideo(
-                        prompt: prompt,
-                        config: VideoGenerationConfig()
-                    )
+                    do {
+                        try await viewModel.generateVideo(
+                            prompt: prompt,
+                            config: VideoGenerationConfig()
+                        )
+                    } catch {
+                        Log.ui.warning("GenerativeContextMenuItems: video animation failed: \(error)")
+                    }
                 }
             } label: {
                 Label("Animate as Video", systemImage: "play.rectangle.on.rectangle")


### PR DESCRIPTION
## Summary

- `SilentCatchAuditTest` caught five unapproved silent error swallows introduced in #1537 (`GenerativeContextMenuItems`) and the `VideoGenerationToolSource` tool source
- Replaced all five `try?` call sites with `do/catch` blocks that route failures through `Log.ui.warning(...)` so errors are visible in Console rather than silently dropped
- The `try? JSONSerialization.jsonObject(...)` in `VideoGenerationToolSource` is untouched — that's optional decoding at a trust boundary, which the audit explicitly allows

## Test plan

- [x] `SilentCatchAuditTest` passes (was the failing test)
- [x] Full local gate green: `scripts/test.sh --profile local` — 83 Swift Testing + all XCTest suites, 0 failures