### PR TITLE
feat(test-support): Glass Box P4a — flagship research session scenario

### DIFF
--- a/Sources/ManifoldContractTestSupport/RuntimeScenarioRunner.swift
+++ b/Sources/ManifoldContractTestSupport/RuntimeScenarioRunner.swift
@@ -74,7 +74,8 @@ public enum RuntimeScenarioRunner {
         let runtime = ConversationRuntime(
             messageStore: store,
             sessionStore: nil,
-            inferenceService: inferenceService
+            inferenceService: inferenceService,
+            preTurnCompressionPolicy: scenario.preTurnCompressionPolicy
         )
 
         let recorder = ConversationEventRecorder()

--- a/Sources/ManifoldTestSupport/FixedCountPreTurnCompressionPolicy.swift
+++ b/Sources/ManifoldTestSupport/FixedCountPreTurnCompressionPolicy.swift
@@ -1,0 +1,64 @@
+#if DEBUG
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+
+/// A ``PreTurnCompressionPolicy`` that fires after a fixed number of messages
+/// have accumulated. Designed for hermetic ``RuntimeScenario`` runs where
+/// compression must trigger deterministically without real token-usage data.
+///
+/// The policy fires at the top of the turn after `compressAfterMessages`
+/// messages exist in the session. It returns a single `.system` memory record
+/// whose content is a synthetic summary, exercising the full
+/// ``ConversationEvent/historyCompressed(sessionID:insertedRecords:)`` path
+/// without calling the inference backend for summarisation.
+///
+/// The `generate` closure supplied by the runtime is intentionally ignored —
+/// scripted runs need zero network or model activity for compression.
+///
+/// ## Thread safety
+///
+/// Value type — inherits `Sendable` implicitly.
+public struct FixedCountPreTurnCompressionPolicy: PreTurnCompressionPolicy {
+
+    /// Number of messages that must exist before compression fires.
+    ///
+    /// Compression triggers at the start of the turn after `compressAfterMessages`
+    /// messages are present — i.e. the *first* turn where `messageCount >=
+    /// compressAfterMessages`.
+    public let compressAfterMessages: Int
+
+    /// Content written into the synthetic memory record emitted by compression.
+    public let summaryContent: String
+
+    public init(
+        compressAfterMessages: Int,
+        summaryContent: String = "Compressed history summary."
+    ) {
+        self.compressAfterMessages = compressAfterMessages
+        self.summaryContent = summaryContent
+    }
+
+    // MARK: - PreTurnCompressionPolicy
+
+    public func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+        messageCount >= compressAfterMessages
+    }
+
+    public func compressBeforeTurn(
+        history: [ChatMessageRecord],
+        sessionID: UUID,
+        generate: @Sendable ([ChatMessageRecord]) async throws -> String
+    ) async throws -> [ChatMessageRecord] {
+        // Return a single memory record instead of calling `generate` — the
+        // scripted backend's turns are pre-assigned to user turns, and consuming
+        // one here would mis-align the scripted turn sequence.
+        [ChatMessageRecord(
+            role: .system,
+            content: summaryContent,
+            sessionID: sessionID,
+            kind: .memory("scripted-compression-summary")
+        )]
+    }
+}
+#endif

--- a/Sources/ManifoldTestSupport/RuntimeScenario.swift
+++ b/Sources/ManifoldTestSupport/RuntimeScenario.swift
@@ -14,6 +14,11 @@ import ManifoldRuntime
 ///   regardless of which backend drives the conversation.
 /// - Display metadata (``displayName``, ``scenarioDescription``) for the
 ///   demo picker UI that the Architect view (P5) will surface.
+/// - An optional ``preTurnCompressionPolicy`` for scenarios that exercise the
+///   runtime's history-compression path. When supplied,
+///   ``RuntimeScenarioRunner`` wires it into ``ConversationRuntime`` so
+///   compression fires deterministically — without requiring real token-usage
+///   data from the scripted backend.
 public struct RuntimeScenario: Sendable {
 
     /// Stable identifier — used as the test name and demo card key.
@@ -36,13 +41,25 @@ public struct RuntimeScenario: Sendable {
     /// recorded trace for the scenario to pass — in both scripted and live mode.
     public let expectedSubsequence: [ConversationEventKind]
 
+    /// Optional pre-turn compression policy. When non-nil,
+    /// ``RuntimeScenarioRunner`` passes this to
+    /// ``ConversationRuntime/init(messageStore:sessionStore:inferenceService:preTurnCompressionPolicy:)``
+    /// so the scenario can exercise the ``ConversationEvent/historyCompressed``
+    /// path deterministically.
+    ///
+    /// Pre-turn compression fires before the user message is appended to the
+    /// store, so ``ConversationEvent/historyCompressed`` appears *before* the
+    /// ``ConversationEvent/contextAssembled`` event for the same turn.
+    public let preTurnCompressionPolicy: (any PreTurnCompressionPolicy)?
+
     public init(
         id: String,
         displayName: String,
         scenarioDescription: String,
         userMessages: [String],
         scriptedTurns: [ScriptedGenerationBackend.TurnScript],
-        expectedSubsequence: [ConversationEventKind]
+        expectedSubsequence: [ConversationEventKind],
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil
     ) {
         precondition(
             userMessages.count == scriptedTurns.count,
@@ -54,6 +71,7 @@ public struct RuntimeScenario: Sendable {
         self.userMessages = userMessages
         self.scriptedTurns = scriptedTurns
         self.expectedSubsequence = expectedSubsequence
+        self.preTurnCompressionPolicy = preTurnCompressionPolicy
     }
 }
 #endif

--- a/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
+++ b/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
@@ -20,6 +20,8 @@ public enum RuntimeScenarioRegistry {
         .swapTheBrain,
         .midStreamErrorRecovery,
         .researcherWriterHandoff,
+        // P4a: flagship scenario:
+        .researchSession,
     ]
 }
 
@@ -173,6 +175,63 @@ extension RuntimeScenario {
             .streamStarted, .tokenEmitted, .streamFinished,
             .streamStarted, .tokenEmitted, .streamFinished,
         ]
+    )
+
+    // MARK: - P4a: flagship scenario
+
+    /// The centerpiece Glass Box scenario: a multi-turn research conversation
+    /// that fills the context window, triggers automatic history compression,
+    /// then continues answering coherently from the compressed history.
+    ///
+    /// The structural assertion it validates is:
+    /// ```
+    /// contextAssembled         // turn 1 context assembly
+    ///   ≺ streamFinished       // turn 1 generation complete
+    ///   ≺ contextAssembled     // turn 2 context assembly
+    ///   ≺ streamFinished       // turn 2 generation complete
+    ///   ≺ historyCompressed    // runtime compresses history before turn 3
+    ///   ≺ contextAssembled     // turn 3 assembles from compressed history
+    ///   ≺ streamFinished       // turn 3 generation complete
+    ///   ≺ contextAssembled     // turn 4 context assembly
+    ///   ≺ streamFinished       // turn 4 generation complete
+    /// ```
+    ///
+    /// Pre-turn compression fires when `messageCount >= 4` (2 user + 2
+    /// assistant messages from the first two turns). The policy replaces the
+    /// stored history with a single synthetic memory record without calling the
+    /// inference backend, so the scripted turn sequence is not disrupted.
+    ///
+    /// This scenario is the scripted (CI) counterpart of the flagship demo
+    /// described in Glass Box issue #1531. No real RAG or external calls are
+    /// needed — ``FixedCountPreTurnCompressionPolicy`` drives compression
+    /// deterministically via message count.
+    public static let researchSession = RuntimeScenario(
+        id: "self-managing-research-session",
+        displayName: "Self-Managing Research Session",
+        scenarioDescription: "A 4-turn research conversation that fills the context window after 2 turns, triggers automatic history compression at the start of turn 3 (replacing prior history with a synthetic memory record), then continues coherently from the compressed history. Verifies the full historyCompressed → contextAssembled → streamFinished structural ordering.",
+        userMessages: [
+            "What is photosynthesis?",
+            "How does the light-dependent reaction work?",
+            "What role does chlorophyll play?",
+            "Summarise everything you've told me so far.",
+        ],
+        scriptedTurns: [
+            .tokens(["Photosynthesis", " converts", " light", " to", " energy", "."]),
+            .tokens(["Light", "-dependent", " reactions", " use", " ATP", "."]),
+            .tokens(["Chlorophyll", " absorbs", " light", "."]),
+            .tokens(["Summary", ": photosynthesis", ", reactions", ", chlorophyll", "."]),
+        ],
+        // Compression fires before turn 3 (messageCount == 4: 2 user + 2 assistant
+        // from turns 1–2), emitting historyCompressed before contextAssembled for
+        // that turn. Turns 1, 2, and 4 run without compression.
+        expectedSubsequence: [
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 1
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 2
+            .historyCompressed,                                                  // compression fires before turn 3
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 3
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 4
+        ],
+        preTurnCompressionPolicy: FixedCountPreTurnCompressionPolicy(compressAfterMessages: 4)
     )
 }
 #endif

--- a/Tests/ManifoldTestSupportTests/RuntimeScenarioRunnerTests.swift
+++ b/Tests/ManifoldTestSupportTests/RuntimeScenarioRunnerTests.swift
@@ -70,6 +70,45 @@ final class RuntimeScenarioRunnerTests: XCTestCase {
         XCTAssertEqual(finishedCount, 2, "Expected 2 streamFinished events, got \(finishedCount)")
     }
 
+    // MARK: - P4a: flagship scenario structural assertions
+
+    /// The self-managing research session must contain exactly one
+    /// `historyCompressed` event, and it must appear *before* the third
+    /// `contextAssembled` — proving that turn 3 assembled its context from
+    /// the compressed history.
+    func test_researchSession_historyCompressedBeforeThirdContextAssembled() async throws {
+        let result = try await RuntimeScenarioRunner.run(.researchSession)
+
+        XCTAssertTrue(result.subsequencePassed, result.subsequenceFailureReason ?? "subsequence check failed")
+
+        // Exactly one compression event must fire (the policy fires once at
+        // messageCount == 4, then the count drops back below the threshold).
+        let compressionCount = result.trace.kinds.filter { $0 == .historyCompressed }.count
+        XCTAssertEqual(compressionCount, 1, "Expected exactly 1 historyCompressed event, got \(compressionCount)")
+
+        // The structural ordering guarantee: historyCompressed must precede the
+        // third contextAssembled in the trace.
+        let kinds = result.trace.kinds
+        let compressionIndex = kinds.firstIndex(of: .historyCompressed)
+        let contextAssembledIndices = kinds.enumerated()
+            .filter { $0.element == .contextAssembled }
+            .map(\.offset)
+
+        XCTAssertNotNil(compressionIndex, "historyCompressed must appear in the trace")
+        XCTAssertGreaterThanOrEqual(
+            contextAssembledIndices.count, 3,
+            "Expected at least 3 contextAssembled events (one per post-compression turn)"
+        )
+        if let ci = compressionIndex, contextAssembledIndices.count >= 3 {
+            let thirdContextAssembledIndex = contextAssembledIndices[2]
+            XCTAssertLessThan(
+                ci,
+                thirdContextAssembledIndex,
+                "historyCompressed must precede the third contextAssembled — got historyCompressed at \(ci), third contextAssembled at \(thirdContextAssembledIndex)"
+            )
+        }
+    }
+
     // MARK: - Registry integrity
 
     /// All scenario IDs in the registry must be unique — duplicate IDs would


### PR DESCRIPTION
## Summary

Closes the P4a item from #1531 — the scripted flagship scenario for the Glass Box demo.

### What this adds

- **`FixedCountPreTurnCompressionPolicy`** (`ManifoldTestSupport`) — a `PreTurnCompressionPolicy` that fires when the session's message count reaches a configurable threshold. Returns a single synthetic memory record without calling the inference backend, so scripted turn sequences are not disrupted.

- **`RuntimeScenario.preTurnCompressionPolicy`** — optional field wired through `RuntimeScenarioRunner` into `ConversationRuntime(preTurnCompressionPolicy:)`. All existing scenarios default to `nil` (no compression) and compile unchanged.

- **`RuntimeScenario.researchSession`** (`RuntimeScenarioRegistry`) — the P4a flagship: a 4-turn research conversation where compression fires before turn 3, replacing the prior 4 messages with a synthetic memory record. Turn 3 then assembles context from the compressed history.

- **`test_researchSession_historyCompressedBeforeThirdContextAssembled`** — structural assertion test that verifies exactly one `historyCompressed` event fires, and that it precedes the third `contextAssembled` in the trace.

### Structural assertion shape (P4a spec)

```
contextAssembled  ≺  streamFinished     // turn 1
contextAssembled  ≺  streamFinished     // turn 2
historyCompressed                       // compression fires before turn 3 (messageCount == 4)
contextAssembled  ≺  streamFinished     // turn 3 assembles from compressed history
contextAssembled  ≺  streamFinished     // turn 4
```

### Compression wiring

The post-turn `CompressionPolicy` requires real token-usage data (`promptTokens`) that `ScriptedGenerationBackend` does not emit. `PreTurnCompressionPolicy` fires on message count instead — no token-usage gate — making it the right seam for deterministic scripted scenarios. The `RuntimeScenarioRunner` is extended by one parameter (`scenario.preTurnCompressionPolicy`) with zero change to any existing call site.

### Test results

`test_allRegisteredScenarios_passInScriptedMode` now covers 8 scenarios (was 7). All pass.

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — clean
- [x] `swift test --disable-default-traits --filter RuntimeScenarioRunnerTests` — 8/8 pass
- [x] `test_researchSession_historyCompressedBeforeThirdContextAssembled` — 1 compression event, ordering verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)