### PR TITLE
feat: model-fit scoring + use-case-aware model ranking

### DIFF
--- a/Sources/ManifoldInference/Models/ModelFitScore.swift
+++ b/Sources/ManifoldInference/Models/ModelFitScore.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+// Algorithm inspired by llmfit (https://github.com/AlexsJones/llmfit),
+// MIT License, © Alex Jones. Reimplemented natively in Swift; no Rust dependency.
+//
+// This file defines the pure value types for a model-fit *scoring/ranking* layer.
+// It complements — and does NOT replace — the existing fit machinery
+// (`ModelLoadPlan`, `ModelCapabilityTier`, `DownloadableModelGroup.recommendedVariant`).
+// The scorer ranks downloadable models by a composite of four dimensions
+// (quality, speed, fit, context) using use-case-specific weights, so the UI can
+// surface "best for coding" / "best for chat" orderings without changing the
+// authoritative will-it-run gate that `ModelLoadPlan` owns.
+
+/// A task category that biases how the four fit dimensions are weighted.
+///
+/// Each case carries both the dimension `weights` used to compute the composite
+/// score and a `contextNeed` — the rough working-context budget the use case
+/// benefits from. The weights encode intent, not measurement: e.g. `chat` favours
+/// responsiveness (speed) while `reasoning` favours quality.
+public enum ModelUseCase: String, Codable, Sendable, CaseIterable {
+    case general
+    case coding
+    case reasoning
+    case chat
+    case multimodal
+    case embedding
+
+    /// Dimension weights for this use case. Weights sum to 1.0 so the composite
+    /// stays in the same 0...1 range as the individual dimensions.
+    public var weights: FitWeights {
+        switch self {
+        // Balanced default — no dimension dominates.
+        case .general:
+            return FitWeights(quality: 0.30, speed: 0.25, fit: 0.25, context: 0.20)
+        // Coding rewards capable models with room for large files/diffs in context.
+        case .coding:
+            return FitWeights(quality: 0.35, speed: 0.15, fit: 0.20, context: 0.30)
+        // Reasoning is quality-dominant; latency matters least.
+        case .reasoning:
+            return FitWeights(quality: 0.50, speed: 0.10, fit: 0.20, context: 0.20)
+        // Interactive chat rewards responsiveness above raw capability.
+        case .chat:
+            return FitWeights(quality: 0.20, speed: 0.45, fit: 0.25, context: 0.10)
+        // Multimodal needs capable models and generous context for image tokens.
+        case .multimodal:
+            return FitWeights(quality: 0.35, speed: 0.15, fit: 0.20, context: 0.30)
+        // Embedding models are small and run in tight loops — speed and fit dominate;
+        // long generation context is largely irrelevant.
+        case .embedding:
+            return FitWeights(quality: 0.20, speed: 0.40, fit: 0.35, context: 0.05)
+        }
+    }
+
+    /// Rough working-context budget (in tokens) this use case benefits from.
+    ///
+    /// Used to normalise the context dimension: a model whose (known) context
+    /// length meets or exceeds this need scores 1.0 on context. Pre-download,
+    /// context length is usually unknown (see `ModelFitScorer`), so this is only
+    /// applied for curated models with a declared `contextSize`.
+    public var contextNeed: Int {
+        switch self {
+        case .general:    return 8_192
+        case .coding:     return 32_768
+        case .reasoning:  return 16_384
+        case .chat:       return 4_096
+        case .multimodal: return 32_768
+        case .embedding:  return 512
+        }
+    }
+}
+
+/// Per-dimension weights for the composite fit score. Conventionally sums to 1.0.
+public struct FitWeights: Sendable, Equatable {
+    public let quality: Double
+    public let speed: Double
+    public let fit: Double
+    public let context: Double
+
+    public init(quality: Double, speed: Double, fit: Double, context: Double) {
+        self.quality = quality
+        self.speed = speed
+        self.fit = fit
+        self.context = context
+    }
+}
+
+/// A composite fit score for a single model under a given use case.
+///
+/// The four dimensions are each normalised to 0...1; `composite` is their
+/// weighted sum (also 0...1) using the use case's `FitWeights`. `Comparable`
+/// orders by `composite` so a `[ModelFitScore]` sorts best-first with `.sorted().reversed()`
+/// or worst-first with `.sorted()`.
+public struct ModelFitScore: Sendable, Comparable, Equatable {
+    /// Capability proxy derived from model size tier + quantization bits (0...1).
+    public let quality: Double
+    /// Throughput proxy: device memory bandwidth ÷ model footprint, normalised (0...1).
+    public let speed: Double
+    /// Will-it-run proxy derived from `ModelLoadPlan` verdict + headroom (0...1).
+    public let fit: Double
+    /// Context-window proxy vs. the use case's need (0...1). Neutral when unknown.
+    public let context: Double
+    /// Weighted composite of the four dimensions (0...1).
+    public let composite: Double
+
+    /// Rough estimated decode throughput used to derive `speed`, surfaced for display.
+    public let estimatedTokensPerSecond: Double
+    /// Estimated total resident + KV footprint from the load plan, surfaced for display.
+    public let memoryBytes: UInt64
+    /// Whether `ModelLoadPlan` judged the model loadable on the target device.
+    public let willRun: Bool
+
+    public init(
+        quality: Double,
+        speed: Double,
+        fit: Double,
+        context: Double,
+        composite: Double,
+        estimatedTokensPerSecond: Double,
+        memoryBytes: UInt64,
+        willRun: Bool
+    ) {
+        self.quality = quality
+        self.speed = speed
+        self.fit = fit
+        self.context = context
+        self.composite = composite
+        self.estimatedTokensPerSecond = estimatedTokensPerSecond
+        self.memoryBytes = memoryBytes
+        self.willRun = willRun
+    }
+
+    public static func < (lhs: ModelFitScore, rhs: ModelFitScore) -> Bool {
+        lhs.composite < rhs.composite
+    }
+}

--- a/Sources/ManifoldInference/Services/AppleSiliconBandwidth.swift
+++ b/Sources/ManifoldInference/Services/AppleSiliconBandwidth.swift
@@ -1,0 +1,427 @@
+import Foundation
+
+// MARK: - Device Profile
+
+/// A snapshot of the host device's memory characteristics used by `ModelFitScorer`
+/// to derive the speed dimension.
+///
+/// `memoryBandwidthGBs` is the dominant term for local-LLM decode throughput:
+/// autoregressive generation is memory-bandwidth bound (every token streams the
+/// full weight set through the memory bus), so tokens/sec scales roughly with
+/// bandwidth ÷ model footprint. We surface bandwidth here rather than recomputing
+/// it inside the scorer so tests can inject hypothetical devices.
+public struct DeviceProfile: Sendable, Equatable {
+    /// Total physical RAM (`ProcessInfo.physicalMemory`).
+    public let physicalMemoryBytes: UInt64
+    /// Memory available for allocation (jetsam budget on iOS, physical on macOS).
+    public let usableMemoryBytes: UInt64
+    /// Approximate unified-memory bandwidth in GB/s. See `AppleSiliconBandwidth`
+    /// for the source table and its caveats (figures are published approximations;
+    /// unknown chips fall back conservatively).
+    public let memoryBandwidthGBs: Double
+
+    public init(
+        physicalMemoryBytes: UInt64,
+        usableMemoryBytes: UInt64,
+        memoryBandwidthGBs: Double
+    ) {
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.usableMemoryBytes = usableMemoryBytes
+        self.memoryBandwidthGBs = memoryBandwidthGBs
+    }
+
+    /// The real host device. Reads physical/usable memory from the system and
+    /// estimates bandwidth from the detected chip.
+    public static var current: DeviceProfile {
+        DeviceProfile(
+            physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
+            usableMemoryBytes: DeviceCapabilityService.queryAvailableMemory(),
+            memoryBandwidthGBs: AppleSiliconBandwidth.estimatedBandwidthGBs()
+        )
+    }
+}
+
+// MARK: - Apple Silicon Bandwidth Table
+
+/// Maps the host chip to an approximate unified-memory bandwidth (GB/s).
+///
+/// ## Why a table
+/// There is no public runtime API that reports memory bandwidth. The figures
+/// below are Apple's published per-chip numbers (Apple Newsroom / Tech specs).
+/// They are approximations — binned SKUs of the same chip can differ (e.g. the
+/// base M3 Max ships in 300 and 400 GB/s variants), and we cannot distinguish the
+/// bin at runtime, so we pick a representative value and document it. The scorer
+/// only uses bandwidth to *rank* candidates, so the relative ordering matters far
+/// more than absolute precision.
+///
+/// ## Detection
+/// - macOS: `sysctlbyname("machdep.cpu.brand_string")` returns e.g. "Apple M1 Pro".
+/// - iOS/visionOS: that sysctl is restricted, so we map the `hw.machine` device
+///   identifier (e.g. "iPhone16,1") to a conservative A-/M-series figure.
+/// - Unknown chip → a deliberately conservative `fallbackBandwidthGBs`.
+public enum AppleSiliconBandwidth {
+
+    /// Conservative fallback for chips we can't identify (older Intel Macs, future
+    /// silicon, restricted environments). Picked low on purpose: an unknown device
+    /// should not be ranked as if it had flagship bandwidth.
+    public static let fallbackBandwidthGBs: Double = 50.0
+
+    /// Returns the estimated bandwidth for the current host device.
+    public static func estimatedBandwidthGBs() -> Double {
+        #if os(macOS)
+        if let brand = cpuBrandString() {
+            return bandwidth(forBrandString: brand)
+        }
+        return fallbackBandwidthGBs
+        #elseif os(iOS) || os(visionOS)
+        if let machine = machineIdentifier() {
+            return bandwidth(forIOSMachine: machine)
+        }
+        return fallbackBandwidthGBs
+        #else
+        return fallbackBandwidthGBs
+        #endif
+    }
+
+    // MARK: Brand-string mapping (macOS / Apple Silicon)
+
+    /// Maps an Apple Silicon CPU brand string ("Apple M3 Max") to GB/s.
+    ///
+    /// Published figures (GB/s):
+    /// M1 68 · M1 Pro 200 · M1 Max 400 · M1 Ultra 800;
+    /// M2 100 · M2 Pro 200 · M2 Max 400 · M2 Ultra 800;
+    /// M3 100 · M3 Pro 150 · M3 Max 400 (300 GB/s on the cut-down bin — we use 400);
+    /// M4 120 · M4 Pro 273 · M4 Max 546.
+    /// Order matters: check the most specific suffix (Ultra/Max/Pro) before the base chip.
+    static func bandwidth(forBrandString brand: String) -> Double {
+        let s = brand.lowercased()
+        // Helper: does the brand mention this generation token ("m1".."m4")?
+        func gen(_ token: String) -> Bool { s.contains(token) }
+
+        if s.contains("ultra") {
+            if gen("m1") { return 800 }
+            if gen("m2") { return 800 }
+            return 800 // future Ultra parts: assume flagship-class
+        }
+        if s.contains("max") {
+            if gen("m1") { return 400 }
+            if gen("m2") { return 400 }
+            if gen("m3") { return 400 }
+            if gen("m4") { return 546 }
+            return 400
+        }
+        if s.contains("pro") {
+            if gen("m1") { return 200 }
+            if gen("m2") { return 200 }
+            if gen("m3") { return 150 }
+            if gen("m4") { return 273 }
+            return 200
+        }
+        // Base chips (no Pro/Max/Ultra suffix).
+        if gen("m1") { return 68 }
+        if gen("m2") { return 100 }
+        if gen("m3") { return 100 }
+        if gen("m4") { return 120 }
+        // Apple Silicon we don't recognise, or an Intel Mac brand string.
+        return fallbackBandwidthGBs
+    }
+
+    // MARK: Machine-identifier mapping (iOS / visionOS)
+
+    /// Maps an iOS `hw.machine` identifier (e.g. "iPhone16,1") to a conservative GB/s.
+    ///
+    /// iOS restricts `machdep.cpu.brand_string`, so we approximate from the device
+    /// generation. A-series phone/tablet bandwidth is far lower than desktop M-series:
+    /// A14/A15 ~34 GB/s, A16 ~? (~50 GB/s estimated), A17 Pro ~? (~60 GB/s estimated),
+    /// M-class iPads track their Mac counterparts. These are conservative estimates;
+    /// Apple does not publish A-series bandwidth, so we err low.
+    static func bandwidth(forIOSMachine machine: String) -> Double {
+        // iPad with an M-series chip ("iPad14,x" Pro lines) — approximate as base M-class.
+        // We cannot tell the exact M generation from the model string reliably, so use
+        // a single conservative M-class figure rather than over-claiming.
+        if machine.hasPrefix("iPad13") || machine.hasPrefix("iPad14")
+            || machine.hasPrefix("iPad15") || machine.hasPrefix("iPad16") {
+            return 100 // M-class iPad, conservative base-M figure
+        }
+        // Recent A-series phones. iPhone16,x = A17 Pro / A18 era.
+        if machine.hasPrefix("iPhone16") || machine.hasPrefix("iPhone17") {
+            return 60
+        }
+        if machine.hasPrefix("iPhone15") || machine.hasPrefix("iPhone14") {
+            return 50
+        }
+        // Older / unrecognised iOS hardware: low estimate.
+        return 34
+    }
+
+    // MARK: sysctl helpers
+
+    #if os(macOS)
+    /// Reads `machdep.cpu.brand_string` (e.g. "Apple M1 Pro"). Available on macOS;
+    /// restricted on iOS, hence the platform guard.
+    static func cpuBrandString() -> String? {
+        var size = 0
+        guard sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0) == 0, size > 0 else {
+            return nil
+        }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("machdep.cpu.brand_string", &buffer, &size, nil, 0) == 0 else {
+            return nil
+        }
+        let brand = String(decoding: buffer.map(UInt8.init(bitPattern:)), as: UTF8.self)
+            .trimmingCharacters(in: .controlCharacters)
+        return brand.isEmpty ? nil : brand
+    }
+    #endif
+
+    #if os(iOS) || os(visionOS)
+    /// Reads the `hw.machine` device identifier (e.g. "iPhone16,1").
+    static func machineIdentifier() -> String? {
+        var size = 0
+        guard sysctlbyname("hw.machine", nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("hw.machine", &buffer, &size, nil, 0) == 0 else { return nil }
+        let id = String(decoding: buffer.map(UInt8.init(bitPattern:)), as: UTF8.self)
+            .trimmingCharacters(in: .controlCharacters)
+        return id.isEmpty ? nil : id
+    }
+    #endif
+}
+
+// MARK: - Quantization → bits-per-weight
+
+/// Maps a GGUF quantization tag to an approximate bits-per-weight, used for the
+/// quality dimension. Lower bit-width trades capability for size; the scorer treats
+/// a wider quant as higher quality at equal parameter count.
+enum QuantizationBits {
+
+    /// Neutral default when the quant tag is missing or unrecognised (e.g. MLX
+    /// snapshots that don't encode quant in the filename). 5.0 bpw sits between the
+    /// common Q4 and Q6 levels so an unknown quant is neither rewarded nor punished.
+    static let neutralBitsPerWeight: Double = 5.0
+
+    /// Approximate effective bits-per-weight for a GGUF quant tag like "Q4_K_M".
+    /// Figures are the well-known llama.cpp ggml type sizes (effective bpw including
+    /// block overhead), rounded to one decimal.
+    static func bitsPerWeight(for tag: String?) -> Double {
+        guard let tag = tag?.uppercased() else { return neutralBitsPerWeight }
+
+        // Full-precision floats first.
+        if tag.hasPrefix("F32") { return 32.0 }
+        if tag.hasPrefix("BF16") || tag.hasPrefix("F16") { return 16.0 }
+
+        // K-quants and legacy quants, by leading digit. Match longer/more specific
+        // tags before shorter ones where ambiguous.
+        switch true {
+        case tag.hasPrefix("Q8"):  return 8.5
+        case tag.hasPrefix("Q6"):  return 6.6
+        case tag.hasPrefix("Q5"):  return 5.5
+        case tag.hasPrefix("Q4"):  return 4.5
+        case tag.hasPrefix("IQ4"): return 4.25
+        case tag.hasPrefix("Q3"):  return 3.4
+        case tag.hasPrefix("IQ3"): return 3.1
+        case tag.hasPrefix("Q2"):  return 2.6
+        case tag.hasPrefix("IQ2"): return 2.2
+        case tag.hasPrefix("IQ1"): return 1.6
+        default:                   return neutralBitsPerWeight
+        }
+    }
+}
+
+// MARK: - Model Fit Scorer
+
+/// Scores and ranks downloadable models by a composite of four dimensions —
+/// quality, speed, fit, context — under a use-case-specific weighting.
+///
+/// ## Dimensions
+/// - **quality**: capability proxy from `ModelCapabilityTier` (size tier) scaled by
+///   quantization bits-per-weight. Larger + wider-quant ⇒ higher.
+/// - **speed**: `bandwidthGBs / modelSizeGB × efficiencyFactor`, normalised. Decode
+///   throughput is memory-bandwidth bound, so this approximates tokens/sec.
+/// - **fit**: derived from `ModelLoadPlan.estimate(...)` — `.allow` ⇒ high, `.warn` ⇒
+///   mid, `.deny` ⇒ 0. We reuse the load plan rather than recomputing memory math.
+/// - **context**: known context length vs. the use case's `contextNeed`. Neutral
+///   (0.5) when the context length is unknown (the common pre-download case).
+///
+/// The scorer is a pure value type: no I/O, no mutation, fully `Sendable`.
+public struct ModelFitScorer: Sendable {
+
+    /// Reference decode throughput (tokens/sec) at which `speed` saturates to 1.0.
+    /// Tuned so that a flagship M-class device on a small model approaches the cap
+    /// while a phone on a 7B model lands mid-range. Ranking is relative, so the exact
+    /// value only sets the normalisation curve, not the ordering.
+    private let speedSaturationTokensPerSecond: Double
+
+    /// Fudge factor translating "GB/s per GB of weights" into a tokens/sec estimate.
+    /// Real throughput is lower than the raw bandwidth/size ratio due to compute,
+    /// sampling, and memory-subsystem inefficiency; 1 GB of weights streamed once per
+    /// token at the device's bandwidth is the upper bound.
+    private let efficiencyFactor: Double
+
+    public init(
+        speedSaturationTokensPerSecond: Double = 120.0,
+        efficiencyFactor: Double = 1.0
+    ) {
+        self.speedSaturationTokensPerSecond = speedSaturationTokensPerSecond
+        self.efficiencyFactor = efficiencyFactor
+    }
+
+    /// Scores a single model under a use case.
+    ///
+    /// - Parameters:
+    ///   - model: The downloadable candidate.
+    ///   - useCase: Biases the dimension weights and context need.
+    ///   - requestedContextSize: Context size to evaluate the fit dimension at.
+    ///   - knownContextLength: The model's trained context length when known (e.g.
+    ///     from `CuratedModel.contextSize`). `nil` for arbitrary HF search results,
+    ///     where pre-download context length is genuinely unknown — the context
+    ///     dimension is then neutral. We never fabricate a context length.
+    ///   - device: Device profile supplying memory + bandwidth (injectable for tests).
+    ///   - environment: Memory environment for the `ModelLoadPlan` fit estimate.
+    /// - Returns: A `ModelFitScore`, or `nil` if the model has no usable size (size 0).
+    public func score(
+        _ model: DownloadableModel,
+        useCase: ModelUseCase,
+        requestedContextSize: Int = 4_096,
+        knownContextLength: Int? = nil,
+        device: DeviceProfile = .current,
+        environment: ModelLoadPlan.Environment? = nil
+    ) -> ModelFitScore? {
+        guard model.sizeBytes > 0 else { return nil }
+
+        let weights = useCase.weights
+
+        // --- fit: reuse ModelLoadPlan; do NOT recompute resident/KV byte math. ---
+        let env = environment ?? ModelLoadPlan.Environment(
+            availableMemoryBytes: { device.usableMemoryBytes },
+            physicalMemoryBytes: device.physicalMemoryBytes
+        )
+        let plan = ModelLoadPlan.estimate(
+            for: model,
+            requestedContextSize: requestedContextSize,
+            environment: env
+        )
+        let willRun = plan.verdict != .deny
+        let fit: Double
+        switch plan.verdict {
+        case .allow: fit = 1.0
+        case .warn:  fit = 0.5
+        case .deny:  fit = 0.0
+        }
+
+        // --- quality: size tier × quantization width. ---
+        let quality = qualityScore(for: model)
+
+        // --- speed: bandwidth ÷ footprint, scaled, normalised against saturation. ---
+        let modelSizeGB = max(Double(model.sizeBytes) / 1_073_741_824, 0.001)
+        let estimatedTPS = (device.memoryBandwidthGBs / modelSizeGB) * efficiencyFactor
+        let speed = clamp01(estimatedTPS / speedSaturationTokensPerSecond)
+
+        // --- context: known length vs. need; neutral when unknown. ---
+        let context: Double
+        if let known = knownContextLength, known > 0 {
+            context = clamp01(Double(known) / Double(max(useCase.contextNeed, 1)))
+        } else {
+            // Pre-download context length is unknown for arbitrary HF models; stay
+            // neutral rather than fabricating a value. See ModelUseCase.contextNeed.
+            context = 0.5
+        }
+
+        let weightedSum = quality * weights.quality
+            + speed * weights.speed
+            + fit * weights.fit
+            + context * weights.context
+
+        // A model that won't load is useless regardless of how capable it is, so a
+        // `.deny` verdict must rank below every runnable candidate — not merely lose
+        // the fit dimension's weight. Without this gate a 30B frontier model that
+        // can't fit would still out-score a 7B that runs, because its quality term
+        // dominates. Collapse the composite into a strictly-lower band when the load
+        // plan denies. (`.warn` keeps its proportional fit penalty — it can still run.)
+        let composite = willRun ? weightedSum : weightedSum * 0.1
+
+        return ModelFitScore(
+            quality: quality,
+            speed: speed,
+            fit: fit,
+            context: context,
+            composite: composite,
+            estimatedTokensPerSecond: estimatedTPS,
+            memoryBytes: plan.outcome.totalEstimatedBytes,
+            willRun: willRun
+        )
+    }
+
+    /// Ranks models best-first (descending composite) under a use case.
+    ///
+    /// Models that fail to score (size 0) are dropped. `knownContextLength` cannot be
+    /// supplied per-model here because `DownloadableModel` does not carry it; callers
+    /// with curated context data should call `score(...)` directly per variant.
+    public func rank(
+        _ models: [DownloadableModel],
+        useCase: ModelUseCase,
+        requestedContextSize: Int = 4_096,
+        device: DeviceProfile = .current,
+        environment: ModelLoadPlan.Environment? = nil
+    ) -> [(DownloadableModel, ModelFitScore)] {
+        models.compactMap { model in
+            guard let s = score(
+                model,
+                useCase: useCase,
+                requestedContextSize: requestedContextSize,
+                device: device,
+                environment: environment
+            ) else { return nil }
+            return (model, s)
+        }
+        .sorted { $0.1.composite > $1.1.composite }
+    }
+
+    // MARK: - Quality
+
+    /// Capability proxy in 0...1 from size tier and quantization width.
+    ///
+    /// Param count (proxied by file size via `ModelCapabilityTier`) is the dominant
+    /// term; quantization width modulates within a tier. We deliberately read the
+    /// tier from `DownloadableModel.sizeBytes` rather than adding fields to
+    /// `ModelCapabilityTier`, which is a pure file-size enum by design.
+    private func qualityScore(for model: DownloadableModel) -> Double {
+        // Reconstruct the tier from size using the same thresholds ModelCapabilityTier
+        // applies to on-disk models, then map to a 0...1 capability base.
+        let gb = Double(model.sizeBytes) / 1_073_741_824
+        let tierBase: Double
+        switch gb {
+        case ..<2:    tierBase = 0.20  // minimal
+        case 2..<5:   tierBase = 0.45  // fast
+        case 5..<10:  tierBase = 0.65  // balanced
+        case 10..<21: tierBase = 0.85  // capable
+        default:      tierBase = 1.00  // frontier
+        }
+
+        // Quantization width modulates quality meaningfully. There is a well-known
+        // perplexity cliff below ~Q3: 2-bit quants degrade so much that a wider-quant
+        // model one size tier down is usually the better pick. We model this with an
+        // accelerating-below-Q4 curve rather than a straight line: above ~4 bpw the
+        // factor is gentle (0.90...1.0, diminishing returns past Q6), but below it the
+        // penalty steepens so a Q2 (factor ~0.55) cannot ride its larger param count
+        // past a Q4/Q5 of the adjacent smaller tier.
+        let bpw = QuantizationBits.bitsPerWeight(for: model.quantization)
+        let quantFactor: Double
+        if bpw >= 4.0 {
+            // 4 bpw → 0.90, 8.5 bpw → ~1.0.
+            quantFactor = clamp(0.90 + (bpw - 4.0) / 4.5 * 0.10, min: 0.90, max: 1.0)
+        } else {
+            // 4 bpw → 0.90 down to ~2 bpw → 0.50: steep penalty in the sub-Q4 cliff.
+            quantFactor = clamp(0.50 + (bpw - 2.0) / 2.0 * 0.40, min: 0.40, max: 0.90)
+        }
+
+        return clamp01(tierBase * quantFactor)
+    }
+
+    // MARK: - Math helpers
+
+    private func clamp01(_ x: Double) -> Double { clamp(x, min: 0.0, max: 1.0) }
+    private func clamp(_ x: Double, min lo: Double, max hi: Double) -> Double {
+        Swift.max(lo, Swift.min(hi, x))
+    }
+}

--- a/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
@@ -596,6 +596,25 @@ public final class ModelManagementViewModel {
         return 2
     }
 
+    /// Ranks the current `searchResults` by composite model-fit score for a use case.
+    ///
+    /// Additive helper that layers `ModelFitScorer` (quality / speed / fit / context)
+    /// over the existing browse results. It does NOT alter `compatibilityTier(for:)` or
+    /// the default group sort — the authoritative will-it-run gate stays `ModelLoadPlan`.
+    /// Returns best-first.
+    ///
+    /// Next: a SwiftUI use-case picker that drives this ranking is the natural follow-up UI.
+    public func rankedVariants(
+        useCase: ModelUseCase = .general
+    ) -> [(DownloadableModel, ModelFitScore)] {
+        let device = DeviceProfile(
+            physicalMemoryBytes: deviceCapability.physicalMemory,
+            usableMemoryBytes: DeviceCapabilityService.queryAvailableMemory(),
+            memoryBandwidthGBs: AppleSiliconBandwidth.estimatedBandwidthGBs()
+        )
+        return ModelFitScorer().rank(searchResults, useCase: useCase, device: device)
+    }
+
     /// Whether a downloadable model's file already exists on disk.
     ///
     /// Uses a cached snapshot of discovered models to avoid repeated filesystem scans.

--- a/Tests/ManifoldInferenceTests/ModelFitScorerTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelFitScorerTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit tests for `ModelFitScorer` and the composite model-fit ranking.
+///
+/// All inputs are injected (device profile + memory environment) so results are
+/// deterministic regardless of the host machine's RAM or chip.
+final class ModelFitScorerTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    // MARK: - Fixtures
+
+    /// A GGUF download fixture. `quant` is encoded into the filename so the
+    /// production `DownloadableModel.quantization` regex extracts it.
+    private func ggufModel(sizeGB: Double, quant: String, name: String = "Model") -> DownloadableModel {
+        DownloadableModel(
+            repoID: "test/\(name)-GGUF",
+            fileName: "\(name).\(quant).gguf",
+            displayName: "\(name) \(quant)",
+            modelType: .gguf,
+            sizeBytes: UInt64(sizeGB * Double(oneGB))
+        )
+    }
+
+    /// A fixed device profile so bandwidth/memory are not read from the host.
+    private func device(ramGB: UInt64, bandwidthGBs: Double) -> DeviceProfile {
+        let bytes = ramGB * oneGB
+        return DeviceProfile(
+            physicalMemoryBytes: bytes,
+            usableMemoryBytes: bytes,
+            memoryBandwidthGBs: bandwidthGBs
+        )
+    }
+
+    /// Memory environment matching a device profile, so `ModelLoadPlan.estimate`
+    /// evaluates against the test's RAM rather than the real machine.
+    private func environment(for device: DeviceProfile) -> ModelLoadPlan.Environment {
+        ModelLoadPlan.Environment(
+            availableMemoryBytes: { device.usableMemoryBytes },
+            physicalMemoryBytes: device.physicalMemoryBytes
+        )
+    }
+
+    // MARK: - Quality / size ordering
+
+    func test_7B_Q4_outranks_13B_Q2_onSmallMemoryDevice() {
+        // 8 GB device: the 13B-Q2 (~5 GB) is a tight/over fit while the 7B-Q4 (~4 GB)
+        // fits comfortably AND has wider quant. Composite should favour the 7B-Q4.
+        let dev = device(ramGB: 8, bandwidthGBs: 100)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let smallQ4 = ggufModel(sizeGB: 4.0, quant: "Q4_K_M", name: "Seven")
+        let bigQ2 = ggufModel(sizeGB: 5.5, quant: "Q2_K", name: "Thirteen")
+
+        let s7 = scorer.score(smallQ4, useCase: .general, device: dev, environment: env)
+        let s13 = scorer.score(bigQ2, useCase: .general, device: dev, environment: env)
+
+        XCTAssertNotNil(s7)
+        XCTAssertNotNil(s13)
+        XCTAssertGreaterThan(
+            s7!.composite, s13!.composite,
+            "7B-Q4 should outrank 13B-Q2 on a small-memory device"
+        )
+    }
+
+    // MARK: - willRun gate via ModelLoadPlan
+
+    func test_willRun_false_whenModelExceedsMemory() {
+        // 4 GB device, 30 GB model: ModelLoadPlan's impossible-fit guard denies.
+        let dev = device(ramGB: 4, bandwidthGBs: 68)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let huge = ggufModel(sizeGB: 30.0, quant: "Q4_K_M", name: "Seventy")
+        let score = scorer.score(huge, useCase: .general, device: dev, environment: env)
+
+        XCTAssertNotNil(score)
+        XCTAssertFalse(score!.willRun, "30 GB model on 4 GB device must not be runnable")
+        XCTAssertEqual(score!.fit, 0.0, "deny verdict maps to fit == 0")
+    }
+
+    func test_willRun_true_whenModelFitsComfortably() {
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let small = ggufModel(sizeGB: 4.0, quant: "Q4_K_M")
+        let score = scorer.score(small, useCase: .general, device: dev, environment: env)
+
+        XCTAssertNotNil(score)
+        XCTAssertTrue(score!.willRun, "4 GB model on 16 GB device should run")
+    }
+
+    // MARK: - Use-case weighting shifts the ranking
+
+    func test_chatFavoursSpeed_reasoningFavoursQuality() {
+        // Two models that both fit: a small/fast one and a large/capable one.
+        // `chat` (speed-weighted) should prefer the small model; `reasoning`
+        // (quality-weighted) should prefer the large model. Same device for both.
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let fastSmall = ggufModel(sizeGB: 2.0, quant: "Q4_K_M", name: "Small")
+        let capableBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "Big")
+
+        let chatSmall = scorer.score(fastSmall, useCase: .chat, device: dev, environment: env)!
+        let chatBig = scorer.score(capableBig, useCase: .chat, device: dev, environment: env)!
+        XCTAssertGreaterThan(
+            chatSmall.composite, chatBig.composite,
+            "chat (speed-weighted) should prefer the smaller/faster model"
+        )
+
+        let reasonSmall = scorer.score(fastSmall, useCase: .reasoning, device: dev, environment: env)!
+        let reasonBig = scorer.score(capableBig, useCase: .reasoning, device: dev, environment: env)!
+        XCTAssertGreaterThan(
+            reasonBig.composite, reasonSmall.composite,
+            "reasoning (quality-weighted) should prefer the larger/more-capable model"
+        )
+    }
+
+    // MARK: - rank() ordering
+
+    func test_rank_returnsBestFirst() {
+        // 8 GB device. The 30 GB model trips ModelLoadPlan's impossible-fit guard
+        // (30/8 ≥ 3× available) → .deny → willRun == false, so the willRun gate must
+        // push it last despite its frontier-tier size.
+        let dev = device(ramGB: 8, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let wontFit = ggufModel(sizeGB: 30.0, quant: "Q4_K_M", name: "Wont-Fit")
+        let goodFit = ggufModel(sizeGB: 4.0, quant: "Q4_K_M", name: "Good-Fit")
+        let tinyLossy = ggufModel(sizeGB: 1.5, quant: "Q2_K", name: "Tiny-Lossy")
+
+        // Precondition: confirm the load plan actually denies the 30 GB model here, so
+        // the test exercises the willRun gate rather than a coincidental quality gap.
+        XCTAssertFalse(
+            scorer.score(wontFit, useCase: .general, device: dev, environment: env)!.willRun,
+            "30 GB model on 8 GB device should be denied by ModelLoadPlan"
+        )
+
+        let ranked = scorer.rank([wontFit, goodFit, tinyLossy], useCase: .general, device: dev, environment: env)
+
+        XCTAssertEqual(ranked.count, 3)
+        // Descending composite.
+        for i in 1..<ranked.count {
+            XCTAssertGreaterThanOrEqual(
+                ranked[i - 1].1.composite, ranked[i].1.composite,
+                "rank() must be sorted best-first"
+            )
+        }
+        // The non-runnable model must land last.
+        XCTAssertEqual(ranked.last?.0.fileName, "Wont-Fit.Q4_K_M.gguf")
+    }
+
+    // MARK: - Edge cases
+
+    func test_zeroSizeModel_returnsNil() {
+        let dev = device(ramGB: 8, bandwidthGBs: 100)
+        let env = environment(for: dev)
+        let model = DownloadableModel(
+            repoID: "test/Unknown",
+            fileName: "unknown.gguf",
+            displayName: "Unknown",
+            modelType: .gguf,
+            sizeBytes: 0
+        )
+        XCTAssertNil(
+            ModelFitScorer().score(model, useCase: .general, device: dev, environment: env),
+            "a zero-size model has nothing to score"
+        )
+    }
+
+    func test_unknownContextLength_isNeutral() {
+        // No knownContextLength → context dimension is the neutral 0.5, never fabricated.
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let score = ModelFitScorer().score(
+            ggufModel(sizeGB: 4.0, quant: "Q4_K_M"),
+            useCase: .general,
+            device: dev,
+            environment: env
+        )!
+        XCTAssertEqual(score.context, 0.5, accuracy: 0.0001)
+    }
+
+    func test_knownContextMeetingNeed_scoresFullContext() {
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        // chat contextNeed is 4096; supplying 8192 meets it ⇒ context == 1.0.
+        let score = ModelFitScorer().score(
+            ggufModel(sizeGB: 4.0, quant: "Q4_K_M"),
+            useCase: .chat,
+            knownContextLength: 8_192,
+            device: dev,
+            environment: env
+        )!
+        XCTAssertEqual(score.context, 1.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Bandwidth table sanity
+
+    func test_bandwidthTable_ordersChipsByTier() {
+        // Relative ordering is what the scorer relies on.
+        let base = AppleSiliconBandwidth.bandwidth(forBrandString: "Apple M1")
+        let pro = AppleSiliconBandwidth.bandwidth(forBrandString: "Apple M1 Pro")
+        let max = AppleSiliconBandwidth.bandwidth(forBrandString: "Apple M1 Max")
+        let ultra = AppleSiliconBandwidth.bandwidth(forBrandString: "Apple M1 Ultra")
+        XCTAssertLessThan(base, pro)
+        XCTAssertLessThan(pro, max)
+        XCTAssertLessThan(max, ultra)
+    }
+
+    func test_unknownChip_fallsBackConservatively() {
+        let bw = AppleSiliconBandwidth.bandwidth(forBrandString: "Intel(R) Core(TM) i9")
+        XCTAssertEqual(bw, AppleSiliconBandwidth.fallbackBandwidthGBs)
+    }
+
+    func test_quantBits_widerQuantIsHigher() {
+        XCTAssertGreaterThan(
+            QuantizationBits.bitsPerWeight(for: "Q6_K"),
+            QuantizationBits.bitsPerWeight(for: "Q2_K")
+        )
+        XCTAssertEqual(
+            QuantizationBits.bitsPerWeight(for: nil),
+            QuantizationBits.neutralBitsPerWeight
+        )
+    }
+}


### PR DESCRIPTION
## What & why

Adds a composite **model-fit scoring/ranking** layer so the model browser can surface "best for coding" / "best for chat" orderings over downloadable models. It is **additive and non-breaking** — it complements, and does not replace, the existing fit machinery (`ModelLoadPlan`, `ModelCapabilityTier`, `DownloadableModelGroup.recommendedVariant`). The authoritative will-it-run gate stays `ModelLoadPlan`.

Inspired by [llmfit](https://github.com/AlexsJones/llmfit) (MIT, © Alex Jones), reimplemented natively in Swift. **No Rust dependency.**

## The four dimensions

Each model is scored on four normalised (0…1) dimensions, combined into a weighted composite using use-case-specific `FitWeights`:

- **quality** — capability proxy from size tier × quantization bits-per-weight (sub-Q4 cliff modelled).
- **speed** — `memoryBandwidthGBs / modelSizeGB × efficiency`, normalised (decode is memory-bandwidth bound).
- **fit** — derived from `ModelLoadPlan.estimate(for:)` verdict: `.allow` → 1.0, `.warn` → 0.5, `.deny` → 0.0. A non-runnable model is gated below every runnable one.
- **context** — known context length vs. the use case's need; neutral (0.5) when unknown.

Use cases: `general, coding, reasoning, chat, multimodal, embedding` — e.g. `chat` favours speed, `reasoning` favours quality.

## Design notes

- **Reuses `ModelLoadPlan` for the fit dimension** — does **not** reinvent the resident/KV byte math. The scorer calls `ModelLoadPlan.estimate(for:requestedContextSize:environment:)` and derives `fit` + `willRun` from the `Outcome.verdict`.
- **No new fields on `ModelCapabilityTier`** — it stays a pure file-size enum. Quality is derived from `DownloadableModel.sizeBytes` (tier thresholds) plus `DownloadableModel.quantization` (bits-per-weight).
- New `AppleSiliconBandwidth` table maps the host chip → approximate unified-memory bandwidth for the speed term.

## Documented limitations

- **Pre-download context length is unknown** for arbitrary HF search results, so the context dimension is neutral (0.5) unless the caller supplies `knownContextLength` (e.g. from `CuratedModel.contextSize`). We never fabricate a context length.
- **Bandwidth table is approximate** — Apple publishes no runtime bandwidth API; figures are published per-chip approximations and binned SKUs can't be distinguished at runtime. Ranking is relative, so ordering matters more than absolute precision.
- **Chip detection is conservative on iOS** — `machdep.cpu.brand_string` is restricted there, so we map `hw.machine` to a conservative A-/M-series figure; unknown chips fall back to 50 GB/s.

## Wiring

- Added `ModelManagementViewModel.rankedVariants(useCase:)` (additive). `compatibilityTier(for:)`, `recommendedVariant`, and the default group sort are **unchanged** — verified against `DownloadableModelGroupCompatibilityTests` (14 tests, green).
- No SwiftUI use-case picker in this PR (left as a `// Next:` note) to keep it shippable.

## Backend applicability

Inference-layer + model-management only. The scorer operates on `DownloadableModel` manifests and reuses the shared `ModelLoadPlan`; there is no per-backend behavior, so **no per-backend fan-out is needed**.

## Tests

`Tests/ManifoldInferenceTests/ModelFitScorerTests.swift` (11 pure unit tests, fully injected device/memory): 7B-Q4 outranks 13B-Q2 on a small-memory device; `willRun == false` when a model exceeds memory; use-case weights shift the ranking (chat→speed, reasoning→quality); `rank()` best-first ordering with a denied model gated last; bandwidth-table tier ordering; quant-bits monotonicity.

- `swift build --build-tests --disable-default-traits` — Build complete
- `swift build --build-tests` (default traits) — Build complete
- `swift test --disable-default-traits --filter ModelFitScorerTests` — 11/11 pass
- `swift test --disable-default-traits --filter ModelLoadPlan` — 45/45 + adjacent pass
- `ManifoldInferenceSwiftTestingTests.ModelCapabilityTierTests` — 11/11 pass
- `DownloadableModelGroupCompatibilityTests` — 14/14 pass (existing behavior intact)

## Checklist

- [ ] Full `scripts/test.sh --profile local` gate run before merge (maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)