### PR TITLE
docs: video generation quickstart, TokenProvider guide, GenerativeContextMenuItems coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ Full runnable: [`Example/Examples/MinimalExample`](Example/Examples/MinimalExamp
 The same backend, model-management, persistence, and download infrastructure that powers the chat UI is reusable for non-chat consumers. The framing is "chat-first" because that's the most complete reference integration, but the public surface explicitly supports:
 
 - **On-device image generation** — `FluxDiffusionBackend` (FLUX.1 Schnell, 1024×1024 in 4 steps) and `MLXDiffusionBackend` (SDXL Turbo) conform to `ImageGenerationBackend` and stream `ImageGenerationEvent`s exactly like text inference streams `GenerationEvent`. See [docs/QUICKSTART-IMAGE-GEN.md](docs/QUICKSTART-IMAGE-GEN.md) for an end-to-end example.
+- **Cloud video generation** — Any cloud service that conforms to `VideoGenerationBackend` wires into `VideoGenerationService` and `VideoGenerationRuntime`, which persist the result via `MessageStore` and expose real-time progress through `ChatViewModel.videoGenerationProgress`. The same `ManifoldBootstrap` init that accepts an `imageGenerationService` also accepts a `videoGenerationService`, so adding video is one extra parameter:
+
+  ```swift,no-build
+  let backend = MyVideoBackend()
+  backend.configure(baseURL: videoAPIURL, tokenProvider: tokenProvider, modelName: "my-video-model")
+  let service = VideoGenerationService(backend: backend)
+  let kit = try ManifoldBootstrap(
+      configuration: config,
+      videoGenerationService: service
+  )
+  // Trigger a generation from anywhere you hold the view model:
+  try await kit.viewModel.generateVideo(
+      prompt: "a sun rising over mountains",
+      config: VideoGenerationConfig(duration: 5, aspectRatio: VideoGenerationConfig.AspectRatio.landscape)
+  )
+  ```
+
+  See [docs/QUICKSTART-VIDEO-GEN.md](docs/QUICKSTART-VIDEO-GEN.md) for the full walkthrough.
 - **Standalone speech-to-text / text-to-speech** — `ManifoldVoice` wraps Apple `Speech` + `AVFoundation` behind a chat-agnostic `VoiceConversationController` that anything (image-gen prompt fields, search bars, CLI dictation) can drive. See [docs/QUICKSTART-VOICE.md](docs/QUICKSTART-VOICE.md).
 - **CLI / server / non-SwiftUI consumers** — backends, model management, and persistence work without `ChatView`. See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md).
 

--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
@@ -81,3 +81,42 @@ Both tool sources require their corresponding generation runtimes to be wired in
 - ``VideoGenerationToolSource`` — requires a ``VideoGenerationRuntime`` wired into ``ChatViewModel``.
 
 If a generation runtime is absent, the tool source is safe to register — the underlying `ChatViewModel` call will surface an error through ``ChatViewModel/backgroundTaskError`` rather than crashing.
+
+## Context Menu Items
+
+``GenerativeContextMenuItems`` surfaces generation actions directly in the
+long-press context menu of each chat bubble. Pass it to ``ChatView`` via the
+`contextMenuItems` trailing closure:
+
+```swift,no-build
+ChatView(showModelManagement: $show) { message in
+    GenerativeContextMenuItems(message: message, viewModel: viewModel)
+}
+```
+
+Items appear conditionally based on the message content and which runtimes are
+configured on the view model:
+
+- **Generate Image from This** — shown when the message has text content and
+  an ``ImageGenerationRuntime`` is wired via
+  ``ChatViewModel/configure(imageRuntime:)``.
+- **Generate Video from This** — shown when the message has text content and a
+  ``VideoGenerationRuntime`` is wired via
+  ``ChatViewModel/configure(videoRuntime:)``.
+- **Remix Image** — shown when the message contains a generated image part and
+  an ``ImageGenerationRuntime`` is configured. Re-triggers image generation
+  using the original prompt (or the message text as a fallback).
+- **Animate as Video** — shown when the message contains a generated image part
+  and a ``VideoGenerationRuntime`` is configured. Submits the original image
+  prompt for video generation in image-to-video mode.
+
+``GenerativeContextMenuItems`` reads ``ChatViewModel/imageRuntime`` and
+``ChatViewModel/videoRuntime`` at render time, so items appear and disappear
+automatically if runtimes are added or removed at runtime — no additional
+configuration is required beyond wiring the runtimes.
+
+> Note: ``GenerativeContextMenuItems`` does not show menu items for runtimes
+> that are absent. An app that wires only an ``ImageGenerationRuntime`` will
+> never see the video items, and vice versa. This makes it safe to register
+> ``GenerativeContextMenuItems`` unconditionally regardless of which generation
+> surface your app supports.

--- a/docs/CLOUD-OAUTH.md
+++ b/docs/CLOUD-OAUTH.md
@@ -1,0 +1,211 @@
+# Cloud OAuth / Token Rotation with `TokenProvider`
+
+`TokenProvider` is the protocol that lets `SSECloudBackend` work with
+short-lived credentials — OAuth access tokens, JWTs, or any credential that
+may expire and needs silent refresh. The backend calls `token()` on every
+outbound request, so the implementation can refresh transparently without the
+caller noticing.
+
+---
+
+## 1. When to use `TokenProvider` vs static API keys
+
+| Scenario | Recommended approach |
+|---|---|
+| Long-lived API key stored in Keychain | `configure(baseURL:keychainAccount:modelName:)` |
+| Server-issued short-lived JWT / OAuth token | `TokenProvider` + `configure(baseURL:tokenProvider:modelName:)` |
+| Multi-tenant app where each user has a separate token | `TokenProvider` with per-user token storage |
+| Proxy server that vends session tokens to mobile clients | `TokenProvider` that calls your proxy's `/token` endpoint |
+
+Static Keychain-backed keys are simpler and avoid the overhead of an async
+hop on every request. Reserve `TokenProvider` for credentials that rotate —
+if you put a static key behind a `TokenProvider`, you gain nothing.
+
+---
+
+## 2. Implementing `TokenProvider`
+
+`TokenProvider` is declared in `ManifoldCloudCore` and re-exported through
+`ManifoldCloud` and the `ManifoldKit` umbrella. You only need to import the
+module your target already depends on.
+
+```swift,no-build
+import ManifoldCloudCore // or ManifoldKit / ManifoldCloud
+
+public protocol TokenProvider: Sendable {
+    /// Returns a valid bearer token. May perform a network round-trip to
+    /// refresh an expired token before returning.
+    func token() async throws -> String
+}
+```
+
+**Minimal conforming example** — reads from an in-memory store with a
+simulated refresh:
+
+```swift,no-build
+import Foundation
+import ManifoldCloudCore
+
+/// Stores a token in memory and refreshes it via a network call when expired.
+actor MyOAuthTokenProvider: TokenProvider {
+    private var accessToken: String
+    private var expiresAt: Date
+
+    init(initialToken: String, expiresAt: Date) {
+        self.accessToken = initialToken
+        self.expiresAt = expiresAt
+    }
+
+    func token() async throws -> String {
+        if Date.now < expiresAt {
+            return accessToken
+        }
+        // Token expired — refresh from your auth server.
+        let refreshed = try await fetchNewToken()
+        self.accessToken = refreshed.token
+        self.expiresAt = refreshed.expiresAt
+        return refreshed.token
+    }
+
+    private struct TokenResponse {
+        let token: String
+        let expiresAt: Date
+    }
+
+    private func fetchNewToken() async throws -> TokenResponse {
+        // Replace with a real URLSession call to your OAuth token endpoint.
+        TokenResponse(token: "new-token-\(UUID())", expiresAt: Date.now.addingTimeInterval(3600))
+    }
+}
+```
+
+**Server-proxy pattern** — each call hits your own backend, which
+validates the user session and mints a short-lived token for the upstream AI
+provider. This keeps the upstream API key entirely off the device:
+
+```swift,no-build
+import Foundation
+import ManifoldCloudCore
+
+struct ProxyTokenProvider: TokenProvider {
+    let proxyURL: URL
+    let sessionCookie: String // your app's own auth credential
+
+    func token() async throws -> String {
+        var request = URLRequest(url: proxyURL.appendingPathComponent("/ai-token"))
+        request.setValue("session=\(sessionCookie)", forHTTPHeaderField: "Cookie")
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let body = try JSONDecoder().decode(TokenResponse.self, from: data)
+        return body.token
+    }
+
+    private struct TokenResponse: Decodable { let token: String }
+}
+```
+
+---
+
+## 3. Wiring via `SSECloudBackend.configure(tokenProvider:)`
+
+`configure(baseURL:tokenProvider:modelName:)` is the `SSECloudBackend` overload
+that installs a `TokenProvider`. It replaces any previously set API key or
+Keychain account — only one credential source is active at a time.
+
+**Anthropic `ClaudeBackend` example:**
+
+```swift,no-build
+import ManifoldCloud
+import ManifoldCloudCore
+
+// 1. Build the provider. The actor serialises concurrent refresh calls.
+let tokenProvider = MyOAuthTokenProvider(
+    initialToken: "sk-ant-...",     // boot token from your auth flow
+    expiresAt: Date.now.addingTimeInterval(3600)
+)
+
+// 2. Construct the backend.
+let backend = ClaudeBackend()
+
+// 3. Configure it with the token provider.
+backend.configure(
+    baseURL: URL(string: "https://api.anthropic.com")!,
+    tokenProvider: tokenProvider,
+    modelName: "claude-opus-4-5"
+)
+
+// 4. Load it (marks `isModelLoaded = true`).
+try await backend.loadModel(from: nil, plan: .init(modelInfo: .init(id: "claude-opus-4-5")))
+```
+
+From this point, every call to `backend.generate(prompt:systemPrompt:config:)`
+will call `tokenProvider.token()` before building the outbound HTTP request.
+If the token has expired, `token()` refreshes it transparently.
+
+**Tip:** Use `ManifoldBootstrap` with a custom `InferenceService` when you
+want token rotation inside the full SwiftData-backed stack:
+
+```swift,no-build
+import ManifoldKit
+import ManifoldCloud
+import ManifoldCloudCore
+
+let tokenProvider = MyOAuthTokenProvider(...)
+let backend = ClaudeBackend()
+backend.configure(
+    baseURL: URL(string: "https://api.anthropic.com")!,
+    tokenProvider: tokenProvider,
+    modelName: "claude-opus-4-5"
+)
+
+let inferenceService = InferenceService()
+inferenceService.register(backend)
+
+let kit = try ManifoldBootstrap(
+    configuration: ManifoldConfiguration(bundleIdentifier: "com.example.MyApp"),
+    inferenceService: inferenceService
+)
+```
+
+---
+
+## 4. Thread safety
+
+`TokenProvider.token()` is called from within `SSECloudBackend`'s internal
+async context — the call may arrive from any actor or cooperative thread. Your
+implementation must be safe to call concurrently from multiple contexts.
+
+The recommended patterns:
+
+- **`actor`** — Swift actors serialise access automatically. This is the
+  simplest choice when your token cache involves mutable state (expiry
+  timestamps, stored tokens). See the `MyOAuthTokenProvider` example above.
+- **Value type + Keychain** — If your token refresh is entirely stateless
+  (e.g. you always call a remote endpoint), a `struct` that conforms to both
+  `TokenProvider` and `Sendable` works without an actor.
+
+Avoid `@unchecked Sendable` on a class with unprotected mutable state — two
+concurrent `token()` calls could interleave the expiry check and the refresh
+assignment, causing a double-refresh or a stale token to be returned.
+
+---
+
+## Relationship to Keychain-backed configuration
+
+`configure(baseURL:tokenProvider:modelName:)` and
+`configure(baseURL:keychainAccount:modelName:)` are mutually exclusive. Calling
+either one clears the other:
+
+```swift,no-build
+// Sets token provider; clears any prior Keychain account.
+backend.configure(baseURL: url, tokenProvider: myProvider, modelName: model)
+
+// Sets Keychain account; clears any prior token provider.
+backend.configure(baseURL: url, keychainAccount: "com.example.claude-key", modelName: model)
+```
+
+The internal resolution order in `resolveTokenAsync()` is:
+1. `TokenProvider.token()` (async, may refresh)
+2. Keychain-backed `SecureBytes` (sync)
+3. Ephemeral API key (sync, test use only)
+
+Only the first configured source is used.

--- a/docs/QUICKSTART-IMAGE-GEN.md
+++ b/docs/QUICKSTART-IMAGE-GEN.md
@@ -81,6 +81,11 @@ struct ImageGen {
             seed: 42,
             outputDirectory: FileManager.default.temporaryDirectory
         )
+        // Backends that accept a ratio string (e.g. cloud backends) read
+        // `aspectRatio` directly. On-device backends that operate on explicit
+        // pixel dimensions derive the ratio from `width`/`height` instead.
+        // let config = ImageGenerationConfig(steps: 4, width: 1024, height: 1024,
+        //     aspectRatio: "16:9", outputDirectory: FileManager.default.temporaryDirectory)
 
         // 4. `generate` returns an AsyncThrowingStream. Iterate it to observe
         //    progress; the terminal `.completed(url)` event carries the

--- a/docs/QUICKSTART-VIDEO-GEN.md
+++ b/docs/QUICKSTART-VIDEO-GEN.md
@@ -1,0 +1,292 @@
+# ManifoldKit Video-Gen Quickstart
+
+A one-page tutorial for adding cloud video generation to any Swift app. Unlike
+on-device image generation, `VideoGenerationBackend` is cloud-only by design —
+requests are submitted to a remote API, polled for progress, and the finished
+video is downloaded to a local file. No model loading step; the service is
+always "ready" from construction time.
+
+> **Platform.** iOS 18+ / macOS 15+. Video generation requires a cloud backend
+> — there is no on-device video model supported today. Bring your own backend
+> conformer (or use one from `ManifoldCloud` when available).
+
+---
+
+## 1. Prerequisites
+
+Add `ManifoldKit` to your consumer `Package.swift`. No extra traits are needed
+for video generation — the `VideoGenerationBackend` protocol, config types, and
+runtime all ship in `ManifoldInference` and `ManifoldRuntime`, which are in the
+default dependency graph.
+
+```swift,no-build
+dependencies: [
+    .package(
+        url: "https://github.com/roryford/ManifoldKit.git",
+        from: "0.36.0" // x-release-please-version
+    ),
+],
+targets: [
+    .target(
+        name: "MyVideoApp",
+        dependencies: [
+            .product(name: "ManifoldKit", package: "ManifoldKit"),
+            // For UI: also import ManifoldUI (already in ManifoldKit umbrella)
+        ]
+    ),
+],
+```
+
+If you are building a non-SwiftUI CLI or server consumer, depend on
+`ManifoldInference` and `ManifoldRuntime` individually instead of the umbrella.
+
+---
+
+## 2. Implement `VideoGenerationBackend`
+
+`VideoGenerationBackend` is the protocol every cloud video service must
+conform to. It lives in `ManifoldInference`. You supply one conformer per
+service provider.
+
+```swift,no-build
+import Foundation
+import ManifoldInference
+
+/// Minimal stub — replace HTTP calls with your real API.
+final class MyVideoBackend: VideoGenerationBackend {
+
+    private var pollTask: Task<Void, Never>?
+
+    /// Submits the job and begins polling. Throws on auth / rate-limit / network
+    /// errors before the stream starts.
+    func generate(
+        prompt: String,
+        config: VideoGenerationConfig
+    ) async throws -> AsyncThrowingStream<VideoGenerationEvent, Error> {
+        // 1. Submit to the cloud API. A real implementation would make an HTTP
+        //    POST and extract a job ID from the response.
+        let jobID = try await submitJob(prompt: prompt, config: config)
+
+        return AsyncThrowingStream { continuation in
+            // 2. Poll until done. The backend owns the poll loop; the runtime
+            //    calls `cancel()` to tear it down.
+            self.pollTask = Task.detached(priority: .userInitiated) {
+                do {
+                    continuation.yield(.queued)
+                    while true {
+                        try Task.checkCancellation()
+                        let status = try await self.pollStatus(jobID: jobID)
+                        switch status {
+                        case .queued:
+                            continuation.yield(.queued)
+                        case .generating(let fraction):
+                            continuation.yield(.generating(fractionComplete: fraction))
+                        case .done(let remoteURL):
+                            let localURL = try await self.download(from: remoteURL)
+                            continuation.yield(.completed(localURL))
+                            continuation.finish()
+                            return
+                        }
+                        try await Task.sleep(for: .seconds(2))
+                    }
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { [weak self] _ in
+                self?.pollTask?.cancel()
+            }
+        }
+    }
+
+    func cancel() async {
+        pollTask?.cancel()
+        await pollTask?.value
+    }
+
+    // MARK: - Stubs (replace with real HTTP)
+    private func submitJob(prompt: String, config: VideoGenerationConfig) async throws -> String { "job-123" }
+    private enum StatusResult { case queued, generating(Double), done(URL) }
+    private func pollStatus(jobID: String) async throws -> StatusResult { .done(FileManager.default.temporaryDirectory.appendingPathComponent("out.mp4")) }
+    private func download(from url: URL) async throws -> URL { url }
+}
+```
+
+For cloud backends that ride `SSECloudBackend` (OpenAI-compatible endpoints,
+Anthropic), use the `configure(baseURL:tokenProvider:modelName:)` overload on
+the concrete subclass instead of writing a custom `VideoGenerationBackend`
+conformer — the SSE envelope handles polling and retries for you.
+
+---
+
+## 3. Wire via `ManifoldBootstrap`
+
+Pass your backend to `VideoGenerationService`, then hand the service to
+`ManifoldBootstrap`. The bootstrap constructs `VideoGenerationRuntime`
+automatically and exposes it via `bootstrap.videoGenerationRuntime`.
+
+```swift,no-build
+import ManifoldKit
+import ManifoldInference
+
+let backend = MyVideoBackend()
+let videoService = VideoGenerationService(backend: backend)
+
+let config = ManifoldConfiguration(bundleIdentifier: "com.example.MyVideoApp")
+let bootstrap = try ManifoldBootstrap(
+    configuration: config,
+    videoGenerationService: videoService
+)
+```
+
+---
+
+## 4. Configure `ChatViewModel`
+
+`ManifoldBootstrap` pre-wires the runtime but does not install it on
+`ChatViewModel` automatically. Call `configure(videoRuntime:)` after
+constructing the view model (or use `ManifoldKit.quickStart()` which does
+this via `RuntimeConfiguration`):
+
+```swift,no-build
+// If you're using the full bootstrap:
+if let videoRuntime = bootstrap.videoGenerationRuntime {
+    chatViewModel.configure(videoRuntime: videoRuntime)
+}
+```
+
+After this call `chatViewModel.videoRuntime` is non-nil and
+`chatViewModel.videoGenerationProgress` starts populating as generations
+progress.
+
+---
+
+## 5. Trigger generation and observe progress
+
+```swift,no-build
+import SwiftUI
+import ManifoldUI
+import ManifoldInference
+
+@MainActor
+func requestVideo(viewModel: ChatViewModel) async throws {
+    let config = VideoGenerationConfig(
+        duration: 5,                                          // seconds
+        aspectRatio: VideoGenerationConfig.AspectRatio.landscape, // "16:9"
+        width: nil,                                           // nil → backend default
+        height: nil
+    )
+
+    // `generateVideo` returns after the backend accepts the submission.
+    // Progress events arrive asynchronously through `videoGenerationProgress`.
+    try await viewModel.generateVideo(
+        prompt: "a sun rising over misty mountains, cinematic, 4K",
+        config: config
+    )
+}
+```
+
+Observe progress in a SwiftUI view by reading
+`chatViewModel.videoGenerationProgress`, a `[UUID: VideoGenerationProgress]`
+dictionary keyed by the placeholder message ID emitted when generation starts:
+
+```swift,no-build
+struct VideoProgressIndicator: View {
+    @Environment(ChatViewModel.self) var viewModel
+
+    var body: some View {
+        ForEach(viewModel.videoGenerationProgress.values.sorted(by: { $0.prompt < $1.prompt }), id: \.messageID) { progress in
+            ProgressView(
+                progress.prompt,
+                value: progress.fractionComplete,
+                total: 1.0
+            )
+        }
+    }
+}
+```
+
+---
+
+## 6. Complete runnable example
+
+Below is a self-contained CLI-style harness. Swap `MyVideoBackend` for a real
+implementation and run it from any Swift target.
+
+```swift,no-build
+import Foundation
+import ManifoldInference
+
+@main
+struct VideoGen {
+    static func main() async throws {
+        let backend = MyVideoBackend()
+        let service = VideoGenerationService(backend: backend)
+
+        // `generate` submits the job and begins polling.
+        let config = VideoGenerationConfig(
+            duration: 5,
+            aspectRatio: VideoGenerationConfig.AspectRatio.landscape
+        )
+        let stream = try await service.generate(
+            prompt: "a red fox bounding through a snowy forest",
+            config: config
+        )
+
+        // Iterate the stream. The terminal `.completed(url)` event carries
+        // a local file URL. The file is fully written before the event is yielded.
+        for try await event in stream {
+            switch event {
+            case .queued:
+                print("queued — waiting for backend to start generation")
+            case .generating(let fraction):
+                let pct = Int(fraction * 100)
+                print("generating … \(pct)%")
+            case .completed(let url):
+                print("done: \(url.path)")
+            }
+        }
+    }
+}
+```
+
+---
+
+## `VideoGenerationConfig` reference
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `duration` | `Int` | `5` | Duration in seconds. Backend enforces min/max. |
+| `aspectRatio` | `String` | `"16:9"` | Use `AspectRatio` constants or any string your backend accepts. |
+| `width` | `Int?` | `nil` | Explicit pixel width. `nil` → backend default. |
+| `height` | `Int?` | `nil` | Explicit pixel height. `nil` → backend default. |
+| `sourceImageURL` | `URL?` | `nil` | Local file URL for image-to-video mode. |
+
+`AspectRatio` constants: `landscape` (`"16:9"`), `portrait` (`"9:16"`),
+`square` (`"1:1"`), `wide` (`"4:3"`), `tall` (`"3:4"`).
+
+---
+
+## `VideoGenerationEvent` reference
+
+| Case | When |
+|---|---|
+| `.queued` | Request accepted; backend has not started generating yet. |
+| `.generating(fractionComplete:)` | In progress. `fractionComplete` is 0.0–1.0; clamp before display. |
+| `.completed(URL)` | Finished. `URL` is a local file URL; the file is fully written. |
+
+If download fails after the cloud generation completes, the stream terminates
+with a thrown error instead of emitting `.completed`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `VideoGenerationServiceError.alreadyGenerating` | A generation is still in flight. Await or cancel the current generation before starting a new one. |
+| `generateVideo` throws `.notConfigured` | `configure(videoRuntime:)` was not called on `ChatViewModel`. See §4. |
+| Stream finishes without `.completed` and without throwing | The generation was cancelled (task cancellation or `cancel(messageID:)` from the runtime). |
+| Backend hangs at `.queued` indefinitely | The poll interval may be too short for your quota tier, or the backend is rate-limiting. Implement exponential backoff in your poll loop. |


### PR DESCRIPTION
## Summary

Fixes five documentation gaps identified in the ManifoldKit public surface:

- **Gap 1 — README "Beyond chat"**: Added a video generation bullet alongside image generation, with a concise wiring snippet (`VideoGenerationService`, `ManifoldBootstrap`, `generateVideo(prompt:config:)`) and a link to the new quickstart.

- **Gap 2 — `docs/QUICKSTART-VIDEO-GEN.md`** (new): End-to-end video generation guide modelled on `QUICKSTART-IMAGE-GEN.md`. Covers `VideoGenerationBackend` protocol implementation, `VideoGenerationService` construction, `ManifoldBootstrap` wiring, `ChatViewModel.configure(videoRuntime:)`, SwiftUI progress observation, and a complete runnable example. Includes `VideoGenerationConfig` and `VideoGenerationEvent` reference tables.

- **Gap 3 — `GenerationComponents.md`**: Added `GenerativeContextMenuItems` section explaining the four conditional menu items (Generate Image, Generate Video, Remix Image, Animate as Video), how item visibility depends on installed runtimes, and how to pass it to `ChatView` via the `contextMenuItems` closure. Based on reading `GenerativeContextMenuItems.swift` directly.

- **Gap 4 — `docs/CLOUD-OAUTH.md`** (new): Guide for `TokenProvider` (added in #1541). Covers when to use it vs static API keys, implementing the protocol (actor-based and struct-based examples, server-proxy pattern), wiring via `SSECloudBackend.configure(baseURL:tokenProvider:modelName:)` with `ClaudeBackend`, thread safety requirements, and the relationship to Keychain-backed configuration. Sourced from `TokenProvider.swift` and `SSECloudBackend.swift`.

- **Gap 5 — `docs/QUICKSTART-IMAGE-GEN.md`**: Added 2-line comment block immediately after the `ImageGenerationConfig(...)` construction showing `aspectRatio: "16:9"` as an optional parameter for cloud backends. Confirmed field name and type from `ImageGenerationConfig.swift`.

## Test plan

- [ ] Read through each new/modified doc and verify all type names, field names, and method signatures match the source files
- [ ] Confirm `docs/QUICKSTART-VIDEO-GEN.md` links correctly from `README.md`
- [ ] Confirm `docs/CLOUD-OAUTH.md` references the correct `configure(baseURL:tokenProvider:modelName:)` overload signature
- [ ] Confirm `GenerationComponents.md` section matches the four items visible in `GenerativeContextMenuItems.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)