### PR TITLE
feat(ui): Glass Box P5 — Architect developer inspector

### DIFF
--- a/Sources/ManifoldContractTestSupport/RuntimeScenarioRunner.swift
+++ b/Sources/ManifoldContractTestSupport/RuntimeScenarioRunner.swift
@@ -74,7 +74,8 @@ public enum RuntimeScenarioRunner {
         let runtime = ConversationRuntime(
             messageStore: store,
             sessionStore: nil,
-            inferenceService: inferenceService
+            inferenceService: inferenceService,
+            preTurnCompressionPolicy: scenario.preTurnCompressionPolicy
         )
 
         let recorder = ConversationEventRecorder()

--- a/Sources/ManifoldTestSupport/FixedCountPreTurnCompressionPolicy.swift
+++ b/Sources/ManifoldTestSupport/FixedCountPreTurnCompressionPolicy.swift
@@ -1,0 +1,64 @@
+#if DEBUG
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+
+/// A ``PreTurnCompressionPolicy`` that fires after a fixed number of messages
+/// have accumulated. Designed for hermetic ``RuntimeScenario`` runs where
+/// compression must trigger deterministically without real token-usage data.
+///
+/// The policy fires at the top of the turn after `compressAfterMessages`
+/// messages exist in the session. It returns a single `.system` memory record
+/// whose content is a synthetic summary, exercising the full
+/// ``ConversationEvent/historyCompressed(sessionID:insertedRecords:)`` path
+/// without calling the inference backend for summarisation.
+///
+/// The `generate` closure supplied by the runtime is intentionally ignored —
+/// scripted runs need zero network or model activity for compression.
+///
+/// ## Thread safety
+///
+/// Value type — inherits `Sendable` implicitly.
+public struct FixedCountPreTurnCompressionPolicy: PreTurnCompressionPolicy {
+
+    /// Number of messages that must exist before compression fires.
+    ///
+    /// Compression triggers at the start of the turn after `compressAfterMessages`
+    /// messages are present — i.e. the *first* turn where `messageCount >=
+    /// compressAfterMessages`.
+    public let compressAfterMessages: Int
+
+    /// Content written into the synthetic memory record emitted by compression.
+    public let summaryContent: String
+
+    public init(
+        compressAfterMessages: Int,
+        summaryContent: String = "Compressed history summary."
+    ) {
+        self.compressAfterMessages = compressAfterMessages
+        self.summaryContent = summaryContent
+    }
+
+    // MARK: - PreTurnCompressionPolicy
+
+    public func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+        messageCount >= compressAfterMessages
+    }
+
+    public func compressBeforeTurn(
+        history: [ChatMessageRecord],
+        sessionID: UUID,
+        generate: @Sendable ([ChatMessageRecord]) async throws -> String
+    ) async throws -> [ChatMessageRecord] {
+        // Return a single memory record instead of calling `generate` — the
+        // scripted backend's turns are pre-assigned to user turns, and consuming
+        // one here would mis-align the scripted turn sequence.
+        [ChatMessageRecord(
+            role: .system,
+            content: summaryContent,
+            sessionID: sessionID,
+            kind: .memory("scripted-compression-summary")
+        )]
+    }
+}
+#endif

--- a/Sources/ManifoldTestSupport/RuntimeScenario.swift
+++ b/Sources/ManifoldTestSupport/RuntimeScenario.swift
@@ -14,6 +14,11 @@ import ManifoldRuntime
 ///   regardless of which backend drives the conversation.
 /// - Display metadata (``displayName``, ``scenarioDescription``) for the
 ///   demo picker UI that the Architect view (P5) will surface.
+/// - An optional ``preTurnCompressionPolicy`` for scenarios that exercise the
+///   runtime's history-compression path. When supplied,
+///   ``RuntimeScenarioRunner`` wires it into ``ConversationRuntime`` so
+///   compression fires deterministically — without requiring real token-usage
+///   data from the scripted backend.
 public struct RuntimeScenario: Sendable {
 
     /// Stable identifier — used as the test name and demo card key.
@@ -36,13 +41,25 @@ public struct RuntimeScenario: Sendable {
     /// recorded trace for the scenario to pass — in both scripted and live mode.
     public let expectedSubsequence: [ConversationEventKind]
 
+    /// Optional pre-turn compression policy. When non-nil,
+    /// ``RuntimeScenarioRunner`` passes this to
+    /// ``ConversationRuntime/init(messageStore:sessionStore:inferenceService:preTurnCompressionPolicy:)``
+    /// so the scenario can exercise the ``ConversationEvent/historyCompressed``
+    /// path deterministically.
+    ///
+    /// Pre-turn compression fires before the user message is appended to the
+    /// store, so ``ConversationEvent/historyCompressed`` appears *before* the
+    /// ``ConversationEvent/contextAssembled`` event for the same turn.
+    public let preTurnCompressionPolicy: (any PreTurnCompressionPolicy)?
+
     public init(
         id: String,
         displayName: String,
         scenarioDescription: String,
         userMessages: [String],
         scriptedTurns: [ScriptedGenerationBackend.TurnScript],
-        expectedSubsequence: [ConversationEventKind]
+        expectedSubsequence: [ConversationEventKind],
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil
     ) {
         precondition(
             userMessages.count == scriptedTurns.count,
@@ -54,6 +71,7 @@ public struct RuntimeScenario: Sendable {
         self.userMessages = userMessages
         self.scriptedTurns = scriptedTurns
         self.expectedSubsequence = expectedSubsequence
+        self.preTurnCompressionPolicy = preTurnCompressionPolicy
     }
 }
 #endif

--- a/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
+++ b/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
@@ -20,6 +20,8 @@ public enum RuntimeScenarioRegistry {
         .swapTheBrain,
         .midStreamErrorRecovery,
         .researcherWriterHandoff,
+        // P4a: flagship scenario:
+        .researchSession,
     ]
 }
 
@@ -173,6 +175,63 @@ extension RuntimeScenario {
             .streamStarted, .tokenEmitted, .streamFinished,
             .streamStarted, .tokenEmitted, .streamFinished,
         ]
+    )
+
+    // MARK: - P4a: flagship scenario
+
+    /// The centerpiece Glass Box scenario: a multi-turn research conversation
+    /// that fills the context window, triggers automatic history compression,
+    /// then continues answering coherently from the compressed history.
+    ///
+    /// The structural assertion it validates is:
+    /// ```
+    /// contextAssembled         // turn 1 context assembly
+    ///   ≺ streamFinished       // turn 1 generation complete
+    ///   ≺ contextAssembled     // turn 2 context assembly
+    ///   ≺ streamFinished       // turn 2 generation complete
+    ///   ≺ historyCompressed    // runtime compresses history before turn 3
+    ///   ≺ contextAssembled     // turn 3 assembles from compressed history
+    ///   ≺ streamFinished       // turn 3 generation complete
+    ///   ≺ contextAssembled     // turn 4 context assembly
+    ///   ≺ streamFinished       // turn 4 generation complete
+    /// ```
+    ///
+    /// Pre-turn compression fires when `messageCount >= 4` (2 user + 2
+    /// assistant messages from the first two turns). The policy replaces the
+    /// stored history with a single synthetic memory record without calling the
+    /// inference backend, so the scripted turn sequence is not disrupted.
+    ///
+    /// This scenario is the scripted (CI) counterpart of the flagship demo
+    /// described in Glass Box issue #1531. No real RAG or external calls are
+    /// needed — ``FixedCountPreTurnCompressionPolicy`` drives compression
+    /// deterministically via message count.
+    public static let researchSession = RuntimeScenario(
+        id: "self-managing-research-session",
+        displayName: "Self-Managing Research Session",
+        scenarioDescription: "A 4-turn research conversation that fills the context window after 2 turns, triggers automatic history compression at the start of turn 3 (replacing prior history with a synthetic memory record), then continues coherently from the compressed history. Verifies the full historyCompressed → contextAssembled → streamFinished structural ordering.",
+        userMessages: [
+            "What is photosynthesis?",
+            "How does the light-dependent reaction work?",
+            "What role does chlorophyll play?",
+            "Summarise everything you've told me so far.",
+        ],
+        scriptedTurns: [
+            .tokens(["Photosynthesis", " converts", " light", " to", " energy", "."]),
+            .tokens(["Light", "-dependent", " reactions", " use", " ATP", "."]),
+            .tokens(["Chlorophyll", " absorbs", " light", "."]),
+            .tokens(["Summary", ": photosynthesis", ", reactions", ", chlorophyll", "."]),
+        ],
+        // Compression fires before turn 3 (messageCount == 4: 2 user + 2 assistant
+        // from turns 1–2), emitting historyCompressed before contextAssembled for
+        // that turn. Turns 1, 2, and 4 run without compression.
+        expectedSubsequence: [
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 1
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 2
+            .historyCompressed,                                                  // compression fires before turn 3
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 3
+            .contextAssembled, .streamStarted, .tokenEmitted, .streamFinished,  // turn 4
+        ],
+        preTurnCompressionPolicy: FixedCountPreTurnCompressionPolicy(compressAfterMessages: 4)
     )
 }
 #endif

--- a/Sources/ManifoldUI/ViewModels/ArchitectViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ArchitectViewModel.swift
@@ -1,0 +1,234 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ArchitectEventEntry
+
+/// A single event captured from the conversation runtime's event tap.
+///
+/// Stores the raw event alongside derived display properties so views can render
+/// rows without re-switching on the event each frame.
+public struct ArchitectEventEntry: Identifiable, Sendable {
+
+    public let id: UUID
+    /// Monotonically-increasing index within the current recording session.
+    public let index: Int
+    /// The kind discriminant, matching ``ConversationEventKind``.
+    public let kind: ConversationEventKind
+    /// Short human-readable summary of the event's key associated values.
+    public let summary: String
+    /// The underlying event, retained for per-entry detail views (e.g. slot inspector).
+    public let event: ConversationEvent
+    /// True for `.compressionTriggered` and `.historyCompressed`.
+    public let isCompressionRelated: Bool
+    /// True for `.errorRaised`.
+    public let isError: Bool
+
+    public init(event: ConversationEvent, index: Int) {
+        self.id = UUID()
+        self.index = index
+        self.kind = event.kind
+        self.event = event
+        self.isCompressionRelated = {
+            switch event {
+            case .compressionTriggered, .historyCompressed:
+                return true
+            default:
+                return false
+            }
+        }()
+        self.isError = {
+            if case .errorRaised = event { return true }
+            return false
+        }()
+        self.summary = ArchitectEventEntry.makeSummary(for: event)
+    }
+
+    // MARK: - Summary Derivation
+
+    private static func makeSummary(for event: ConversationEvent) -> String {
+        switch event {
+        case .tokenEmitted(_, let delta):
+            let truncated = delta.prefix(40)
+            return "\"\(truncated)\(delta.count > 40 ? "…" : "")\""
+
+        case .streamFinished(_, let reason):
+            switch reason {
+            case .stop:      return "stop"
+            case .cancelled: return "cancelled"
+            case .empty:     return "empty"
+            case .length:    return "length"
+            }
+
+        case .errorRaised(let error):
+            let description = error.localizedDescription
+            let truncated = description.prefix(80)
+            return "\(truncated)\(description.count > 80 ? "…" : "")"
+
+        case .contextAssembled(let slots):
+            return "slots:\(slots.count)"
+
+        case .compressionTriggered(let removed, let reason):
+            let reasonStr: String = {
+                switch reason {
+                case .contextWindowExceeded: return "contextWindowExceeded"
+                case .manual:               return "manual"
+                }
+            }()
+            return "removed:\(removed.count) reason:\(reasonStr)"
+
+        case .historyCompressed(_, let insertedRecords):
+            return "inserted:\(insertedRecords.count)"
+
+        case .toolCallRequested(let call):
+            return call.toolName
+
+        case .toolCallApproved(let callID):
+            return callID
+
+        case .toolCallCompleted(let callID, _):
+            return callID
+
+        case .streamStarted(let messageID):
+            return messageID.uuidString.prefix(8).description
+
+        case .messageInserted(let record):
+            return record.role.rawValue
+
+        case .messageRemoved(let messageID):
+            return messageID.uuidString.prefix(8).description
+
+        case .messageUpdated(let record):
+            return record.role.rawValue
+
+        case .sessionBranched(let newSessionID, let count):
+            return "new:\(newSessionID.uuidString.prefix(8)) copied:\(count)"
+
+        case .tokenUsageRecorded(_, let prompt, let completion):
+            return "prompt:\(prompt) completion:\(completion)"
+
+        case .thinkingStarted:
+            return ""
+
+        case .thinkingUpdated:
+            return ""
+
+        case .thinkingFinalized:
+            return ""
+
+        case .loopDetected:
+            return "loop"
+
+        case .sessionTouchFailed(let sessionID):
+            return sessionID.uuidString.prefix(8).description
+
+        case .beforeContextAssembly(let prompt, _):
+            if let prompt {
+                let truncated = prompt.prefix(40)
+                return "\"\(truncated)\(prompt.count > 40 ? "…" : "")\""
+            }
+            return "(no prompt)"
+
+        case .historyShaped(_, let diagnostics):
+            return "diagnostics:\(diagnostics.count)"
+
+        case .afterGeneration(_, let finalText):
+            if finalText.isEmpty { return "(empty)" }
+            let truncated = finalText.prefix(40)
+            return "\"\(truncated)\(finalText.count > 40 ? "…" : "")\""
+
+        case .agentHandoff(let from, let to):
+            let fromStr = from.map { $0.uuidString.prefix(8).description } ?? "nil"
+            return "from:\(fromStr) to:\(to.uuidString.prefix(8))"
+
+        case .skillInvoked(let name, _):
+            return name
+
+        case .hookFired(let hookEvent, _):
+            return hookEvent
+        }
+    }
+}
+
+// MARK: - ArchitectViewModel
+
+/// Observable model backing ``ArchitectView``.
+///
+/// Installs an event tap on the supplied ``ConversationRuntime`` and drains
+/// it into `eventLog`, bounded to the most recent 500 entries. Recording
+/// begins automatically on tap installation and can be paused / restarted
+/// via ``startRecording()`` and ``stopRecording()``.
+@Observable
+@MainActor
+public final class ArchitectViewModel {
+
+    // MARK: Public state
+
+    /// Live event log bounded to the last 500 entries.
+    public private(set) var eventLog: [ArchitectEventEntry] = []
+    /// Whether the tap task is currently draining events.
+    public private(set) var isRecording: Bool = false
+
+    /// Compression-related events extracted for the context inspector.
+    public var compressionEvents: [ArchitectEventEntry] {
+        eventLog.filter { $0.isCompressionRelated }
+    }
+
+    /// The most recent `.contextAssembled` event.
+    public var latestContextEvent: ArchitectEventEntry? {
+        eventLog.last { $0.kind == .contextAssembled }
+    }
+
+    // MARK: Private
+
+    private let runtime: ConversationRuntime
+    @ObservationIgnored private var tapTask: Task<Void, Never>?
+
+    private static let maxLogSize = 500
+
+    // MARK: Init
+
+    public init(runtime: ConversationRuntime) {
+        self.runtime = runtime
+    }
+
+    // MARK: Recording control
+
+    /// Installs an event tap and begins draining events into ``eventLog``.
+    ///
+    /// Safe to call while already recording — the second call is a no-op.
+    public func startRecording() {
+        guard tapTask == nil else { return }
+        isRecording = true
+        let tap = runtime.addEventTap(bufferingPolicy: .bufferingOldest(Self.maxLogSize))
+        tapTask = Task { [weak self] in
+            var idx = await self?.eventLog.count ?? 0
+            for await event in tap {
+                guard let self else { break }
+                let entry = ArchitectEventEntry(event: event, index: idx)
+                if self.eventLog.count >= Self.maxLogSize {
+                    self.eventLog.removeFirst()
+                }
+                self.eventLog.append(entry)
+                idx += 1
+            }
+            self?.isRecording = false
+        }
+    }
+
+    /// Cancels the active tap task and stops recording.
+    public func stopRecording() {
+        tapTask?.cancel()
+        tapTask = nil
+        isRecording = false
+    }
+
+    /// Removes all captured entries from the log.
+    public func clearLog() {
+        eventLog.removeAll()
+    }
+
+    deinit {
+        tapTask?.cancel()
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -592,6 +592,16 @@ public final class ChatViewModel {
         generationCoordinator.conversationRuntime
     }
 
+    /// Public accessor exposing the runtime for developer tooling (e.g. ``ArchitectView``).
+    ///
+    /// Surfaces the same runtime that the internal turn loop uses. Callers
+    /// should install event taps rather than driving turns directly — use
+    /// ``sendMessage()``, ``regenerateLastResponse()``, and ``editMessage(_:newContent:)``
+    /// for all turn-level operations.
+    public var runtime: ConversationRuntime {
+        conversationRuntime
+    }
+
     /// Forwarding accessor so callers that hold `activeConversationStreamHandle` references
     /// (tests, Messages extension) continue to compile without changes.
     var activeConversationStreamHandle: ConversationStreamHandle? {

--- a/Sources/ManifoldUI/Views/Chat/ChatView.swift
+++ b/Sources/ManifoldUI/Views/Chat/ChatView.swift
@@ -27,6 +27,9 @@ public struct ChatView<APIConfig: View>: View {
     @State private var isExportPresented: Bool = false
     @State private var showClearConfirmation: Bool = false
     @State private var showAPIConfiguration: Bool = false
+    #if DEBUG
+    @State private var showArchitectView: Bool = false
+    #endif
 
     /// Optional replacement for the built-in "Send a message to start chatting."
     /// placeholder shown when the session has no messages. Hosts pass a custom
@@ -403,6 +406,16 @@ public struct ChatView<APIConfig: View>: View {
                 showClearConfirmation: $showClearConfirmation,
                 apiConfiguration: apiConfigurationBuilder
             )
+            #if DEBUG
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showArchitectView = true
+                } label: {
+                    Label("Architect", systemImage: "magnifyingglass.circle")
+                }
+                .accessibilityLabel("Open Architect developer inspector")
+            }
+            #endif
         }
         .chatShellPresentations(
             viewModel: viewModel,
@@ -418,6 +431,14 @@ public struct ChatView<APIConfig: View>: View {
             isPresented: $showAPIConfiguration,
             apiConfiguration: apiConfigurationBuilder
         )
+        #if DEBUG
+        .sheet(isPresented: $showArchitectView) {
+            ArchitectView(
+                runtime: viewModel.runtime,
+                capabilities: viewModel.backendCapabilities
+            )
+        }
+        #endif
     }
 
     // MARK: - Message List

--- a/Sources/ManifoldUI/Views/Settings/ArchitectView.swift
+++ b/Sources/ManifoldUI/Views/Settings/ArchitectView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ArchitectView
+
+/// Developer-facing inspector sheet that makes ManifoldKit internals observable
+/// in real time.
+///
+/// ## Tabs
+///
+/// - **Timeline** (P5a): Live event log draining from the runtime's event tap.
+///   Each row shows the event kind in monospace, a short summary of associated
+///   values, and a colour-coded category dot. Compression events are visually
+///   distinct with an orange tint and badge.
+///
+/// - **Context** (P5b): Slot inspector showing the most recent
+///   `.contextAssembled` event's slots and a token budget bar. A compression
+///   history table lists all `.historyCompressed` events.
+///
+/// - **Backend** (P5c): Capability matrix for the active backend, plus an
+///   optional Incognito mode toggle wired via ``onRequestIncognitoMode``.
+///
+/// ## Integration
+///
+/// ```swift
+/// .sheet(isPresented: $showArchitectView) {
+///     ArchitectView(
+///         runtime: viewModel.runtime,
+///         capabilities: viewModel.backendCapabilities
+///     )
+/// }
+/// ```
+///
+/// The `onRequestIncognitoMode` closure is optional. When set, a toggle
+/// in the Backend tab calls it; the host app is responsible for rebuilding
+/// persistence with an in-memory store. This decouples the inspector from
+/// any specific persistence implementation.
+public struct ArchitectView: View {
+
+    @State private var viewModel: ArchitectViewModel
+    @State private var selectedTab: ArchitectTab = .timeline
+    @Environment(\.dismiss) private var dismiss
+
+    private let capabilities: BackendCapabilities?
+    /// Optional closure called when the user enables Incognito mode.
+    public var onRequestIncognitoMode: (() -> Void)?
+
+    // MARK: - Init
+
+    public init(
+        runtime: ConversationRuntime,
+        capabilities: BackendCapabilities? = nil
+    ) {
+        _viewModel = State(initialValue: ArchitectViewModel(runtime: runtime))
+        self.capabilities = capabilities
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Picker("Tab", selection: $selectedTab) {
+                    ForEach(ArchitectTab.allCases, id: \.self) { tab in
+                        Text(tab.rawValue).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+
+                tabContent
+            }
+            .navigationTitle("Architect")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button(viewModel.isRecording ? "Pause" : "Record") {
+                        if viewModel.isRecording {
+                            viewModel.stopRecording()
+                        } else {
+                            viewModel.startRecording()
+                        }
+                    }
+                    .foregroundStyle(viewModel.isRecording ? .orange : .accentColor)
+                }
+                ToolbarItem(placement: .destructiveAction) {
+                    Button("Clear") { viewModel.clearLog() }
+                        .disabled(viewModel.eventLog.isEmpty)
+                }
+            }
+            .onAppear { viewModel.startRecording() }
+            .onDisappear { viewModel.stopRecording() }
+        }
+    }
+
+    // MARK: - Tab Content
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch selectedTab {
+        case .timeline:
+            EventTimelineView(viewModel: viewModel)
+        case .context:
+            ContextSlotInspectorView(viewModel: viewModel)
+        case .backend:
+            BackendCapabilityView(
+                capabilities: capabilities,
+                onRequestIncognitoMode: onRequestIncognitoMode
+            )
+        }
+    }
+
+    // MARK: - Tab enum
+
+    enum ArchitectTab: String, CaseIterable {
+        case timeline = "Timeline"
+        case context = "Context"
+        case backend = "Backend"
+    }
+}

--- a/Sources/ManifoldUI/Views/Settings/BackendCapabilityView.swift
+++ b/Sources/ManifoldUI/Views/Settings/BackendCapabilityView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+import ManifoldInference
+
+// MARK: - BackendCapabilityView
+
+/// P5c: Backend capability matrix and incognito persistence switch.
+///
+/// Displays the active backend's ``BackendCapabilities`` as a form with
+/// boolean checkmarks and integer/string values. When the host app provides
+/// an `onRequestIncognitoMode` closure, an Incognito toggle appears that the
+/// host wires to an in-memory persistence rebuild.
+struct BackendCapabilityView: View {
+
+    let capabilities: BackendCapabilities?
+    /// Optional closure called when the user enables Incognito mode.
+    /// When `nil`, the Incognito toggle is hidden.
+    var onRequestIncognitoMode: (() -> Void)?
+
+    @State private var incognitoEnabled: Bool = false
+
+    var body: some View {
+        Group {
+            if let cap = capabilities {
+                capabilityForm(cap)
+            } else {
+                noBackendView
+            }
+        }
+    }
+
+    // MARK: - No Backend
+
+    private var noBackendView: some View {
+        ContentUnavailableView {
+            Label("No Backend Loaded", systemImage: "cpu.fill")
+        } description: {
+            Text("Load a model to inspect backend capabilities.")
+        }
+    }
+
+    // MARK: - Capability Form
+
+    private func capabilityForm(_ cap: BackendCapabilities) -> some View {
+        Form {
+            Section("Context & Output") {
+                LabeledContent("Max Context Tokens") {
+                    Text("\(cap.maxContextTokens)")
+                        .monospacedDigit()
+                }
+                .accessibilityLabel("Max context tokens: \(cap.maxContextTokens)")
+
+                LabeledContent("Max Output Tokens") {
+                    Text("\(cap.maxOutputTokens)")
+                        .monospacedDigit()
+                }
+                .accessibilityLabel("Max output tokens: \(cap.maxOutputTokens)")
+            }
+
+            Section("Capabilities") {
+                capabilityRow("Streaming", value: cap.supportsStreaming)
+                capabilityRow("Tool Calling", value: cap.supportsToolCalling)
+                capabilityRow("Parallel Tool Calls", value: cap.supportsParallelToolCalls)
+                capabilityRow("Structured Output", value: cap.supportsStructuredOutput)
+                capabilityRow("Native JSON Mode", value: cap.supportsNativeJSONMode)
+                capabilityRow("Grammar Constrained Sampling", value: cap.supportsGrammarConstrainedSampling)
+                capabilityRow("Guided Structured Output", value: cap.supportsGuidedStructuredOutput)
+                capabilityRow("Thinking", value: cap.supportsThinking)
+                capabilityRow("Vision", value: cap.supportsVision)
+                capabilityRow("System Prompt", value: cap.supportsSystemPrompt)
+                capabilityRow("Token Counting", value: cap.supportsTokenCounting)
+                capabilityRow("KV Cache Persistence", value: cap.supportsKVCachePersistence)
+                capabilityRow("Streams Tool Call Arguments", value: cap.streamsToolCallArguments)
+            }
+
+            Section("Runtime") {
+                LabeledContent("Memory Strategy") {
+                    Text(cap.memoryStrategy.rawValue)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Memory strategy: \(cap.memoryStrategy.rawValue)")
+
+                LabeledContent("Cancellation Style") {
+                    Text(cap.cancellationStyle.rawValue)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Cancellation style: \(cap.cancellationStyle.rawValue)")
+
+                capabilityRow("Remote", value: cap.isRemote)
+                capabilityRow("Requires Prompt Template", value: cap.requiresPromptTemplate)
+                capabilityRow("Shares MLX Process Resources", value: cap.sharesMLXProcessResources)
+
+                if let maxTools = cap.maxAdvertisedToolCount {
+                    LabeledContent("Max Advertised Tools") {
+                        Text("\(maxTools)")
+                            .monospacedDigit()
+                    }
+                    .accessibilityLabel("Max advertised tool count: \(maxTools)")
+                }
+            }
+
+            Section("Sampling Parameters") {
+                if cap.supportedParameters.isEmpty {
+                    Text("No sampling parameters reported.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(cap.visibleParameters, id: \.rawValue) { param in
+                        Label(param.rawValue, systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                            .font(.callout)
+                            .accessibilityLabel("\(param.rawValue) supported")
+                    }
+                }
+            }
+
+            if onRequestIncognitoMode != nil {
+                incognitoSection
+            }
+        }
+    }
+
+    // MARK: - Incognito Section
+
+    private var incognitoSection: some View {
+        Section {
+            Toggle(isOn: $incognitoEnabled) {
+                Label("Incognito Mode", systemImage: "eye.slash")
+            }
+            .onChange(of: incognitoEnabled) { _, newValue in
+                if newValue {
+                    onRequestIncognitoMode?()
+                }
+            }
+            .accessibilityLabel("Incognito mode toggle")
+            .accessibilityHint("When enabled, conversation history is stored in memory only and not persisted")
+
+            if incognitoEnabled {
+                Label("History is stored in memory only and will not be saved.", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Privacy")
+        } footer: {
+            Text("Incognito mode switches to an in-memory message store. Reopen the session to restore normal persistence.")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func capabilityRow(_ label: String, value: Bool) -> some View {
+        HStack {
+            Text(label)
+                .font(.callout)
+            Spacer()
+            Image(systemName: value ? "checkmark.circle.fill" : "xmark.circle")
+                .foregroundStyle(value ? .green : .secondary)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value ? "supported" : "not supported")")
+    }
+}

--- a/Sources/ManifoldUI/Views/Settings/ContextSlotInspectorView.swift
+++ b/Sources/ManifoldUI/Views/Settings/ContextSlotInspectorView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ContextSlotInspectorView
+
+/// P5b: Context slot inspector and compression visualizer.
+///
+/// Shows the assembled slots from the most recent `.contextAssembled` event,
+/// a token budget bar, and a compression history table from
+/// `.historyCompressed` events in the log.
+struct ContextSlotInspectorView: View {
+
+    let viewModel: ArchitectViewModel
+
+    var body: some View {
+        Group {
+            if let contextEvent = viewModel.latestContextEvent {
+                contextContent(contextEvent)
+            } else {
+                noContextView
+            }
+        }
+    }
+
+    // MARK: - No Data
+
+    private var noContextView: some View {
+        ContentUnavailableView {
+            Label("No Context Data", systemImage: "doc.text.magnifyingglass")
+        } description: {
+            Text("Send a message while recording to capture context assembly.")
+        }
+    }
+
+    // MARK: - Context Content
+
+    private func contextContent(_ entry: ArchitectEventEntry) -> some View {
+        Form {
+            if case .contextAssembled(let slots) = entry.event {
+                Section("Token Budget") {
+                    SlotBudgetBar(slots: slots)
+                        .padding(.vertical, 4)
+                }
+
+                Section("Slots (\(slots.count))") {
+                    if slots.isEmpty {
+                        Text("No slots assembled for this turn.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(slots) { slot in
+                            SlotRowView(slot: slot)
+                        }
+                    }
+                }
+            }
+
+            if !viewModel.compressionEvents.isEmpty {
+                compressionHistorySection
+            }
+        }
+    }
+
+    // MARK: - Compression History
+
+    private var compressionHistorySection: some View {
+        Section("Compression History (\(viewModel.compressionEvents.count))") {
+            ForEach(viewModel.compressionEvents) { entry in
+                HStack {
+                    Image(systemName: "arrow.down.right.circle.fill")
+                        .foregroundStyle(.orange)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(entry.kind.rawValue)
+                            .font(.system(.caption, design: .monospaced))
+                        if !entry.summary.isEmpty {
+                            Text(entry.summary)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Spacer()
+
+                    Text("#\(entry.index)")
+                        .font(.caption2)
+                        .monospacedDigit()
+                        .foregroundStyle(.tertiary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(entry.kind.rawValue)\(entry.summary.isEmpty ? "" : ": \(entry.summary)"), event \(entry.index)")
+            }
+        }
+    }
+}
+
+// MARK: - SlotBudgetBar
+
+/// Proportional token budget bar using `tokenBudget` values from each slot.
+/// When no budgets are set, shows an equal-width segment per enabled slot.
+private struct SlotBudgetBar: View {
+
+    let slots: [PromptSlot]
+
+    private var enabledSlots: [PromptSlot] { slots.filter { $0.isEnabled } }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let budgets = enabledSlots.compactMap { $0.tokenBudget }
+            let totalBudget = budgets.reduce(0, +)
+
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.quaternary)
+                    .frame(height: 20)
+
+                if totalBudget > 0 {
+                    // Budget-proportional segments
+                    HStack(spacing: 0) {
+                        ForEach(Array(enabledSlots.enumerated()), id: \.offset) { idx, slot in
+                            if let budget = slot.tokenBudget, budget > 0 {
+                                let ratio = Double(budget) / Double(totalBudget)
+                                let segmentWidth = totalWidth * ratio
+                                if segmentWidth >= 1 {
+                                    Rectangle()
+                                        .fill(slotColor(index: idx))
+                                        .frame(width: segmentWidth, height: 20)
+                                }
+                            }
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                } else if !enabledSlots.isEmpty {
+                    // Equal-width segments when no budgets are specified
+                    HStack(spacing: 0) {
+                        ForEach(Array(enabledSlots.enumerated()), id: \.offset) { idx, _ in
+                            Rectangle()
+                                .fill(slotColor(index: idx))
+                                .frame(width: totalWidth / Double(enabledSlots.count), height: 20)
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+            }
+        }
+        .frame(height: 20)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Token budget bar for \(slots.count) slots")
+    }
+
+    private func slotColor(index: Int) -> Color {
+        let palette: [Color] = [.blue, .purple, .green, .orange, .cyan, .indigo, .mint, .pink]
+        return palette[index % palette.count]
+    }
+}
+
+// MARK: - SlotRowView
+
+private struct SlotRowView: View {
+
+    let slot: PromptSlot
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 4) {
+                            Text(slot.label)
+                                .font(.body)
+                                .foregroundStyle(slot.isEnabled ? .primary : .tertiary)
+                            if !slot.isEnabled {
+                                Text("disabled")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        Text(slot.position.displayName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    if let budget = slot.tokenBudget {
+                        Text("≤\(budget) tokens")
+                            .font(.callout)
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .accessibilityHidden(true)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(slot.label), \(slot.position.displayName)\(slot.tokenBudget.map { ", budget \($0) tokens" } ?? "")")
+            .accessibilityHint(isExpanded ? "Tap to collapse" : "Tap to expand content")
+
+            if isExpanded {
+                Text(slot.content.isEmpty ? "(empty)" : slot.content)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                    .accessibilityLabel("Slot content: \(slot.content)")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+

--- a/Sources/ManifoldUI/Views/Settings/EventTimelineView.swift
+++ b/Sources/ManifoldUI/Views/Settings/EventTimelineView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import ManifoldRuntime
+
+// MARK: - EventTimelineView
+
+/// P5a: Live event timeline — scrolling list of ``ArchitectEventEntry`` values
+/// captured from the conversation runtime.
+///
+/// Each row shows the event kind in monospace, a secondary summary, and a
+/// colour-coded dot by category. Compression events receive a distinct
+/// background tint and a "COMPRESSION" badge so the "context collapses" moment
+/// is immediately visible in the stream.
+struct EventTimelineView: View {
+
+    let viewModel: ArchitectViewModel
+
+    @State private var lastEntryID: UUID?
+
+    var body: some View {
+        Group {
+            if viewModel.eventLog.isEmpty {
+                emptyState
+            } else {
+                eventList
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Events Captured", systemImage: "waveform.slash")
+        } description: {
+            Text("Tap Record to start capturing runtime events.")
+        }
+    }
+
+    // MARK: - Event List
+
+    private var eventList: some View {
+        ScrollViewReader { proxy in
+            List(viewModel.eventLog) { entry in
+                EventRowView(entry: entry)
+                    .id(entry.id)
+                    .listRowBackground(entry.isCompressionRelated ? Color.orange.opacity(0.08) : Color.clear)
+                    .listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
+            }
+            .listStyle(.plain)
+            .onChange(of: viewModel.eventLog.count) { _, _ in
+                if let last = viewModel.eventLog.last {
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - EventRowView
+
+private struct EventRowView: View {
+
+    let entry: ArchitectEventEntry
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            // Category colour dot
+            Circle()
+                .fill(categoryColor(for: entry.kind))
+                .frame(width: 8, height: 8)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 6) {
+                    Text(entry.kind.rawValue)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.primary)
+
+                    if entry.isCompressionRelated {
+                        Text("COMPRESSION")
+                            .font(.system(size: 9, weight: .semibold))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(.orange.opacity(0.2), in: RoundedRectangle(cornerRadius: 3))
+                            .foregroundStyle(.orange)
+                    }
+                    if entry.isError {
+                        Text("ERROR")
+                            .font(.system(size: 9, weight: .semibold))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(.red.opacity(0.2), in: RoundedRectangle(cornerRadius: 3))
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                if !entry.summary.isEmpty {
+                    Text(entry.summary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Text("#\(entry.index)")
+                .font(.caption2)
+                .monospacedDigit()
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(entry.kind.rawValue)\(entry.summary.isEmpty ? "" : ": \(entry.summary)"), event \(entry.index)")
+    }
+
+    // MARK: - Category colour mapping
+
+    private func categoryColor(for kind: ConversationEventKind) -> Color {
+        switch kind {
+        case .streamStarted, .streamFinished, .tokenEmitted:
+            return .green
+
+        case .contextAssembled, .beforeContextAssembly, .historyShaped:
+            return .blue
+
+        case .compressionTriggered, .historyCompressed:
+            return .orange
+
+        case .errorRaised:
+            return .red
+
+        case .toolCallRequested, .toolCallApproved, .toolCallCompleted:
+            return .purple
+
+        case .agentHandoff, .skillInvoked, .hookFired:
+            return .indigo
+
+        case .thinkingStarted, .thinkingUpdated, .thinkingFinalized:
+            return .cyan
+
+        default:
+            return .secondary
+        }
+    }
+}

--- a/Tests/ManifoldTestSupportTests/RuntimeScenarioRunnerTests.swift
+++ b/Tests/ManifoldTestSupportTests/RuntimeScenarioRunnerTests.swift
@@ -70,6 +70,45 @@ final class RuntimeScenarioRunnerTests: XCTestCase {
         XCTAssertEqual(finishedCount, 2, "Expected 2 streamFinished events, got \(finishedCount)")
     }
 
+    // MARK: - P4a: flagship scenario structural assertions
+
+    /// The self-managing research session must contain exactly one
+    /// `historyCompressed` event, and it must appear *before* the third
+    /// `contextAssembled` — proving that turn 3 assembled its context from
+    /// the compressed history.
+    func test_researchSession_historyCompressedBeforeThirdContextAssembled() async throws {
+        let result = try await RuntimeScenarioRunner.run(.researchSession)
+
+        XCTAssertTrue(result.subsequencePassed, result.subsequenceFailureReason ?? "subsequence check failed")
+
+        // Exactly one compression event must fire (the policy fires once at
+        // messageCount == 4, then the count drops back below the threshold).
+        let compressionCount = result.trace.kinds.filter { $0 == .historyCompressed }.count
+        XCTAssertEqual(compressionCount, 1, "Expected exactly 1 historyCompressed event, got \(compressionCount)")
+
+        // The structural ordering guarantee: historyCompressed must precede the
+        // third contextAssembled in the trace.
+        let kinds = result.trace.kinds
+        let compressionIndex = kinds.firstIndex(of: .historyCompressed)
+        let contextAssembledIndices = kinds.enumerated()
+            .filter { $0.element == .contextAssembled }
+            .map(\.offset)
+
+        XCTAssertNotNil(compressionIndex, "historyCompressed must appear in the trace")
+        XCTAssertGreaterThanOrEqual(
+            contextAssembledIndices.count, 3,
+            "Expected at least 3 contextAssembled events (one per post-compression turn)"
+        )
+        if let ci = compressionIndex, contextAssembledIndices.count >= 3 {
+            let thirdContextAssembledIndex = contextAssembledIndices[2]
+            XCTAssertLessThan(
+                ci,
+                thirdContextAssembledIndex,
+                "historyCompressed must precede the third contextAssembled — got historyCompressed at \(ci), third contextAssembled at \(thirdContextAssembledIndex)"
+            )
+        }
+    }
+
     // MARK: - Registry integrity
 
     /// All scenario IDs in the registry must be unique — duplicate IDs would


### PR DESCRIPTION
Closes part of #1531 (P5: Architect view shell + live event timeline + context-slot inspector + compression visualizer + capability matrix + incognito persistence switch).

## What this ships

### P5a — Live Event Timeline (`EventTimelineView`)

A scrolling `List` draining from `ConversationRuntime.addEventTap(bufferingPolicy:)`. Each row shows the event kind in SF Mono, a short summary of key associated values, and a colour-coded category dot:

- **Green**: `streamStarted`, `streamFinished`, `tokenEmitted`
- **Blue**: `contextAssembled`, `beforeContextAssembly`, `historyShaped`
- **Orange**: `compressionTriggered`, `historyCompressed` — plus an `COMPRESSION` badge and row tint
- **Red**: `errorRaised` — plus an `ERROR` badge
- **Purple**: `toolCallRequested`, `toolCallApproved`, `toolCallCompleted`
- **Indigo**: `agentHandoff`, `skillInvoked`, `hookFired`
- **Cyan**: thinking events

Auto-scrolls to bottom on new events. Empty state when recording hasn't started.

### P5b — Context Slot Inspector (`ContextSlotInspectorView`)

Shows the most recent `.contextAssembled` event's `[PromptSlot]` with:
- A proportional token budget bar (budget-weighted when slots carry `tokenBudget`, equal-width otherwise)
- Expandable slot rows: label, position display name, budget cap, and raw content
- A **Compression History** section listing all `.historyCompressed` and `.compressionTriggered` events

### P5c — Backend Capability Matrix + Incognito Switch (`BackendCapabilityView`)

Full `BackendCapabilities` displayed in a Form with boolean checkmarks, integer fields, and enum string values. Groups: Context & Output, Capabilities, Runtime, Sampling Parameters.

Incognito mode toggle: shown only when host passes `onRequestIncognitoMode` closure — calls it and host rebuilds with in-memory store. `ArchitectView` stays decoupled from persistence.

### `ArchitectViewModel` (public)

`@Observable @MainActor` class. Installs a tap via `addEventTap(bufferingPolicy: .bufferingOldest(500))`, drains into `eventLog` (bounded to 500 entries). `startRecording()` / `stopRecording()` / `clearLog()`. Stores the full `ConversationEvent` on each `ArchitectEventEntry` so the context inspector can extract `[PromptSlot]`.

### `ArchitectView` (public)

`NavigationStack` sheet with a segmented `Timeline / Context / Backend` tab picker. Toolbar: Done, Record/Pause, Clear. Starts recording on `.onAppear`, stops on `.onDisappear`.

```swift
.sheet(isPresented: $showArchitectView) {
    ArchitectView(
        runtime: viewModel.runtime,
        capabilities: viewModel.backendCapabilities,
        onRequestIncognitoMode: { /* rebuild with in-memory store */ }
    )
}
```

### ChatView integration

`#if DEBUG` gated toolbar button (`magnifyingglass.circle`) and sheet presentation on `ChatView`. Uses the new public `ChatViewModel.runtime` accessor (forwards `conversationRuntime`).

## Public API surface

- `public struct ArchitectView` — the sheet
- `public final class ArchitectViewModel` — the observable model
- `public var ChatViewModel.runtime: ConversationRuntime` — public accessor for tooling

All sub-views (`EventTimelineView`, `ContextSlotInspectorView`, `BackendCapabilityView`) are `internal`.

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` passes (verified clean)
- [ ] Build with `--traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` for exhaustiveness
- [ ] In a DEBUG build: tap the `magnifyingglass.circle` toolbar button; the Architect sheet opens
- [ ] Send a message while recording; Timeline shows `beforeContextAssembly`, `contextAssembled`, `streamStarted`, `tokenEmitted*`, `streamFinished`
- [ ] Context tab shows assembled slots after a send
- [ ] Backend tab shows capability checkmarks when a model is loaded
- [ ] Pause / Record / Clear toolbar buttons all work as expected
- [ ] Release builds: `#if DEBUG` guard means the Architect button never appears in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)