### PR TITLE
feat: device-aware model recommendation UI

### DIFF
--- a/Sources/ManifoldInference/Models/ModelFitScore.swift
+++ b/Sources/ManifoldInference/Models/ModelFitScore.swift
@@ -133,3 +133,175 @@ public struct ModelFitScore: Sendable, Comparable, Equatable {
         lhs.composite < rhs.composite
     }
 }
+
+// MARK: - Honest qualitative abstractions
+
+// The dimensions above (`composite`, `estimatedTokensPerSecond`, …) are raw,
+// continuous proxies. Showing a user a bare "12.7 tok/s" or "fit 0.62" reads as
+// a measured fact when it is a coarse pre-download *estimate* — and a confidently
+// wrong number erodes trust faster than honest vagueness does. These abstractions
+// collapse the raw values into a small number of qualitative buckets the UI can
+// present without implying false precision. Power users still read the raw fields.
+
+/// A coarse, reading-pace bucket for decode throughput.
+///
+/// Derived from `ModelFitScore.estimatedTokensPerSecond`. The thresholds are tuned
+/// for *chat-style reading pace* — the rate at which streamed text feels responsive
+/// to a person reading along — not for batch throughput. They are deliberately
+/// coarse: the underlying estimate is bandwidth ÷ footprint, accurate only to a
+/// factor, so finer buckets would imply precision we do not have.
+///
+/// - Note: This is approximate guidance, not a guarantee. Real throughput depends
+///   on prompt length, sampler, thermal state, and concurrent load.
+public enum SpeedClass: Sendable, Equatable, CaseIterable {
+    /// At or above comfortable reading pace; streaming keeps ahead of the eye.
+    case fast
+    /// Readable but visibly streaming; fine for interactive chat.
+    case usable
+    /// Noticeably slow — usable for short replies, tedious for long ones.
+    case sluggish
+    /// Below the threshold where interactive use is reasonable.
+    case tooSlow
+
+    /// Buckets a tokens/sec estimate.
+    ///
+    /// Thresholds (tok/s): `≥ 30` fast · `12...<30` usable · `5...<12` sluggish ·
+    /// `< 5` tooSlow. ~30 tok/s is roughly fast adult silent-reading pace (~5 words/s
+    /// ≈ a token every 130 ms), so the stream stays ahead of the reader. Below ~5
+    /// tok/s a sentence takes long enough to feel broken for chat. The exact cuts are
+    /// judgement calls on a noisy estimate, hence the wide bands.
+    public init(tokensPerSecond: Double) {
+        switch tokensPerSecond {
+        case 30...:      self = .fast
+        case 12..<30:    self = .usable
+        case 5..<12:     self = .sluggish
+        default:         self = .tooSlow
+        }
+    }
+
+    /// Short, plain-language label suitable for a badge. No punctuation or marketing tone.
+    public var label: String {
+        switch self {
+        case .fast:     return "Fast"
+        case .usable:   return "Usable"
+        case .sluggish: return "Sluggish"
+        case .tooSlow:  return "Too slow"
+        }
+    }
+}
+
+/// A coarse quality bucket for the composite fit score.
+///
+/// Derived from `ModelFitScore.composite`. Buckets, not a percentage: a "62%" reads
+/// as a precise measurement, but the composite is a weighted sum of four estimates,
+/// so we present a band instead. A `.notRecommended` model is one the device cannot
+/// run well (or at all) — see `ModelFitScore.fitQuality` for the won't-run override.
+///
+/// - Note: Approximate guidance, not a guarantee.
+public enum FitQuality: Sendable, Equatable, CaseIterable {
+    /// Strong match for the device and use case.
+    case excellent
+    /// Solid, workable match.
+    case good
+    /// Runs, but with real trade-offs (slow, tight on memory, or weak for the task).
+    case marginal
+    /// Not a sensible choice on this device — typically won't run, or runs badly.
+    case notRecommended
+
+    /// Buckets a composite score in 0...1.
+    ///
+    /// Thresholds: `≥ 0.70` excellent · `0.50...<0.70` good · `0.30...<0.50` marginal ·
+    /// `< 0.30` notRecommended. These align with the scorer's `willRun` collapse
+    /// (a denied model's composite is multiplied by 0.1), so non-runnable candidates
+    /// land in `notRecommended` without a special case here.
+    public init(composite: Double) {
+        switch composite {
+        case 0.70...:    self = .excellent
+        case 0.50..<0.70: self = .good
+        case 0.30..<0.50: self = .marginal
+        default:         self = .notRecommended
+        }
+    }
+
+    /// Short, plain-language label suitable for a badge.
+    public var label: String {
+        switch self {
+        case .excellent:      return "Excellent"
+        case .good:           return "Good"
+        case .marginal:       return "Marginal"
+        case .notRecommended: return "Not recommended"
+        }
+    }
+}
+
+extension ModelFitScore {
+    /// The reading-pace speed bucket for this score's `estimatedTokensPerSecond`.
+    ///
+    /// Prefer this over the raw `estimatedTokensPerSecond` in user-facing UI: the
+    /// estimate is approximate, and a bucket is honest about that. The raw value
+    /// remains available for power users and tests.
+    public var speedClass: SpeedClass {
+        SpeedClass(tokensPerSecond: estimatedTokensPerSecond)
+    }
+
+    /// The qualitative quality bucket for this score's `composite`.
+    ///
+    /// A model that `willRun == false` is always `.notRecommended` regardless of the
+    /// composite band — the scorer already collapses its composite, but we assert it
+    /// here too so callers cannot surface a "marginal" badge on something that will
+    /// not load. Approximate guidance, not a guarantee.
+    public var fitQuality: FitQuality {
+        guard willRun else { return .notRecommended }
+        return FitQuality(composite: composite)
+    }
+
+    /// A one-line, factual "why" assembled from the dominant dimensions and `willRun`.
+    ///
+    /// Intended as the single human-readable justification a UI shows on a recommended
+    /// model. It is generated from the same buckets as `speedClass`/`fitQuality`, never
+    /// from raw decimals, so it stays honest about precision. No exclamation marks, no
+    /// marketing tone — just what the device can and cannot do.
+    ///
+    /// - Note: Approximate guidance, not a guarantee.
+    public var rationale: String {
+        // A model that will not load has nothing else worth saying.
+        guard willRun else {
+            return "Too large to run well on this device"
+        }
+
+        var clauses: [String] = []
+
+        // Speed clause — the dimension users feel most directly.
+        switch speedClass {
+        case .fast:     clauses.append("fast on your device")
+        case .usable:   clauses.append("usable speed on your device")
+        case .sluggish: clauses.append("slower on your device")
+        case .tooSlow:  clauses.append("very slow on your device")
+        }
+
+        // Memory headroom clause, from the fit dimension. `fit == 1.0` is an
+        // `.allow` verdict (comfortable); `0.5` is `.warn` (tight).
+        if fit >= 1.0 {
+            clauses.append("fits comfortably")
+        } else if fit > 0 {
+            clauses.append("a tight fit in memory")
+        }
+
+        // Capability clause only when quality is a genuine strength, to avoid
+        // padding every line. ~0.7 is the boundary into the capable/frontier tiers.
+        if quality >= 0.7 {
+            clauses.append("strong capability")
+        } else if quality < 0.35 {
+            clauses.append("limited capability")
+        }
+
+        // Sentence-case the first clause; join the rest with middots for a compact line.
+        guard let first = clauses.first else {
+            // Defensive: speedClass always contributes a clause, so this is unreachable.
+            return "Runnable on this device"
+        }
+        let head = first.prefix(1).uppercased() + first.dropFirst()
+        let rest = clauses.dropFirst()
+        return ([head] + rest).joined(separator: " · ")
+    }
+}

--- a/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/DeviceAwareModelRecommendations.md
+++ b/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/DeviceAwareModelRecommendations.md
@@ -35,11 +35,12 @@ State lives on `ModelManagementViewModel`:
 
 If you render your own model list, drive it with `ModelFitScorer` directly. Score or rank your candidates, then present the qualitative abstractions — not the raw figures.
 
-```swift,no-build
+```swift
 import ManifoldInference
 
-// Your candidate models (e.g. from a HuggingFace search or a curated catalog).
-let candidates: [DownloadableModel] = …
+// Your candidate models — replace with the results of a HuggingFace search
+// or a curated catalog. Empty here so the snippet stands alone.
+let candidates: [DownloadableModel] = []
 
 // Rank best-first for the user's task. `DeviceProfile.current` reads the host's
 // memory + estimated bandwidth; inject a fixed profile in tests for determinism.

--- a/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/DeviceAwareModelRecommendations.md
+++ b/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/DeviceAwareModelRecommendations.md
@@ -1,0 +1,91 @@
+# Device-Aware Model Recommendations
+
+Rank surfaced models by how well they fit the current device, and present that fit honestly.
+
+## Overview
+
+Picking a local model is hard: a 13B at Q2 sounds bigger than a 7B at Q4, but the 7B usually runs faster *and* answers better on a laptop. ManifoldKit scores each downloadable model along four dimensions — quality, speed, memory fit, and context — weights them for the user's task, and surfaces a single ranked order.
+
+The guiding principle is **honesty of presentation, not raw numbers.** A pre-download throughput figure is a coarse estimate (memory bandwidth ÷ model footprint), accurate only to a factor. Showing "12.7 tok/s" reads as a measured fact and erodes trust when it turns out wrong. So the public surface deliberately exposes *qualitative buckets* on top of the raw values:
+
+- ``SpeedClass`` — `fast` / `usable` / `sluggish` / `tooSlow`, bucketed for chat reading pace.
+- ``FitQuality`` — `excellent` / `good` / `marginal` / `notRecommended`, bucketed from the composite.
+- ``ModelFitScore/rationale`` — a one-line, factual "why" assembled from the buckets, never from raw decimals.
+
+The raw ``ModelFitScore/estimatedTokensPerSecond`` and ``ModelFitScore/composite`` remain available for power users and tests — the buckets are an honest layer *on top of* them, not a replacement.
+
+> Important: All of these are **approximate guidance, not guarantees.** Real throughput depends on prompt length, sampler settings, thermal state, and concurrent load. Present them as estimates, never as benchmarks.
+
+There are two ways to consume this, and they share no code path — pick the one that matches your app.
+
+## Path 1 — The built-in browser (high-level)
+
+If you use ManifoldKit's model browser, you get device-aware recommendations automatically. The browser shows a **use-case picker** (General / Coding / Reasoning / Chat / …) that re-orders results, and a **Sort** control (`Recommended` / `Size` / `Downloads`) as an escape hatch.
+
+The browser **ranks, it never filters** — every model stays visible regardless of the selected use case, so a power user can always reach the model they want. Each row shows a qualitative ``SpeedClass`` badge (Fast / Usable / Sluggish / Too slow), and the top-ranked model carries its one-line rationale. The exact on-disk size and quantization string stay visible for power users.
+
+State lives on `ModelManagementViewModel`:
+
+- `selectedUseCase` — the ``ModelUseCase`` to rank for (default `.general`).
+- `sortMode` — `.recommended` / `.size` / `.downloads`.
+
+`selectedUseCase` persists only when you inject a `UserDefaults` into the view model (never `UserDefaults.standard` implicitly — that is a `--parallel` test-flake source). Without one it is purely in-memory.
+
+## Path 2 — Bring your own UI
+
+If you render your own model list, drive it with `ModelFitScorer` directly. Score or rank your candidates, then present the qualitative abstractions — not the raw figures.
+
+```swift,no-build
+import ManifoldInference
+
+// Your candidate models (e.g. from a HuggingFace search or a curated catalog).
+let candidates: [DownloadableModel] = …
+
+// Rank best-first for the user's task. `DeviceProfile.current` reads the host's
+// memory + estimated bandwidth; inject a fixed profile in tests for determinism.
+let ranked = ModelFitScorer().rank(candidates, useCase: .chat, device: .current)
+
+for (model, score) in ranked {
+    // Present the HONEST abstractions, not the raw estimate.
+    let speed = score.speedClass.label        // "Fast" / "Usable" / "Sluggish" / "Too slow"
+    let quality = score.fitQuality.label      // "Excellent" / "Good" / "Marginal" / "Not recommended"
+    let why = score.rationale                 // "Fast on your device · fits comfortably · strong capability"
+
+    print("\(model.displayName): \(quality) — \(speed). \(why)")
+
+    // The raw values are still here for a power-user "details" disclosure, but
+    // never present `estimatedTokensPerSecond` as a bare, unqualified fact.
+    // e.g. show "~\(Int(score.estimatedTokensPerSecond)) tok/s (estimate)".
+}
+```
+
+### Honesty guidance for your own UI
+
+- Lead with ``SpeedClass`` and ``ModelFitScore/rationale``, not ``ModelFitScore/estimatedTokensPerSecond``.
+- If you must show a number, label it as an estimate (`~N tok/s`) or show a range — never a bare decimal presented as fact.
+- **Rank, don't filter.** Keep every model reachable; ordering is a recommendation, not a gate.
+- Keep size and quantization visible — they are the ground truth a power user reasons about.
+- The authoritative will-it-run gate stays `ModelLoadPlan`; ``ModelFitScore/willRun`` mirrors its verdict, and a non-runnable model is always ``FitQuality/notRecommended``.
+
+## When recommendations do nothing
+
+Recommendations require models to be *surfaced* in the first place. They have nothing to rank for:
+
+- **Cloud-only apps** — there is no local file to fit to the device.
+- **Single-bundled-model apps** — one model, no choice to rank.
+
+To populate candidates you need either the HuggingFace search trait enabled or a populated `CuratedModel` catalog. Without surfaced models the picker and ranking are inert.
+
+## Topics
+
+### Core scoring
+
+- ``ModelFitScorer``
+- ``ModelFitScore``
+- ``ModelUseCase``
+
+### Honest presentation
+
+- ``SpeedClass``
+- ``FitQuality``
+- ``ModelFitScore/rationale``

--- a/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/ManifoldUIModelManagement.md
+++ b/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/ManifoldUIModelManagement.md
@@ -1,0 +1,15 @@
+# ``ManifoldUIModelManagement``
+
+The model browser, downloader, and storage-management UI, plus cloud API endpoint editors.
+
+## Overview
+
+ManifoldUIModelManagement is the optional management surface that sits on top of ``ManifoldUI``. It provides the HuggingFace model browser, download progress, local-model storage management, and the API endpoint editors for cloud backends. A chat-only app does not need it; reach for it when your app lets users discover and install models at runtime.
+
+This module also surfaces **device-aware model recommendations** — ranking surfaced models by how well they fit the current device for a chosen use case. The recommendations are designed around one principle: *honesty of presentation*. See <doc:DeviceAwareModelRecommendations>.
+
+## Topics
+
+### Articles
+
+- <doc:DeviceAwareModelRecommendations>

--- a/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
@@ -46,6 +46,44 @@ public final class ModelManagementViewModel {
     /// User-facing error from the last search or download attempt.
     public var searchError: String?
 
+    // MARK: - Recommendation State
+
+    /// The use case the browser ranks search results for.
+    ///
+    /// Drives `rankedVariants(useCase:)` ordering. In-memory `@Observable` state with
+    /// a `.general` default; persisted only when a `UserDefaults` is injected (see
+    /// `init`). Changing it re-orders the list but never hides a model — ranking, not
+    /// filtering, is the contract (see `SortMode`).
+    public var selectedUseCase: ModelUseCase = .general {
+        didSet { persistSelectedUseCase() }
+    }
+
+    /// How the browser orders search-result groups.
+    ///
+    /// The escape hatch for power users: `.recommended` applies device-aware fit
+    /// ranking, `.size`/`.downloads` fall back to the pre-existing deterministic order
+    /// so no model is ever buried behind a recommendation they disagree with.
+    public enum SortMode: String, CaseIterable, Sendable {
+        /// Device-aware fit ranking for `selectedUseCase` (the new default).
+        case recommended
+        /// Smallest on-disk size first — the historical compatibility-tier order.
+        case size
+        /// Most-downloaded first.
+        case downloads
+
+        /// Short label for a segmented control or menu.
+        public var label: String {
+            switch self {
+            case .recommended: return "Recommended"
+            case .size:        return "Size"
+            case .downloads:   return "Downloads"
+            }
+        }
+    }
+
+    /// The active sort mode for the browser. In-memory; defaults to `.recommended`.
+    public var sortMode: SortMode = .recommended
+
     // MARK: - Services
 
     private let huggingFaceService: (any HuggingFaceServiceProtocol)?
@@ -54,6 +92,16 @@ public final class ModelManagementViewModel {
     private let modelStorage: ModelStorageService
     private let diagnostics: DiagnosticsService?
     private let fileRemover: @Sendable (URL) throws -> Void
+
+    /// Injected defaults store for persisting `selectedUseCase`.
+    ///
+    /// Never `UserDefaults.standard` implicitly — a shared instance is a documented
+    /// `--parallel` flake source (#734, #761). Callers opt into persistence by passing
+    /// a suite; the default `nil` keeps the picker purely in-memory.
+    private let userDefaults: UserDefaults?
+
+    /// Defaults key for the persisted use case. Namespaced to avoid host-app collisions.
+    private static let selectedUseCaseKey = "ManifoldKit.ModelManagement.selectedUseCase"
 
     // MARK: - Download Tracking
 
@@ -111,6 +159,7 @@ public final class ModelManagementViewModel {
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
         modelStorage: ModelStorageService = ModelStorageService(),
         diagnostics: DiagnosticsService? = nil,
+        userDefaults: UserDefaults? = nil,
         fileRemover: @escaping @Sendable (URL) throws -> Void = { try FileManager.default.removeItem(at: $0) }
     ) {
         self.huggingFaceService = huggingFaceService
@@ -118,7 +167,9 @@ public final class ModelManagementViewModel {
         self.deviceCapability = deviceCapability
         self.modelStorage = modelStorage
         self.diagnostics = diagnostics
+        self.userDefaults = userDefaults
         self.fileRemover = fileRemover
+        restoreSelectedUseCase()
     }
 
     /// Creates a production-ready model manager with search and downloads enabled.
@@ -603,16 +654,58 @@ public final class ModelManagementViewModel {
     /// the default group sort — the authoritative will-it-run gate stays `ModelLoadPlan`.
     /// Returns best-first.
     ///
-    /// Next: a SwiftUI use-case picker that drives this ranking is the natural follow-up UI.
+    /// - Parameters:
+    ///   - useCase: The use case to weight dimensions for. Defaults to `selectedUseCase`.
+    ///   - device: Device profile for scoring. Defaults to the real host profile; tests
+    ///     inject a fixed profile so ranking is deterministic regardless of the runner.
     public func rankedVariants(
-        useCase: ModelUseCase = .general
+        useCase: ModelUseCase? = nil,
+        device: DeviceProfile? = nil
     ) -> [(DownloadableModel, ModelFitScore)] {
-        let device = DeviceProfile(
+        let resolvedDevice = device ?? DeviceProfile(
             physicalMemoryBytes: deviceCapability.physicalMemory,
             usableMemoryBytes: DeviceCapabilityService.queryAvailableMemory(),
             memoryBandwidthGBs: AppleSiliconBandwidth.estimatedBandwidthGBs()
         )
-        return ModelFitScorer().rank(searchResults, useCase: useCase, device: device)
+        return ModelFitScorer().rank(searchResults, useCase: useCase ?? selectedUseCase, device: resolvedDevice)
+    }
+
+    /// The fit score for a single downloadable model under the current selection.
+    ///
+    /// Lets the row UI show a `SpeedClass` badge / `rationale` without re-ranking the
+    /// whole list. Returns `nil` for unscoreable (size 0) models. `device` is injectable
+    /// for deterministic tests; production passes `nil` for the real host profile.
+    public func fitScore(
+        for model: DownloadableModel,
+        useCase: ModelUseCase? = nil,
+        device: DeviceProfile? = nil
+    ) -> ModelFitScore? {
+        let resolvedDevice = device ?? DeviceProfile(
+            physicalMemoryBytes: deviceCapability.physicalMemory,
+            usableMemoryBytes: DeviceCapabilityService.queryAvailableMemory(),
+            memoryBandwidthGBs: AppleSiliconBandwidth.estimatedBandwidthGBs()
+        )
+        return ModelFitScorer().score(model, useCase: useCase ?? selectedUseCase, device: resolvedDevice)
+    }
+
+    // MARK: - Use-case persistence
+
+    /// Restores `selectedUseCase` from the injected defaults store, if any.
+    ///
+    /// Sets the backing value directly to avoid re-triggering `persistSelectedUseCase`
+    /// during init (a no-op write, but pointless churn).
+    private func restoreSelectedUseCase() {
+        guard let userDefaults,
+              let raw = userDefaults.string(forKey: Self.selectedUseCaseKey),
+              let restored = ModelUseCase(rawValue: raw) else { return }
+        // Assigning here fires didSet → persistSelectedUseCase, which writes back the
+        // same value. Harmless and keeps the property a plain stored var.
+        selectedUseCase = restored
+    }
+
+    /// Persists `selectedUseCase` when a defaults store was injected; otherwise no-op.
+    private func persistSelectedUseCase() {
+        userDefaults?.set(selectedUseCase.rawValue, forKey: Self.selectedUseCaseKey)
     }
 
     /// Whether a downloadable model's file already exists on disk.

--- a/Sources/ManifoldUIModelManagement/Views/Models/DownloadableModelRow.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/DownloadableModelRow.swift
@@ -12,11 +12,28 @@ public struct DownloadableModelRow: View {
 
     public let model: DownloadableModel
 
+    /// When `true`, render the device-aware speed badge and (if `rationale` is set)
+    /// the one-line "why". The browser passes `true` for search-result variants and
+    /// the recommended pick; it stays `false` for contexts (e.g. the curated
+    /// "Recommended for Your Device" section) that already convey fit some other way.
+    private let showFitGuidance: Bool
+
+    /// Pre-computed one-line justification shown under the row when non-`nil`.
+    /// Surfaced only on the top-ranked / recommended variant to avoid repeating it
+    /// on every row. Honest by construction — see `ModelFitScore.rationale`.
+    private let rationale: String?
+
     @Environment(ModelManagementViewModel.self) private var viewModel
     @Environment(FrameworkCapabilityService.self) private var capabilityService: FrameworkCapabilityService?
 
-    public init(model: DownloadableModel) {
+    public init(
+        model: DownloadableModel,
+        showFitGuidance: Bool = false,
+        rationale: String? = nil
+    ) {
         self.model = model
+        self.showFitGuidance = showFitGuidance
+        self.rationale = rationale
     }
 
     /// Resolves backend compatibility from the injected `FrameworkCapabilityService`
@@ -62,6 +79,8 @@ public struct DownloadableModelRow: View {
                             .foregroundStyle(.blue)
                             .accessibilityLabel("Curated model")
                     }
+
+                    speedBadge
                 }
 
                 Text(model.fileName)
@@ -98,6 +117,17 @@ public struct DownloadableModelRow: View {
                         .foregroundStyle(.secondary)
                         .accessibilityLabel("Unverified source — no SHA-256 hash available")
                 }
+
+                // One-line honest "why" on the recommended/top variant only. Built from
+                // qualitative buckets, never raw tok/s — see ModelFitScore.rationale.
+                if let rationale {
+                    Text(rationale)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .padding(.top, 1)
+                        .accessibilityLabel("Why: \(rationale)")
+                }
             }
 
             Spacer()
@@ -105,6 +135,36 @@ public struct DownloadableModelRow: View {
             trailingContent
         }
         .padding(.vertical, 4)
+    }
+
+    // MARK: - Speed Badge
+
+    /// Qualitative speed badge (Fast / Usable / Sluggish / Too slow) for the device.
+    ///
+    /// Shown only when `showFitGuidance` is set and the model has a usable size. We
+    /// present the `SpeedClass` *word*, never a raw tok/s decimal — the underlying
+    /// figure is a coarse estimate, and a bare number reads as a measured fact.
+    @ViewBuilder
+    private var speedBadge: some View {
+        if showFitGuidance, model.sizeBytes > 0, let score = viewModel.fitScore(for: model) {
+            let speed = score.speedClass
+            Text(speed.label)
+                .font(.caption2)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(speedTint(speed).opacity(0.15), in: Capsule())
+                .foregroundStyle(speedTint(speed))
+                .accessibilityLabel("Estimated speed: \(speed.label). Approximate guidance, not a guarantee.")
+        }
+    }
+
+    private func speedTint(_ speed: SpeedClass) -> Color {
+        switch speed {
+        case .fast:     return .green
+        case .usable:   return .blue
+        case .sluggish: return .orange
+        case .tooSlow:  return .red
+        }
     }
 
     // MARK: - Compatibility Badge

--- a/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
@@ -142,16 +142,44 @@ struct HuggingFaceBrowserView: View {
             }
 
             if !viewModel.searchResults.isEmpty {
-                let groups = DownloadableModelGroup.group(
-                    viewModel.searchResults,
-                    sortKey: { viewModel.compatibilityTier(for: $0) }
-                )
+                Section {
+                    // Use-case picker — biases the fit ranking. Ranks, never filters:
+                    // every model below stays visible regardless of selection.
+                    Picker("Optimize for", selection: $viewModel.selectedUseCase) {
+                        ForEach(ModelUseCase.allCases, id: \.self) { useCase in
+                            Text(useCaseLabel(useCase)).tag(useCase)
+                        }
+                    }
+                    .accessibilityLabel("Optimize recommendations for use case")
+
+                    // Sort escape hatch — power users who distrust the recommendation
+                    // can fall back to the deterministic size / downloads order.
+                    Picker("Sort", selection: $viewModel.sortMode) {
+                        ForEach(ModelManagementViewModel.SortMode.allCases, id: \.self) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityLabel("Sort order")
+                }
+
+                let groups = sortedGroups()
+                let topModelID = (viewModel.sortMode == .recommended)
+                    ? viewModel.rankedVariants().first?.0.id
+                    : nil
                 Section(viewModel.isDirectRepoLookup ? "Files in \(viewModel.searchQuery)" : "Search Results") {
                     ForEach(groups) { group in
                         if group.variants.count == 1 {
-                            DownloadableModelRow(model: group.variants[0])
+                            let variant = group.variants[0]
+                            DownloadableModelRow(
+                                model: variant,
+                                showFitGuidance: true,
+                                rationale: rationale(for: variant, topModelID: topModelID)
+                            )
                         } else {
-                            let recommended = group.recommendedVariant(for: viewModel.deviceCapabilityService)
+                            // "Best for your device": the top-ranked quant for the use
+                            // case when ranking is active, else the legacy memory-fit pick.
+                            let recommended = bestVariant(for: group)
                             let noVariantFits = recommended != nil && !group.variants.contains(where: {
                                 $0.sizeBytes > 0 && viewModel.canRunModel(sizeBytes: $0.sizeBytes)
                             })
@@ -161,9 +189,15 @@ struct HuggingFaceBrowserView: View {
                             DisclosureGroup {
                                 ForEach(sortedVariants) { variant in
                                     VStack(alignment: .leading, spacing: 2) {
-                                        DownloadableModelRow(model: variant)
+                                        DownloadableModelRow(
+                                            model: variant,
+                                            showFitGuidance: true,
+                                            rationale: variant.id == recommended?.id
+                                                ? viewModel.fitScore(for: variant)?.rationale
+                                                : nil
+                                        )
                                         if variant.id == recommended?.id {
-                                            Text(noVariantFits ? "Smallest available" : "Recommended")
+                                            Text(bestForDeviceLabel(noVariantFits: noVariantFits))
                                                 .font(.caption2)
                                                 .padding(.horizontal, 4)
                                                 .padding(.vertical, 1)
@@ -280,6 +314,85 @@ struct HuggingFaceBrowserView: View {
             viewModel.activeModelFileName = modelRegistry.selectedModel?.fileName
             viewModel.loadRecommendations(preferredModelIDs: recommendedModelIDs)
         }
+    }
+
+    // MARK: - Ranking helpers
+
+    /// Groups the current search results and orders them per the selected `sortMode`.
+    ///
+    /// `.recommended` orders groups by their best variant's composite fit score for the
+    /// selected use case (rank, don't filter — all groups stay present). `.size` reuses
+    /// the historical compatibility-tier order; `.downloads` defers to the default
+    /// download-count sort. Within a group, variants are always shown smallest-first
+    /// (see `DownloadableModelGroup.group`).
+    private func sortedGroups() -> [DownloadableModelGroup] {
+        switch viewModel.sortMode {
+        case .size:
+            return DownloadableModelGroup.group(
+                viewModel.searchResults,
+                sortKey: { viewModel.compatibilityTier(for: $0) }
+            )
+        case .downloads:
+            return DownloadableModelGroup.group(viewModel.searchResults)
+        case .recommended:
+            // Best composite per group; higher first. Groups with no scoreable variant
+            // (all size 0) sort to the bottom but are never dropped.
+            let groups = DownloadableModelGroup.group(viewModel.searchResults)
+            return groups.sorted { lhs, rhs in
+                bestComposite(in: lhs) > bestComposite(in: rhs)
+            }
+        }
+    }
+
+    /// Highest composite fit score among a group's variants, or `-1` when none score.
+    private func bestComposite(in group: DownloadableModelGroup) -> Double {
+        group.variants
+            .compactMap { viewModel.fitScore(for: $0)?.composite }
+            .max() ?? -1
+    }
+
+    /// The variant to surface as "Best for your device".
+    ///
+    /// In `.recommended` mode this is the top-ranked quant for the use case; otherwise
+    /// it falls back to the legacy largest-that-fits memory pick so the size/downloads
+    /// modes keep their familiar behaviour.
+    private func bestVariant(for group: DownloadableModelGroup) -> DownloadableModel? {
+        switch viewModel.sortMode {
+        case .recommended:
+            let ranked = group.variants
+                .compactMap { variant -> (DownloadableModel, Double)? in
+                    guard let score = viewModel.fitScore(for: variant) else { return nil }
+                    return (variant, score.composite)
+                }
+                .max(by: { $0.1 < $1.1 })
+            // Fall back to the memory-fit pick when nothing scores (all size 0).
+            return ranked?.0 ?? group.recommendedVariant(for: viewModel.deviceCapabilityService)
+        case .size, .downloads:
+            return group.recommendedVariant(for: viewModel.deviceCapabilityService)
+        }
+    }
+
+    /// The one-line rationale for a single-variant row, shown only on the overall
+    /// top-ranked model so the "why" appears once rather than on every row.
+    private func rationale(for model: DownloadableModel, topModelID: String?) -> String? {
+        guard let topModelID, model.id == topModelID else { return nil }
+        return viewModel.fitScore(for: model)?.rationale
+    }
+
+    private func useCaseLabel(_ useCase: ModelUseCase) -> String {
+        switch useCase {
+        case .general:    return "General"
+        case .coding:     return "Coding"
+        case .reasoning:  return "Reasoning"
+        case .chat:       return "Chat"
+        case .multimodal: return "Multimodal"
+        case .embedding:  return "Embedding"
+        }
+    }
+
+    private func bestForDeviceLabel(noVariantFits: Bool) -> String {
+        if noVariantFits { return "Smallest available" }
+        return viewModel.sortMode == .recommended ? "Best for your device" : "Recommended"
     }
 
     private func handleImport(_ result: Result<[URL], Error>) {

--- a/Tests/ManifoldInferenceTests/ModelFitScoreHonestPresentationTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelFitScoreHonestPresentationTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit tests for the honest qualitative abstractions layered on `ModelFitScore`:
+/// `SpeedClass`, `FitQuality`, and `rationale`.
+///
+/// These guard the *presentation contract* — coarse buckets and a factual one-liner —
+/// not the underlying scoring math (covered by `ModelFitScorerTests`). All scores are
+/// constructed directly so the boundaries are tested without a device dependency.
+final class ModelFitScoreHonestPresentationTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    /// Builds a score with only the fields a given assertion cares about; the rest are
+    /// neutral placeholders. `composite`/`tps`/`willRun` are the load-bearing inputs.
+    private func score(
+        composite: Double = 0.5,
+        tps: Double = 20,
+        willRun: Bool = true,
+        quality: Double = 0.5,
+        fit: Double = 1.0
+    ) -> ModelFitScore {
+        ModelFitScore(
+            quality: quality,
+            speed: 0.5,
+            fit: fit,
+            context: 0.5,
+            composite: composite,
+            estimatedTokensPerSecond: tps,
+            memoryBytes: 4 * oneGB,
+            willRun: willRun
+        )
+    }
+
+    // MARK: - SpeedClass thresholds
+
+    func test_speedClass_boundaries() {
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 60), .fast)
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 30), .fast, "30 is the inclusive lower bound of fast")
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 29.999), .usable)
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 12), .usable, "12 is the inclusive lower bound of usable")
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 11.999), .sluggish)
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 5), .sluggish, "5 is the inclusive lower bound of sluggish")
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 4.999), .tooSlow)
+        XCTAssertEqual(SpeedClass(tokensPerSecond: 0), .tooSlow)
+    }
+
+    func test_speedClass_derivedFromScore() {
+        XCTAssertEqual(score(tps: 45).speedClass, .fast)
+        XCTAssertEqual(score(tps: 8).speedClass, .sluggish)
+    }
+
+    // MARK: - FitQuality buckets
+
+    func test_fitQuality_boundaries() {
+        XCTAssertEqual(FitQuality(composite: 0.85), .excellent)
+        XCTAssertEqual(FitQuality(composite: 0.70), .excellent, "0.70 is the inclusive lower bound of excellent")
+        XCTAssertEqual(FitQuality(composite: 0.699), .good)
+        XCTAssertEqual(FitQuality(composite: 0.50), .good, "0.50 is the inclusive lower bound of good")
+        XCTAssertEqual(FitQuality(composite: 0.499), .marginal)
+        XCTAssertEqual(FitQuality(composite: 0.30), .marginal, "0.30 is the inclusive lower bound of marginal")
+        XCTAssertEqual(FitQuality(composite: 0.299), .notRecommended)
+        XCTAssertEqual(FitQuality(composite: 0.0), .notRecommended)
+    }
+
+    func test_fitQuality_wontRun_alwaysNotRecommended() {
+        // Even with a high composite, a non-runnable model must read as notRecommended.
+        let wontRun = score(composite: 0.9, willRun: false)
+        XCTAssertEqual(
+            wontRun.fitQuality, .notRecommended,
+            "a model that won't load is never excellent/good/marginal"
+        )
+    }
+
+    // MARK: - rationale content
+
+    func test_rationale_wontRun_statesItPlainly() {
+        let r = score(composite: 0.9, tps: 60, willRun: false).rationale
+        XCTAssertEqual(r, "Too large to run well on this device")
+        XCTAssertFalse(r.contains("!"), "no exclamation marks — factual tone")
+    }
+
+    func test_rationale_fastFitting_capableModel() {
+        // Fast (tps 50), comfortable fit (1.0), strong quality (0.8).
+        let r = score(composite: 0.8, tps: 50, willRun: true, quality: 0.8, fit: 1.0).rationale
+        XCTAssertTrue(r.lowercased().contains("fast"), "fast model should say so: \(r)")
+        XCTAssertTrue(r.lowercased().contains("comfort"), "comfortable fit should be mentioned: \(r)")
+        XCTAssertTrue(r.lowercased().contains("strong"), "strong capability should be mentioned: \(r)")
+        XCTAssertFalse(r.contains("!"))
+    }
+
+    func test_rationale_slowFitting_limitedModel() {
+        // Sluggish (tps 7), tight fit (0.5), limited quality (0.2).
+        let r = score(composite: 0.4, tps: 7, willRun: true, quality: 0.2, fit: 0.5).rationale
+        XCTAssertTrue(r.lowercased().contains("slow"), "sluggish model should read as slower: \(r)")
+        XCTAssertTrue(r.lowercased().contains("tight"), "tight memory fit should be mentioned: \(r)")
+        XCTAssertTrue(r.lowercased().contains("limited"), "limited capability should be mentioned: \(r)")
+    }
+
+    func test_rationale_startsCapitalised_andHasNoRawNumbers() {
+        let r = score(composite: 0.7, tps: 35, willRun: true, quality: 0.7, fit: 1.0).rationale
+        let first = r.first
+        XCTAssertNotNil(first)
+        XCTAssertTrue(first!.isUppercase, "rationale should be sentence-cased: \(r)")
+        // Honesty contract: no raw decimals leak into the human line.
+        XCTAssertFalse(
+            r.contains(where: { $0.isNumber }),
+            "rationale must not surface raw numeric estimates: \(r)"
+        )
+    }
+}

--- a/Tests/ManifoldTestSupportTests/SandboxExecNetDenyTests.swift
+++ b/Tests/ManifoldTestSupportTests/SandboxExecNetDenyTests.swift
@@ -54,6 +54,13 @@ final class SandboxExecNetDenyTests: XCTestCase {
 
     /// `sandbox-exec` ships with macOS; gate Linux and any host where the
     /// binary is missing (e.g., a sandboxed CI runner that filtered it out).
+    ///
+    /// Also skipped by default: `test_networkFrameworkConnection` spawns the Swift
+    /// compiler as a subprocess (cold-start ≈ 30–120 s) and calls
+    /// `Process.waitUntilExit`, which blocks a cooperative thread-pool thread
+    /// for the full duration — exceeding the 242 s CI watchdog (see #1582).
+    /// Run these locally by setting `MANIFOLD_TEST_SANDBOX_EXEC=1`; they cover
+    /// OS-level sandbox wiring, not logic that changes per commit.
     private func skipIfSandboxExecUnavailable() throws {
         // These tests cover OS-level sandbox wiring that doesn't change per commit.
         // They spawn subprocesses (including /usr/bin/swift with a cold-start cost of

--- a/Tests/ManifoldUIModelManagementTests/ModelRecommendationRankingTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/ModelRecommendationRankingTests.swift
@@ -1,0 +1,147 @@
+@preconcurrency import XCTest
+@testable import ManifoldUIModelManagement
+@testable import ManifoldInference
+import ManifoldRuntime
+import ManifoldTestSupport
+
+/// Verifies that `selectedUseCase` reorders `rankedVariants` and that the use-case
+/// picker state persists only when a `UserDefaults` is injected.
+///
+/// Device + memory are injected via `DeviceProfile`, so ranking is deterministic
+/// regardless of the host runner's RAM or chip — no real hardware is touched.
+@MainActor
+final class ModelRecommendationRankingTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    /// A GGUF download fixture. `quant` is encoded into the filename so the production
+    /// `DownloadableModel.quantization` regex extracts it.
+    private func ggufModel(sizeGB: Double, quant: String, name: String) -> DownloadableModel {
+        DownloadableModel(
+            repoID: "test/\(name)-GGUF",
+            fileName: "\(name).\(quant).gguf",
+            displayName: "\(name) \(quant)",
+            modelType: .gguf,
+            sizeBytes: UInt64(sizeGB * Double(oneGB))
+        )
+    }
+
+    /// A fixed device profile so bandwidth/memory come from the test, not the host.
+    private func device(ramGB: UInt64, bandwidthGBs: Double) -> DeviceProfile {
+        let bytes = ramGB * oneGB
+        return DeviceProfile(
+            physicalMemoryBytes: bytes,
+            usableMemoryBytes: bytes,
+            memoryBandwidthGBs: bandwidthGBs
+        )
+    }
+
+    /// Builds a VM whose `searchResults` are populated through the mock + `search()`.
+    private func makeViewModel(
+        results: [DownloadableModel],
+        userDefaults: UserDefaults? = nil
+    ) async -> ModelManagementViewModel {
+        let mock = MockHuggingFaceService()
+        mock.searchResults = results
+        let vm = ModelManagementViewModel(
+            huggingFaceService: mock,
+            deviceCapability: DeviceCapabilityService(physicalMemory: 32 * oneGB),
+            userDefaults: userDefaults
+        )
+        vm.searchQuery = "test"
+        await vm.search()
+        return vm
+    }
+
+    // MARK: - Use-case reorders ranking
+
+    func test_chatPutsFastSmallModelFirst() async {
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let fastSmall = ggufModel(sizeGB: 2.0, quant: "Q4_K_M", name: "Small")
+        let capableBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "Big")
+
+        let vm = await makeViewModel(results: [capableBig, fastSmall])
+        vm.selectedUseCase = .chat
+
+        let ranked = vm.rankedVariants(device: dev)
+        XCTAssertEqual(
+            ranked.first?.0.fileName, fastSmall.fileName,
+            "chat (speed-weighted) should put the fast small model first"
+        )
+    }
+
+    func test_reasoningFavoursLargerHigherQualityModel() async {
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let fastSmall = ggufModel(sizeGB: 2.0, quant: "Q4_K_M", name: "Small")
+        let capableBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "Big")
+
+        let vm = await makeViewModel(results: [fastSmall, capableBig])
+        vm.selectedUseCase = .reasoning
+
+        let ranked = vm.rankedVariants(device: dev)
+        XCTAssertEqual(
+            ranked.first?.0.fileName, capableBig.fileName,
+            "reasoning (quality-weighted) should put the larger, more-capable model first"
+        )
+    }
+
+    func test_changingUseCase_flipsTopRankedModel() async {
+        // Same inputs, opposite orderings under chat vs reasoning — proves the picker
+        // actually drives the order rather than a fixed default.
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let fastSmall = ggufModel(sizeGB: 2.0, quant: "Q4_K_M", name: "Small")
+        let capableBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "Big")
+
+        let vm = await makeViewModel(results: [fastSmall, capableBig])
+
+        vm.selectedUseCase = .chat
+        let chatTop = vm.rankedVariants(device: dev).first?.0.fileName
+
+        vm.selectedUseCase = .reasoning
+        let reasoningTop = vm.rankedVariants(device: dev).first?.0.fileName
+
+        XCTAssertNotEqual(
+            chatTop, reasoningTop,
+            "switching use case should change which model ranks first"
+        )
+        XCTAssertEqual(chatTop, fastSmall.fileName)
+        XCTAssertEqual(reasoningTop, capableBig.fileName)
+    }
+
+    func test_rankedVariants_usesSelectedUseCaseByDefault() async {
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let fastSmall = ggufModel(sizeGB: 2.0, quant: "Q4_K_M", name: "Small")
+        let capableBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "Big")
+
+        let vm = await makeViewModel(results: [fastSmall, capableBig])
+        vm.selectedUseCase = .chat
+
+        // No explicit useCase argument → should fall back to selectedUseCase (.chat).
+        let ranked = vm.rankedVariants(device: dev)
+        XCTAssertEqual(ranked.first?.0.fileName, fastSmall.fileName)
+    }
+
+    // MARK: - Persistence (injected UserDefaults only)
+
+    func test_selectedUseCase_persistsToInjectedDefaults() async {
+        let suite = "ModelRecommendationRankingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removeSuite(named: suite) }
+
+        let vm = await makeViewModel(results: [], userDefaults: defaults)
+        vm.selectedUseCase = .coding
+
+        // A fresh VM reading the same store should restore the selection.
+        let restored = ModelManagementViewModel(userDefaults: defaults)
+        XCTAssertEqual(restored.selectedUseCase, .coding, "use case should round-trip through injected defaults")
+    }
+
+    func test_selectedUseCase_withoutDefaults_doesNotPersist() async {
+        let vm = await makeViewModel(results: [], userDefaults: nil)
+        vm.selectedUseCase = .reasoning
+
+        // A new VM with no injected store must default to .general.
+        let fresh = ModelManagementViewModel()
+        XCTAssertEqual(fresh.selectedUseCase, .general, "without an injected store the picker stays in-memory")
+    }
+}


### PR DESCRIPTION
Stacked on #1581 (`feat/model-fit-scorer`). Surfaces the model-fit scorer to end users, governed by **honesty of presentation** — coarse qualitative buckets and a factual one-liner instead of raw `tok/s` decimals that read as measured facts when they are coarse pre-download estimates.

## Honesty principle
- **Qualitative buckets, not numbers.** `SpeedClass` (Fast/Usable/Sluggish/Too slow) and `FitQuality` (Excellent/Good/Marginal/Not recommended) replace raw `estimatedTokensPerSecond`/`composite` in the UI. The raw values stay public for power users and tests — the buckets are an honest layer on top, not a replacement.
- **Rank, don't filter.** The use-case picker re-orders results; every model stays visible. A `Sort: Recommended / Size / Downloads` control is the power-user escape hatch back to the deterministic order.
- **Estimates labeled as estimates.** No bare decimals; `rationale` is built only from buckets and `willRun`, never from raw numbers. Doc comments on every new symbol restate that estimates are approximate guidance, not guarantees.

## Layer 1 — Core API (`ManifoldInference`)
Added to `ModelFitScore.swift` so honesty is enforced for all consumers including BYO-UI:
- `enum SpeedClass` from `estimatedTokensPerSecond` — thresholds (tok/s): **≥30 fast · 12–30 usable · 5–12 sluggish · <5 tooSlow**, tuned for chat reading pace (~30 tok/s ≈ fast silent-reading pace; <5 feels broken for chat).
- `enum FitQuality` from `composite` — **≥0.70 excellent · 0.50–0.70 good · 0.30–0.50 marginal · <0.30 notRecommended**; aligns with the scorer's `willRun` composite collapse. `willRun == false` always maps to `.notRecommended`.
- `ModelFitScore.rationale` — factual one-liner (e.g. "Fast on your device · fits comfortably · strong capability", or "Too large to run well on this device").
- `estimatedTokensPerSecond` / `composite` retained.

## Layer 2 — Built-in UI (`ManifoldUIModelManagement`)
- Use-case `Picker` bound to new VM state `selectedUseCase` (default `.general`); segmented `Sort` control bound to `sortMode`.
- `rankedVariants`/new `fitScore(for:)` gain an injectable `device:` for deterministic tests; default unchanged.
- `DownloadableModelRow` shows a `SpeedClass` word badge and the `rationale` on the top/recommended variant; size + quant stay visible.
- "Best for your device" affordance on grouped variants' top-ranked quant.
- `selectedUseCase` persists only via an **injected `UserDefaults`** (never `.standard`).

## Layer 3 — Docs (this PR)
New DocC catalog + article `DeviceAwareModelRecommendations.md` covering both non-overlapping cold-start paths: the high-level built-in browser, and the BYO-UI path with a runnable `ModelFitScorer` snippet. Includes an explicit honesty-guidance section and the note that recommendations need surfaced models (HuggingFace trait or a populated `CuratedModel` catalog) — inert for cloud-only / single-bundled-model apps.

## Tests
- `ModelFitScoreHonestPresentationTests` (8) — SpeedClass/FitQuality boundary cuts, won't-run override, rationale content for fast-fitting/slow-fitting/won't-run, and a guard that no raw numbers leak into `rationale`. Sabotage-verified during development, removed before commit.
- `ModelRecommendationRankingTests` (6) — `selectedUseCase` reorders `rankedVariants` (chat → fast small first; reasoning → larger higher-quality first), switching use case flips the top model, and persistence round-trips only through injected defaults. Device injected; no hardware.

## E2E / existing assertions
No E2E assertion changes required. The default group sort (`compatibilityTier` / `sortKey`) is preserved as the `.size` mode; recommendation is additive. `DownloadableModelGroupCompatibilityTests` (14) and `ModelManagementViewModelTests` (34) pass unchanged.

## Limitation
Recommendations do nothing without surfaced models — cloud-only and single-bundled-model apps see no effect.

## Gate
- `swift build --build-tests` and `--disable-default-traits`: both green.
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`: green.
- `ModelFitScorerTests` (11), new suites (8 + 6), touched model-management suites (14 + 34), `SilentCatchAuditTest`: all green.
- `Package.resolved` restored from base; not staged.

- [ ] Full `scripts/test.sh --profile local` gate before merge (maintainer)
- [ ] Rebase onto main after #1581 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)