### PR TITLE
chore(ci): batch Dependabot bumps into grouped weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Collapse all action bumps into one PR/week. Each PR is a full CI run
+    # (macOS, 10× billing); batching trades per-dep granularity for far fewer
+    # cold-compile runs. See CLAUDE.md "Issue & PR hygiene".
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "swift"
     directory: "/"
     schedule:
       interval: "weekly"
+    # One PR/week for all swift dep bumps instead of one per dependency — a
+    # Package.resolved change busts the SPM cache and re-runs the full job
+    # matrix, so each dep PR is among the most expensive CI runs.
+    groups:
+      swift-dependencies:
+        patterns:
+          - "*"
     ignore:
       # ML deps are tightly coupled and must be updated together manually.
       # mlx-swift-lm is pinned to a commit (not a tag) due to a bug in 2.31.x —


### PR DESCRIPTION
## What

Group Dependabot updates so each ecosystem produces **one PR per week** instead of one PR per dependency:
- `swift` deps → one `swift-dependencies` group
- `github-actions` → one `github-actions` group

## Why

A `Package.resolved` change busts the SwiftPM dependency cache and re-fires the **entire macOS job matrix** (10× billing) with cold compiles — so each per-dependency Dependabot PR is among the most expensive CI runs we have. Batching trades per-dep granularity for far fewer of these runs.

## Scope

Split out from #1587. This is the **zero-risk** half — pure `dependabot.yml` config, no test-behavior change. The trait-unification half of #1587 is parked: it exposed a pre-existing `BackendContractChecks` parallel race (`test_z_contract_metaContract`) when CloudSaaS backends are co-scheduled under `--parallel`, which is being fixed separately before that perf change can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)