### PR TITLE
fix(ui): replace try? with do/catch in SessionListView pin/unpin actions

### DIFF
--- a/Sources/ManifoldUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/ManifoldUI/Views/Sidebar/SessionListView.swift
@@ -57,7 +57,13 @@ public struct SessionListView: View {
                                     }
                                     .swipeActions(edge: .leading) {
                                         Button {
-                                            Task { try? await sessionManager.unpinSession(session) }
+                                            Task {
+                                                do {
+                                                    try await sessionManager.unpinSession(session)
+                                                } catch {
+                                                    errorMessage = "Failed to unpin session: \(error.localizedDescription)"
+                                                }
+                                            }
                                         } label: {
                                             Label("Unpin", systemImage: "pin.slash")
                                         }
@@ -72,7 +78,13 @@ public struct SessionListView: View {
                                     }
                                     .contextMenu {
                                         Button {
-                                            Task { try? await sessionManager.unpinSession(session) }
+                                            Task {
+                                                do {
+                                                    try await sessionManager.unpinSession(session)
+                                                } catch {
+                                                    errorMessage = "Failed to unpin session: \(error.localizedDescription)"
+                                                }
+                                            }
                                         } label: {
                                             Label("Unpin", systemImage: "pin.slash")
                                         }
@@ -105,7 +117,13 @@ public struct SessionListView: View {
                                 }
                                 .swipeActions(edge: .leading) {
                                     Button {
-                                        Task { try? await sessionManager.pinSession(session) }
+                                        Task {
+                                            do {
+                                                try await sessionManager.pinSession(session)
+                                            } catch {
+                                                errorMessage = "Failed to pin session: \(error.localizedDescription)"
+                                            }
+                                        }
                                     } label: {
                                         Label("Pin", systemImage: "pin")
                                     }
@@ -120,7 +138,13 @@ public struct SessionListView: View {
                                 }
                                 .contextMenu {
                                     Button {
-                                        Task { try? await sessionManager.pinSession(session) }
+                                        Task {
+                                            do {
+                                                try await sessionManager.pinSession(session)
+                                            } catch {
+                                                errorMessage = "Failed to pin session: \(error.localizedDescription)"
+                                            }
+                                        }
                                     } label: {
                                         Label("Pin", systemImage: "pin")
                                     }
@@ -266,6 +290,7 @@ public struct SessionListView: View {
             return
         }
         debounceTask = Task { @MainActor [sessionManager] in
+            // CancellationError is expected on task cancel — Task.isCancelled checked below.
             try? await Task.sleep(nanoseconds: 200_000_000)
             if Task.isCancelled { return }
             runSearch(query: query, scope: scope, on: sessionManager)


### PR DESCRIPTION
Fixes four `try?` violations in `SessionListView` that were failing `SilentCatchAuditTest`: the swipe-action and context-menu handlers for `pinSession`/`unpinSession` now use `do/catch` and surface failures through the existing `errorMessage` alert, consistent with how `renameSession` and `deleteSession` are already handled. The `try? await Task.sleep` on the debounce path is left as `try?` — it matches the `await Task.sleep` approved idiom in the audit and cancellation is the expected non-error path there.