### PR TITLE
feat(persistence): ManifoldBootstrap.makeInMemory — public in-memory bootstrap

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -93,6 +93,15 @@ public final class ManifoldBootstrap {
     /// Persists per-turn token counts for all cloud-backed sessions. Host apps
     /// can read aggregated totals via ``usageStore`` to surface cost dashboards.
     public let usageStore: SwiftDataUsageStore
+
+    /// `true` when this bootstrap was created with
+    /// ``makeInMemory(configuration:inferenceService:ragConfiguration:)``.
+    ///
+    /// Useful for surfaces that need to indicate an Incognito/ephemeral mode —
+    /// for example the Architect view's Incognito indicator.
+    public var isInMemory: Bool { _isInMemory }
+    private let _isInMemory: Bool
+
     /// The shared turn-loop runtime, pre-wired against ``persistence`` and
     /// ``inferenceService``. Apps that bootstrap through this type should pass
     /// this instance to ``ChatViewModel/configure(conversationRuntime:)`` (or
@@ -154,7 +163,8 @@ public final class ManifoldBootstrap {
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
-        makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
+        makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() },
+        isInMemory: Bool = false
     ) throws {
         // Capture the previous configuration before any mutation so a failure
         // partway through bootstrap leaves `ManifoldConfiguration.shared`
@@ -223,6 +233,7 @@ public final class ManifoldBootstrap {
             self.videoRuntime = videoService.map {
                 VideoGenerationRuntime(service: $0, messageStore: resolvedPersistence)
             }
+            self._isInMemory = isInMemory
         } catch {
             ManifoldConfiguration.shared = previousConfiguration
             throw error
@@ -243,7 +254,8 @@ public final class ManifoldBootstrap {
         ragService: RAGService? = nil,
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
-        hookRegistry: HookRegistry? = nil
+        hookRegistry: HookRegistry? = nil,
+        isInMemory: Bool = false
     ) {
         self.inferenceService = inferenceService
         self.diagnostics = diagnostics
@@ -254,6 +266,7 @@ public final class ManifoldBootstrap {
         self.endpointStore = endpointStore
         self.usageStore = usageStore
         self.ragService = ragService
+        self._isInMemory = isInMemory
         self.conversationRuntime = ConversationRuntime(
             messageStore: persistence,
             sessionStore: persistence,
@@ -408,6 +421,49 @@ public final class ManifoldBootstrap {
         }
 
         return (stream, task)
+    }
+
+    // MARK: - In-memory bootstrap
+
+    /// Creates a ``ManifoldBootstrap`` backed by an ephemeral in-memory SwiftData
+    /// container — nothing is written to disk.
+    ///
+    /// Use for Incognito sessions (no conversation history persisted), SwiftUI
+    /// Previews, and test helpers that need the full bootstrap stack without
+    /// touching the production store.
+    ///
+    /// ```swift
+    /// let incognito = try ManifoldBootstrap.makeInMemory(
+    ///     configuration: ManifoldConfiguration(bundleIdentifier: "com.example.MyApp"),
+    ///     inferenceService: InferenceService(backend: myBackend)
+    /// )
+    /// // incognito.isInMemory == true
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - configuration: The ``ManifoldConfiguration`` to install.
+    ///   - inferenceService: The inference service to use. A default
+    ///     ``InferenceService`` is created when `nil`.
+    ///   - ragConfiguration: Optional RAG configuration. When supplied, the
+    ///     RAG service is wired against the in-memory document store and the
+    ///     vector index URL from ``RAGConfiguration/vectorStoreURL`` (or a
+    ///     resolved Application Support path). Pass `nil` to disable retrieval.
+    /// - Returns: A fully-wired ``ManifoldBootstrap`` whose persistence is
+    ///   ephemeral — all data is discarded when the instance is deallocated.
+    /// - Throws: If the in-memory ``ModelContainer`` cannot be created.
+    public static func makeInMemory(
+        configuration: ManifoldConfiguration,
+        inferenceService: InferenceService? = nil,
+        ragConfiguration: RAGConfiguration? = nil
+    ) throws -> ManifoldBootstrap {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        return try ManifoldBootstrap(
+            configuration: configuration,
+            ragConfiguration: ragConfiguration,
+            inferenceService: inferenceService,
+            makeModelContainer: { container },
+            isInMemory: true
+        )
     }
 
     // MARK: - Boot hooks

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
@@ -50,6 +50,21 @@ let bootstrap = try ManifoldBootstrap(
 // `InferenceService`. Pass it into ChatViewModel (or drive it directly).
 ```
 
+### Incognito (in-memory) sessions with ``ManifoldBootstrap/makeInMemory(configuration:inferenceService:ragConfiguration:)``
+
+For sessions where conversation history must never touch disk — Incognito mode, SwiftUI Previews, or test scaffolding — use the `makeInMemory` factory. It returns a fully-wired bootstrap backed by an ephemeral SwiftData container; all data is discarded when the instance is deallocated:
+
+```swift,no-build
+let incognito = try ManifoldBootstrap.makeInMemory(
+    configuration: ManifoldConfiguration(bundleIdentifier: "com.example.MyApp"),
+    inferenceService: myInferenceService
+)
+// incognito.isInMemory == true
+// Pass to ChatViewModel exactly like a regular bootstrap — no API difference.
+```
+
+Check ``ManifoldBootstrap/isInMemory`` to surface the ephemeral badge in your UI (for example the Architect view's Incognito indicator).
+
 ### Splash-screen progress with ``ManifoldBootstrap/build(configuration:inferenceService:imageGenerationService:diagnostics:sessionToolSources:hookRegistry:makeModelContainer:)``
 
 For apps that want a launch progress UI, the static `build(configuration:)` factory returns an `AsyncStream<RuntimeBootstrapMilestone>` you can iterate on the main actor while bootstrap runs concurrently:

--- a/Sources/ManifoldUI/ViewModels/ArchitectViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ArchitectViewModel.swift
@@ -30,12 +30,9 @@ public struct ArchitectEventEntry: Identifiable, Sendable {
         self.kind = event.kind
         self.event = event
         self.isCompressionRelated = {
-            switch event {
-            case .compressionTriggered, .historyCompressed:
-                return true
-            default:
-                return false
-            }
+            if case .compressionTriggered = event { return true }
+            if case .historyCompressed = event { return true }
+            return false
         }()
         self.isError = {
             if case .errorRaised = event { return true }
@@ -202,7 +199,7 @@ public final class ArchitectViewModel {
         isRecording = true
         let tap = runtime.addEventTap(bufferingPolicy: .bufferingOldest(Self.maxLogSize))
         tapTask = Task { [weak self] in
-            var idx = await self?.eventLog.count ?? 0
+            var idx = self?.eventLog.count ?? 0
             for await event in tap {
                 guard let self else { break }
                 let entry = ArchitectEventEntry(event: event, index: idx)

--- a/Sources/ManifoldUI/Views/Settings/EventTimelineView.swift
+++ b/Sources/ManifoldUI/Views/Settings/EventTimelineView.swift
@@ -141,7 +141,9 @@ private struct EventRowView: View {
         case .thinkingStarted, .thinkingUpdated, .thinkingFinalized:
             return .cyan
 
-        default:
+        case .messageInserted, .messageRemoved, .messageUpdated,
+             .sessionBranched, .tokenUsageRecorded, .loopDetected,
+             .sessionTouchFailed, .afterGeneration:
             return .secondary
         }
     }

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapInMemoryTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapInMemoryTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import ManifoldPersistenceSwiftData
+@testable import ManifoldInference
+
+/// Integration tests for ``ManifoldBootstrap/makeInMemory(configuration:inferenceService:ragConfiguration:)``.
+///
+/// Validates the public in-memory bootstrap path introduced in P6.1: that the
+/// factory correctly signals ephemeral storage via ``ManifoldBootstrap/isInMemory``
+/// and that the full persistence stack is functional for message round-trips.
+@MainActor
+final class ManifoldBootstrapInMemoryTests: XCTestCase {
+
+    // Stash the original configuration so each test can restore it cleanly.
+    private var originalConfiguration: ManifoldConfiguration!
+
+    override func setUp() {
+        super.setUp()
+        originalConfiguration = ManifoldConfiguration.shared
+    }
+
+    override func tearDown() {
+        ManifoldConfiguration.shared = originalConfiguration
+        super.tearDown()
+    }
+
+    // MARK: - isInMemory
+
+    func test_makeInMemory_isInMemory() throws {
+        let bootstrap = try ManifoldBootstrap.makeInMemory(
+            configuration: ManifoldConfiguration(
+                appName: "InMemory Test",
+                bundleIdentifier: "com.manifoldkit.bootstrap-inmemory-tests.ismemory.\(UUID().uuidString)"
+            )
+        )
+
+        XCTAssertTrue(bootstrap.isInMemory,
+            "makeInMemory must set isInMemory = true so callers can detect ephemeral mode")
+    }
+
+    func test_standardInit_isNotInMemory() throws {
+        // Guards that the normal init path leaves isInMemory == false, confirming
+        // that makeInMemory is the only route that sets the flag.
+        let bootstrap = try ManifoldBootstrap(
+            configuration: ManifoldConfiguration(
+                appName: "Standard Init",
+                bundleIdentifier: "com.manifoldkit.bootstrap-inmemory-tests.standard.\(UUID().uuidString)"
+            ),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+
+        XCTAssertFalse(bootstrap.isInMemory,
+            "The standard init must leave isInMemory = false")
+    }
+
+    // MARK: - Message round-trip
+
+    func test_makeInMemory_messageStoreWorks() async throws {
+        let bootstrap = try ManifoldBootstrap.makeInMemory(
+            configuration: ManifoldConfiguration(
+                appName: "Message Round-trip",
+                bundleIdentifier: "com.manifoldkit.bootstrap-inmemory-tests.roundtrip.\(UUID().uuidString)"
+            )
+        )
+
+        // Insert a session so the message foreign-key constraint is satisfied.
+        let session = ChatSessionRecord(title: "Incognito Session")
+        try await bootstrap.persistence.insertSession(session)
+
+        // Insert a message and fetch it back through the same provider.
+        let message = ChatMessageRecord(
+            role: .user,
+            content: "Hello from in-memory land",
+            sessionID: session.id
+        )
+        try await bootstrap.persistence.insertMessage(message)
+
+        let fetched = try await bootstrap.persistence.fetchMessages(for: session.id)
+
+        XCTAssertEqual(fetched.count, 1,
+            "One message was inserted; fetchMessages must return exactly one record")
+        XCTAssertEqual(fetched.first?.id, message.id,
+            "The fetched message must have the same ID as the inserted record")
+        XCTAssertEqual(fetched.first?.role, .user,
+            "The message role must survive the round-trip")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ManifoldBootstrap.makeInMemory(configuration:inferenceService:ragConfiguration:)` — a public static factory that returns a fully-wired bootstrap backed by an ephemeral SwiftData in-memory container. Nothing is written to disk; all data is discarded when the instance is deallocated.
- Adds `ManifoldBootstrap.isInMemory: Bool` so callers can detect ephemeral mode without inspecting container internals.
- Documents the new surface in the `ManifoldPersistenceSwiftData` DocC article with a usage snippet.

Closes #1531 P6.

## Usage

```swift
let incognito = try ManifoldBootstrap.makeInMemory(
    configuration: ManifoldConfiguration(bundleIdentifier: "com.example.MyApp"),
    inferenceService: myInferenceService
)
// incognito.isInMemory == true
// Pass to ChatViewModel exactly like a regular bootstrap — no API difference.
```

`isInMemory` powers the Architect view's Incognito indicator: the view checks `bootstrap.isInMemory` to badge the session as ephemeral without needing to reach into the container configuration.

`InMemoryPersistenceHarness` in `ManifoldTestSupport` continues to exist as the test-only harness (bare `SwiftDataPersistenceProvider` without the full bootstrap stack). `makeInMemory` is the production-grade counterpart: full bootstrap, all ports wired, intended for Incognito sessions, previews, and consumer tests that need the whole stack.

## Test plan

- `test_makeInMemory_isInMemory` — asserts `bootstrap.isInMemory == true`
- `test_standardInit_isNotInMemory` — sabotage guard; asserts normal init leaves the flag `false`
- `test_makeInMemory_messageStoreWorks` — inserts a session + message, fetches back, asserts round-trip

All three pass: `swift test --disable-default-traits --filter ManifoldBootstrapInMemory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)