### PR TITLE
feat(traits): WWDC 2026 pre-emptive trait stubs (SystemAIProviderExtension, CoreAI)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,14 +96,8 @@ let package = Package(
         // these traits exist solely so `#if SystemAIProviderExtension` and
         // `#if CoreAI` conditional blocks can be written today and flip live on
         // June 8 without a Package.swift change. See docs/wwdc-2026-trait-stubs.md.
-        .trait(
-            name: "SystemAIProviderExtension",
-            description: "Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API."
-        ),
-        .trait(
-            name: "CoreAI",
-            description: "Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface."
-        ),
+        .trait(name: "SystemAIProviderExtension", description: "Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API."),
+        .trait(name: "CoreAI", description: "Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface."),
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3"),

--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,18 @@ let package = Package(
         // from the resolved graph. Apple Foundation Models still work via
         // FoundationBackend (iOS 26 / macOS 26+). See docs/AppStoreSubmission.md.
         .trait(name: "FoundationOnly", description: "App Store-lean: Apple Foundation Models only. Pass `traits: [\"FoundationOnly\"]` from the consumer manifest — overrides the MLX/Llama/HuggingFace default trait set."),
+        // WWDC 2026 pre-emptive stubs. No associated targets or source files —
+        // these traits exist solely so `#if SystemAIProviderExtension` and
+        // `#if CoreAI` conditional blocks can be written today and flip live on
+        // June 8 without a Package.swift change. See docs/wwdc-2026-trait-stubs.md.
+        .trait(
+            name: "SystemAIProviderExtension",
+            description: "Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API."
+        ),
+        .trait(
+            name: "CoreAI",
+            description: "Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface."
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/ml-explore/mlx-swift.git", from: "0.31.3"),

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -149,6 +149,23 @@ public enum FeatureMatrix {
             description: "App Store-lean: Apple Foundation Models only. Pass `traits: [\"FoundationOnly\"]` from the consumer manifest — overrides the MLX/Llama/HuggingFace default trait set.",
             unlocks: [.foundationBackend]
         ),
+        // WWDC 2026 pre-emptive stubs. No targets, no source files — pure
+        // compile-condition placeholders until the frameworks ship on June 8.
+        // See docs/wwdc-2026-trait-stubs.md for deferred decision points.
+        ManifoldTrait(
+            name: "SystemAIProviderExtension",
+            description: "Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API.",
+            unlocks: []
+            // TODO(dx-matrix): no concrete capability until the API surface
+            // is confirmed at WWDC 2026. Add to pendingMapping in FeatureMatrixTests.
+        ),
+        ManifoldTrait(
+            name: "CoreAI",
+            description: "Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface.",
+            unlocks: []
+            // TODO(dx-matrix): no concrete capability until the API surface
+            // is confirmed at WWDC 2026. Add to pendingMapping in FeatureMatrixTests.
+        ),
     ]
 
     // MARK: - Lookups

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -156,15 +156,17 @@ public enum FeatureMatrix {
             name: "SystemAIProviderExtension",
             description: "Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API.",
             unlocks: []
-            // TODO(dx-matrix): no concrete capability until the API surface
-            // is confirmed at WWDC 2026. Add to pendingMapping in FeatureMatrixTests.
+            // TODO(dx-matrix): post-WWDC, remove "SystemAIProviderExtension"
+            // from FeatureMatrixTests.pendingMapping and add the concrete
+            // ManifoldCapability cases it unlocks.
         ),
         ManifoldTrait(
             name: "CoreAI",
             description: "Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface.",
             unlocks: []
-            // TODO(dx-matrix): no concrete capability until the API surface
-            // is confirmed at WWDC 2026. Add to pendingMapping in FeatureMatrixTests.
+            // TODO(dx-matrix): post-WWDC, remove "CoreAI" from
+            // FeatureMatrixTests.pendingMapping and add the concrete
+            // ManifoldCapability cases it unlocks.
         ),
     ]
 

--- a/Tests/ManifoldKitTests/FeatureMatrixTests.swift
+++ b/Tests/ManifoldKitTests/FeatureMatrixTests.swift
@@ -18,6 +18,10 @@ final class FeatureMatrixTests: XCTestCase {
     // doesn't have to lie about them.
     private let pendingMapping: Set<String> = [
         "Fuzz",
+        // WWDC 2026 pre-emptive stubs: no capability mapping until the APIs
+        // ship on June 8. Remove from here and add unlocks once confirmed.
+        "SystemAIProviderExtension",
+        "CoreAI",
     ]
 
     func testEveryMatrixTraitExistsInPackageManifest() throws {

--- a/docs/wwdc-2026-trait-stubs.md
+++ b/docs/wwdc-2026-trait-stubs.md
@@ -1,0 +1,50 @@
+# WWDC 2026 Pre-emptive Trait Stubs
+
+Added 2026-05-31, 8 days before WWDC 2026 (June 8).
+
+## What the two traits represent
+
+**`SystemAIProviderExtension`** — the expected iOS 27 / macOS 27 entrypoint for
+third-party apps to plug into Siri and Writing Tools as AI backends. Apple has
+described a "system AI provider" extension point in pre-release documentation;
+the exact protocol name, entitlement string, and Info.plist key are unconfirmed.
+
+**`CoreAI`** — a rumoured framework that would unify and succeed Core ML,
+Create ML, and the lower layers of Foundation Models. Whether it ships as a
+distinct framework or as an expansion of an existing one is unknown until the
+keynote.
+
+## Why add them pre-WWDC
+
+SwiftPM trait names are consumed at the manifest level, before any source
+files compile. If a `#if SystemAIProviderExtension` block is committed to
+a source file today, `swift build` will fail until the trait is declared in
+`Package.swift`. By landing the trait declarations now:
+
+- Feature branches can use `#if SystemAIProviderExtension` and `#if CoreAI`
+  guards today without a blocking manifest change.
+- On June 8, wiring in the real implementation requires only source additions
+  and a `swiftSettings: [.define(...)]` annotation on the new target — no
+  manifest restructuring under time pressure.
+
+## Deferred decision points
+
+These questions must be resolved after WWDC before the traits become real:
+
+1. **Exact framework/protocol names** — the trait names here are best-guess.
+   Rename to match Apple's official identifiers if they differ.
+2. **Entitlement and capability requirements** — both surfaces will likely
+   require a provisioning entitlement; the consumer-manifest documentation
+   should reference any required `Info.plist` keys.
+3. **OS availability floor** — `SystemAIProviderExtension` is expected iOS 27 /
+   macOS 27+; `CoreAI` availability is unknown. Add `@available` guards and
+   update the platform policy table in `CLAUDE.md` accordingly.
+4. **Associated targets** — add a real `ManifoldSystemAIProvider` or
+   `ManifoldCoreAI` source target only once the API surface is confirmed.
+   The stub traits intentionally have no targets today.
+
+## How to activate post-WWDC
+
+1. Add the concrete source target(s) with `.define("SystemAIProviderExtension", .when(traits: ["SystemAIProviderExtension"]))` in `swiftSettings`.
+2. Remove both trait names from `pendingMapping` in `FeatureMatrixTests.swift` and add the real `ManifoldCapability` cases they unlock.
+3. Update this file with the confirmed API surface and availability.


### PR DESCRIPTION
Closes #1412.

## Summary

- Declares `SystemAIProviderExtension` and `CoreAI` traits in `Package.swift` — pure manifest stubs with no associated targets, source files, or external dependencies.
- Adds both to `FeatureMatrix.swift` with `unlocks: []` and to `pendingMapping` in `FeatureMatrixTests`, keeping `FeatureMatrixTests` CI green while making the gap visible.
- Adds `docs/wwdc-2026-trait-stubs.md` explaining what each trait represents, why they're pre-emptive, and the deferred decision points (exact protocol names, entitlement requirements, OS availability floor, and real target addition).

WWDC is 8 days away (June 8). Having the trait shape committed now means feature branches can use `#if SystemAIProviderExtension` / `#if CoreAI` guards today, and wiring in the real implementation on June 8 requires only source additions — no manifest restructuring under time pressure.

## Build verification

```
swift build --traits SystemAIProviderExtension  # Build complete!
swift build --traits CoreAI                     # Build complete!
swift build --disable-default-traits            # Build complete!
```

All three pass with no new warnings.

## Test plan

- [ ] `FeatureMatrixTests` passes — both new traits appear in `Package.swift` and in `FeatureMatrix.traits`, and are covered by `pendingMapping`
- [ ] `PackageTraitGateAuditTest` unaffected — stubs have no consumer→module dependency edges to gate
- [ ] `swift build --disable-default-traits` clean