### PR TITLE
feat(persistence): addGenerationToolSources — image/video tool source convenience

### DIFF
--- a/Sources/ManifoldKit/ManifoldBootstrap+GenerationToolSources.swift
+++ b/Sources/ManifoldKit/ManifoldBootstrap+GenerationToolSources.swift
@@ -1,0 +1,51 @@
+// ManifoldBootstrap+GenerationToolSources.swift
+//
+// Convenience wiring that bridges ManifoldPersistenceSwiftData (ManifoldBootstrap)
+// with ManifoldUI (ImageGenerationToolSource, VideoGenerationToolSource, ChatViewModel).
+// Lives in the ManifoldKit umbrella — the only target that imports both modules —
+// to avoid a layering violation.
+
+import ManifoldPersistenceSwiftData
+import ManifoldUI
+
+extension ManifoldBootstrap {
+
+    /// Registers ``ImageGenerationToolSource`` and ``VideoGenerationToolSource``
+    /// on the bootstrap's runtime so the active language model can invoke
+    /// ``generate_image`` and ``generate_video`` tools.
+    ///
+    /// Call after wiring the ``ChatViewModel`` and after the bootstrap has been
+    /// fully configured:
+    ///
+    /// ```swift
+    /// await bootstrap.addGenerationToolSources(viewModel: chatViewModel)
+    /// ```
+    ///
+    /// Both sources are only active when the bootstrap has the corresponding
+    /// service wired: ``ImageGenerationToolSource`` requires
+    /// ``ManifoldBootstrap/imageGenerationService`` to be non-nil;
+    /// ``VideoGenerationToolSource`` requires
+    /// ``ManifoldBootstrap/videoGenerationService`` to be non-nil. Sources for
+    /// nil services are silently skipped so the call is safe to issue
+    /// unconditionally regardless of which generation surfaces your app enables.
+    ///
+    /// This replaces the more verbose:
+    /// ```swift
+    /// await bootstrap.addToolSources([
+    ///     ImageGenerationToolSource(viewModel: chatVM),
+    ///     VideoGenerationToolSource(viewModel: chatVM)
+    /// ])
+    /// ```
+    @MainActor
+    public func addGenerationToolSources(viewModel: ChatViewModel) async {
+        var sources: [any SessionToolSource] = []
+        if imageGenerationService != nil {
+            sources.append(ImageGenerationToolSource(viewModel: viewModel))
+        }
+        if videoGenerationService != nil {
+            sources.append(VideoGenerationToolSource(viewModel: viewModel))
+        }
+        guard !sources.isEmpty else { return }
+        await addToolSources(sources)
+    }
+}

--- a/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Articles/GenerationComponents.md
@@ -89,7 +89,15 @@ Once registered, the model will call `generate_image` or `generate_video` autono
 
 ## Registering tool sources
 
-Use `ManifoldBootstrap.addToolSources(_:)` to register generation tool sources after `quickStart()`:
+When importing `ManifoldKit` (the umbrella module), use the one-liner convenience:
+
+```swift,no-build
+// One call registers whichever generation services are wired in the bootstrap.
+// Sources for nil services are silently skipped.
+await kit.bootstrap.addGenerationToolSources(viewModel: kit.viewModel)
+```
+
+For apps that import `ManifoldPersistenceSwiftData` directly (without the umbrella), use `addToolSources(_:)`:
 
 ```swift,no-build
 await kit.bootstrap.addToolSources([
@@ -98,7 +106,7 @@ await kit.bootstrap.addToolSources([
 ])
 ```
 
-This replaces the more verbose `conversationRuntime.updateSessionToolSources(_:)` call.
+Both calls replace the more verbose `conversationRuntime.updateSessionToolSources(_:)` call.
 
 ### Prerequisites
 
@@ -107,7 +115,7 @@ Both tool sources require their corresponding generation runtimes to be wired in
 - ``ImageGenerationToolSource`` — requires an ``ImageGenerationRuntime`` wired via `ManifoldBootstrap.build(imageGenerationService:)`.
 - ``VideoGenerationToolSource`` — requires a ``VideoGenerationRuntime`` wired into ``ChatViewModel``.
 
-If a generation runtime is absent, the tool source is safe to register — the underlying `ChatViewModel` call will surface an error through ``ChatViewModel/backgroundTaskError`` rather than crashing.
+`addGenerationToolSources(viewModel:)` silently skips sources whose corresponding service is absent, so it is safe to call unconditionally — no conditional check required at the call site.
 
 ## Context Menu Items
 


### PR DESCRIPTION
## Summary

- Adds `ManifoldBootstrap.addGenerationToolSources(viewModel:)` as a convenience in the `ManifoldKit` umbrella module, reducing image/video tool source registration to a one-liner (closes P6.3 of #1531, absorbing #706)
- Sources for nil services are silently skipped — safe to call unconditionally regardless of which generation surfaces the host enables
- `addMCPToolSource` is intentionally omitted: `ManifoldMCP` is not in the `ManifoldKit` umbrella dependency graph (`ManifoldPersistenceSwiftData` only depends on `ManifoldRuntime`/`ManifoldInference`), so `addToolSources([mcpSource])` remains the correct path
- Updates `GenerationComponents.md` to surface the one-liner and distinguish umbrella vs direct-import usage

## One-liner API

```swift
// Before (still works — addToolSources is unchanged):
await bootstrap.addToolSources([
    ImageGenerationToolSource(viewModel: chatVM),
    VideoGenerationToolSource(viewModel: chatVM)
])

// After (import ManifoldKit umbrella):
await bootstrap.addGenerationToolSources(viewModel: chatVM)
```

The nil-service guard means hosts can call this unconditionally even when only one generation service is wired — the absent source is skipped without error.

## Architecture note

The extension lives in `Sources/ManifoldKit/ManifoldBootstrap+GenerationToolSources.swift` (the umbrella target), not in `ManifoldPersistenceSwiftData`. `ManifoldPersistenceSwiftData` has no dependency on `ManifoldUI`, so adding the method there would require a new layering edge. The umbrella already imports both modules, following the same pattern as `QuickStart.swift`.

## Test plan

- [x] `swift build --build-tests --disable-default-traits` passes clean (Build complete in ~29s)
- [x] No `Package.resolved` changes staged
- [x] No `try?` in new source code
- [x] No layering violations — extension is in `ManifoldKit` umbrella only

Closes part of #1531 (Glass Box P6), absorbs #706 (MCP filesystem server as tool source — MCP side already works via `addToolSources([mcpSource])`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)