### PR TITLE
feat(test-support): Glass Box P4b — scenario batch (3 new scenarios)

### DIFF
--- a/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
+++ b/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
@@ -16,6 +16,10 @@ public enum RuntimeScenarioRegistry {
         .kvCacheReuseAdvisory,
         .diagnosticThrottleAdvisory,
         .multiTurnConversation,
+        // P4b batch:
+        .swapTheBrain,
+        .midStreamErrorRecovery,
+        .researcherWriterHandoff,
     ]
 }
 
@@ -85,6 +89,85 @@ extension RuntimeScenario {
         scriptedTurns: [
             .tokens(["Turn", " one", "."]),
             .tokens(["Turn", " two", "."]),
+        ],
+        expectedSubsequence: [
+            .streamStarted, .tokenEmitted, .streamFinished,
+            .streamStarted, .tokenEmitted, .streamFinished,
+        ]
+    )
+
+    // MARK: - P4b scenarios
+
+    /// Simulates a capability-degraded backend: the first turn produces a rich
+    /// response; the second produces a minimal, token-poor response as if the
+    /// underlying model had been downgraded. Verifies the runtime completes both
+    /// turns cleanly regardless of response quality.
+    public static let swapTheBrain = RuntimeScenario(
+        id: "swap-the-brain",
+        displayName: "Swap the Brain",
+        scenarioDescription: "Two-turn conversation where the second turn simulates a capability-degraded backend response (fewer tokens). Verifies the runtime completes cleanly with minimal output.",
+        userMessages: [
+            "Explain the theory of relativity in detail.",
+            "Summarise that in one word.",
+        ],
+        scriptedTurns: [
+            .tokens(["Mass", " warps", " spacetime", "."]),  // full response
+            .tokens(["Spacetime", "."]),                      // degraded — minimal
+        ],
+        expectedSubsequence: [
+            .streamStarted, .tokenEmitted, .streamFinished,
+            .streamStarted, .tokenEmitted, .streamFinished,
+        ]
+    )
+
+    /// First turn errors mid-stream; second turn succeeds. Verifies that
+    /// `errorRaised` appears in the trace after the partial first turn and
+    /// that the runtime remains usable for the subsequent turn.
+    public static let midStreamErrorRecovery = RuntimeScenario(
+        id: "mid-stream-error-recovery",
+        displayName: "Mid-Stream Error Recovery",
+        scenarioDescription: "First turn errors mid-stream; second turn succeeds. Verifies errorRaised appears and the runtime stays usable for the next turn.",
+        userMessages: [
+            "What is 2 + 2?",
+            "Try again.",
+        ],
+        scriptedTurns: [
+            .failMidStream(
+                NSError(domain: "ScenarioTest", code: 503, userInfo: [NSLocalizedDescriptionKey: "upstream timeout"]),
+                afterTokens: 1,
+                tokens: ["Four"]
+            ),
+            .tokens(["Four", "."]),
+        ],
+        expectedSubsequence: [
+            .streamStarted, .tokenEmitted, .errorRaised,
+            .streamStarted, .tokenEmitted, .streamFinished,
+        ]
+    )
+
+    /// Two-phase conversation that models a researcher → writer agent handoff:
+    /// the first turn represents the researcher phase (context-gathering tokens)
+    /// and the second represents the writer phase (synthesis tokens). Verifies
+    /// two clean stream lifecycles without error, exercising the same structural
+    /// multi-turn path that a live handoff would traverse.
+    ///
+    /// - Note: `GenerationEvent.handoffRequested` maps to `StreamAction.recordHandoff`
+    ///   in `GenerationStreamConsumer` and is then handled by `ConversationTurnExecutor`,
+    ///   which emits `ConversationEvent.agentHandoff` only when a session record is
+    ///   available. The hermetic ``RuntimeScenarioRunner`` runs without a session store,
+    ///   so the handoff event would be silently dropped. This two-turn shape exercises
+    ///   the same runtime lifecycle path without requiring session state.
+    public static let researcherWriterHandoff = RuntimeScenario(
+        id: "researcher-writer-handoff",
+        displayName: "Researcher → Writer Handoff",
+        scenarioDescription: "Two-phase conversation: researcher phase gathers context, writer phase synthesises. Verifies two clean lifecycles without error.",
+        userMessages: [
+            "Research: what is photosynthesis?",
+            "Write: summarise your research findings.",
+        ],
+        scriptedTurns: [
+            .tokens(["Photosynthesis", " converts", " light", " to", " energy", "."]),
+            .tokens(["Plants", " use", " sunlight", " to", " make", " food", "."]),
         ],
         expectedSubsequence: [
             .streamStarted, .tokenEmitted, .streamFinished,


### PR DESCRIPTION
Closes #1531 (P4b batch).

## Summary

Adds three new scenarios to `RuntimeScenarioRegistry`, bringing the total from 4 to 7. The existing `test_allRegisteredScenarios_passInScriptedMode` matrix gate exercises all of them automatically — no new test methods were needed.

### New scenarios

| ID | Display name | What it exercises |
|----|---|---|
| `swap-the-brain` | Swap the Brain | Two-turn conversation where the second turn simulates a capability-degraded backend (fewer tokens). Verifies the runtime completes cleanly regardless of output richness. |
| `mid-stream-error-recovery` | Mid-Stream Error Recovery | First turn errors mid-stream after one token; second turn succeeds. Verifies `errorRaised` appears in the trace and the runtime remains usable for the subsequent turn. |
| `researcher-writer-handoff` | Researcher → Writer Handoff | Two-phase conversation: researcher phase gathers context tokens, writer phase synthesises. Verifies two clean `streamStarted → streamFinished` lifecycles without error. Uses the fallback two-turn shape because `ConversationEvent.agentHandoff` requires a session record that the hermetic `RuntimeScenarioRunner` does not supply (documented in a `- Note:` on the scenario). |

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — clean
- [x] `swift test --disable-default-traits --filter RuntimeScenarioRunner` — 7 tests, 0 failures
- [x] All 7 `RuntimeScenarioRunnerTests` pass including `test_allRegisteredScenarios_passInScriptedMode` and `test_registry_hasNoIDCollisions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)