### PR TITLE
feat(runtime): Glass Box P0 — multicast event tap, ConversationEventRecorder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -431,7 +431,11 @@ let package = Package(
         // UI: SwiftUI views and view models — depends on runtime ports, not persistence adapters.
         .target(
             name: "ManifoldUI",
-            dependencies: ["ManifoldRuntime", "ManifoldInference"],
+            dependencies: [
+                "ManifoldRuntime",
+                "ManifoldInference",
+                .target(name: "ManifoldCloudCore", condition: .when(traits: ["CloudSaaS"])),
+            ],
             path: "Sources/ManifoldUI",
             swiftSettings: [
                 .define("Ollama", .when(traits: ["Ollama"])),

--- a/Sources/ManifoldUI/Tools/WebSearchToolSource.swift
+++ b/Sources/ManifoldUI/Tools/WebSearchToolSource.swift
@@ -1,8 +1,11 @@
 import Foundation
 import ManifoldRuntime
 import ManifoldInference
+#if CloudSaaS
 import ManifoldCloudCore
+#endif
 
+#if CloudSaaS
 /// SessionToolSource that exposes a `search_web` tool backed by a live
 /// search-enabled chat completion endpoint.
 ///
@@ -69,3 +72,4 @@ public final class WebSearchToolSource: SessionToolSource {
         return ToolResult(callId: toolName, content: content)
     }
 }
+#endif


### PR DESCRIPTION
Closes #1531 (Glass Box P0).

## Summary

- **`EventTapRegistry`** — internal `Mutex`-guarded continuation map; `broadcast` snapshots under lock then yields outside (yield-outside-lock invariant prevents re-entrant deadlock from `onTermination` callbacks).
- **`ConversationRuntime.addEventTap(bufferingPolicy:)`** — public multicast tap API; each returned `AsyncStream` receives every event the primary `events` stream sees, independently, without starvation risk.
- **`ConversationEventRecorder`** — public `actor` that wraps a tap and accumulates events into `trace: [ConversationEvent]`; designed for tests and diagnostic tooling.
- **Tests** — `ConversationEventTapTests` (5 tests covering full trace, multi-tap, mid-turn install, deregister-on-cancel, finish-on-teardown) + `ConversationEventRecorderTests` (2 tests covering single and dual recorder scenarios). All use `MockInferenceBackend` and in-memory stores; no SwiftData.
- **DocC** — `ObservingATurn.md` article covering when to use taps vs primary stream, install pattern, `ConversationEventRecorder` usage, backpressure tradeoff, and the yield-outside-lock re-entrancy rule. Registered in `ManifoldRuntime.md` Topics.

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` — confirms clean compile
- [ ] `swift test --disable-default-traits --filter ConversationEventTap` — all 5 tests pass
- [ ] `swift test --disable-default-traits --filter ConversationEventRecorder` — all 2 tests pass
- [ ] CI green across the full default-traits suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)