### PR TITLE
fix(ci): deflake two intermittent failures (tool-cancellation handle race + PinnedSession watchdog)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,13 +343,20 @@ jobs:
       # workflow (a separate macos-15 runner). Folded in here to save ~90 billed
       # macOS-minutes per push. MCPHardeningTests are already covered by the
       # ManifoldMCPTests filter above; only this test requires the CloudSaaS trait.
+      # STALL_SECONDS is 240 (not 120) because this step changes the trait set
+      # from the prior steps (CloudSaaS vs MCP/none) and `swift test` rebuilds
+      # the whole test tree on a trait change — a legitimate ~2min compile that
+      # emits no "test progress" output. At 120s the stall watchdog SIGABRT'd
+      # that compile intermittently (flaking main, not just PRs). 240s matches
+      # the other two test steps and still catches a genuine runtime hang (the
+      # PinnedSession tests themselves run in <1s once built).
       - name: Test — PinnedSessionDelegate (CloudSaaS)
         if: always()
         id: test-pinned-session-delegate
         timeout-minutes: 10
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-pinned-session-delegate.log
-          STALL_SECONDS: "120"
+          STALL_SECONDS: "240"
         run: scripts/ci-test-with-watchdog.sh --filter PinnedSessionDelegateTests --disable-default-traits --traits CloudSaaS --skip-update --min-passed 1
 
       - name: Stage test diagnostics

--- a/Tests/ManifoldInferenceTests/ToolCancellationContractTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolCancellationContractTests.swift
@@ -336,10 +336,18 @@ final class ToolCancellationContractTests: XCTestCase {
         let result = await dispatchTask.value
         XCTAssertEqual(result.errorKind, .cancelled)
 
-        // The handle's local scope ends when `withTaskCancellationHandler`
-        // unwinds with the thrown `CancellationError` from `Task.sleep`,
-        // at which point its deinit fires synchronously. The tracker must
-        // be back to zero with no further await needed.
+        // The handle deinits when `withTaskCancellationHandler` unwinds with the
+        // thrown `CancellationError`. That unwinding happens inside the child
+        // task the default `executeStreaming` wrapper spawns, so it is ordered
+        // *after* `dispatch` returns but is not synchronous with it. Bound-wait
+        // for the release rather than assuming it already happened — otherwise
+        // the assertion races the deinit and flakes under `--parallel`
+        // main-actor contention. A genuine leak holds `liveHandles == 1` past
+        // the deadline and still fails the assertion.
+        let releaseDeadline = Date().addingTimeInterval(2)
+        while tracker.liveHandles > 0 && Date() < releaseDeadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
         XCTAssertEqual(
             tracker.liveHandles,
             0,


### PR DESCRIPTION
Two independent, pre-existing intermittent CI failures on `main`, both surfaced while investigating CI reliability this week. Neither is a product bug.

## 1. `ToolCancellationContractTests` handle-release race

`test_bridgedCallbackExecutor_releasesHandle_onCancellation` asserts the bridged handle is freed **synchronously** right after `dispatch` returns. But the handle deinits inside the child task the default `executeStreaming` wrapper spawns, whose unwinding is ordered *after*, not synchronous with, `dispatch` returning. Under `--parallel` main-actor contention the deinit slips past the assertion → `liveHandles == 1`. Runs under the default `--traits MCP` lane, so it flakes `main`.

**Fix:** bound-wait for the release (mirroring the allocation poll already in the test). A genuine leak still fails past the 2s deadline. Verified 3/3 locally.

## 2. PinnedSessionDelegate compile-watchdog timeout

That step runs `--traits CloudSaaS` — a different trait set from the steps before it — so `swift test` rebuilds the whole test tree (the `--filter` only gates execution). That ~2min compile emits no "test progress", and at `STALL_SECONDS=120` the stall watchdog SIGABRT'd it mid-compile intermittently (observed: swift-test in state `R<`/compiling at 2:02 when the watchdog fired). Fails `main`, not just PRs.

**Fix:** raise to 240s, matching the other two test steps. The PinnedSession tests run in <1s once built, so a genuine runtime hang is still caught.

Together these remove two sources of red-for-no-reason CI. (The deeper trait-unification perf work remains tracked in #1601.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)