### PR TITLE
fix(test): stop ConversationEventTap teardown test from hanging CI for 240s

### DIFF
--- a/Tests/ManifoldRuntimeTests/ConversationEventTapTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationEventTapTests.swift
@@ -325,10 +325,12 @@ final class ConversationEventTapTests: XCTestCase {
             await finishFlag.signal()
         }
 
-        // Drain primary stream to avoid blocking broadcasts.
-        let primaryTask = Task { [weak runtime] in
-            guard let runtime else { return }
-            for await _ in runtime.events {}
+        // Drain primary stream to avoid blocking broadcasts. Capture the
+        // stream itself, not the runtime: draining must not retain the runtime,
+        // or the drain loop would prevent the very deallocation it waits for.
+        let primaryStream = runtime!.events
+        let primaryTask = Task {
+            for await _ in primaryStream {}
         }
         defer { primaryTask.cancel() }
 
@@ -365,19 +367,34 @@ final class ConversationEventTapTests: XCTestCase {
 
     private actor FinishFlag {
         private var isSet = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
 
         func signal() {
             guard !isSet else { return }
             isSet = true
             let pending = waiters
             waiters.removeAll()
-            for w in pending { w.resume() }
+            for w in pending.values { w.resume() }
         }
 
+        /// Cancellation-aware so a racing safety-net timeout can tear this
+        /// waiter down. Without this, a structured task group that cancels a
+        /// pending `wait()` would block forever awaiting the un-resumed
+        /// continuation — turning a clean 5 s test failure into a 240 s CI
+        /// watchdog kill.
         func wait() async {
             if isSet { return }
-            await withCheckedContinuation { waiters.append($0) }
+            let id = UUID()
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { waiters[id] = $0 }
+            } onCancel: {
+                Task { await self.resumeIfWaiting(id) }
+            }
+        }
+
+        private func resumeIfWaiting(_ id: UUID) {
+            guard let continuation = waiters.removeValue(forKey: id) else { return }
+            continuation.resume()
         }
     }
 }


### PR DESCRIPTION
## Problem

Every CI run on `main` has been **red and slow** since the Glass Box P0 multicast-tap work landed. The parallel XCTest invocation hangs on a single test — `ConversationEventTapTests.test_tap_finishesWhenRuntimeTeardown` — until the 240 s stall watchdog SIGABRTs the run (exit 124). I confirmed the hung worker from the CI watchdog diagnostics (`xctest -XCTest …/test_tap_finishesWhenRuntimeTeardown`) and reproduced it locally in isolation.

The earlier bounded-wait fix (#1584) didn't help because it bounded the wrong layer.

## Root cause — two compounding bugs in the test

**1. A self-sustaining retain cycle stops `deinit` from firing.** The primary-stream drain task captured the runtime weakly then immediately promoted it back to strong:

```swift
let primaryTask = Task { [weak runtime] in
    guard let runtime else { return }   // weak → STRONG for the whole loop
    for await _ in runtime.events {}     // only ends when continuation.finish() runs in deinit
}
```

`runtime.events` only finishes when `continuation.finish()` runs in `deinit`, but `deinit` can't run while this task strongly holds the runtime. So `runtime = nil` never deallocated, `eventTaps.finishAll()` never fired, and the tap never finished. **Fix:** capture the `events` stream value, not the runtime — draining the stream doesn't retain the runtime, so `deinit` fires.

**2. The 5 s safety net deadlocks instead of failing fast.** The fallback `Task.sleep(5s)` *does* fire, but `FinishFlag.wait()` used a plain `withCheckedContinuation` with no cancellation handling. When the structured task group unwinds on the timeout throw, it blocks forever awaiting the un-resumed continuation — turning a clean 5 s failure into a 240 s watchdog kill (this is why #1584's bound didn't surface as a failure). **Fix:** make `FinishFlag.wait()` cancellation-aware.

Fix 1 makes the test pass; fix 2 ensures any future teardown regression fails fast instead of hanging the whole suite.

## Verification

- `test_tap_finishesWhenRuntimeTeardown`: 240 s hang → **passes in 0.005 s**.
- `ConversationEventTapTests` (5), `ConversationEventRecorderTests` (2), `ConversationEventTraceTests` (6): green.
- Full `ManifoldRuntimeTests` module, parallel: **420/420, no hang**.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)