### PR TITLE
feat(runtime): Glass Box P1 — ConversationEventKind, JSONL trace, assertSubsequence

### DIFF
--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/ObservingATurn.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/ObservingATurn.md
@@ -69,6 +69,41 @@ print(tokens)
 
 `ConversationEventRecorder` is an `actor`, so `trace` is safe to read from any isolation context.
 
+## Saving a trace for debugging
+
+After draining a ``ConversationEventRecorder``, wrap the raw event array in a
+``ConversationEventTrace`` and call ``ConversationEventTrace/save(to:)`` to
+persist the turn as a JSONL file. Each line is a JSON object with three fields:
+`index` (0-based position), `kind` (the ``ConversationEventKind`` raw value),
+and `summary` (a human-readable one-liner derived from the event's associated
+values — the token delta for `.tokenEmitted`, the finish reason for
+`.streamFinished`, the slot count for `.contextAssembled`, and so on).
+
+```swift,no-build
+import ManifoldRuntime
+
+let recorder = ConversationEventRecorder()
+let drainTask = await recorder.start(on: runtime)
+
+let turn = try await runtime.processTurnWithOutcome(input)
+await turn?.outcome
+drainTask.cancel()
+await drainTask.value
+
+let trace = await ConversationEventTrace(recorder: recorder)
+
+// Inspect kinds inline
+print(trace.kinds) // [.contextAssembled, .streamStarted, .tokenEmitted, ...]
+
+// Save to disk for golden-trace comparison (P3) or offline debugging
+let url = URL(fileURLWithPath: "/tmp/turn.jsonl")
+try trace.save(to: url)
+```
+
+The JSONL format is intentionally minimal so it remains readable in any text
+editor and diff-friendly in version control. A future P3 pass will add a
+structured read path for golden-trace regression testing.
+
 ## Backpressure tradeoff
 
 The default buffering policy for taps is `.unbounded`, which means events accumulate in memory if the consumer lags. This eliminates any risk of the tap consumer blocking the turn loop or missing events during a burst.

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
@@ -156,6 +156,8 @@ try await endpointStore.insertEndpoint(
 
 - ``ConversationRuntime``
 - ``ConversationEvent``
+- ``ConversationEventKind``
+- ``ConversationEventTrace``
 - ``ConversationEventRecorder``
 - ``ConversationStreamHandle``
 - ``ConversationTurnHandle``

--- a/Sources/ManifoldRuntime/Models/ConversationEventKind.swift
+++ b/Sources/ManifoldRuntime/Models/ConversationEventKind.swift
@@ -1,0 +1,34 @@
+// MARK: - ConversationEventKind
+
+/// The kind of a ``ConversationEvent``, stripped of associated values.
+///
+/// Used as the stable key in JSONL trace files and as the discriminant in
+/// ``XCTAssertEventSubsequence(_:contains:file:line:)``.
+public enum ConversationEventKind: String, Codable, Sendable, CaseIterable {
+    case messageInserted
+    case messageRemoved
+    case messageUpdated
+    case sessionBranched
+    case streamStarted
+    case tokenEmitted
+    case tokenUsageRecorded
+    case thinkingStarted
+    case thinkingUpdated
+    case thinkingFinalized
+    case loopDetected
+    case streamFinished
+    case errorRaised
+    case sessionTouchFailed
+    case beforeContextAssembly
+    case historyShaped
+    case contextAssembled
+    case afterGeneration
+    case compressionTriggered
+    case historyCompressed
+    case toolCallRequested
+    case toolCallApproved
+    case toolCallCompleted
+    case agentHandoff
+    case skillInvoked
+    case hookFired
+}

--- a/Sources/ManifoldRuntime/Services/ConversationEvent.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationEvent.swift
@@ -239,3 +239,43 @@ public enum ConversationEvent: Sendable {
 extension ToolCall {
     public typealias ID = String
 }
+
+// MARK: - Kind
+
+extension ConversationEvent {
+
+    /// The kind of this event, stripped of associated values.
+    ///
+    /// Used as the stable discriminant in JSONL traces and
+    /// ``XCTAssertEventSubsequence(_:contains:file:line:)`` assertions.
+    public var kind: ConversationEventKind {
+        switch self {
+        case .messageInserted:          return .messageInserted
+        case .messageRemoved:           return .messageRemoved
+        case .messageUpdated:           return .messageUpdated
+        case .sessionBranched:          return .sessionBranched
+        case .streamStarted:            return .streamStarted
+        case .tokenEmitted:             return .tokenEmitted
+        case .tokenUsageRecorded:       return .tokenUsageRecorded
+        case .thinkingStarted:          return .thinkingStarted
+        case .thinkingUpdated:          return .thinkingUpdated
+        case .thinkingFinalized:        return .thinkingFinalized
+        case .loopDetected:             return .loopDetected
+        case .streamFinished:           return .streamFinished
+        case .errorRaised:              return .errorRaised
+        case .sessionTouchFailed:       return .sessionTouchFailed
+        case .beforeContextAssembly:    return .beforeContextAssembly
+        case .historyShaped:            return .historyShaped
+        case .contextAssembled:         return .contextAssembled
+        case .afterGeneration:          return .afterGeneration
+        case .compressionTriggered:     return .compressionTriggered
+        case .historyCompressed:        return .historyCompressed
+        case .toolCallRequested:        return .toolCallRequested
+        case .toolCallApproved:         return .toolCallApproved
+        case .toolCallCompleted:        return .toolCallCompleted
+        case .agentHandoff:             return .agentHandoff
+        case .skillInvoked:             return .skillInvoked
+        case .hookFired:                return .hookFired
+        }
+    }
+}

--- a/Sources/ManifoldRuntime/Services/ConversationEventTrace.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationEventTrace.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+// MARK: - ConversationEventTrace
+
+/// A recorded sequence of ``ConversationEvent`` values with a JSONL write path.
+///
+/// Build a trace from a ``ConversationEventRecorder`` after its drain task
+/// has completed, then call ``save(to:)`` to persist the JSONL file for
+/// offline debugging or golden-trace comparison (P3).
+///
+/// ```swift,no-build
+/// let recorder = ConversationEventRecorder()
+/// let drainTask = await recorder.start(on: runtime)
+///
+/// let turn = try await runtime.processTurnWithOutcome(input)
+/// await turn?.outcome
+/// drainTask.cancel()
+/// await drainTask.value
+///
+/// let trace = await ConversationEventTrace(recorder: recorder)
+/// let url = URL(fileURLWithPath: "/tmp/turn.jsonl")
+/// try trace.save(to: url)
+/// ```
+public struct ConversationEventTrace: Sendable {
+
+    /// The events in delivery order.
+    public let events: [ConversationEvent]
+
+    public init(events: [ConversationEvent]) {
+        self.events = events
+    }
+
+    /// Builds a trace from a ``ConversationEventRecorder`` after its drain
+    /// task has completed.
+    public init(recorder: ConversationEventRecorder) async {
+        self.events = await recorder.trace
+    }
+
+    /// The kinds of events in delivery order — useful for quick subsequence checks.
+    public var kinds: [ConversationEventKind] {
+        events.map(\.kind)
+    }
+
+    /// Writes the trace as JSONL to `url`. Each line is a JSON object with
+    /// `index`, `kind`, and `summary` fields.
+    ///
+    /// - Throws: `CocoaError` if the file cannot be written.
+    public func save(to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        var lines: [String] = []
+        for (i, event) in events.enumerated() {
+            let entry = ConversationEventTraceEntry(
+                index: i,
+                kind: event.kind,
+                summary: event.traceSummary
+            )
+            let data = try encoder.encode(entry)
+            lines.append(String(decoding: data, as: UTF8.self))
+        }
+        let content = lines.joined(separator: "\n") + "\n"
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+// MARK: - ConversationEventTraceEntry
+
+/// One line of a JSONL trace file.
+///
+/// Internal implementation detail of the JSONL format — not part of the
+/// public API surface.
+struct ConversationEventTraceEntry: Encodable, Sendable {
+    let index: Int
+    let kind: ConversationEventKind
+    let summary: String
+}
+
+// MARK: - traceSummary
+
+private extension ConversationEvent {
+
+    /// A human-readable one-liner derived from the event, used as the
+    /// `summary` field in JSONL trace entries.
+    var traceSummary: String {
+        switch self {
+        case let .tokenEmitted(_, delta):
+            // Truncate long deltas so traces remain human-readable.
+            return String(delta.prefix(40))
+
+        case let .streamFinished(_, reason):
+            return "\(reason)"
+
+        case let .errorRaised(error):
+            // Truncate to keep individual trace lines reasonable.
+            return String(error.localizedDescription.prefix(80))
+
+        case let .contextAssembled(slots):
+            return "slots:\(slots.count)"
+
+        case let .compressionTriggered(_, reason):
+            return "\(reason)"
+
+        case let .historyCompressed(_, insertedRecords):
+            return "inserted:\(insertedRecords.count)"
+
+        case let .toolCallRequested(toolCall):
+            return toolCall.toolName
+
+        case let .toolCallCompleted(callID, _):
+            return callID
+
+        default:
+            return ""
+        }
+    }
+}

--- a/Sources/ManifoldTestSupport/EventSubsequenceAssertion.swift
+++ b/Sources/ManifoldTestSupport/EventSubsequenceAssertion.swift
@@ -1,0 +1,48 @@
+#if DEBUG
+import XCTest
+import ManifoldRuntime
+
+// MARK: - XCTAssertEventSubsequence
+
+/// Asserts that `kinds` appears as a subsequence of `trace`, in order.
+///
+/// A subsequence match means every kind in `kinds` appears in `trace` (in
+/// the same order), but the events do not have to be consecutive. Extra
+/// events between matched kinds are ignored.
+///
+/// ```swift,no-build
+/// XCTAssertEventSubsequence(trace, contains: [
+///     .contextAssembled,
+///     .compressionTriggered,
+///     .historyCompressed,
+///     .contextAssembled,   // subsequence allows a second occurrence
+/// ])
+/// ```
+public func XCTAssertEventSubsequence(
+    _ trace: [ConversationEvent],
+    contains kinds: [ConversationEventKind],
+    _ message: String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    // Greedy left-to-right scan: advance the `kinds` pointer on each match.
+    var kindIdx = kinds.startIndex
+    for event in trace {
+        guard kindIdx < kinds.endIndex else { break }
+        if event.kind == kinds[kindIdx] {
+            kindIdx = kinds.index(after: kindIdx)
+        }
+    }
+    if kindIdx < kinds.endIndex {
+        let matched = kinds[..<kindIdx].map(\.rawValue).joined(separator: ", ")
+        let missing = kinds[kindIdx...].map(\.rawValue).joined(separator: ", ")
+        let traceDesc = trace.map(\.kind.rawValue).joined(separator: ", ")
+        let detail = message.isEmpty ? "" : " — \(message)"
+        XCTFail(
+            "Event subsequence not satisfied\(detail).\nMatched: [\(matched)]\nMissing: [\(missing)]\nTrace: [\(traceDesc)]",
+            file: file,
+            line: line
+        )
+    }
+}
+#endif

--- a/Tests/ManifoldRuntimeTests/ConversationEventTraceTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationEventTraceTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+import Foundation
+@testable import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ConversationEventTraceTests
+
+/// Unit tests for ``ConversationEventTrace``.
+final class ConversationEventTraceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private static func message(role: MessageRole = .assistant) -> ChatMessageRecord {
+        ChatMessageRecord(
+            id: UUID(),
+            role: role,
+            content: "test",
+            sessionID: UUID()
+        )
+    }
+
+    private static func tempURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString + ".jsonl")
+    }
+
+    // MARK: - kinds property
+
+    func test_trace_kinds_property() {
+        let messageID = UUID()
+        let events: [ConversationEvent] = [
+            .streamStarted(messageID: messageID),
+            .tokenEmitted(messageID: messageID, delta: "hello"),
+            .streamFinished(messageID: messageID, reason: .stop),
+        ]
+        let trace = ConversationEventTrace(events: events)
+        XCTAssertEqual(trace.kinds, [.streamStarted, .tokenEmitted, .streamFinished])
+    }
+
+    // MARK: - save(to:) — valid JSONL
+
+    func test_trace_save_writesValidJSONL() throws {
+        let messageID = UUID()
+        let events: [ConversationEvent] = [
+            .streamStarted(messageID: messageID),
+            .tokenEmitted(messageID: messageID, delta: "hi"),
+            .streamFinished(messageID: messageID, reason: .stop),
+        ]
+        let trace = ConversationEventTrace(events: events)
+        let url = Self.tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try trace.save(to: url)
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        // Each event produces one non-empty line; a trailing newline is expected.
+        let lines = content
+            .components(separatedBy: "\n")
+            .filter { !$0.isEmpty }
+
+        XCTAssertEqual(lines.count, 3, "Expected one line per event")
+
+        // Parse each line as JSON and verify the `kind` field.
+        let expectedKinds = ["streamStarted", "tokenEmitted", "streamFinished"]
+        for (lineText, expectedKind) in zip(lines, expectedKinds) {
+            let data = Data(lineText.utf8)
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertNotNil(json, "Line should be valid JSON: \(lineText)")
+            XCTAssertEqual(json?["kind"] as? String, expectedKind,
+                           "Line \(lineText) had wrong kind")
+        }
+    }
+
+    func test_trace_save_includesIndexField() throws {
+        let messageID = UUID()
+        let events: [ConversationEvent] = [
+            .streamStarted(messageID: messageID),
+            .tokenEmitted(messageID: messageID, delta: "world"),
+        ]
+        let trace = ConversationEventTrace(events: events)
+        let url = Self.tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try trace.save(to: url)
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+
+        for (expectedIndex, lineText) in lines.enumerated() {
+            let data = Data(lineText.utf8)
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertEqual(json?["index"] as? Int, expectedIndex,
+                           "Line \(expectedIndex) should have index field \(expectedIndex)")
+        }
+    }
+
+    // MARK: - save(to:) — summary fields
+
+    func test_trace_save_includesSummaryFields() throws {
+        let messageID = UUID()
+        let delta = "Hello, world!"
+        let events: [ConversationEvent] = [
+            .tokenEmitted(messageID: messageID, delta: delta),
+        ]
+        let trace = ConversationEventTrace(events: events)
+        let url = Self.tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try trace.save(to: url)
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 1)
+
+        let data = Data(lines[0].utf8)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let summary = json?["summary"] as? String
+        XCTAssertEqual(summary, delta,
+                       "tokenEmitted summary should equal the delta string")
+    }
+
+    func test_trace_save_truncatesLongDelta() throws {
+        let messageID = UUID()
+        // Construct a delta longer than 40 characters.
+        let longDelta = String(repeating: "x", count: 80)
+        let events: [ConversationEvent] = [
+            .tokenEmitted(messageID: messageID, delta: longDelta),
+        ]
+        let trace = ConversationEventTrace(events: events)
+        let url = Self.tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try trace.save(to: url)
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+        let data = Data(lines[0].utf8)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let summary = json?["summary"] as? String
+        XCTAssertEqual(summary?.count, 40,
+                       "tokenEmitted summary should be truncated to 40 characters")
+    }
+
+    func test_trace_save_emptyTraceWritesSingleNewline() throws {
+        let trace = ConversationEventTrace(events: [])
+        let url = Self.tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try trace.save(to: url)
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        // An empty trace produces just the trailing newline (one newline only).
+        XCTAssertEqual(content, "\n", "Empty trace should write a single trailing newline")
+    }
+}

--- a/Tests/ManifoldTestSupportTests/ConversationEventSubsequenceTests.swift
+++ b/Tests/ManifoldTestSupportTests/ConversationEventSubsequenceTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+import Foundation
+@testable import ManifoldRuntime
+import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - ConversationEventSubsequenceTests
+
+/// Unit tests for ``XCTAssertEventSubsequence(_:contains:file:line:)`` and
+/// ``ConversationEventKind``.
+final class ConversationEventSubsequenceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private static func message(role: MessageRole = .user) -> ChatMessageRecord {
+        ChatMessageRecord(
+            id: UUID(),
+            role: role,
+            content: "hello",
+            sessionID: UUID()
+        )
+    }
+
+    private static func makeSlot() -> PromptSlot {
+        PromptSlot(
+            id: UUID().uuidString,
+            content: "ctx",
+            label: "test"
+        )
+    }
+
+    private static func makeToolCall() -> ToolCall {
+        ToolCall(id: UUID().uuidString, toolName: "search", arguments: "{}")
+    }
+
+    // MARK: - Subsequence assertion tests
+
+    /// Exact match — every kind appears once in the same order.
+    func test_assertSubsequence_passes_when_exact_match() {
+        let trace: [ConversationEvent] = [
+            .streamStarted(messageID: UUID()),
+            .tokenEmitted(messageID: UUID(), delta: "hi"),
+            .streamFinished(messageID: UUID(), reason: .stop),
+        ]
+        XCTAssertEventSubsequence(trace, contains: [
+            .streamStarted,
+            .tokenEmitted,
+            .streamFinished,
+        ])
+    }
+
+    /// Gaps between matched kinds are silently ignored.
+    func test_assertSubsequence_passes_with_gaps() {
+        let sessionID = UUID()
+        let trace: [ConversationEvent] = [
+            .beforeContextAssembly(prompt: nil, request: PromptContextRequest(sessionID: sessionID, messageCount: 0, userInput: nil)),
+            .contextAssembled(slots: [Self.makeSlot()]),
+            .streamStarted(messageID: UUID()),
+            .tokenEmitted(messageID: UUID(), delta: "t1"),
+            .tokenEmitted(messageID: UUID(), delta: "t2"),
+            .streamFinished(messageID: UUID(), reason: .stop),
+            .afterGeneration(messageID: UUID(), finalText: "t1t2"),
+        ]
+        // Verify that the interleaved tokenEmitted events don't block matching
+        // the terminal pair.
+        XCTAssertEventSubsequence(trace, contains: [
+            .contextAssembled,
+            .streamStarted,
+            .streamFinished,
+        ])
+    }
+
+    /// A kind can be required multiple times; the matcher finds each in order.
+    func test_assertSubsequence_passes_repeated_kind() {
+        let sessionID = UUID()
+        let slots = [Self.makeSlot()]
+        let trace: [ConversationEvent] = [
+            .contextAssembled(slots: slots),
+            .streamFinished(messageID: UUID(), reason: .stop),
+            .contextAssembled(slots: slots),
+        ]
+        XCTAssertEventSubsequence(trace, contains: [
+            .contextAssembled,
+            .contextAssembled,
+        ])
+    }
+
+    /// A required kind that never appears triggers a test failure.
+    func test_assertSubsequence_fails_when_kind_absent() {
+        let trace: [ConversationEvent] = [
+            .streamStarted(messageID: UUID()),
+            .streamFinished(messageID: UUID(), reason: .stop),
+        ]
+        // The assertion should fail because .tokenEmitted is never in the trace.
+        XCTExpectFailure("tokenEmitted is absent from the trace") {
+            XCTAssertEventSubsequence(trace, contains: [
+                .streamStarted,
+                .tokenEmitted,
+                .streamFinished,
+            ])
+        }
+    }
+
+    /// Kinds required in the wrong order (relative to the trace) trigger failure.
+    func test_assertSubsequence_fails_when_out_of_order() {
+        let trace: [ConversationEvent] = [
+            .streamStarted(messageID: UUID()),
+            .streamFinished(messageID: UUID(), reason: .stop),
+        ]
+        // streamFinished before streamStarted cannot be matched left-to-right.
+        XCTExpectFailure("streamStarted appears after streamFinished in the required sequence") {
+            XCTAssertEventSubsequence(trace, contains: [
+                .streamFinished,
+                .streamStarted,
+            ])
+        }
+    }
+
+    // MARK: - Exhaustiveness sabotage check
+
+    /// For every ``ConversationEventKind`` case, construct a representative
+    /// ``ConversationEvent`` and assert that `.kind` returns the expected value.
+    ///
+    /// This test will not compile if a new case is added to ``ConversationEvent``
+    /// without a matching update to the `kind` computed property (the switch
+    /// in `ConversationEvent.kind` must be exhaustive).
+    func test_conversationEventKind_exhaustive() {
+        let sessionID = UUID()
+        let messageID = UUID()
+        let toolCall = Self.makeToolCall()
+        let toolResult = ToolResult(callId: toolCall.id, content: "ok")
+        let message = Self.message(role: .assistant)
+
+        let pairs: [(ConversationEvent, ConversationEventKind)] = [
+            (.messageInserted(message), .messageInserted),
+            (.messageRemoved(messageID: messageID), .messageRemoved),
+            (.messageUpdated(message), .messageUpdated),
+            (.sessionBranched(newSessionID: sessionID, copiedCount: 3), .sessionBranched),
+            (.streamStarted(messageID: messageID), .streamStarted),
+            (.tokenEmitted(messageID: messageID, delta: "hi"), .tokenEmitted),
+            (.tokenUsageRecorded(messageID: messageID, promptTokens: 10, completionTokens: 5), .tokenUsageRecorded),
+            (.thinkingStarted(messageID: messageID), .thinkingStarted),
+            (.thinkingUpdated(messageID: messageID, partialText: "..."), .thinkingUpdated),
+            (.thinkingFinalized(messageID: messageID, text: "done", signature: nil), .thinkingFinalized),
+            (.loopDetected(messageID: messageID), .loopDetected),
+            (.streamFinished(messageID: messageID, reason: .stop), .streamFinished),
+            (.errorRaised(.providerNotConfigured), .errorRaised),
+            (.sessionTouchFailed(sessionID: sessionID), .sessionTouchFailed),
+            (.beforeContextAssembly(prompt: nil, request: PromptContextRequest(sessionID: sessionID, messageCount: 0, userInput: nil)), .beforeContextAssembly),
+            (.historyShaped(sessionID: sessionID, diagnostics: []), .historyShaped),
+            (.contextAssembled(slots: []), .contextAssembled),
+            (.afterGeneration(messageID: messageID, finalText: "done"), .afterGeneration),
+            (.compressionTriggered(removed: [], reason: .contextWindowExceeded), .compressionTriggered),
+            (.historyCompressed(sessionID: sessionID, insertedRecords: []), .historyCompressed),
+            (.toolCallRequested(toolCall), .toolCallRequested),
+            (.toolCallApproved(toolCall.id), .toolCallApproved),
+            (.toolCallCompleted(toolCall.id, toolResult), .toolCallCompleted),
+            (.agentHandoff(from: nil, to: sessionID), .agentHandoff),
+            (.skillInvoked(name: "summarise", sessionID: sessionID), .skillInvoked),
+            (.hookFired(event: "preToolUse", sessionID: sessionID), .hookFired),
+        ]
+
+        // Verify count matches CaseIterable so a missing pair is caught here
+        // even if the switch somehow remains exhaustive.
+        XCTAssertEqual(pairs.count, ConversationEventKind.allCases.count,
+                       "pairs count must match ConversationEventKind.allCases.count — add the missing case")
+
+        for (event, expectedKind) in pairs {
+            XCTAssertEqual(event.kind, expectedKind,
+                           "event \(event) had kind \(event.kind.rawValue), expected \(expectedKind.rawValue)")
+        }
+    }
+}


### PR DESCRIPTION
Closes #1531 (P1 deliverable from the Glass Box tracking issue).

## Summary

- **`ConversationEventKind`** — new `String`-rawValue enum (`Codable`, `Sendable`, `CaseIterable`) covering all 26 `ConversationEvent` cases, used as the stable key in JSONL traces and subsequence assertions.
- **`ConversationEvent.kind`** — exhaustive computed property mapping each event to its `ConversationEventKind`; the compiler enforces the mapping stays current when new cases are added.
- **`ConversationEventTrace`** — value type wrapping `[ConversationEvent]` with a `save(to:)` method that writes a JSONL file (`index`, `kind`, `summary` per line). `summary` encodes the most diagnostic associated value per case (token delta, finish reason, slot count, etc.) and truncates to keep lines human-readable.
- **`XCTAssertEventSubsequence`** — greedy left-to-right subsequence matcher in `ManifoldTestSupport`; asserts all required kinds appear in the trace in order (gaps allowed). Gated `#if DEBUG`. Produces a readable failure message with matched / missing / full-trace breakdown.

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` — clean compile, no new errors
- [ ] `swift test --disable-default-traits --filter ConversationEventSubsequence` — 6 tests pass (exact match, gaps, repeated kind, absent kind failure, out-of-order failure, exhaustive kind mapping)
- [ ] `swift test --disable-default-traits --filter ConversationEventTrace` — 6 tests pass (kinds property, valid JSONL, index field, summary field, delta truncation, empty trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)