### PR TITLE
feat(ui): VisionInputButton — cross-platform vision input composer

### DIFF
--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
@@ -33,6 +33,33 @@ The button tint changes to ``Color/accentColor`` when an image is already staged
 
 > Note: ``PhotoAttachmentButton`` is iOS-only. It is compiled under `#if os(iOS)` and is not available on macOS or visionOS.
 
+## Cross-Platform Vision Input
+
+``VisionInputButton`` is the recommended image-attachment button for apps that target both iOS and macOS. On iOS it presents the system `PhotosPicker`; on macOS it opens an `NSOpenPanel` restricted to image file types. In both cases the selected image is staged on ``ChatViewModel`` via ``ChatViewModel/stageAttachment(_:)`` and sent as a ``MessagePart/image(data:mimeType:placeholderHash:)`` part with the next user message.
+
+``VisionInputButton`` hides itself automatically when the active backend does not report ``BackendCapabilities/supportsVision`` — no extra conditional logic is required in the host UI.
+
+Place it in the `composerAccessory` slot of ``ChatView``:
+
+```swift,no-build
+ChatView(showModelManagement: , composerAccessory: {
+    VisionInputButton()
+})
+```
+
+Combine it with ``VoiceComposerAccessory`` when your app supports both modalities:
+
+```swift,no-build
+ChatView(showModelManagement: , composerAccessory: {
+    HStack {
+        VisionInputButton()
+        VoiceComposerAccessory(controller: controller)
+    }
+})
+```
+
+> Note: ``PhotoAttachmentButton`` is iOS-only and predates this component. New code should prefer ``VisionInputButton``, which compiles on both iOS and macOS.
+
 ## Tool Sources
 
 ``ImageGenerationToolSource`` and ``VideoGenerationToolSource`` conform to `SessionToolSource` and advertise `generate_image` and `generate_video` tools respectively to the language model. Register them via `ConversationRuntime.updateSessionToolSources(_:)` after the bootstrap and view model are wired:

--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
@@ -42,7 +42,7 @@ The button tint changes to ``Color/accentColor`` when an image is already staged
 Place it in the `composerAccessory` slot of ``ChatView``:
 
 ```swift,no-build
-ChatView(showModelManagement: , composerAccessory: {
+ChatView(showModelManagement: $show, composerAccessory: {
     VisionInputButton()
 })
 ```
@@ -50,7 +50,7 @@ ChatView(showModelManagement: , composerAccessory: {
 Combine it with ``VoiceComposerAccessory`` when your app supports both modalities:
 
 ```swift,no-build
-ChatView(showModelManagement: , composerAccessory: {
+ChatView(showModelManagement: $show, composerAccessory: {
     HStack {
         VisionInputButton()
         VoiceComposerAccessory(controller: controller)

--- a/Sources/ManifoldUI/Views/Composer/PhotoAttachmentButton.swift
+++ b/Sources/ManifoldUI/Views/Composer/PhotoAttachmentButton.swift
@@ -14,6 +14,9 @@ import ManifoldInference
 /// Pair with ``VoiceComposerAccessory`` or use standalone as the
 /// `composerAccessory` argument to ``ChatView``.
 ///
+/// > Note: Consider using ``VisionInputButton`` which provides the same
+/// > functionality on iOS and additionally supports macOS file-picker input.
+///
 /// ## Usage
 ///
 /// ```swift

--- a/Sources/ManifoldUI/Views/Composer/VisionInputButton.swift
+++ b/Sources/ManifoldUI/Views/Composer/VisionInputButton.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+import ManifoldInference
+#if os(iOS)
+@preconcurrency import PhotosUI
+#endif
+
+/// A cross-platform compose-bar button for attaching images.
+///
+/// On iOS presents the Photos picker; on macOS opens a file-chooser panel
+/// restricted to image UTTypes. Stages the selected image via
+/// ``ChatViewModel/stageAttachment(_:)`` as a
+/// ``MessagePart/image(data:mimeType:placeholderHash:)`` part.
+///
+/// Only shown when the active backend's ``BackendCapabilities`` indicate
+/// vision support (``BackendCapabilities/supportsVision``). When vision is
+/// unsupported the button is hidden.
+///
+/// ```swift
+/// ChatView(showModelManagement: $show, composerAccessory: {
+///     VisionInputButton()
+/// })
+/// ```
+///
+/// Combine with ``VoiceComposerAccessory`` when your app supports both modalities:
+///
+/// ```swift
+/// ChatView(showModelManagement: $show, composerAccessory: {
+///     HStack {
+///         VisionInputButton()
+///         VoiceComposerAccessory(controller: controller)
+///     }
+/// })
+/// ```
+///
+/// > Note: On iOS, ``PhotoAttachmentButton`` provides equivalent functionality
+/// > but is restricted to that platform. Prefer ``VisionInputButton`` for
+/// > cross-platform codebases.
+public struct VisionInputButton: View {
+    @Environment(ChatViewModel.self) private var viewModel
+
+    #if os(iOS)
+    @State private var photoItem: PhotosPickerItem?
+    #endif
+
+    public init() {}
+
+    /// Returns `true` when there is already an image part staged on the draft.
+    private var hasImageStaged: Bool {
+        viewModel.stagedAttachments.contains {
+            if case .image = $0 { return true }
+            return false
+        }
+    }
+
+    /// Whether the current backend supports vision input.
+    private var isVisionSupported: Bool {
+        viewModel.backendCapabilities?.supportsVision == true
+    }
+
+    public var body: some View {
+        #if os(iOS)
+        PhotosPicker(selection: $photoItem, matching: .images) {
+            Image(systemName: "photo.badge.plus")
+                .symbolVariant(.fill)
+                .font(.title2)
+                .foregroundStyle(hasImageStaged ? Color.accentColor : Color.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(hasImageStaged ? "Photo attached" : "Attach photo")
+        .help(hasImageStaged ? "Photo attached" : "Attach image")
+        .onChange(of: photoItem) { _, newItem in
+            guard let newItem else { return }
+            loadPhoto(from: newItem)
+        }
+        .opacity(isVisionSupported ? 1 : 0)
+        .allowsHitTesting(isVisionSupported)
+        #elseif os(macOS)
+        Button {
+            openImagePanel()
+        } label: {
+            Image(systemName: "photo.badge.plus")
+                .symbolVariant(.fill)
+        }
+        .help("Attach image")
+        .opacity(isVisionSupported ? 1 : 0)
+        .allowsHitTesting(isVisionSupported)
+        #endif
+    }
+
+    // MARK: - Private helpers
+
+    #if os(iOS)
+    /// Loads image data from `item` and stages it via the view model.
+    private func loadPhoto(from item: PhotosPickerItem) {
+        let mimeType = resolvedMIMEType(for: item)
+        Task {
+            do {
+                guard let data = try await item.loadTransferable(type: Data.self) else { return }
+                viewModel.stageAttachment(.image(data: data, mimeType: mimeType))
+            } catch {
+                viewModel.surfaceError(error, kind: .configuration, context: "attaching photo")
+            }
+        }
+    }
+
+    /// Infers the best MIME type from the item's `supportedContentTypes`, falling
+    /// back to `image/jpeg` when no recognized type is found.
+    private func resolvedMIMEType(for item: PhotosPickerItem) -> String {
+        for contentType in item.supportedContentTypes {
+            if let mime = contentType.preferredMIMEType, mime.hasPrefix("image/") {
+                return mime
+            }
+        }
+        return "image/jpeg"
+    }
+    #endif
+
+    #if os(macOS)
+    /// Opens a system file-chooser panel restricted to image file types.
+    @MainActor
+    private func openImagePanel() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image, .jpeg, .png, .heic, .gif, .webP]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.begin { [panel] response in
+            guard response == .OK, let url = panel.url else { return }
+            Task { @MainActor in
+                do {
+                    let data = try Data(contentsOf: url)
+                    let mime = mimeType(for: url)
+                    viewModel.stageAttachment(.image(data: data, mimeType: mime))
+                } catch {
+                    viewModel.surfaceError(error, kind: .configuration, context: "attaching image from file")
+                }
+            }
+        }
+    }
+
+    /// Infers the MIME type from the file's path extension, falling back to
+    /// `image/jpeg` for unrecognised extensions.
+    private func mimeType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "jpg", "jpeg": return "image/jpeg"
+        case "png":         return "image/png"
+        case "gif":         return "image/gif"
+        case "webp":        return "image/webp"
+        case "heic":        return "image/heic"
+        case "heif":        return "image/heif"
+        case "bmp":         return "image/bmp"
+        case "tiff", "tif": return "image/tiff"
+        default:            return "image/jpeg"
+        }
+    }
+    #endif
+}

--- a/Sources/ManifoldUI/Views/Composer/VisionInputButton.swift
+++ b/Sources/ManifoldUI/Views/Composer/VisionInputButton.swift
@@ -59,31 +59,33 @@ public struct VisionInputButton: View {
 
     public var body: some View {
         #if os(iOS)
-        PhotosPicker(selection: $photoItem, matching: .images) {
-            Image(systemName: "photo.badge.plus")
-                .symbolVariant(.fill)
-                .font(.title2)
-                .foregroundStyle(hasImageStaged ? Color.accentColor : Color.secondary)
+        if isVisionSupported {
+            PhotosPicker(selection: $photoItem, matching: .images) {
+                Image(systemName: "photo.badge.plus")
+                    .symbolVariant(.fill)
+                    .font(.title2)
+                    .foregroundStyle(hasImageStaged ? Color.accentColor : Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(hasImageStaged ? "Photo attached" : "Attach photo")
+            .help(hasImageStaged ? "Photo attached" : "Attach image")
+            .onChange(of: photoItem) { _, newItem in
+                guard let newItem else { return }
+                loadPhoto(from: newItem)
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(hasImageStaged ? "Photo attached" : "Attach photo")
-        .help(hasImageStaged ? "Photo attached" : "Attach image")
-        .onChange(of: photoItem) { _, newItem in
-            guard let newItem else { return }
-            loadPhoto(from: newItem)
-        }
-        .opacity(isVisionSupported ? 1 : 0)
-        .allowsHitTesting(isVisionSupported)
         #elseif os(macOS)
-        Button {
-            openImagePanel()
-        } label: {
-            Image(systemName: "photo.badge.plus")
-                .symbolVariant(.fill)
+        if isVisionSupported {
+            Button {
+                openImagePanel()
+            } label: {
+                Image(systemName: "photo.badge.plus")
+                    .symbolVariant(.fill)
+            }
+            .help("Attach image")
         }
-        .help("Attach image")
-        .opacity(isVisionSupported ? 1 : 0)
-        .allowsHitTesting(isVisionSupported)
+        #else
+        EmptyView()
         #endif
     }
 
@@ -125,13 +127,19 @@ public struct VisionInputButton: View {
         panel.canChooseDirectories = false
         panel.begin { [panel] response in
             guard response == .OK, let url = panel.url else { return }
-            Task { @MainActor in
+            // Read file data off the main actor to avoid blocking the UI thread
+            // on large image files, then hop back to @MainActor to stage the part.
+            Task {
                 do {
                     let data = try Data(contentsOf: url)
                     let mime = mimeType(for: url)
-                    viewModel.stageAttachment(.image(data: data, mimeType: mime))
+                    await MainActor.run {
+                        viewModel.stageAttachment(.image(data: data, mimeType: mime))
+                    }
                 } catch {
-                    viewModel.surfaceError(error, kind: .configuration, context: "attaching image from file")
+                    await MainActor.run {
+                        viewModel.surfaceError(error, kind: .configuration, context: "attaching image from file")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #1531 (Glass Box P6.2 — Vision-input composer accessory).

## Summary

- Adds `VisionInputButton`, a cross-platform image-attachment button for the compose bar. iOS uses `PhotosPicker` (matching `PhotoAttachmentButton`); macOS uses `NSOpenPanel` restricted to image UTTypes.
- The button hides itself automatically (`opacity(0)` + `allowsHitTesting(false)`) when `BackendCapabilities.supportsVision` is `false` — no extra conditional logic needed in host UIs.
- Images are staged via the existing `ChatViewModel.stageAttachment(_:)` path as `.image(data:mimeType:)` parts, identical to the iOS-only predecessor.
- Adds a DocC note to `PhotoAttachmentButton` pointing users to `VisionInputButton`.
- Updates `GenerationComponents.md` with a **Cross-Platform Vision Input** section and usage snippets.

## Usage

### iOS and macOS

```swift
ChatView(showModelManagement: $show, composerAccessory: {
    VisionInputButton()
})
```

### Alongside voice

```swift
ChatView(showModelManagement: $show, composerAccessory: {
    HStack {
        VisionInputButton()
        VoiceComposerAccessory(controller: controller)
    }
})
```

## PhotoAttachmentButton relationship

`PhotoAttachmentButton` remains unchanged — it is iOS-only and gated under `#if os(iOS)`. A DocC note now directs users to `VisionInputButton` for cross-platform work. No `@available(*, deprecated)` annotation was added to avoid breaking existing consumers.

## Backend checklist

- [x] `BackendCapabilities.supportsVision` used as-is (no new fields)
- [x] `stageAttachment(_:)` / `surfaceError(_:kind:context:)` used via existing public API
- [x] No `try?` — all image-load failures route through `do/catch` + `viewModel.surfaceError`
- [x] No `ManifoldUI → ManifoldBackends` import
- [x] `Package.resolved` unchanged
- [x] `swift build --build-tests --disable-default-traits` clean