### PR TITLE
feat(ui): ChatExporter — export chat sessions to Markdown

### DIFF
--- a/Sources/ManifoldRuntime/Services/ChatExportService.swift
+++ b/Sources/ManifoldRuntime/Services/ChatExportService.swift
@@ -14,6 +14,14 @@ public enum ExportFormat: String, CaseIterable, Identifiable {
         case .markdown: "md"
         }
     }
+
+    /// The UTI MIME type for the format, suitable for `ShareLink` preview metadata.
+    public var mimeType: String {
+        switch self {
+        case .plainText: "text/plain"
+        case .markdown: "text/markdown"
+        }
+    }
 }
 
 /// Exports chat messages to plain text or markdown format.


### PR DESCRIPTION
Re-lands PR #1550 which was accidentally closed without merging.

## Changes

- `Sources/ManifoldUI/Utilities/ChatExporter.swift` — public `enum ChatExporter` with `string(title:messages:format:)` and `exportFile(title:messages:format:)` using `ManifoldInference.ChatMessageRecord`. Already on `main` via direct commit; this PR formally tracks it.
- `Sources/ManifoldRuntime/Services/ChatExportService.swift` — adds `mimeType` property to `ExportFormat` for `ShareLink` preview metadata (`text/plain` / `text/markdown`).

## Test plan

- [ ] `swift build` in ManifoldKit passes clean
- [ ] grok-app `xcodebuild` passes — `AppRootView.exportChat` compiles against `ChatExporter.exportFile`
- [ ] Export Chat button in grok-app produces a shareable `.md` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)