### PR TITLE
feat(test-support): Glass Box P2 — ScriptedGenerationBackend

### DIFF
--- a/Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift
+++ b/Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift
@@ -1,0 +1,186 @@
+import Foundation
+import ManifoldInference
+
+/// A turn-by-turn ``InferenceBackend`` whose event sequence is fully
+/// scripted. Each call to `generate` pops the next ``TurnScript`` and
+/// emits its ``ScriptedEvent`` values in order.
+///
+/// Use `ScriptedGenerationBackend` when you need deterministic control
+/// over ``GenerationEvent`` values that real backends only produce under
+/// specific conditions — KV-cache reuse hits, throttle signals, partial
+/// thinking blocks, mid-stream errors — and you want to assert the
+/// runtime's handling via ``ConversationEventRecorder`` +
+/// ``XCTAssertEventSubsequence``.
+///
+/// ## Basic usage
+///
+/// ```swift
+/// let backend = ScriptedGenerationBackend(turns: [
+///     .kvCacheReuse(reuseCount: 256, then: ["Hello", " world"]),
+///     .tokens(["Follow", "-up"]),
+/// ])
+/// ```
+///
+/// ## Thread safety
+///
+/// `ScriptedGenerationBackend` is `@unchecked Sendable` — the same pattern
+/// used by ``MockInferenceBackend`` in this module. An `NSLock` serialises
+/// all reads and writes to `turns`, `cursor`, and `generateCallCount`.
+/// `isGenerating` and `isModelLoaded` are unsynchronised because they are
+/// used only for assertion purposes in tests, not for safety-critical paths.
+public final class ScriptedGenerationBackend: InferenceBackend, @unchecked Sendable {
+
+    // MARK: - Types
+
+    /// One turn's event sequence.
+    public struct TurnScript: Sendable {
+        public let events: [ScriptedEvent]
+
+        public init(_ events: [ScriptedEvent]) {
+            self.events = events
+        }
+
+        // MARK: Convenience factories
+
+        /// Emits plain text tokens and finishes normally.
+        public static func tokens(_ tokens: [String]) -> TurnScript {
+            TurnScript(tokens.map { .emit(.token($0)) })
+        }
+
+        /// Emits a `kvCacheReuse` event followed by text tokens.
+        public static func kvCacheReuse(reuseCount: Int, then tokens: [String]) -> TurnScript {
+            var events: [ScriptedEvent] = [.emit(.kvCacheReuse(promptTokensReused: reuseCount))]
+            events += tokens.map { .emit(.token($0)) }
+            return TurnScript(events)
+        }
+
+        /// Emits a `diagnosticThrottle` event followed by text tokens.
+        public static func throttle(reason: String, then tokens: [String]) -> TurnScript {
+            var events: [ScriptedEvent] = [.emit(.diagnosticThrottle(reason: reason))]
+            events += tokens.map { .emit(.token($0)) }
+            return TurnScript(events)
+        }
+
+        /// Emits a `usage` event followed by text tokens.
+        public static func withUsage(prompt: Int, completion: Int, tokens: [String]) -> TurnScript {
+            var events: [ScriptedEvent] = [.emit(.usage(prompt: prompt, completion: completion))]
+            events += tokens.map { .emit(.token($0)) }
+            return TurnScript(events)
+        }
+
+        /// Throws `error` mid-stream after emitting `afterTokens` tokens from `tokens`.
+        public static func failMidStream(_ error: Error, afterTokens: Int = 0, tokens: [String] = []) -> TurnScript {
+            var events: [ScriptedEvent] = Array(tokens.prefix(afterTokens).map { .emit(.token($0)) })
+            events.append(.throwError(error))
+            return TurnScript(events)
+        }
+
+        /// Empty turn — stream finishes with no events. The runtime treats
+        /// this as a no-content response.
+        public static var empty: TurnScript { TurnScript([]) }
+    }
+
+    /// A single scripted step within a ``TurnScript``.
+    public enum ScriptedEvent: Sendable {
+        /// Yield this ``GenerationEvent`` into the stream.
+        case emit(GenerationEvent)
+        /// Throw this error into the stream (terminates the turn).
+        case throwError(Error)
+        /// Sleep before the next event (keep <= 100 ms in tests).
+        case delay(Duration)
+    }
+
+    // MARK: - InferenceBackend conformance
+
+    public var isModelLoaded: Bool = true
+    public var isGenerating: Bool = false
+    public var capabilities: BackendCapabilities
+
+    /// The number of `generate` calls made so far.
+    public private(set) var generateCallCount: Int = 0
+
+    // NSLock serialises mutations to `turns`, `cursor`, and `generateCallCount`.
+    private let lock = NSLock()
+    private var turns: [TurnScript]
+    private var cursor: Int = 0
+
+    public init(turns: [TurnScript] = [], capabilities: BackendCapabilities? = nil) {
+        self.turns = turns
+        self.capabilities = capabilities ?? BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        )
+    }
+
+    public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        isModelLoaded = true
+    }
+
+    public func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        let script = nextTurn()
+        isGenerating = true
+
+        let raw = AsyncThrowingStream<GenerationEvent, Error> { [weak self] continuation in
+            Task {
+                for event in script.events {
+                    switch event {
+                    case .emit(let generationEvent):
+                        continuation.yield(generationEvent)
+                    case .throwError(let error):
+                        self?.isGenerating = false
+                        continuation.finish(throwing: error)
+                        return
+                    case .delay(let duration):
+                        do {
+                            try await Task.sleep(for: duration)
+                        } catch {
+                            continuation.finish(throwing: error)
+                            return
+                        }
+                    }
+                }
+                self?.isGenerating = false
+                continuation.finish()
+            }
+        }
+        return GenerationStream(raw)
+    }
+
+    public func stopGeneration() {
+        isGenerating = false
+    }
+
+    public func unloadModel() {
+        isModelLoaded = false
+    }
+
+    // MARK: - Script management
+
+    /// Appends additional turns to the script at runtime.
+    public func appendTurns(_ newTurns: [TurnScript]) {
+        lock.withLock { turns.append(contentsOf: newTurns) }
+    }
+
+    /// Resets the cursor to turn 0 without clearing the script.
+    public func reset() {
+        lock.withLock { cursor = 0 }
+    }
+
+    private func nextTurn() -> TurnScript {
+        lock.withLock {
+            generateCallCount += 1
+            if cursor < turns.count {
+                let t = turns[cursor]
+                cursor += 1
+                return t
+            }
+            return .empty
+        }
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift
@@ -102,7 +102,7 @@ final class ScriptedBackendRuntimeTests: XCTestCase {
     /// `.kvCacheReuse` is advisory metadata that the runtime passes through
     /// as `.ignore`. The turn must still complete normally — `streamFinished`
     /// (not `errorRaised`) must appear in the trace.
-    func test_kvCacheReuse_appearsInTokenUsageRecorded() async throws {
+    func test_kvCacheReuse_completesNormally() async throws {
         let backend = ScriptedGenerationBackend(turns: [
             .kvCacheReuse(reuseCount: 256, then: ["Hello", " world"])
         ])

--- a/Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift
@@ -1,0 +1,265 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - ScriptedBackendRuntimeTests
+
+/// Integration tests wiring ``ScriptedGenerationBackend`` through
+/// ``ConversationRuntime``, ``ConversationEventRecorder``, and
+/// ``XCTAssertEventSubsequence``.
+///
+/// Prerequisites: P0 (`ConversationEventRecorder`) and P1
+/// (`ConversationEventKind`, `XCTAssertEventSubsequence`) must be merged.
+@MainActor
+final class ScriptedBackendRuntimeTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    private final class ScriptedTestMessageStore: MessageStore, @unchecked Sendable {
+        private let lock = NSLock()
+        private var messages: [UUID: ChatMessageRecord] = [:]
+        private var hooks: [any MessageStorePostWriteHook] = []
+
+        func insertMessage(_ message: ChatMessageRecord) async throws {
+            let snapshot = upsert(message)
+            for hook in snapshot {
+                await hook.messageDidWrite(message, in: message.sessionID)
+            }
+        }
+
+        func updateMessage(_ message: ChatMessageRecord) async throws {
+            guard lock.withLock({ messages[message.id] != nil }) else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            let snapshot = upsert(message)
+            for hook in snapshot {
+                await hook.messageDidWrite(message, in: message.sessionID)
+            }
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            lock.withLock { messages.removeValue(forKey: messageID) }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
+            lock.withLock {
+                messages.values
+                    .filter { $0.sessionID == sessionID }
+                    .sorted { $0.timestamp < $1.timestamp }
+            }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            lock.withLock {
+                messages = messages.filter { $0.value.sessionID != sessionID }
+            }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {
+            lock.withLock { hooks.append(hook) }
+        }
+
+        private func upsert(_ message: ChatMessageRecord) -> [any MessageStorePostWriteHook] {
+            lock.withLock {
+                messages[message.id] = message
+                return hooks
+            }
+        }
+    }
+
+    // MARK: - Fixture factory
+
+    private func makeRuntime(
+        backend: ScriptedGenerationBackend
+    ) -> (runtime: ConversationRuntime, backend: ScriptedGenerationBackend) {
+        let inference = InferenceService(backend: backend, name: "Scripted")
+        let store = ScriptedTestMessageStore()
+        let runtime = ConversationRuntime(messageStore: store, inferenceService: inference)
+        return (runtime, backend)
+    }
+
+    // MARK: - Drain helper
+
+    /// Drains the primary `runtime.events` stream until `streamFinished` (or
+    /// `errorRaised`) arrives, or the deadline elapses.
+    private func drainUntilTerminal(
+        _ runtime: ConversationRuntime,
+        deadline: Duration = .seconds(5)
+    ) -> Task<Void, Never> {
+        Task { [weak runtime] in
+            guard let runtime else { return }
+            for await event in runtime.events {
+                if case .streamFinished = event { break }
+                if case .errorRaised = event { break }
+            }
+        }
+    }
+
+    // MARK: - Tests
+
+    /// `.kvCacheReuse` is advisory metadata that the runtime passes through
+    /// as `.ignore`. The turn must still complete normally — `streamFinished`
+    /// (not `errorRaised`) must appear in the trace.
+    func test_kvCacheReuse_appearsInTokenUsageRecorded() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .kvCacheReuse(reuseCount: 256, then: ["Hello", " world"])
+        ])
+        let (runtime, _) = makeRuntime(backend: backend)
+
+        let primaryTask = drainUntilTerminal(runtime)
+        defer { primaryTask.cancel() }
+
+        let recorder = ConversationEventRecorder()
+        let drainTask = await recorder.start(on: runtime)
+
+        let turn = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "test kv-cache"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        _ = await turn?.outcome
+
+        drainTask.cancel()
+        _ = await drainTask.value
+
+        let trace = await recorder.trace
+
+        // The runtime ignores .kvCacheReuse at the ConversationEvent level but
+        // must complete the turn successfully — streamFinished (not errorRaised)
+        // must appear.
+        XCTAssertEventSubsequence(trace, contains: [
+            .streamStarted,
+            .tokenEmitted,
+            .streamFinished,
+        ], "turn with kvCacheReuse must complete normally")
+
+        // errorRaised must not appear — kvCacheReuse is advisory.
+        let hasError = trace.contains { $0.kind == .errorRaised }
+        XCTAssertFalse(hasError, "kvCacheReuse must not cause errorRaised")
+    }
+
+    /// `.diagnosticThrottle` is advisory and must not abort generation.
+    /// The turn must complete with `streamFinished`, not `errorRaised`.
+    func test_diagnosticThrottle_doesNotAbortGeneration() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .throttle(reason: "rate-limit", then: ["ok"])
+        ])
+        let (runtime, _) = makeRuntime(backend: backend)
+
+        let primaryTask = drainUntilTerminal(runtime)
+        defer { primaryTask.cancel() }
+
+        let recorder = ConversationEventRecorder()
+        let drainTask = await recorder.start(on: runtime)
+
+        let turn = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "throttle test"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        _ = await turn?.outcome
+
+        drainTask.cancel()
+        _ = await drainTask.value
+
+        let trace = await recorder.trace
+
+        XCTAssertEventSubsequence(trace, contains: [
+            .streamStarted,
+            .tokenEmitted,
+            .streamFinished,
+        ], "throttle is advisory — generation must complete normally")
+
+        let hasError = trace.contains { $0.kind == .errorRaised }
+        XCTAssertFalse(hasError, "diagnosticThrottle must not cause errorRaised")
+    }
+
+    /// A mid-stream error surfaces as `errorRaised` in the trace. The
+    /// token emitted before the throw must also appear so the test verifies
+    /// the ordering of the partial-output + error path.
+    func test_midStreamError_surfacesAsErrorRaised() async throws {
+        let testError = NSError(domain: "test.mid-stream", code: 42)
+        let backend = ScriptedGenerationBackend(turns: [
+            .failMidStream(testError, afterTokens: 1, tokens: ["hi", "bye"])
+        ])
+        let (runtime, _) = makeRuntime(backend: backend)
+
+        // Drain primary stream — errorRaised terminates the loop.
+        let primaryTask = drainUntilTerminal(runtime)
+        defer { primaryTask.cancel() }
+
+        let recorder = ConversationEventRecorder()
+        let drainTask = await recorder.start(on: runtime)
+
+        let turn = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: UUID(),
+            kind: .send(text: "error test"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        _ = await turn?.outcome
+
+        drainTask.cancel()
+        _ = await drainTask.value
+
+        let trace = await recorder.trace
+
+        XCTAssertEventSubsequence(trace, contains: [
+            .tokenEmitted,
+            .errorRaised,
+        ], "partial token then errorRaised must appear after mid-stream throw")
+    }
+
+    /// A two-turn script drives two independent `processTurnWithOutcome` calls.
+    /// The combined trace must contain the per-turn landmarks in order.
+    func test_multiTurnScript_eachTurnTracedIndependently() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .tokens(["A"]),
+            .kvCacheReuse(reuseCount: 64, then: ["B"]),
+        ])
+        let (runtime, _) = makeRuntime(backend: backend)
+
+        let primaryTask = Task { [weak runtime] in
+            guard let runtime else { return }
+            for await _ in runtime.events {}
+        }
+        defer { primaryTask.cancel() }
+
+        let recorder = ConversationEventRecorder()
+        let drainTask = await recorder.start(on: runtime)
+
+        let sessionID = UUID()
+
+        let turn1 = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "first"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        _ = await turn1?.outcome
+
+        let turn2 = try await runtime.processTurnWithOutcome(TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "second"),
+            config: TurnConfig(streamingBatchCharacterLimit: 1)
+        ))
+        _ = await turn2?.outcome
+
+        drainTask.cancel()
+        _ = await drainTask.value
+
+        let trace = await recorder.trace
+
+        // Both turns must have completed with their own streamStarted / tokenEmitted /
+        // streamFinished lifecycle. The six-event subsequence below is the minimal
+        // proof that two independent generation rounds ran.
+        XCTAssertEventSubsequence(trace, contains: [
+            .streamStarted,
+            .tokenEmitted,
+            .streamFinished,
+            .streamStarted,
+            .tokenEmitted,
+            .streamFinished,
+        ], "two-turn scripted session must produce two complete generation lifecycles")
+    }
+}

--- a/Tests/ManifoldTestSupportTests/ScriptedGenerationBackendTests.swift
+++ b/Tests/ManifoldTestSupportTests/ScriptedGenerationBackendTests.swift
@@ -1,0 +1,174 @@
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - ScriptedGenerationBackendTests
+
+/// Unit tests for ``ScriptedGenerationBackend``.
+///
+/// These tests drive the backend directly without ``ConversationRuntime`` so
+/// they cover only the backend's own scripting mechanics. Integration coverage
+/// against the runtime lives in ``ScriptedBackendRuntimeTests``.
+@MainActor
+final class ScriptedGenerationBackendTests: XCTestCase {
+
+    // MARK: - Drain helper
+
+    /// Collects all events from a ``GenerationStream`` into an array.
+    /// The helper propagates any error thrown by the stream.
+    private func drain(_ stream: GenerationStream) async throws -> [GenerationEvent] {
+        var collected: [GenerationEvent] = []
+        for try await event in stream.events {
+            collected.append(event)
+        }
+        return collected
+    }
+
+    // MARK: - Tests
+
+    /// Tokens emitted by `.tokens(_:)` arrive in the scripted order.
+    func test_tokens_emittedInOrder() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .tokens(["a", "b", "c"])
+        ])
+
+        let stream = try backend.generate(
+            prompt: "hi", systemPrompt: nil, config: GenerationConfig()
+        )
+        let events = try await drain(stream)
+
+        XCTAssertEqual(events, [.token("a"), .token("b"), .token("c")])
+    }
+
+    /// A `.kvCacheReuse` event arrives before the token events when using the
+    /// `.kvCacheReuse(reuseCount:then:)` factory.
+    func test_kvCacheReuse_emittedBeforeTokens() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .kvCacheReuse(reuseCount: 128, then: ["hi"])
+        ])
+
+        let stream = try backend.generate(
+            prompt: "go", systemPrompt: nil, config: GenerationConfig()
+        )
+        let events = try await drain(stream)
+
+        XCTAssertEqual(events.count, 2, "expected kvCacheReuse + token")
+        XCTAssertEqual(events[0], .kvCacheReuse(promptTokensReused: 128))
+        XCTAssertEqual(events[1], .token("hi"))
+    }
+
+    /// A `.diagnosticThrottle` event arrives before the token events when using
+    /// the `.throttle(reason:then:)` factory.
+    func test_throttle_emittedBeforeTokens() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .throttle(reason: "burst-limit", then: ["x"])
+        ])
+
+        let stream = try backend.generate(
+            prompt: "go", systemPrompt: nil, config: GenerationConfig()
+        )
+        let events = try await drain(stream)
+
+        XCTAssertEqual(events.count, 2, "expected diagnosticThrottle + token")
+        XCTAssertEqual(events[0], .diagnosticThrottle(reason: "burst-limit"))
+        XCTAssertEqual(events[1], .token("x"))
+    }
+
+    /// When using `.failMidStream(_:afterTokens:tokens:)`, the stream yields
+    /// exactly `afterTokens` tokens then throws — remaining tokens are not emitted.
+    func test_failMidStream_throwsAfterTokens() async throws {
+        let testError = NSError(domain: "test", code: 42)
+        let backend = ScriptedGenerationBackend(turns: [
+            .failMidStream(testError, afterTokens: 2, tokens: ["a", "b", "c"])
+        ])
+
+        let stream = try backend.generate(
+            prompt: "go", systemPrompt: nil, config: GenerationConfig()
+        )
+
+        var collected: [GenerationEvent] = []
+        var caughtError: Error?
+        do {
+            for try await event in stream.events {
+                collected.append(event)
+            }
+        } catch {
+            caughtError = error
+        }
+
+        XCTAssertEqual(collected, [.token("a"), .token("b")],
+                       "exactly 2 tokens before the throw")
+        let nsError = try XCTUnwrap(caughtError as? NSError)
+        XCTAssertEqual(nsError.code, 42)
+    }
+
+    /// Calling `generate` beyond the script length produces an empty stream
+    /// that finishes normally.
+    func test_exhaustedScript_returnsEmptyStream() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .tokens(["only-turn"])
+        ])
+
+        // Consume the only scripted turn.
+        _ = try await drain(try backend.generate(
+            prompt: "first", systemPrompt: nil, config: GenerationConfig()
+        ))
+
+        // Second call — no turns left.
+        let stream = try backend.generate(
+            prompt: "second", systemPrompt: nil, config: GenerationConfig()
+        )
+        let events = try await drain(stream)
+
+        XCTAssertTrue(events.isEmpty, "exhausted script must produce an empty stream")
+    }
+
+    /// Each `generate` call increments `generateCallCount` by exactly one.
+    func test_generateCallCount_incrementsEachCall() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .tokens(["t1"]),
+            .tokens(["t2"]),
+            .tokens(["t3"]),
+        ])
+
+        _ = try await drain(try backend.generate(
+            prompt: "1", systemPrompt: nil, config: GenerationConfig()
+        ))
+        _ = try await drain(try backend.generate(
+            prompt: "2", systemPrompt: nil, config: GenerationConfig()
+        ))
+        _ = try await drain(try backend.generate(
+            prompt: "3", systemPrompt: nil, config: GenerationConfig()
+        ))
+
+        XCTAssertEqual(backend.generateCallCount, 3)
+    }
+
+    /// After `reset()`, the next `generate` call replays from the first turn.
+    func test_reset_restartsFromFirstTurn() async throws {
+        let backend = ScriptedGenerationBackend(turns: [
+            .tokens(["first"]),
+            .tokens(["second"]),
+        ])
+
+        let pass1turn1 = try await drain(try backend.generate(
+            prompt: "a", systemPrompt: nil, config: GenerationConfig()
+        ))
+        let pass1turn2 = try await drain(try backend.generate(
+            prompt: "b", systemPrompt: nil, config: GenerationConfig()
+        ))
+
+        backend.reset()
+
+        let pass2turn1 = try await drain(try backend.generate(
+            prompt: "c", systemPrompt: nil, config: GenerationConfig()
+        ))
+        let pass2turn2 = try await drain(try backend.generate(
+            prompt: "d", systemPrompt: nil, config: GenerationConfig()
+        ))
+
+        XCTAssertEqual(pass1turn1, pass2turn1, "reset must replay turn 1 identically")
+        XCTAssertEqual(pass1turn2, pass2turn2, "reset must replay turn 2 identically")
+    }
+}


### PR DESCRIPTION
Closes #1531 (P2 deliverable).

## Summary

- Adds `ScriptedGenerationBackend` to `ManifoldTestSupport` — a `public` turn-by-turn `InferenceBackend` whose each turn is an explicit `[ScriptedEvent]` sequence. Any `GenerationEvent` can be emitted, or a throw injected at any point.
- 7 unit tests in `ManifoldTestSupportTests/ScriptedGenerationBackendTests` verify the backend's own scripting mechanics (event ordering, mid-stream throws, exhausted-script behaviour, `generateCallCount`, `reset()`).
- 4 runtime integration tests in `ManifoldRuntimeTests/ScriptedBackendRuntimeTests` wire `ScriptedGenerationBackend` through `ConversationRuntime` + `ConversationEventRecorder` + `XCTAssertEventSubsequence` (P0+P1 prerequisites merged).

## Prerequisites

- P0 — `ConversationEventRecorder` (merged #1555)
- P1 — `ConversationEventKind`, `XCTAssertEventSubsequence` (merged #1561)

## Deliverables

- `Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift` — `ScriptedGenerationBackend` with `TurnScript` and `ScriptedEvent` types; convenience factories `.tokens(_:)`, `.kvCacheReuse(reuseCount:then:)`, `.throttle(reason:then:)`, `.withUsage(prompt:completion:tokens:)`, `.failMidStream(_:afterTokens:tokens:)`, `.empty`.
- `Tests/ManifoldTestSupportTests/ScriptedGenerationBackendTests.swift` — 7 unit tests.
- `Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift` — 4 integration tests covering: kvCacheReuse advisory pass-through, diagnosticThrottle non-abort, mid-stream error surfaces as `errorRaised`, two-turn multi-script lifecycle.

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` — clean build
- [ ] `swift test --disable-default-traits --filter ScriptedGenerationBackend` — 7 unit tests pass
- [ ] `swift test --disable-default-traits --filter ScriptedBackendRuntime` — 4 integration tests pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)