### PR TITLE
feat(runtime): Glass Box P0 — multicast event tap, ConversationEventRecorder

### DIFF
--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/ObservingATurn.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/ObservingATurn.md
@@ -1,0 +1,90 @@
+# Observing a Turn
+
+Subscribe to the live event flow from a `ConversationRuntime` without competing with the primary consumer.
+
+## When to use
+
+Every ``ConversationRuntime`` exposes a primary ``ConversationRuntime/events`` stream that delivers the full ``ConversationEvent`` sequence for every turn. That stream is **single-consumer by design** — when two tasks iterate it concurrently, only one sees each event. Common adapters such as `ChatViewModel` own the primary stream and drain it continuously on a long-lived task.
+
+Use ``ConversationRuntime/addEventTap(bufferingPolicy:)`` when you need a **second independent view** of the same event flow:
+
+- Diagnostic tooling or loggers that must not interfere with the primary adapter.
+- Test assertions that observe the live event sequence alongside a UI adapter.
+- Analytics or telemetry sinks that need every token delta without risk of starving the main consumer.
+- Concurrent feature code (e.g. a summarisation sidekick) that watches the turn stream without owning it.
+
+For single-consumer flows where `events` is not already taken — bare scripts, lightweight CLIs, one-off utilities — iterating `events` directly is simpler.
+
+## Installing a tap
+
+`addEventTap` returns an `AsyncStream<ConversationEvent>` that begins delivering events immediately. Install it before driving the turn you want to observe, then drain it on a `Task`:
+
+```swift,no-build
+import ManifoldRuntime
+
+let tap = runtime.addEventTap()
+
+Task {
+    for await event in tap {
+        switch event {
+        case let .tokenEmitted(_, delta):
+            print("delta:", delta)
+        case let .streamFinished(_, reason):
+            print("finished:", reason)
+            break
+        default:
+            break
+        }
+    }
+}
+
+try await runtime.processTurn(input)
+```
+
+The tap stream finishes normally when the runtime terminates. You do not need to explicitly remove it — when the iterating `Task` is cancelled or goes out of scope the stream's `onTermination` handler automatically deregisters the tap from the registry.
+
+## Using ConversationEventRecorder
+
+For the common testing pattern of "capture everything, then assert", ``ConversationEventRecorder`` wraps a tap and accumulates the full event array:
+
+```swift,no-build
+import ManifoldRuntime
+
+let recorder = ConversationEventRecorder()
+let drainTask = await recorder.start(on: runtime)
+
+let turn = try await runtime.processTurnWithOutcome(input)
+await turn?.outcome          // wait for turn to complete
+
+drainTask.cancel()
+await drainTask.value        // let recorder observe the final streamFinished
+
+let trace = await recorder.trace
+let tokens = trace.compactMap { event -> String? in
+    guard case let .tokenEmitted(_, delta) = event else { return nil }
+    return delta
+}.joined()
+print(tokens)
+```
+
+`ConversationEventRecorder` is an `actor`, so `trace` is safe to read from any isolation context.
+
+## Backpressure tradeoff
+
+The default buffering policy for taps is `.unbounded`, which means events accumulate in memory if the consumer lags. This eliminates any risk of the tap consumer blocking the turn loop or missing events during a burst.
+
+Pass a bounded policy when you need explicit backpressure semantics — for example, a tap consumer that writes to disk and must cap memory usage:
+
+```swift,no-build
+let tap = runtime.addEventTap(bufferingPolicy: .bufferingNewest(200))
+```
+
+Bounded taps drop events when the consumer falls behind. The primary ``ConversationRuntime/events`` stream uses `.bufferingOldest(500)` — a different policy — so a slow bounded tap does not affect it.
+
+## Re-entrancy rule (yield-outside-lock)
+
+If you implement a custom continuation-based observer, be aware of the **yield-outside-lock invariant** that ``EventTapRegistry`` maintains:
+
+The registry's `broadcast` method snapshots registered continuations under a `Mutex` lock, releases the lock, and only then calls `yield` on each continuation. This ordering is required because `AsyncStream.Continuation.onTermination` fires synchronously on the thread that detects cancellation, which calls back into the registry to deregister. Calling `yield` while the lock is held would cause a re-entrant deadlock in that path.
+
+Custom wrappers that layer additional synchronisation around a tap continuation must respect the same contract: never call `yield` or `finish` while holding a lock that the `onTermination` handler also tries to acquire.

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
@@ -150,11 +150,13 @@ try await endpointStore.insertEndpoint(
 
 - <doc:AgentHandoffs>
 - <doc:HookSystem>
+- <doc:ObservingATurn>
 
 ### Conversation runtime
 
 - ``ConversationRuntime``
 - ``ConversationEvent``
+- ``ConversationEventRecorder``
 - ``ConversationStreamHandle``
 - ``ConversationTurnHandle``
 - ``ConversationTurnOutcome``

--- a/Sources/ManifoldRuntime/Services/ConversationEventRecorder.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationEventRecorder.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// MARK: - ConversationEventRecorder
+
+/// Records the full ``ConversationEvent`` trace from a ``ConversationRuntime``
+/// tap into an in-memory array.
+///
+/// Use `ConversationEventRecorder` in tests and diagnostic tooling to capture
+/// and inspect the structured trace of a turn without writing a custom drain loop.
+///
+/// ```swift,no-build
+/// let recorder = ConversationEventRecorder()
+/// let drainTask = await recorder.start(on: runtime)
+///
+/// let turn = try await runtime.processTurnWithOutcome(input)
+/// await turn?.outcome   // wait for turn to complete
+///
+/// await drainTask.value // let recorder observe the streamFinished event
+/// let trace = await recorder.trace
+/// ```
+public actor ConversationEventRecorder {
+
+    /// The events recorded so far, in delivery order.
+    public private(set) var trace: [ConversationEvent] = []
+
+    public init() {}
+
+    /// Installs a tap on `runtime` and begins recording events into ``trace``.
+    ///
+    /// Returns a `Task` that drains the tap until the runtime terminates or the
+    /// task is cancelled. Await `task.value` after a turn completes to ensure
+    /// the final `streamFinished` event is captured before reading ``trace``.
+    @discardableResult
+    public func start(on runtime: ConversationRuntime) -> Task<Void, Never> {
+        let tap = runtime.addEventTap()
+        return Task { [weak self] in
+            for await event in tap {
+                await self?.append(event)
+            }
+        }
+    }
+
+    private func append(_ event: ConversationEvent) {
+        trace.append(event)
+    }
+}

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -96,8 +96,18 @@ public final class ConversationRuntime: Sendable {
     /// during a long generation). Await
     /// ``processTurnWithOutcome(_:)``'s ``ConversationTurnHandle/outcome`` when
     /// command-style turn completion must be reliable.
+    ///
+    /// For multi-consumer observation, use ``addEventTap(bufferingPolicy:)``
+    /// to install additional independent streams that each receive the full
+    /// event flow without competing with this consumer.
     public let events: AsyncStream<ConversationEvent>
     private let continuation: AsyncStream<ConversationEvent>.Continuation
+
+    /// Fan-out registry for secondary event consumers installed via
+    /// ``addEventTap(bufferingPolicy:)``. Separate from the primary
+    /// ``continuation`` so the primary stream's `.bufferingOldest(500)` policy
+    /// does not affect tap consumers, and a slow tap cannot stall the turn loop.
+    private let eventTaps = EventTapRegistry()
 
     // MARK: In-flight state
 
@@ -272,7 +282,10 @@ public final class ConversationRuntime: Sendable {
             ragService: ragService,
             usageStore: usageStore,
             registry: registry,
-            emit: { continuation.yield($0) },
+            emit: { [eventTaps] event in
+                continuation.yield(event)
+                eventTaps.broadcast(event)
+            },
             emptyResponseObserver: emptyResponseObserver,
             generationHooks: generationHooks,
             compressionPolicy: compressionPolicy,
@@ -321,6 +334,7 @@ public final class ConversationRuntime: Sendable {
             }
         }
         continuation.finish()
+        eventTaps.finishAll()
     }
 
     package var activeTurnTaskCount: Int {
@@ -424,6 +438,31 @@ public final class ConversationRuntime: Sendable {
         turnTasks.cancel(handle)
         guard let token else { return }
         await inferenceService.cancelAsync(token)
+    }
+
+    // MARK: Secondary event taps
+
+    /// Installs a secondary multicast tap on this runtime's event flow.
+    ///
+    /// The returned stream receives every ``ConversationEvent`` the primary
+    /// ``events`` stream sees. The tap is independent of the primary consumer —
+    /// installing one does not starve ``events``, and a slow tap does not stall
+    /// the turn loop.
+    ///
+    /// - Parameter bufferingPolicy: Controls what happens when the tap consumer
+    ///   falls behind. Defaults to `.unbounded` so no events are dropped; pass a
+    ///   bounded policy if you need backpressure semantics.
+    /// - Returns: An `AsyncStream` that delivers events until the runtime
+    ///   terminates, at which point the stream finishes normally.
+    public func addEventTap(
+        bufferingPolicy: AsyncStream<ConversationEvent>.Continuation.BufferingPolicy = .unbounded
+    ) -> AsyncStream<ConversationEvent> {
+        AsyncStream(bufferingPolicy: bufferingPolicy) { [eventTaps] continuation in
+            let id = eventTaps.register(continuation)
+            continuation.onTermination = { _ in
+                eventTaps.deregister(id)
+            }
+        }
     }
 
     // MARK: Legacy command surface (deprecated)

--- a/Sources/ManifoldRuntime/Services/EventTapRegistry.swift
+++ b/Sources/ManifoldRuntime/Services/EventTapRegistry.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Synchronization
+
+// MARK: - EventTapRegistry
+
+/// Maintains a mutable collection of AsyncStream continuations and fans out
+/// each ``ConversationEvent`` to every registered consumer.
+///
+/// ### Yield-outside-lock invariant
+///
+/// `broadcast` snapshots the continuation map under the lock, releases the
+/// lock, and *then* calls `yield` on each continuation. This is a correctness
+/// requirement, not a performance hint: `AsyncStream.Continuation.onTermination`
+/// calls back synchronously on the thread that detects stream cancellation,
+/// which re-enters `deregister`. If `yield` were called while the lock is held
+/// the re-entrant `deregister` would deadlock.
+final class EventTapRegistry: Sendable {
+    private let taps = Mutex<[UUID: AsyncStream<ConversationEvent>.Continuation]>([:])
+
+    /// Adds a continuation to the fan-out set and returns the opaque token
+    /// needed to remove it later via ``deregister(_:)``.
+    func register(_ continuation: AsyncStream<ConversationEvent>.Continuation) -> UUID {
+        let id = UUID()
+        taps.withLock { $0[id] = continuation }
+        return id
+    }
+
+    /// Removes the continuation identified by `id` from the fan-out set.
+    /// Safe to call from any thread, including from inside a continuation's
+    /// `onTermination` handler (see yield-outside-lock invariant above).
+    func deregister(_ id: UUID) {
+        taps.withLock { _ = $0.removeValue(forKey: id) }
+    }
+
+    /// Delivers `event` to every registered continuation.
+    ///
+    /// Continuations are snapshotted under the lock and then yielded to
+    /// outside the lock. See the yield-outside-lock invariant for why this
+    /// ordering matters.
+    func broadcast(_ event: ConversationEvent) {
+        let snapshot = taps.withLock { Array($0.values) }
+        for continuation in snapshot {
+            continuation.yield(event)
+        }
+    }
+
+    /// Calls `finish()` on every registered continuation and removes them all
+    /// from the registry. Subsequent `broadcast` calls are no-ops.
+    ///
+    /// Continuations are snapshotted and cleared under the lock, then finished
+    /// outside it — same ordering invariant as ``broadcast(_:)``.
+    func finishAll() {
+        let snapshot = taps.withLock { existing -> [AsyncStream<ConversationEvent>.Continuation] in
+            let values = Array(existing.values)
+            existing.removeAll()
+            return values
+        }
+        for continuation in snapshot {
+            continuation.finish()
+        }
+    }
+}

--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
@@ -125,7 +125,7 @@ configuration is required beyond wiring the runtimes.
 
 `SpotlightIndexer` indexes chat sessions in iOS/macOS Core Spotlight so users can find and open conversations from system search:
 
-```swift
+```swift,no-build
 // After loading sessions:
 await SpotlightIndexer.index(sessions: kit.sessionManager.sessions)
 

--- a/Tests/ManifoldRuntimeTests/ConversationEventRecorderTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationEventRecorderTests.swift
@@ -1,0 +1,179 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - ConversationEventRecorderTests
+
+/// Coverage for ``ConversationEventRecorder``.
+///
+/// Verifies that the recorder captures a full turn trace and that multiple
+/// independent recorders on the same runtime each see the complete event
+/// sequence without interference.
+@MainActor
+final class ConversationEventRecorderTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    private final class RecorderMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+    }
+
+    // MARK: - Fixture factory
+
+    private func makeRuntime(
+        tokens: [String] = ["Hi", " there"]
+    ) -> (runtime: ConversationRuntime, mock: MockInferenceBackend) {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = tokens
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let store = RecorderMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        return (runtime, mock)
+    }
+
+    // MARK: - Tests
+
+    /// A recorder started before a turn captures the full trace including
+    /// `streamStarted`, token deltas, and `streamFinished`.
+    func test_recorder_capturesFullTrace() async throws {
+        let (runtime, _) = makeRuntime(tokens: ["Hello", " recorder"])
+
+        // Drain primary stream.
+        let primaryTask = Task { [weak runtime] in
+            guard let runtime else { return }
+            for await _ in runtime.events {}
+        }
+        defer { primaryTask.cancel() }
+
+        let recorder = ConversationEventRecorder()
+        let drainTask = await recorder.start(on: runtime)
+
+        let turn = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "go"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        let outcome = await turn?.outcome
+        XCTAssertEqual(outcome?.reason, .stop)
+        let messageID = try XCTUnwrap(outcome?.assistantMessageID)
+
+        // Await the drain task to ensure streamFinished is captured.
+        drainTask.cancel()
+        _ = await drainTask.value
+
+        let trace = await recorder.trace
+
+        // Must contain streamStarted for this turn.
+        let sawStart = trace.contains {
+            if case let .streamStarted(id) = $0 { return id == messageID }
+            return false
+        }
+        XCTAssertTrue(sawStart, "recorder must capture streamStarted")
+
+        // Must contain at least one tokenEmitted.
+        let tokenCount = trace.filter {
+            if case let .tokenEmitted(id, _) = $0 { return id == messageID }
+            return false
+        }.count
+        XCTAssertGreaterThan(tokenCount, 0, "recorder must capture token deltas")
+
+        // Must contain streamFinished.
+        let sawFinish = trace.contains {
+            if case let .streamFinished(id, _) = $0 { return id == messageID }
+            return false
+        }
+        XCTAssertTrue(sawFinish, "recorder must capture streamFinished")
+
+        // Reassembled text must match scripted output.
+        let text = trace.compactMap { event -> String? in
+            guard case let .tokenEmitted(id, delta) = event, id == messageID else { return nil }
+            return delta
+        }.joined()
+        XCTAssertEqual(text, "Hello recorder", "recorder must reassemble the full streamed text")
+    }
+
+    /// Two independent recorders on the same runtime both capture the full event
+    /// sequence without interfering with each other.
+    func test_recorder_multipleRecorders() async throws {
+        let (runtime, _) = makeRuntime(tokens: ["multi", "cast"])
+
+        // Drain primary stream.
+        let primaryTask = Task { [weak runtime] in
+            guard let runtime else { return }
+            for await _ in runtime.events {}
+        }
+        defer { primaryTask.cancel() }
+
+        let recorder1 = ConversationEventRecorder()
+        let recorder2 = ConversationEventRecorder()
+
+        let drain1 = await recorder1.start(on: runtime)
+        let drain2 = await recorder2.start(on: runtime)
+
+        let turn = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "ping"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        let outcome = await turn?.outcome
+        XCTAssertEqual(outcome?.reason, .stop)
+        let messageID = try XCTUnwrap(outcome?.assistantMessageID)
+
+        // Give both drain tasks time to observe streamFinished.
+        drain1.cancel()
+        drain2.cancel()
+        _ = await drain1.value
+        _ = await drain2.value
+
+        let trace1 = await recorder1.trace
+        let trace2 = await recorder2.trace
+
+        func tokenText(from trace: [ConversationEvent], id: UUID) -> String {
+            trace.compactMap { event -> String? in
+                guard case let .tokenEmitted(eID, delta) = event, eID == id else { return nil }
+                return delta
+            }.joined()
+        }
+
+        let text1 = tokenText(from: trace1, id: messageID)
+        let text2 = tokenText(from: trace2, id: messageID)
+        XCTAssertEqual(text1, "multicast", "recorder1 must capture full token stream")
+        XCTAssertEqual(text2, "multicast", "recorder2 must capture the same token stream independently")
+
+        // Both recorders must see streamFinished.
+        let finish1 = trace1.contains { if case .streamFinished = $0 { return true }; return false }
+        let finish2 = trace2.contains { if case .streamFinished = $0 { return true }; return false }
+        XCTAssertTrue(finish1, "recorder1 must observe streamFinished")
+        XCTAssertTrue(finish2, "recorder2 must observe streamFinished")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationEventTapTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationEventTapTests.swift
@@ -1,0 +1,367 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - ConversationEventTapTests
+
+/// Integration coverage for the multicast event tap on ``ConversationRuntime``.
+///
+/// A tap installed via ``ConversationRuntime/addEventTap(bufferingPolicy:)``
+/// receives the full turn transcript independently of the primary ``events``
+/// consumer.
+@MainActor
+final class ConversationEventTapTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    private final class TapMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessageRecord] = [:]
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            messages[message.id] = message
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+    }
+
+    // MARK: - Drain helper
+
+    /// Drains `stream` until a ``ConversationEvent/streamFinished`` event arrives
+    /// or the `deadline` elapses. Returns the full captured transcript.
+    private func drain(
+        _ stream: AsyncStream<ConversationEvent>,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [ConversationEvent] {
+        let task = Task {
+            var collected: [ConversationEvent] = []
+            for await event in stream {
+                collected.append(event)
+                if case .streamFinished = event { break }
+            }
+            return collected
+        }
+        return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw NSError(domain: "ConversationEventTapTests", code: 1,
+                              userInfo: [NSLocalizedDescriptionKey: "deadline elapsed waiting for streamFinished"])
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    // MARK: - Fixture factory
+
+    private func makeRuntime(
+        tokens: [String] = ["Hello", " world"]
+    ) -> (runtime: ConversationRuntime, mock: MockInferenceBackend) {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = tokens
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let store = TapMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        return (runtime, mock)
+    }
+
+    private func sendTurn(
+        on runtime: ConversationRuntime,
+        text: String = "hi"
+    ) async throws -> ConversationTurnHandle? {
+        let sessionID = UUID()
+        return try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: text),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+    }
+
+    // MARK: - Tests
+
+    /// A tap installed before a turn sees `.streamStarted`, token deltas, and
+    /// `.streamFinished`. The primary `events` stream is not starved.
+    func test_tap_seesFullTurnTrace() async throws {
+        let (runtime, _) = makeRuntime(tokens: ["Hel", "lo", " world"])
+
+        let tapStream = runtime.addEventTap()
+        let tapDrainTask = Task { try await self.drain(tapStream) }
+        let primaryDrainTask = Task { try await self.drain(runtime.events) }
+
+        let turn = try await sendTurn(on: runtime)
+        let outcome = await turn?.outcome
+        XCTAssertEqual(outcome?.reason, .stop)
+        let messageID = try XCTUnwrap(outcome?.assistantMessageID)
+
+        let tapTrace = try await tapDrainTask.value
+        let primaryTrace = try await primaryDrainTask.value
+
+        // Tap must contain the structural subsequence: started < tokens < finished.
+        let startIdx = tapTrace.firstIndex {
+            if case let .streamStarted(id) = $0 { return id == messageID }
+            return false
+        }
+        let finishIdx = tapTrace.firstIndex {
+            if case let .streamFinished(id, _) = $0 { return id == messageID }
+            return false
+        }
+        let tokenIdxs = tapTrace.indices.filter {
+            if case let .tokenEmitted(id, _) = tapTrace[$0] { return id == messageID }
+            return false
+        }
+
+        let started = try XCTUnwrap(startIdx, "tap must observe streamStarted")
+        let finished = try XCTUnwrap(finishIdx, "tap must observe streamFinished")
+        XCTAssertFalse(tokenIdxs.isEmpty, "tap must observe at least one tokenEmitted")
+        XCTAssertLessThan(started, tokenIdxs.first!, "streamStarted must precede first tokenEmitted in tap")
+        XCTAssertLessThan(tokenIdxs.last!, finished, "last tokenEmitted must precede streamFinished in tap")
+
+        // Reassembled text must match the scripted output.
+        let tapText = tapTrace.compactMap { event -> String? in
+            guard case let .tokenEmitted(id, delta) = event, id == messageID else { return nil }
+            return delta
+        }.joined()
+        XCTAssertEqual(tapText, "Hello world", "tap must reassemble the full streamed text")
+
+        // Primary stream must not be starved.
+        let primarySawStart = primaryTrace.contains {
+            if case let .streamStarted(id) = $0 { return id == messageID }
+            return false
+        }
+        let primarySawFinish = primaryTrace.contains {
+            if case let .streamFinished(id, _) = $0 { return id == messageID }
+            return false
+        }
+        XCTAssertTrue(primarySawStart, "primary events stream must observe streamStarted")
+        XCTAssertTrue(primarySawFinish, "primary events stream must observe streamFinished")
+    }
+
+    /// Two taps installed before a turn each independently receive every event.
+    func test_multipleTaps_eachReceiveAllEvents() async throws {
+        let (runtime, _) = makeRuntime(tokens: ["tok1", "tok2"])
+
+        let tap1 = runtime.addEventTap()
+        let tap2 = runtime.addEventTap()
+
+        let drainTask1 = Task { try await self.drain(tap1) }
+        let drainTask2 = Task { try await self.drain(tap2) }
+        // Keep the primary stream drained so it doesn't interfere.
+        let primaryTask = Task { try await self.drain(runtime.events) }
+
+        let turn = try await sendTurn(on: runtime)
+        let outcome = await turn?.outcome
+        let messageID = try XCTUnwrap(outcome?.assistantMessageID)
+
+        let trace1 = try await drainTask1.value
+        let trace2 = try await drainTask2.value
+        primaryTask.cancel()
+
+        // Both taps must see identical token content.
+        func tokens(in trace: [ConversationEvent], id: UUID) -> [String] {
+            trace.compactMap { event -> String? in
+                guard case let .tokenEmitted(eID, delta) = event, eID == id else { return nil }
+                return delta
+            }
+        }
+
+        let tokens1 = tokens(in: trace1, id: messageID)
+        let tokens2 = tokens(in: trace2, id: messageID)
+        XCTAssertFalse(tokens1.isEmpty, "tap1 must capture tokens")
+        XCTAssertEqual(tokens1, tokens2, "both taps must see the same token sequence")
+
+        // Both taps must see streamFinished.
+        XCTAssertTrue(trace1.contains { if case .streamFinished = $0 { return true }; return false },
+                      "tap1 must observe streamFinished")
+        XCTAssertTrue(trace2.contains { if case .streamFinished = $0 { return true }; return false },
+                      "tap2 must observe streamFinished")
+    }
+
+    /// A tap installed after the turn has already started still receives the
+    /// remaining events for that turn (tail observation).
+    func test_tap_installedAfterTurnStart_seesRemainingEvents() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        // Use a gate so we can insert the tap between tokens.
+        let gate = TokenEmissionGate()
+        mock.tokenEmissionGate = gate
+        mock.tokensToYield = ["early", "late"]
+        let inference = InferenceService(backend: mock, name: "Mock")
+        let store = TapMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+
+        // Drain the primary stream to prevent it from blocking broadcast.
+        let primaryTask = Task { [weak runtime] in
+            guard let runtime else { return }
+            for await _ in runtime.events {}
+        }
+        defer { primaryTask.cancel() }
+
+        // Start the turn, release only the first token.
+        let sessionID = UUID()
+        let turnTask = Task {
+            try await runtime.processTurnWithOutcome(TurnInput(
+                sessionID: sessionID,
+                kind: .send(text: "hello"),
+                config: TurnConfig(streamingBatchCharacterLimit: 1)
+            ))
+        }
+
+        // Release first token so generation is clearly underway.
+        await gate.advance()
+        // Small yield to let the event propagate.
+        await Task.yield()
+
+        // Install tap NOW (mid-turn).
+        let lateStream = runtime.addEventTap()
+        let lateTask = Task { try await self.drain(lateStream) }
+
+        // Release remaining token + allow stream to finish.
+        await gate.advance()
+        await gate.release()
+
+        let turn = try await turnTask.value
+        let _ = await turn?.outcome
+
+        let lateTrace = try await lateTask.value
+
+        // The late tap must have seen at least the streamFinished event.
+        let sawFinish = lateTrace.contains { if case .streamFinished = $0 { return true }; return false }
+        XCTAssertTrue(sawFinish, "late-installed tap must see at least streamFinished")
+    }
+
+    /// Cancelling the tap stream (allowing it to go out of scope / task cancel)
+    /// removes it from the registry so it does not leak.
+    func test_tap_deregistersOnCancel() async throws {
+        let (runtime, _) = makeRuntime()
+
+        // Drain the primary stream.
+        let primaryTask = Task { [weak runtime] in
+            guard let runtime else { return }
+            for await _ in runtime.events {}
+        }
+        defer { primaryTask.cancel() }
+
+        let tapStream = runtime.addEventTap()
+
+        // Install a drain task that we will cancel immediately.
+        let drainTask = Task {
+            for await _ in tapStream {}
+        }
+        drainTask.cancel()
+
+        // Allow the cancellation to propagate through the onTermination handler.
+        for _ in 0..<10 { await Task.yield() }
+
+        // Drive a turn — if the cancelled tap was leaked the registry would hold
+        // a dangling continuation that would receive broadcasts but never be read.
+        // We can only assert the tap task itself is no longer live; the registry
+        // deregistration is an implementation detail, so the observable contract
+        // is that the cancelled drain does not receive further events.
+        let turn = try await sendTurn(on: runtime)
+        let outcome = await turn?.outcome
+        XCTAssertEqual(outcome?.reason, .stop, "turn should complete normally after tap cancel")
+        // The cancelled task completes without blocking.
+        _ = await drainTask.value
+    }
+
+    /// After the runtime is deallocated (turn loop exits), all installed tap
+    /// streams finish normally.
+    func test_tap_finishesWhenRuntimeTeardown() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["one"]
+
+        var runtime: ConversationRuntime? = ConversationRuntime(
+            messageStore: TapMessageStore(),
+            inferenceService: InferenceService(backend: mock, name: "Mock")
+        )
+
+        let tapStream = runtime!.addEventTap()
+
+        // Collect events from the tap until it finishes.
+        let finishFlag = FinishFlag()
+        let drainTask = Task {
+            for await _ in tapStream {}
+            await finishFlag.signal()
+        }
+
+        // Drain primary stream to avoid blocking broadcasts.
+        let primaryTask = Task { [weak runtime] in
+            guard let runtime else { return }
+            for await _ in runtime.events {}
+        }
+        defer { primaryTask.cancel() }
+
+        // Run one turn.
+        let turn = try await runtime!.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "bye"),
+            config: TurnConfig()
+        ))
+        _ = await turn?.outcome
+
+        // Release the runtime — deinit fires and must finish all taps.
+        runtime = nil
+
+        let finished = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask { await finishFlag.wait(); return true }
+            group.addTask {
+                try await Task.sleep(for: .seconds(5))
+                throw NSError(domain: "ConversationEventTapTests", code: 2,
+                              userInfo: [NSLocalizedDescriptionKey: "tap did not finish after runtime teardown"])
+            }
+            let result = try await group.next()
+            group.cancelAll()
+            return result ?? false
+        }
+
+        XCTAssertTrue(finished, "tap stream must finish when runtime deallocates")
+        _ = drainTask
+    }
+
+    // MARK: - Private helpers
+
+    private actor FinishFlag {
+        private var isSet = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func signal() {
+            guard !isSet else { return }
+            isSet = true
+            let pending = waiters
+            waiters.removeAll()
+            for w in pending { w.resume() }
+        }
+
+        func wait() async {
+            if isSet { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+    }
+}


### PR DESCRIPTION
Implements Glass Box P0 from tracking issue #1531.

## Deliverables

- **`EventTapRegistry`** (`ManifoldRuntime`, internal) — `Mutex`-guarded continuation map; `broadcast` snapshots under lock then yields outside to prevent re-entrant deadlock from `onTermination` callbacks
- **`ConversationRuntime.addEventTap(bufferingPolicy:)`** (public) — installs a secondary multicast tap; independent of the primary `events` consumer, `.unbounded` by default so no events are dropped
- **`ConversationEventRecorder`** (public actor) — wraps a tap and accumulates the full event trace into `trace: [ConversationEvent]`; returns a drain `Task` callers `await` before reading the trace
- **`ConversationEventTapTests`** — 5 tests: full trace, multiple taps, mid-turn install, deregister on cancel, finish on teardown
- **`ConversationEventRecorderTests`** — 2 tests: full trace capture, two independent recorders
- **`ObservingATurn.md`** DocC article — when to use tap vs primary stream, install pattern, recorder usage, bounded/unbounded tradeoff, yield-outside-lock invariant

## Checklist

- [x] `swift build --build-tests --disable-default-traits` clean
- [x] `ConversationEventTapTests` pass
- [x] `ConversationEventRecorderTests` pass
- [x] No `try?` in production paths
- [x] `Package.resolved` not bumped

Closes part of #1531 (P0 complete; P1 trace format + `assertSubsequence` follows in v0.39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)