### PR TITLE
docs: target architecture plan ("The Manifold") + migration

### DIFF
--- a/docs/plans/target-architecture-migration.md
+++ b/docs/plans/target-architecture-migration.md
@@ -2,8 +2,8 @@
 
 Sequenced path from today's structure to the end state in
 [`target-architecture.md`](./target-architecture.md). This is a **planning artifact** —
-decisions and sequencing before code, so reviewers argue with the plan, not the diff. It does
-not contain implementation.
+decisions, sequencing, and test/CI prerequisites before code, so reviewers argue with the
+plan, not the diff. It does not contain implementation.
 
 ## Status
 
@@ -11,198 +11,269 @@ not contain implementation.
 - **Strategy:** incremental, never big-bang. Every step is its own PR, passes the full
   `scripts/test.sh --profile local` gate, and keeps `@_exported import` shims on the old
   module names so downstream `import ManifoldInference` / `import ManifoldRuntime` never break
-  mid-flight. Shims retire only in a final breaking release (Phase 7).
-- **Unit-of-work rule:** "fewer, larger units" (CLAUDE.md). Each phase below is one PR unless
-  noted; sub-items bundle into that PR.
-- **Review:** the engine carve (Phase 2) and driver seam (Phase 3) get parallel persona plan
-  review before dispatch (`feedback_plan_review_personas`). File-move phases do not.
+  mid-flight. Shims retire only in a final breaking release (Phase 7), after a ≥2-minor
+  deprecation window with `@available(deprecated, renamed:)` annotations.
+- **Unit-of-work rule:** CLAUDE.md prefers "fewer, larger units" and warns against PR storms.
+  **This structural migration is the sanctioned exception** — it is ~12 PRs of *refactor*, not
+  feature fan-out. Cap in-flight PRs to keep review tractable; do not let it run as a storm.
+- **WWDC gate (keynote 2026-06-08):** **P0 and P1 are WWDC-independent — start now.** P0 is
+  decisions + a bug fix; P1 is pure file-moves with zero behavior change. **P2–P4 sequencing
+  is re-confirmed after the keynote**, since Apple's agent/tool/on-device-media announcements
+  may reprioritize the driver seam (P3) and the media seam (P4).
+- **Agentic scope (decided):** commit to **resumable runs only**. Multi-agent / plan-execute
+  drivers are deferred until explicit adopter demand; the P3 seam keeps the door open but is
+  built for `SingleTurnDriver` + `ResumableRunDriver` only.
+- **Review:** the engine carve (P2) and driver seam (P3) get parallel persona plan review
+  before dispatch. File-move phases do not.
 
 ## Critical-path overview
 
 ```
- P0 prerequisites ──► P1 thin kernel ──► P2 engine carve ──► P3 driver + run model
- (decision + bug)     (leaf evictions)   (the real refactor)  (agentic enabler)
-        │                                                            │
-        │                                                            ├─► P3+ drivers (FEATURE work, post-migration)
-        ▼
- P6 usability  ── can be pulled forward (independent of structure) ──┐
-                                                                     │
- P4 modality generify ── parallelizable with P2/P3 (different files) │
- P5 trait→product ── after products are independent ─────────────────┘
- P7 retire shims ── final breaking release, after downstreams migrate
+ [WWDC-independent — start now]        [re-confirm after 2026-06-08 keynote]
+ P0 prerequisites ──► P1 thin kernel ─┊─► P2 engine carve ──► P3 driver + resumable Run
+ (decisions+bug+P0c)   (leaf evictions)┊   (the real refactor)  (committed: resumable runs)
+        │                              ┊                              │
+        │                              ┊                              └─► multi-agent/plan-exec
+        ▼                              ┊                                  = DEFERRED (seam only)
+ P6 usability ── pull forward (WWDC-independent, high adopter value) ──┐
+                                                                       │
+ P4 modality generify ── parallelizable; re-confirm post-WWDC ─────────│
+ P5 trait→product ── after products are independent ───────────────────┘
+ P7 retire shims ── final breaking release, after deprecation window
 ```
 
 **Ordering rationale:** leaves first (P1) shrink the kernel with zero cycle risk and de-risk
-the hard carve. P2 is the only true refactor and is gated on the P0 coupling decision. P3
-rides P2. P4 (modality) touches a disjoint file set, so it can run in parallel. P5 (traits)
-needs satellites to already be independent products. P6 (usability) is structurally
-independent and high-value — **pull it forward** if it helps adopters sooner. P7 is last.
+the hard carve. P2 is the only true refactor and is gated on the P0a decision **and the P0c
+characterization harness**. P3 rides P2. P4 (modality) touches a disjoint file set, so it can
+run in parallel. P5 (traits) needs satellites to already be independent products. P6
+(usability) is structurally independent and high-value — **pull it forward**. P7 is last.
+
+## Per-phase adopter impact
+
+| Phase | Adopter-affecting? | Why |
+|---|---|---|
+| P0, P1, P2, P3a | **Transparent** | shims preserve imports; behavior preserved |
+| P3b/c (run model) | **Additive** | new API + schema bump; no removals |
+| P4b (`MessagePart` collapse) | **Breaking (data)** | SwiftData schema migration — ships a migration guide |
+| P5 (trait→product) | **Breaking (build)** | consumers add a product dep instead of a trait — migration guide |
+| P7 (retire shims) | **Breaking (source)** | old module names removed — the deprecation window ends here |
 
 ---
 
-## Phase 0 — Prerequisites & de-risking (small, independent, ship first)
-
-Goal: remove the two blockers that make later phases risky, before touching module structure.
+## Phase 0 — Prerequisites & de-risking (WWDC-independent; ship first)
 
 - **P0a — Resolve the `InferenceService.GenerationRequestToken` coupling gate (DECISION).**
-  UI binds the concrete `InferenceService` at ~9 declaration + 22 call sites; the nested token
-  type is the tightest knot. **Recommended decision:** accept *App-layer-sits-above-Engine* —
-  UI may name the concrete `InferenceService` because AppKit depends on Engine anyway. Defer
-  the protocol-token abstraction to a later polish PR. Record the decision here; it unblocks P2
-  without forcing a UI rewrite.
-- **P0b — Fix the `SessionToolSource.resolve` dead-dispatch bug (PR).** `generate_image` /
-  `generate_video` / `web_search` are advertised to the model but unreachable (no
-  `SessionToolSource → ToolExecutor` adapter; zero production callers of `resolve`). Either add
-  a per-turn adapter that registers session-source `resolve` into `ToolRegistry`, or make
-  `SessionToolSource` advertising-only by design and route execution through `ToolExecutor`.
-  Independent of all structural work; ship immediately. *Risk: low. Gate: full local.*
+  Decision: accept *App-above-Engine* — UI may name the concrete `InferenceService`. Defer the
+  protocol-token abstraction. *Test consequence:* cold-start **tier-1** drives `InferenceService`
+  + `GenerationStream` directly, so keeping the token concrete leaves tier-1 unaffected; a later
+  protocol-token change would touch tier-1's fake-backend driver.
+- **P0b — Fix the `SessionToolSource.resolve` dead-dispatch bug (PR).** Wire a per-turn adapter
+  registering session-source `resolve` into `ToolRegistry`, or make `SessionToolSource`
+  advertising-only and route execution through `ToolExecutor`.
+  - **Test & CI:** add a **`SessionToolSourceDispatchTest`** tripwire — an advertised session
+    tool (`generate_image`) must actually reach `ToolExecutor`. The path has *zero production
+    callers* today, exactly the shape that needs a guard against silent re-death.
+- **P0c — Build the turn-loop characterization harness (PR). *Gates P2.*** Snapshot the
+  `ConversationEvent` stream + final persisted records for `send`/`regenerate`/`edit`/`cancel`/
+  `branch` against `MockInferenceBackend` (+ a scripted tool), via `ConversationEventRecorder`
+  + the existing `swift-snapshot-testing` (`ManifoldSnapshotTests`). Record goldens on `main`
+  **before P2**. This is the only thing that makes the P2/P3a "behavior-preserving" claims
+  provable — today there is no turn-transcript golden (only the recorder's own tests, server
+  wire-format goldens, and a hardware-gated load-serialization characterization).
 
 ---
 
-## Phase 1 — Thin the kernel (leaf evictions)
+## Phase 1 — Thin the kernel (leaf evictions)  ·  WWDC-independent
 
-Goal: get `ManifoldInference` from ~25k to ~the ~3.4k Contract by evicting the ~86%
-non-contract mass to leaf modules/adapters. Pure file-moves + dep edges + `@_exported` shims;
-no behavior change. Lowest-risk structural phase.
+Goal: get `ManifoldInference` from ~25k toward the ~3.4k Contract by evicting the ~86%
+non-contract mass. File-moves + dep edges + `@_exported` shims; no behavior change.
 
-- **P1a — Extract `ManifoldNet`** (`Networking/` + `ManifoldCloudCore`'s SSE/TLS/DNS infra).
+- **P1a — Extract `ManifoldNetworking`** (`Networking/` + CloudCore SSE/TLS/DNS infra).
 - **P1b — Extract `ManifoldSecrets`** (`Security/` + `KeychainService`).
-- **P1c — Move device-capability + GGUF readers adapter-side** (only MLX/Llama consume them).
-- **P1d — Move model discovery / catalog / benchmark + image/video-gen records to their own
-  products** (out of the kernel).
+- **P1c — Move device-capability + GGUF readers adapter-side** (MLX/Llama consume them).
+- **P1d — Move discovery / catalog / benchmark + image/video-gen records to their own products.**
 
-Each as its own PR. After P1, `ManifoldInference` ≈ the thin Contract (protocols + value types
-+ records + `BackendRegistrar`). *Risk: low (moves). Gate: full local + trait-combo sweep
-because moves touch trait-gated files.*
+- **Test & CI impact:** **Not "lowest risk" for tests.** The source-walking audit tests
+  (`TrafficBoundaryAuditTest`, `SessionConstructionAuditTest`, `DNSRebindingCoverageAuditTest`,
+  `ContractTestSupportSplitAuditTest`) assert on `Sources/<module>/` paths — moving files
+  silently relocates what they police. **Each eviction PR updates its audit's walked-path root
+  + the paired sabotage entry in the same PR.** New test targets: **`ManifoldNetworkingTests`,
+  `ManifoldSecretsTests`.** The `foundation-only-build` ≤5 MB / no-MLX-symbol gate becomes
+  *more* important (more leaf modules = more symbol-leak surface). *Risk: low (moves) but
+  audit-aware. Gate: full local + trait-combo sweep.*
 
 ---
 
-## Phase 2 — Engine carve (the one real refactor)
+## Phase 2 — Engine carve (the one real refactor)  ·  re-confirm post-WWDC
 
-Goal: create `ManifoldEngine` = today's `ManifoldRuntime` + the orchestration evicted from the
-kernel, cut by *"is it orchestration."* Depends on **P0a**.
+Goal: create `ManifoldEngine` = today's `ManifoldRuntime` + orchestration evicted from the
+kernel. Depends on **P0a** and **P0c**.
 
-- **P2a — Create `ManifoldEngine`; move orchestration in.** Relocate `PromptAssembler`,
+- **P2a — Create `ManifoldEngine`; move orchestration in** (`PromptAssembler`,
   `ContextWindowManager`, `GenerationQueue`, `ToolExecutor`, `GenerationToolDispatchLoop`,
-  `TranscriptHealer`, streaming into `ManifoldEngine` alongside `ConversationRuntime`.
-  `@_exported` shims on `ManifoldInference` + `ManifoldRuntime` keep downstream imports alive.
-- **P2b — De-tangle `ConversationTurnExecutor`.** Lift persistence-writes and event-emission
-  behind narrow ports (they co-change 7× / 5× today); reduce the 1,100–1,628 LOC monolith to a
-  thin per-turn executor. Reconcile the Inference/Runtime tool-dispatch split so a future
-  agent-as-tool can re-enter cleanly.
+  `TranscriptHealer`, streaming). `@_exported` shims on `ManifoldInference` + `ManifoldRuntime`.
+- **P2b — De-tangle `ConversationTurnExecutor`.** Lift persistence-writes + event-emission
+  behind narrow ports; reduce to a thin per-turn executor; reconcile the Inference/Runtime
+  tool-dispatch split.
 
-*Risk: HIGH — the only step that is a refactor, not a move. Persona plan review first. Gate:
-full local + the KV-cache-race-class re-read-after-async-write discipline; this is the
-flake-sensitive turn path.* Likely 2 PRs (P2a move, then P2b de-tangle) to keep diffs reviewable.
+- **Test & CI impact (highest):** **New target `ManifoldEngineTests`** — the doc must name it
+  *and* wire it into `scripts/test.sh`'s `PROFILE_CI/LOCAL_XCTEST_FILTERS` arrays and
+  `ci.yml`'s `--filter` chain, or the suite never runs in the gate. **Duplicate the
+  `ManifoldRuntime` framework-isolation CI lints** (no SwiftData/SwiftUI/URLSession/Keychain)
+  for `Sources/ManifoldEngine/`, or the invariant evaporates. Preserve the XCTest vs
+  Swift-Testing split (#681) and the TestSupport/ContractTestSupport split (#1409) when
+  re-homing suites. **Any new contract suite with a process-global claims registry must follow
+  the `BackendContractChecks` no-`--parallel` rule** (`scripts/test.sh` lines 297–356).
+  **P2/P3a prove behavior-preservation by diffing against the P0c goldens.** *Risk: HIGH —
+  persona-reviewed; flake-sensitive turn path (KV-cache re-read-after-async-write discipline).
+  Likely 2 PRs.*
 
 ---
 
-## Phase 3 — Turn-Driver seam + Run model (agentic enabler)
+## Phase 3 — Turn-Driver seam + resumable Run model  ·  re-confirm post-WWDC
 
-Goal: make the committed multi-agent + stateful/resumable direction *possible at the edge*.
-Depends on **P2**.
+Goal: ship the committed resumable-runs capability. Depends on **P2**.
 
 - **P3a — Introduce `TurnDriver` protocol; extract current behavior into `SingleTurnDriver`**
-  (behavior-preserving refactor — must produce byte-identical turns; verify against existing
-  E2E). This is the seam; no new behavior yet.
-- **P3b — Introduce `Run`/`RunStep` + `RunStore` port + a run-level event type** (separate from
-  `GenerationEvent` — invariant #6). Persistence adds a `RunStore` impl + schema bump (next V).
-- **P3c — Generalize agent state** from single `activeAgentID` to an agent stack/tree; lift
-  handoff into the driver.
+  (behavior-preserving — must diff clean against the P0c goldens). No new behavior.
+- **P3b — Introduce `ConversationRun`/`RunStep` + `RunStore` port + a run-level event type**
+  (separate from `GenerationEvent` — invariant #6) + `ResumableRunDriver`. Persistence adds a
+  `RunStore` impl + schema bump.
+- *Deferred (not built now):* `MultiAgentDriver`, `PlanExecuteDriver`, agent stack/tree state.
+  The seam guarantees they can land as EDGE conformers if an adopter needs them.
 
-After P3 the seam exists and single-turn is the default. **The actual drivers** —
-`MultiAgentDriver`, `PlanExecuteDriver`, `AutonomousRunDriver` — are **feature work that rides
-this seam (post-migration initiatives), not part of the structural migration.** Each should be
-EDGE: conform `TurnDriver`, no engine surgery. *Risk: med (P3a behavior-preserving is the
-careful one; P3b/c are additive). Gate: full local.*
+- **Test & CI impact:** the test triad for P3b —
+  1. **`RunStore` contract conformance** (mirror the existing store-port contracts).
+  2. **Schema-migration fixture** (mirror `SchemaV3MigrationTests`: in-process seed of old
+     version, re-open under new plan, OOD-nonce falsification). *Runs in the nightly Operational
+     tier (`RUN_OPERATIONAL_TESTS=1`) — so a migration regression has up-to-24h detection
+     latency, not per-PR.*
+  3. **`GenerationEventClosedAuditTest`** tripwire enforcing invariant #6 (no run/media payload
+     appears as a `GenerationEvent` case), **with a paired sabotage entry** (QA-PRACTICES §3).
+  - Resumable pause/resume/checkpoint is non-deterministic to test — **inject clock + IDs** so
+    the fixtures don't flake. *Risk: med (P3a behavior-preserving is the careful one; P3b is
+    additive). Gate: full local + nightly operational for the migration fixture.*
 
 ---
 
-## Phase 4 — Modality generify (parallelizable)
+## Phase 4 — Modality generify  ·  parallelizable; re-confirm post-WWDC
 
-Goal: replace per-modality vertical clones with one generic seam. Touches a disjoint file set
-(media-gen), so it can run in parallel with P2/P3 on a separate branch.
+Goal: replace per-modality vertical clones with one generic seam. Disjoint file set, so it can
+run in parallel with P2/P3 on a separate branch.
 
-- **P4a — Introduce generic `MediaGeneration<Output>` + `MediaGenerationService<Output>` +
-  `MediaGenerationRuntime<Output>`** over a `GeneratedMediaPayload` protocol, with a shared
-  media event type allowing both one-shot (`progress→completed`) and a streaming/duplex variant
-  (for realtime audio).
+- **P4a — Introduce generic `MediaGeneration<Output>` (+ service/runtime) over
+  `GeneratedMediaPayload`**, with a shared media event type (one-shot + streaming/duplex for
+  realtime audio). **Ship concrete typealiases** (`ImageGeneration`, `VideoGeneration`,
+  `AudioGeneration`) so adopters rarely write the generic.
 - **P4b — Collapse `MessagePart.generatedImage`/`generatedVideo` → single
-  `MessagePart.generatedMedia(GeneratedMediaPayload)`** (one Codable key, one UI render branch;
-  schema migration).
+  `MessagePart.generatedMedia(GeneratedMediaPayload)`** (one Codable key, one UI render branch).
 - **P4c — Migrate Image + Video impls onto the generic seam; delete the clones.**
 
-*Risk: med (P4b is a schema migration — fixture + migration test required). Gate: full local +
-trait-combo sweep (MLX-gated diffusion bodies).*
+- **Test & CI impact:** P4b is **SwiftData schema migration #2** — needs a `MessagePart`
+  migration fixture (prior art: `MessagePartTests`, `SchemaMigrationReadBackTests`). The generic
+  seam **extends the contract-conformance pattern** to media backends. Watch the
+  `GenerationEvent` exhaustive-switch blast radius (~14+ consumers) — the media event type must
+  stay off the text path. **Acceptance metric: a new modality lands in ≤3 EDGE files.**
+  *Risk: med. Gate: full local + trait-combo sweep (MLX-gated diffusion bodies).*
 
 ---
 
 ## Phase 5 — Trait → product conversion
 
-Goal: shrink ~17 traits to the ~8 with real binary/dependency weight; make optionality
-product-selection where possible.
-
 - **P5a — Retire the clean traits** (`MCP`, `Voice`, `Tools`, `AppIntents`) → product opt-ins.
-  Zero/near-zero source `#if`; trait only gates test edges today. Update `FeatureMatrix.swift`,
-  cold-start gates, and `PackageTraitGateAuditTest` in lockstep (or CI fails).
 - **P5b — Extract `Ollama` + `CloudSaaS` source into dedicated targets, then retire those
   traits** (blocked until the 36 + 53 in-body `#if` directives are carved out).
 
-Keep `MLX`, `Llama`, `HuggingFace`, `Macros`, `Server`, `AnyLanguageModel`, `FoundationOnly`,
-`Fuzz`, and the WWDC stubs. *Risk: low mechanically but touches every manifest target — do as a
-clean sweep, and only after satellites are independent products. Gate: full local + all-traits
-build sweep.*
+- **Test & CI impact (lockstep — naming the exact assertions):** dropping a trait without these
+  edits **fails CI immediately** (intended tripwire, but expect it):
+  - `PackageTraitGateAuditTest.expectedGates` — remove the `ManifoldMCP→MCP`,
+    `ManifoldVoice→Voice`, `ManifoldTools→Tools`, `ManifoldAppIntents→AppIntents` entries.
+  - `FeatureMatrixTests` — both directions (matrix↔manifest) + `pendingMapping`.
+  - The `--traits` strings in `scripts/test.sh` (`PROFILE_LOCAL_TRAITS`) and the
+    `build-modes.yml` matrix (the `ollama`/`saas` modes).
+  - The three cold-start consumer manifests that pass `--traits`.
+  - **CI-matrix delta:** retiring the four clean traits barely changes the switch-combo sweep
+    (they had ~no `#if` bodies). The **real reduction is P5b** — extracting Ollama/CloudSaaS
+    source means default builds stop carrying their 36+53 `#if` bodies, shrinking the
+    all-traits sweep. Net per-PR billing ≈ flat; nightly all-traits sweep gets cheaper.
+  *Do as a clean sweep, after satellites are independent products.*
 
 ---
 
-## Phase 6 — Usability fixes (independent — pull forward)
+## Phase 6 — Usability (moat investment — pull forward)  ·  WWDC-independent
 
-Goal: make "easier to use" part of the target, not an afterthought. Structurally independent of
-P1–P5, so any of these can ship early.
+Goal: make "easier to use" part of the moat. Structurally independent of P1–P5.
 
-- **P6a — `quickStart()` brings a default inlet live** (selects/loads a sensible default
-  backend; cloud is not a silent off-by-default wall).
+- **P6a — `quickStart()` brings a default inlet live**, per a defined **selection policy**:
+  prefer Foundation Models if available → first registered local backend → a clearly-labeled
+  empty state. Not just "a default inlet" — name the fallback chain so a fresh install is never
+  a blank composer.
 - **P6b — Honest one-import** (umbrella genuinely sufficient; fix examples/README that import
   `ManifoldUI` separately).
-- **P6c — Reduce the 9 `configure*` overloads** on `ChatViewModel` to a coherent surface.
+- **P6c — Reduce the 9 `configure*` overloads** to a coherent surface.
 
-*Risk: low–med. Gate: full local + the cold-start human/tier gates (they exist to catch exactly
-this).*
+- **Test & CI impact:** directly exercised by **cold-start tiers 1/2/3** and the DX walkthrough
+  (they exist to catch exactly this); `APIFreezeTests` pins the public surface, so `quickStart()`
+  signature changes trip it intentionally. *Risk: low–med. Gate: full local + cold-start tiers.*
 
 ---
 
 ## Phase 7 — Retire back-compat shims (final breaking release)
 
-After downstream consumers migrate to the new module names, delete the `@_exported import`
-facades on `ManifoldInference`/`ManifoldRuntime`. Single breaking (`feat!`) release. *Do not
-start until adopters have had a deprecation window.*
+Delete the `@_exported import` facades after the ≥2-minor deprecation window.
+- **Precondition:** no `import ManifoldRuntime`/`ManifoldInference` old-name references remain
+  in `Examples/`, README snippets (`readme-snippets.yml`), or the cold-start manifests; the
+  shim-completeness gate (below) is green throughout.
 
 ---
 
 ## Cross-cutting gates (every PR)
 
 - `scripts/test.sh --profile local` before push; `--profile ci` only when chasing a CI failure.
+- **Shim-completeness cold-start tier (add before P2, delete at P7):** from a fresh consumer,
+  import the *old* module names and touch one moved symbol per surface (`ConversationRuntime`,
+  `GenerationQueue`, `PromptAssembler`, a `Networking` symbol, a `Secrets` symbol). The existing
+  tiers only exercise the *new* names, so a missing `@_exported` re-export passes every current
+  gate and breaks only in a downstream months later. This tier is the only proof the shim is
+  complete.
 - Trait-combo build sweep when a PR touches a switched enum or trait-gated source.
 - `FeatureMatrix.swift` + cold-start gates + `PackageTraitGateAuditTest` move in lockstep with
   any trait/module change.
-- Never stage `Package.resolved` regenerations; `@_exported` shims preserve every public import
-  until Phase 7.
+- Never stage `Package.resolved` regenerations.
+- Docs move with each phase (CLAUDE.md: "tests and docs ship in the feature PR"). Renaming
+  `ManifoldRuntime`→`ManifoldEngine` invalidates README's architecture diagram + Key Types
+  table, CLAUDE.md's Targets table, both QUICKSTARTs, and DocC articles — budget that churn in
+  the relevant phase PR, don't leave published docs describing dead modules.
+
+## New test targets & audit tripwires (consolidated)
+
+- **New test targets:** `ManifoldNetworkingTests`, `ManifoldSecretsTests` (P1);
+  `ManifoldEngineTests` (P2) — wire into `scripts/test.sh` filters + `ci.yml`.
+- **New audit tripwires:** `SessionToolSourceDispatchTest` (P0b); `GenerationEventClosedAuditTest`
+  for invariant #6 + sabotage entry (P3); an engine framework-isolation lint for `ManifoldEngine`
+  (P2); ideally a `DriverAdditiveAuditTest` asserting `TurnDriver` conformers live outside the
+  orchestration-core file set (invariant #7).
+
+## Acceptance metrics (per phase — falsifiable "the seam works")
+- **P4:** adding a new modality = ≤3 EDGE files (vs ~14 across 5 modules today).
+- **`APIProvider` work:** adding a cloud provider = register 1 descriptor, 0 switch edits
+  (vs ~14 today).
+- **P1:** `ManifoldInference` drops from ~25k to ≈ the ~3.4k Contract.
+- **P3:** adding a driver = conform `TurnDriver`, 0 engine-core edits.
 
 ## Sequencing summary (recommended order)
-
-1. **P0** (decision + bug) — now.
-2. **P6** usability — pull forward where independent (high adopter value, low risk).
-3. **P1** thin kernel — de-risks everything downstream.
-4. **P2** engine carve — gated on P0a; persona review.
-5. **P3** driver + run model — rides P2; unlocks the agentic frontier.
-6. **P4** modality generify — parallel to P2/P3.
-7. **P5** trait→product — after satellites are products.
-8. **P3+** the actual drivers (multi-agent / plan-execute / autonomous) — feature initiatives
-   on the seam, tracked separately.
-9. **P7** retire shims — final breaking release.
+1. **P0** (P0a decision, P0b bug, **P0c characterization harness**) — now, WWDC-independent.
+2. **P6** usability — pull forward (high adopter value, WWDC-independent).
+3. **P1** thin kernel — now, WWDC-independent; de-risks everything downstream.
+4. **— WWDC keynote 2026-06-08: re-confirm the rest —**
+5. **P2** engine carve — gated on P0a + P0c; persona review.
+6. **P3** driver + resumable Run model — rides P2.
+7. **P4** modality generify — parallel to P2/P3.
+8. **P5** trait→product — after satellites are products.
+9. **P7** retire shims — final breaking release, after the deprecation window.
+- *Deferred (not scheduled): multi-agent / plan-execute drivers — built only on adopter demand,
+  as EDGE conformers on the P3 seam.*
 
 ## Out of scope here
-
-Per-PR issue creation and GitHub tracking-issue setup. When this plan is signed off, open a
-single umbrella tracking issue with the phase checklist (per CLAUDE.md issue-hygiene), not one
-issue per sub-item.
+Per-PR issue creation. When signed off, open a single umbrella tracking issue with the phase
+checklist (CLAUDE.md issue-hygiene), not one issue per sub-item.

--- a/docs/plans/target-architecture-migration.md
+++ b/docs/plans/target-architecture-migration.md
@@ -264,13 +264,23 @@ Delete the `@_exported import` facades after the ≥2-minor deprecation window.
 ## Sequencing summary (recommended order)
 1. **P0** (P0a decision, P0b bug, **P0c characterization harness**) — now, WWDC-independent.
 2. **P6** usability — pull forward (high adopter value, WWDC-independent).
-3. **P1** thin kernel — now, WWDC-independent; de-risks everything downstream.
-4. **— WWDC keynote 2026-06-08: re-confirm the rest —**
-5. **P2** engine carve — gated on P0a + P0c; persona review.
-6. **P3** driver + resumable Run model — rides P2.
-7. **P4** modality generify — parallel to P2/P3.
-8. **P5** trait→product — after satellites are products.
-9. **P7** retire shims — final breaking release, after the deprecation window.
+3. **Unify streaming filtering ([#1593](https://github.com/roryford/ManifoldKit/issues/1593))**
+   — after P0c, **before** the P1 moves; WWDC-independent. **Unify-then-decouple:** collapse
+   the four duplicated chunk-boundary prefix-hold parsers (`ThinkingBlockFilter`,
+   `ThinkingBlockManager`, the MLX/Llama tool-call parsers) into **one shared chunk-safe
+   parser placed in the Contract**, proven behaviour-preserving by the P0c goldens. Doing this
+   first means the P1/P2 moves relocate call sites onto *one shared parser* instead of
+   scattering four divergent copies across three tiers and re-unifying across the new
+   boundaries afterward (the re-coupling trap). Gated behind P0c because chunk-boundary
+   handling is correctness-sensitive. Also tees up the [#1595](https://github.com/roryford/ManifoldKit/issues/1595)
+   single-site fix (grammar-during-thinking).
+4. **P1** thin kernel — now, WWDC-independent; de-risks everything downstream.
+5. **— WWDC keynote 2026-06-08: re-confirm the rest —**
+6. **P2** engine carve — gated on P0a + P0c; persona review.
+7. **P3** driver + resumable Run model — rides P2.
+8. **P4** modality generify — parallel to P2/P3.
+9. **P5** trait→product — after satellites are products.
+10. **P7** retire shims — final breaking release, after the deprecation window.
 - *Deferred (not scheduled): multi-agent / plan-execute drivers — built only on adopter demand,
   as EDGE conformers on the P3 seam.*
 

--- a/docs/plans/target-architecture-migration.md
+++ b/docs/plans/target-architecture-migration.md
@@ -1,0 +1,208 @@
+# Plan — Target Architecture Migration
+
+Sequenced path from today's structure to the end state in
+[`target-architecture.md`](./target-architecture.md). This is a **planning artifact** —
+decisions and sequencing before code, so reviewers argue with the plan, not the diff. It does
+not contain implementation.
+
+## Status
+
+- **Target:** `target-architecture.md` (signed off).
+- **Strategy:** incremental, never big-bang. Every step is its own PR, passes the full
+  `scripts/test.sh --profile local` gate, and keeps `@_exported import` shims on the old
+  module names so downstream `import ManifoldInference` / `import ManifoldRuntime` never break
+  mid-flight. Shims retire only in a final breaking release (Phase 7).
+- **Unit-of-work rule:** "fewer, larger units" (CLAUDE.md). Each phase below is one PR unless
+  noted; sub-items bundle into that PR.
+- **Review:** the engine carve (Phase 2) and driver seam (Phase 3) get parallel persona plan
+  review before dispatch (`feedback_plan_review_personas`). File-move phases do not.
+
+## Critical-path overview
+
+```
+ P0 prerequisites ──► P1 thin kernel ──► P2 engine carve ──► P3 driver + run model
+ (decision + bug)     (leaf evictions)   (the real refactor)  (agentic enabler)
+        │                                                            │
+        │                                                            ├─► P3+ drivers (FEATURE work, post-migration)
+        ▼
+ P6 usability  ── can be pulled forward (independent of structure) ──┐
+                                                                     │
+ P4 modality generify ── parallelizable with P2/P3 (different files) │
+ P5 trait→product ── after products are independent ─────────────────┘
+ P7 retire shims ── final breaking release, after downstreams migrate
+```
+
+**Ordering rationale:** leaves first (P1) shrink the kernel with zero cycle risk and de-risk
+the hard carve. P2 is the only true refactor and is gated on the P0 coupling decision. P3
+rides P2. P4 (modality) touches a disjoint file set, so it can run in parallel. P5 (traits)
+needs satellites to already be independent products. P6 (usability) is structurally
+independent and high-value — **pull it forward** if it helps adopters sooner. P7 is last.
+
+---
+
+## Phase 0 — Prerequisites & de-risking (small, independent, ship first)
+
+Goal: remove the two blockers that make later phases risky, before touching module structure.
+
+- **P0a — Resolve the `InferenceService.GenerationRequestToken` coupling gate (DECISION).**
+  UI binds the concrete `InferenceService` at ~9 declaration + 22 call sites; the nested token
+  type is the tightest knot. **Recommended decision:** accept *App-layer-sits-above-Engine* —
+  UI may name the concrete `InferenceService` because AppKit depends on Engine anyway. Defer
+  the protocol-token abstraction to a later polish PR. Record the decision here; it unblocks P2
+  without forcing a UI rewrite.
+- **P0b — Fix the `SessionToolSource.resolve` dead-dispatch bug (PR).** `generate_image` /
+  `generate_video` / `web_search` are advertised to the model but unreachable (no
+  `SessionToolSource → ToolExecutor` adapter; zero production callers of `resolve`). Either add
+  a per-turn adapter that registers session-source `resolve` into `ToolRegistry`, or make
+  `SessionToolSource` advertising-only by design and route execution through `ToolExecutor`.
+  Independent of all structural work; ship immediately. *Risk: low. Gate: full local.*
+
+---
+
+## Phase 1 — Thin the kernel (leaf evictions)
+
+Goal: get `ManifoldInference` from ~25k to ~the ~3.4k Contract by evicting the ~86%
+non-contract mass to leaf modules/adapters. Pure file-moves + dep edges + `@_exported` shims;
+no behavior change. Lowest-risk structural phase.
+
+- **P1a — Extract `ManifoldNet`** (`Networking/` + `ManifoldCloudCore`'s SSE/TLS/DNS infra).
+- **P1b — Extract `ManifoldSecrets`** (`Security/` + `KeychainService`).
+- **P1c — Move device-capability + GGUF readers adapter-side** (only MLX/Llama consume them).
+- **P1d — Move model discovery / catalog / benchmark + image/video-gen records to their own
+  products** (out of the kernel).
+
+Each as its own PR. After P1, `ManifoldInference` ≈ the thin Contract (protocols + value types
++ records + `BackendRegistrar`). *Risk: low (moves). Gate: full local + trait-combo sweep
+because moves touch trait-gated files.*
+
+---
+
+## Phase 2 — Engine carve (the one real refactor)
+
+Goal: create `ManifoldEngine` = today's `ManifoldRuntime` + the orchestration evicted from the
+kernel, cut by *"is it orchestration."* Depends on **P0a**.
+
+- **P2a — Create `ManifoldEngine`; move orchestration in.** Relocate `PromptAssembler`,
+  `ContextWindowManager`, `GenerationQueue`, `ToolExecutor`, `GenerationToolDispatchLoop`,
+  `TranscriptHealer`, streaming into `ManifoldEngine` alongside `ConversationRuntime`.
+  `@_exported` shims on `ManifoldInference` + `ManifoldRuntime` keep downstream imports alive.
+- **P2b — De-tangle `ConversationTurnExecutor`.** Lift persistence-writes and event-emission
+  behind narrow ports (they co-change 7× / 5× today); reduce the 1,100–1,628 LOC monolith to a
+  thin per-turn executor. Reconcile the Inference/Runtime tool-dispatch split so a future
+  agent-as-tool can re-enter cleanly.
+
+*Risk: HIGH — the only step that is a refactor, not a move. Persona plan review first. Gate:
+full local + the KV-cache-race-class re-read-after-async-write discipline; this is the
+flake-sensitive turn path.* Likely 2 PRs (P2a move, then P2b de-tangle) to keep diffs reviewable.
+
+---
+
+## Phase 3 — Turn-Driver seam + Run model (agentic enabler)
+
+Goal: make the committed multi-agent + stateful/resumable direction *possible at the edge*.
+Depends on **P2**.
+
+- **P3a — Introduce `TurnDriver` protocol; extract current behavior into `SingleTurnDriver`**
+  (behavior-preserving refactor — must produce byte-identical turns; verify against existing
+  E2E). This is the seam; no new behavior yet.
+- **P3b — Introduce `Run`/`RunStep` + `RunStore` port + a run-level event type** (separate from
+  `GenerationEvent` — invariant #6). Persistence adds a `RunStore` impl + schema bump (next V).
+- **P3c — Generalize agent state** from single `activeAgentID` to an agent stack/tree; lift
+  handoff into the driver.
+
+After P3 the seam exists and single-turn is the default. **The actual drivers** —
+`MultiAgentDriver`, `PlanExecuteDriver`, `AutonomousRunDriver` — are **feature work that rides
+this seam (post-migration initiatives), not part of the structural migration.** Each should be
+EDGE: conform `TurnDriver`, no engine surgery. *Risk: med (P3a behavior-preserving is the
+careful one; P3b/c are additive). Gate: full local.*
+
+---
+
+## Phase 4 — Modality generify (parallelizable)
+
+Goal: replace per-modality vertical clones with one generic seam. Touches a disjoint file set
+(media-gen), so it can run in parallel with P2/P3 on a separate branch.
+
+- **P4a — Introduce generic `MediaGeneration<Output>` + `MediaGenerationService<Output>` +
+  `MediaGenerationRuntime<Output>`** over a `GeneratedMediaPayload` protocol, with a shared
+  media event type allowing both one-shot (`progress→completed`) and a streaming/duplex variant
+  (for realtime audio).
+- **P4b — Collapse `MessagePart.generatedImage`/`generatedVideo` → single
+  `MessagePart.generatedMedia(GeneratedMediaPayload)`** (one Codable key, one UI render branch;
+  schema migration).
+- **P4c — Migrate Image + Video impls onto the generic seam; delete the clones.**
+
+*Risk: med (P4b is a schema migration — fixture + migration test required). Gate: full local +
+trait-combo sweep (MLX-gated diffusion bodies).*
+
+---
+
+## Phase 5 — Trait → product conversion
+
+Goal: shrink ~17 traits to the ~8 with real binary/dependency weight; make optionality
+product-selection where possible.
+
+- **P5a — Retire the clean traits** (`MCP`, `Voice`, `Tools`, `AppIntents`) → product opt-ins.
+  Zero/near-zero source `#if`; trait only gates test edges today. Update `FeatureMatrix.swift`,
+  cold-start gates, and `PackageTraitGateAuditTest` in lockstep (or CI fails).
+- **P5b — Extract `Ollama` + `CloudSaaS` source into dedicated targets, then retire those
+  traits** (blocked until the 36 + 53 in-body `#if` directives are carved out).
+
+Keep `MLX`, `Llama`, `HuggingFace`, `Macros`, `Server`, `AnyLanguageModel`, `FoundationOnly`,
+`Fuzz`, and the WWDC stubs. *Risk: low mechanically but touches every manifest target — do as a
+clean sweep, and only after satellites are independent products. Gate: full local + all-traits
+build sweep.*
+
+---
+
+## Phase 6 — Usability fixes (independent — pull forward)
+
+Goal: make "easier to use" part of the target, not an afterthought. Structurally independent of
+P1–P5, so any of these can ship early.
+
+- **P6a — `quickStart()` brings a default inlet live** (selects/loads a sensible default
+  backend; cloud is not a silent off-by-default wall).
+- **P6b — Honest one-import** (umbrella genuinely sufficient; fix examples/README that import
+  `ManifoldUI` separately).
+- **P6c — Reduce the 9 `configure*` overloads** on `ChatViewModel` to a coherent surface.
+
+*Risk: low–med. Gate: full local + the cold-start human/tier gates (they exist to catch exactly
+this).*
+
+---
+
+## Phase 7 — Retire back-compat shims (final breaking release)
+
+After downstream consumers migrate to the new module names, delete the `@_exported import`
+facades on `ManifoldInference`/`ManifoldRuntime`. Single breaking (`feat!`) release. *Do not
+start until adopters have had a deprecation window.*
+
+---
+
+## Cross-cutting gates (every PR)
+
+- `scripts/test.sh --profile local` before push; `--profile ci` only when chasing a CI failure.
+- Trait-combo build sweep when a PR touches a switched enum or trait-gated source.
+- `FeatureMatrix.swift` + cold-start gates + `PackageTraitGateAuditTest` move in lockstep with
+  any trait/module change.
+- Never stage `Package.resolved` regenerations; `@_exported` shims preserve every public import
+  until Phase 7.
+
+## Sequencing summary (recommended order)
+
+1. **P0** (decision + bug) — now.
+2. **P6** usability — pull forward where independent (high adopter value, low risk).
+3. **P1** thin kernel — de-risks everything downstream.
+4. **P2** engine carve — gated on P0a; persona review.
+5. **P3** driver + run model — rides P2; unlocks the agentic frontier.
+6. **P4** modality generify — parallel to P2/P3.
+7. **P5** trait→product — after satellites are products.
+8. **P3+** the actual drivers (multi-agent / plan-execute / autonomous) — feature initiatives
+   on the seam, tracked separately.
+9. **P7** retire shims — final breaking release.
+
+## Out of scope here
+
+Per-PR issue creation and GitHub tracking-issue setup. When this plan is signed off, open a
+single umbrella tracking issue with the phase checklist (per CLAUDE.md issue-hygiene), not one
+issue per sub-item.

--- a/docs/plans/target-architecture.md
+++ b/docs/plans/target-architecture.md
@@ -1,0 +1,349 @@
+# Plan — Target Architecture ("The Manifold")
+
+This is a **planning artifact**, not user-facing documentation and not an implementation
+plan. It captures the agreed *end state* for ManifoldKit's module architecture so a
+subsequent migration plan can be argued against a fixed target. When the structure
+stabilises, the adopter-facing version becomes a DocC article.
+
+## Status
+
+- **End state:** agreed (this document).
+- **Migration plan:** deferred until this target is signed off — written as a separate doc.
+- **Consumer assumption:** *public framework, diverse adopters.* Keep à-la-carte assembly;
+  make optionality **legible**, don't remove it.
+- **Diagram audience:** unified — one picture serves maintainers (north-star) and adopters
+  (consumption map).
+- **Decided design forks:**
+  - **Modality** generifies to a single `MediaGeneration<Output>` seam (no more per-modality
+    vertical clones).
+  - **Agentic:** MK **commits to growing multi-agent + stateful/resumable runs**, built
+    *MK-shaped* (on a pluggable turn-driver seam + the `GenerationEvent`/event stream +
+    persistence ports) — **not** as bolted-on Semantic-Kernel-style separate frameworks.
+
+## The frame: ManifoldKit *is* a manifold
+
+The name encodes the architecture. The canonical visual reads as a literal intake manifold
+first, software diagram second: **many model backends flow in → one common core normalises
+them → a single conversation-event stream flows out to many consumers**, with side ports for
+tools/data/agents and a bottom port for persistence.
+
+```
+   INLETS (backends)            ┌──── THE CORE MANIFOLD ────┐          OUTLETS (consumers)
+   ── adapters plug in ──►      ║                            ║   ──► one event stream ──►
+                                ║   ◆ CONTRACT (kernel)      ║
+   MLX        ┐                 ║   InferenceBackend proto   ║              ┌─ ManifoldUI (drop-in chat)
+   Llama      ├─[Registrar]───► ║   BackendCapabilities      ║ ────────────►├─ your own SwiftUI
+   Foundation ├──────────────── ║   GenerationEvent language ║   normalized ├─ ManifoldServer (HTTP)
+   Cloud      ┘                 ║   tool & message contracts ║   stream     └─ CLI / headless
+   MediaGen   ┐                 ║   ──────────────────────── ║
+   (img/vid/  ├──[generic seam]►║   ◆ ENGINE                 ║
+    audio)    ┘                 ║   Orchestration +          ║
+                                ║   ▸ pluggable TURN-DRIVER  ║
+   SIDE PORTS (tools / agents)  ║     (single · plan-exec ·  ║
+   MCP        ┐                 ║      multi-agent · autonom)║
+   AppIntents ├─[ToolSource]──► ║   over a RUN (resumable)   ║
+   RAG / HF   ┘                 ║                            ║
+                                └────────────┬───────────────┘
+                                             │ ports (dependency-inverted)
+                              PERSISTENCE (messages · sessions · RUN checkpoints)
+```
+
+A rendered diagram exists (manifold cross-section: colour-coded inlets converging to one
+white stream, nested CONTRACT-inside-ENGINE core, chromed multi-branch outlet header, top
+tool/data taps, bottom persistence port, depth-of-import tier legend). Add the export to the
+repo when the structure lands.
+
+## Verified baseline (fact-checked against current code — do not re-litigate)
+
+Corrected several stale session-memory assumptions:
+
+- **Single turn loop, no fork.** `ConversationRuntime` is the canonical, non-optional turn
+  loop (PR #947). The old `GenerationCoordinator` was renamed `GenerationQueue` (#973) and
+  sits *below* the loop as the inference-tier engine — not an alternative path.
+- **`InferenceService` is a real facade**, not a god-object: ~985 LOC delegating to
+  `ModelLifecycleCoordinator` (589) + `GenerationQueue` (929, further decomposed in #1165).
+- **DAG is acyclic and points inward.** Backend families import *only* `ManifoldInference`;
+  `ManifoldUI` imports no backend; conversation **records** live in `ManifoldInference`,
+  persistence **ports** in `ManifoldRuntime`; no cycles.
+- **The kernel is already small inside a large module.** Of `ManifoldInference`'s 25.1k LOC,
+  only **~3.4k (14%)** is the actual contract; the rest is evictable mass.
+- **The turn loop is the heaviest concept** and the instability epicenter:
+  `ConversationTurnExecutor` (1,628 LOC) + `ConversationRuntime` are the hottest-churn files,
+  mixing features and race-fixes, co-changing 12× (a false 2-file boundary).
+- **Tooling is a clean absorber; agentic orchestration is not.** Adding a tool = conform
+  `ToolExecutor` + register. But multi-agent/planning/autonomous runs land squarely on the
+  un-refined `ConversationTurnExecutor`, which has **no turn-strategy/driver abstraction**.
+
+## Moat thesis (triangulated)
+
+Three independent lenses — historical churn, modality-ripple, agentic-ripple — converge on
+the same conclusion:
+
+1. **The backend / tool / connector seams are strong absorbers. Protect, don't polish.**
+   New models, engines, tools, consumers, and (per the WWDC analysis) a new Apple *text*
+   surface all plug in at the edge. This is the industry-standard kernel shape — table
+   stakes, not differentiation.
+2. **The defensible moat is the on-device-first normalization + batteries-included runtime**
+   (MLX/Llama/Foundation behind one capability-negotiated contract, plus persistence + UI).
+   This is precisely what Semantic Kernel / LangChain *lack*.
+3. **The single highest-leverage refinement is cracking the engine turn-loop monolith into a
+   pluggable driver seam over a resumable `Run`.** It is the chokepoint where *every*
+   expansion axis collides — modality, multi-agent, planning. One refinement, compounding
+   returns.
+
+## Target structure — concentric tiers (structure == consumption)
+
+Dependencies point inward to the Contract, so *how deep an adopter imports is how much they
+opt in.* The four rings are simultaneously the internal layering and the consumption ladder.
+Each component below carries: **Responsibility · Owns · Public surface · Edges · Invariants ·
+Absorbs / Amplifies · Evolution.**
+
+---
+
+### RING 0 — CONTRACT (the kernel)  ·  product: `ManifoldInference` (target ~3.4k LOC)
+
+The stable, SemVer-critical public API. Everything connects here; versioned most carefully.
+
+- **Responsibility:** define *what* an inference/media backend is, *what* a tool is, and the
+  vocabulary of a generation — nothing about *how* a conversation runs.
+- **Owns:** `InferenceBackend`, `BackendCapabilities`, `GenerationConfig`, `GenerationEvent`,
+  `EmbeddingBackend`, the media-gen backend protocol(s), `ToolDefinition`/`ToolCall`/
+  `ToolResult`/`ToolChoice`/`ToolOutputPolicy`, `MessagePart`/`MessageKind`/`MessageRole`/
+  `Message`, `ConversationRecords` (records, not ports), `BackendRegistrar`, `Agent`/
+  `AgentHandoff` value types, `Citation`.
+- **Public surface:** the entire module is API. Treat additive enum cases + additive struct
+  fields as minor; any protocol-requirement or signature change is major.
+- **Edges:** depends on nothing (except the `@ToolSchema` macro plugin under the `Macros`
+  trait). Depended on by *everything*.
+- **Invariants:** no SwiftData, no SwiftUI, no networking, no persistence ports, no
+  orchestration. Records live here; ports do not.
+- **Absorbs:** new models/engines (conform `InferenceBackend`); new tools (`ToolDefinition`);
+  additive capability flags; additive `GenerationEvent` *payloads*.
+- **Amplifies (to fix):** `GenerationEvent` *cases* are source-breaking across ~14 consumers;
+  `MessagePart` cases force exhaustive-switch + schema churn; `ToolResult.content` is
+  `String`-only (blocks typed/multimodal tool output before a 1.0 freeze).
+- **Evolution:** stay thin — evict the ~86% non-contract mass (infra, GGUF, device, catalog,
+  discovery, HF probe) to utility leaves and adapters. Keep pushing backend variation into
+  *additive `BackendCapabilities` flags* (the pressure-relief valve) rather than new protocol
+  requirements. Decide the additive shape for non-text `ToolResult` and run/agent events
+  *before* 1.0 locks them.
+
+---
+
+### RING 1 — ENGINE  ·  product: `ManifoldEngine` (merges today's `ManifoldRuntime` + the orchestration evicted from the kernel)
+
+The engine is detailed as **three** components, because the leverage lives in separating
+them. Cut by *"is it orchestration,"* not *"does it touch persistence."*
+
+#### 1a — Orchestration core
+- **Responsibility:** own the public conversation API and the per-turn machinery.
+- **Owns:** `ConversationRuntime` (`send`/`regenerate`/`edit`/`branch`/`cancel`), prompt
+  assembly (`PromptAssembler`/`PromptTemplate`/`PromptSlot`), context budgeting
+  (`ContextWindowManager`/`ContextBudgetPlanner`/`GenerationPreflightTrimmer`), the
+  generation queue (`GenerationQueue`), transcript healing, streaming, the event subsystem
+  (`ConversationEvent`/`EventTapRegistry`/`ConversationEventRecorder`).
+- **Public surface:** `ConversationRuntime`'s verb API + the event stream + the public
+  `ConversationEventRecorder` (Glass Box, #1531).
+- **Edges:** depends on Contract; consumes persistence + tool + driver via ports.
+- **Invariants:** no SwiftData, no SwiftUI, no concrete backend.
+- **Absorbs:** new consumers (read the event stream), new hooks, new tool sources.
+- **Amplifies (to fix):** today persistence-writes and event-emission are tangled *inside*
+  `ConversationTurnExecutor` (co-change 7× and 5×) — they must move behind narrow ports.
+- **Evolution:** shrink `ConversationTurnExecutor` from a 1,100-LOC monolith to a thin
+  per-turn executor that the **driver** calls; lift persistence + event-emit to ports.
+
+#### 1b — Turn-Driver seam  ·  *NEW first-class component*
+- **Responsibility:** decide *how* a goal becomes turns/agent-steps. This is the pluggable
+  strategy the agentic commitment requires.
+- **Owns:** a `TurnDriver` protocol + conformers:
+  - `SingleTurnDriver` — today's linear behavior (default, always available).
+  - `PlanExecuteDriver` — goal decomposition / ReAct-style plan→act phases.
+  - `MultiAgentDriver` — concurrent / collaborating sub-agents, agent-as-tool, handoff.
+  - `AutonomousRunDriver` — long-running, checkpointed, resumable runs.
+- **Public surface:** `TurnDriver` (conform to add an orchestration shape); driver selection
+  on the run/turn input.
+- **Edges:** sits between `ConversationRuntime` (orchestration) and the per-turn executor;
+  uses the Contract's tool/agent types; reconciles the **current Inference/Runtime dispatch
+  split** (the reactive tool loop in `GenerationToolDispatchLoop` vs agent/handoff
+  orchestration in the executor) so "agent-as-tool" can re-enter the runtime cleanly.
+- **Invariants:** drivers are additive — adding one must be EDGE (conform + register), never
+  engine surgery. Single-turn behavior must remain the zero-config default.
+- **Absorbs (by design):** multi-agent, planning, autonomous runs — the whole agentic axis.
+- **Evolution:** this seam *is* MK's answer to SK's Agent Framework + Process Framework,
+  built MK-shaped. Ship `SingleTurnDriver` first (refactor-in-place), then add drivers.
+
+#### 1c — Run model + ports  ·  *NEW, required by the stateful/resumable commitment*
+- **Responsibility:** represent a `Run` (a multi-step unit above a turn) with persisted,
+  resumable state and checkpoints.
+- **Owns:** `Run`/`RunStep` value types, run-level events (started/step/paused/resumed/
+  completed), and the **`RunStore` port** + checkpoint records. Agent state generalises from
+  a single `activeAgentID` to an **agent stack/tree**.
+- **Public surface:** the `Run` API on `ConversationRuntime` (start/pause/resume/cancel a
+  run); `RunStore` port for hosts.
+- **Edges:** persistence ports (Ring 2 SwiftData implements `RunStore`); the driver executes
+  a `Run`.
+- **Invariants:** **run/agent events must NOT be added as `GenerationEvent` cases** — they
+  ride their own event type (precedent: `ImageRuntimeEvent` is deliberately separate from
+  the text-path `ConversationEvent` so exhaustive switches stay closed). This is the modality
+  lesson applied to agentic.
+- **Absorbs:** resumable/long-running/checkpointed orchestration without touching the text
+  event vocabulary.
+- **Evolution:** the persistence layer must gain run/checkpoint storage (SwiftData schema
+  bump) — sequence this with the driver work.
+
+Also in the Engine tier: **ports** (`MessageStore`, `SessionStore`, `EndpointStore`,
+`SamplerPresetStore`, `VectorStore`, `DocumentStore`, `UsageStore`, `RunStore`), **hooks**
+(`HookRegistry`/`PreToolUseHook`/`GenerationHook` — expand coverage to `postToolUse`/
+`onTurnComplete`/`onHandoff`/`onRunStep` as drivers land), and **RAG/export/import** use
+cases.
+
+---
+
+### RING 2 — ADAPTERS (à-la-carte products that plug into the Contract / Engine ports)
+
+Each depends down on the Contract (and Engine ports where relevant), never on each other —
+the "provider package" model expressed as SwiftPM products.
+
+#### Inference backends (inlets)
+- **Products:** `ManifoldMLX`, `ManifoldLlama`, `ManifoldFoundation`, `ManifoldCloud`
+  (+ `ManifoldCloudCore`).
+- **Responsibility:** implement `InferenceBackend` for one engine/provider.
+- **Public surface:** the conformer + its `BackendRegistrar`.
+- **Edges:** Contract only (Cloud also CloudCore). Heavy deps (MLX, LlamaSwift) stay
+  trait-gated.
+- **Invariants:** never import Runtime/Engine or each other; never import UI.
+- **Absorbs:** new engine/provider = conform + register (EDGE).
+- **Amplifies (to fix):** `APIProvider` is an enum behind ~14 exhaustive switches — adding a
+  cloud provider ripples. **Evolution:** make provider selection registry/descriptor-driven
+  (the registrar already uses a factory closure — extend it to encoding/extraction) so a new
+  provider is "register a descriptor," not "edit 14 switches."
+
+#### Media-generation backends (generic seam) — *decided refactor*
+- **Responsibility:** image / video / **audio (incl. realtime)** generation behind ONE
+  generic seam, replacing the per-modality vertical clones.
+- **Owns (target):** `MediaGeneration<Output>` backend + `MediaGenerationService<Output>` +
+  `MediaGenerationRuntime<Output>` over a `GeneratedMediaPayload` protocol, with a shared
+  media event type (allowing both one-shot `progress→completed` *and* a streaming/duplex
+  variant for realtime audio).
+- **Edges:** Contract; MLX-family diffusion impls under the `MLX` trait.
+- **Invariants:** generated media funnels through a single `MessagePart.generatedMedia
+  (GeneratedMediaPayload)` case (not per-type cases) — one Codable key, one UI render branch.
+  Media events stay OFF the text-path `GenerationEvent` switch.
+- **Absorbs (by design):** a new modality = conform the generic seam (~3 EDGE files), not a
+  ~14-file 5-module clone. This is the WWDC hedge against an Apple on-device *media* surface.
+
+#### Tool sources / agentic side-ports
+- **Products:** `ManifoldMCP`, `ManifoldMCPHost`, `ManifoldAppIntents`, `ManifoldHuggingFace`
+  (+ RAG in the Engine).
+- **Responsibility:** contribute tools/agents/data into the registry.
+- **Public surface:** `ToolExecutor`/`ToolRegistry` (the live dispatch seam) and
+  `SessionToolSource` (advertising/allow-listing).
+- **Invariants:** external tool universes (MCP, AppIntents) collapse onto `ToolExecutor`.
+- **Absorbs:** new tool / MCP server / AppIntent = conform + register (EDGE). Approval,
+  streaming progress, cancellation already first-class.
+- **Amplifies / debt (to fix):** **`SessionToolSource.resolve` is dead in the dispatch path**
+  — `generate_image`/`generate_video`/`web_search` are advertised but unreachable (no
+  `SessionToolSource → ToolExecutor` adapter). Either wire it per-turn or make
+  `SessionToolSource` advertising-only by design and route execution through `ToolExecutor`.
+  Also: parallel tool dispatch is *declared* (`supportsConcurrentDispatch`) but not wired.
+
+#### Persistence (bottom port)
+- **Product:** `ManifoldPersistenceSwiftData`.
+- **Responsibility:** implement the Engine ports against SwiftData; own schema + `Bootstrap`.
+- **Edges:** Engine ports + Contract records.
+- **Invariants:** the only place SwiftData lives.
+- **Evolution:** must implement the new `RunStore` + checkpoint records (schema bump) for the
+  stateful/resumable commitment.
+
+---
+
+### RING 3 — APP LAYER (batteries-included)  ·  `ManifoldUI`, `ManifoldUIModelManagement`, `ManifoldVoice`, bootstrap, `ManifoldKit` umbrella
+
+- **Responsibility:** drop-in SwiftUI chat + model-management UI + the one-import umbrella.
+- **Public surface:** `ChatView`/`ChatViewModel`, `ManifoldBootstrap`, `quickStart()`.
+- **Edges:** Engine + Contract; CloudCore under `CloudSaaS`. **Never** a backend (CI-lint).
+- **Absorbs:** new consumer = read the event stream + ports (CORE-free).
+- **Amplifies / debt (usability, to fix in target):** `quickStart()` yields a chat that
+  can't chat (registers backends, selects/loads none); cloud is off-by-default behind a trait
+  edit; "one import" is contradicted by examples importing `ManifoldUI` too; 9 `configure*`
+  overloads. The target bakes in: umbrella genuinely one-import; `quickStart()` brings a
+  default inlet live; cloud not a silent wall.
+
+---
+
+### Utility leaves (evicted from the kernel)
+- `ManifoldNet` — networking policy/factory + CloudCore SSE/TLS/DNS infra.
+- `ManifoldSecrets` — `Security/` + `KeychainService`.
+- Device-capability + GGUF readers → adapter-side (MLX/Llama only).
+- Model discovery / catalog / benchmark → their own products.
+
+## Expansion axes (the design forces this target must absorb)
+
+| Axis | Today | Target seam | Cost after refactor |
+|---|---|---|---|
+| **Modality** (img/video/**audio/realtime**) | per-modality 5-module clone (~14 files) | generic `MediaGeneration<Output>` + single `MessagePart.generatedMedia` | ~3 EDGE files |
+| **Agentic** (multi-agent, plan-execute, autonomous) | single-active-agent + handoff on a monolith | pluggable **TurnDriver** seam over a resumable **Run** | conform a driver (EDGE) |
+| **Models / providers** | `InferenceBackend` clean, but `APIProvider` in ~14 switches | registry/descriptor-driven provider selection | register a descriptor |
+| **Consumers** | already clean | event stream + ports | CORE-free |
+
+## Consumption ladder
+| Adopter wants… | Reaches to… | Imports | Brings |
+|---|---|---|---|
+| Drop-in chat app | App layer | `ManifoldKit` (umbrella) | nothing |
+| Own UI, our engine | Engine | `ManifoldEngine` + a backend + a store | views |
+| Headless / CLI / server | Contract + Engine | `ManifoldInference` + `ManifoldEngine` + a backend | loop |
+| New backend / provider / driver | Contract only | `ManifoldInference` | conform + register |
+
+## Invariants the target must preserve
+1. Acyclic, inward-pointing dependencies — everything depends toward the Contract.
+2. UI never imports a backend (CI-lint enforced).
+3. Records in the Contract; ports in the Engine; adapters implement ports.
+4. Heavy-dependency traits stay traits; product-selection-equivalent traits retire.
+5. The Contract is the SemVer surface — breaking it is a major bump; adapters may churn.
+6. **New modality/agentic events ride their own event types — never new `GenerationEvent`
+   cases on the text path.**
+7. **Adding a driver or a modality is EDGE, never engine surgery.**
+
+## Trait disposition (target)
+- **Stay:** `MLX`, `Llama`, `HuggingFace`, `Macros`, `Server`, `AnyLanguageModel`,
+  `FoundationOnly`, `Fuzz` (Xcode-scheme collision #982), WWDC stubs
+  (`SystemAIProviderExtension`, `CoreAI`).
+- **Retire → product opt-in (clean):** `MCP`, `Voice`, `Tools`, `AppIntents`.
+- **Retire → product, blocked on source extraction first:** `Ollama` (36 in-body `#if`),
+  `CloudSaaS` (53).
+- **Decide later:** `MCPBuiltinCatalog`, `Skills`.
+
+## Known debts & hard problems (carry into the migration plan)
+1. **The one real refactor gate: `InferenceService.GenerationRequestToken`.** UI binds the
+   concrete `InferenceService` at ~9 declaration + 22 call sites; the nested token type is the
+   tightest knot. The engine carve needs either App-above-Engine (UI names the concrete type)
+   or a protocol-level token abstraction.
+2. **`ConversationTurnExecutor` monolith** (1,100–1,628 LOC) must be split into orchestration
+   + thin executor + driver before agentic expansion piles on.
+3. **Tool-dispatch layer split** (Inference `GenerationToolDispatchLoop` vs Runtime executor)
+   must be reconciled so agent-as-tool can re-enter cleanly.
+4. **`SessionToolSource.resolve` dead path** — live bug; wire or redesign.
+5. **`APIProvider` exhaustive-switch sprawl** — make descriptor-driven.
+6. **Run/checkpoint persistence** — new `RunStore` + schema migration for resumable runs.
+7. **Ollama/CloudSaaS `#if` extraction** before those traits can retire.
+8. **Module naming** — `ManifoldEngine`, `ManifoldNet`, `ManifoldSecrets`; whether the App
+   layer is one `ManifoldAppKit` or stays separate products.
+9. **Back-compat** — `@_exported import` shims on old module names during migration; retire
+   in a final breaking release.
+10. **Lockstep CI** — `FeatureMatrix.swift`, cold-start gates, `PackageTraitGateAuditTest`
+    must move with any trait change.
+
+## Semantic Kernel orientation (where MK sits in the landscape)
+MK's inference+tooling **core** is ~60–70% the standard kernel shape SK/LangChain share
+(backends ≈ connectors, `ToolRegistry` ≈ plugins, the tool loop ≈ auto-invocation, RAG ≈
+memory, both speak MCP) — so the kernel shape is **table stakes, not the moat**. MK diverges
+as an **on-device-first Swift chat *runtime* with batteries SK omits** (persistence + SwiftUI
+UI), organised around one normalizing event stream + one turn loop. The two capabilities SK
+has and MK lacks — **formal multi-agent orchestration** and a **stateful/resumable process
+engine** — are exactly the agentic frontier this target now **commits to**, built MK-shaped
+on the TurnDriver seam + `Run` model rather than as SK-style separate frameworks.
+
+## Explicitly out of scope here
+The sequenced migration (leaf evictions → engine carve + driver seam → modality generify →
+trait→product → usability fixes → run/checkpoint persistence), PR scoping, and issue
+creation. That is the next document, written against this target.

--- a/docs/plans/target-architecture.md
+++ b/docs/plans/target-architecture.md
@@ -8,24 +8,32 @@ stabilises, the adopter-facing version becomes a DocC article.
 ## Status
 
 - **End state:** agreed (this document).
-- **Migration plan:** deferred until this target is signed off — written as a separate doc.
+- **Migration plan:** [`target-architecture-migration.md`](./target-architecture-migration.md).
 - **Consumer assumption:** *public framework, diverse adopters.* Keep à-la-carte assembly;
   make optionality **legible**, don't remove it.
 - **Diagram audience:** unified — one picture serves maintainers (north-star) and adopters
   (consumption map).
 - **Decided design forks:**
-  - **Modality** generifies to a single `MediaGeneration<Output>` seam (no more per-modality
-    vertical clones).
-  - **Agentic:** MK **commits to growing multi-agent + stateful/resumable runs**, built
-    *MK-shaped* (on a pluggable turn-driver seam + the `GenerationEvent`/event stream +
-    persistence ports) — **not** as bolted-on Semantic-Kernel-style separate frameworks.
+  - **Modality** generifies to a single `MediaGeneration<Output>` seam (no per-modality
+    vertical clones), with concrete typealiases (`ImageGeneration`, `VideoGeneration`,
+    `AudioGeneration`) so adopters rarely write the generic.
+  - **Agentic:** MK **commits to stateful/resumable runs only** (the on-device-defensible
+    bet — leans on the persistence battery SK lacks). **Multi-agent and plan-execute are
+    out of scope until an adopter explicitly needs them** — the pluggable turn-driver seam
+    keeps the door open, but we do not build for them now. Rationale: multi-agent fan-out
+    burns the context/tokens on-device 3B–8B models are most starved for; it is a
+    cloud-scale pattern, not an on-device one.
+- **WWDC posture (keynote 2026-06-08):** the migration's P0 (decisions + the
+  `SessionToolSource` bug) and P1 (pure file-moves) are WWDC-independent and may start now;
+  P2–P4 sequencing is re-confirmed after the keynote, since Apple's agent/tool/on-device-media
+  announcements could reshape the driver and media seams.
 
 ## The frame: ManifoldKit *is* a manifold
 
 The name encodes the architecture. The canonical visual reads as a literal intake manifold
 first, software diagram second: **many model backends flow in → one common core normalises
 them → a single conversation-event stream flows out to many consumers**, with side ports for
-tools/data/agents and a bottom port for persistence.
+tools/data and a bottom port for persistence.
 
 ```
    INLETS (backends)            ┌──── THE CORE MANIFOLD ────┐          OUTLETS (consumers)
@@ -39,8 +47,8 @@ tools/data/agents and a bottom port for persistence.
    (img/vid/  ├──[generic seam]►║   ◆ ENGINE                 ║
     audio)    ┘                 ║   Orchestration +          ║
                                 ║   ▸ pluggable TURN-DRIVER  ║
-   SIDE PORTS (tools / agents)  ║     (single · plan-exec ·  ║
-   MCP        ┐                 ║      multi-agent · autonom)║
+   SIDE PORTS (tools / data)    ║     (single-turn today ·   ║
+   MCP        ┐                 ║      resumable Run next)   ║
    AppIntents ├─[ToolSource]──► ║   over a RUN (resumable)   ║
    RAG / HF   ┘                 ║                            ║
                                 └────────────┬───────────────┘
@@ -71,31 +79,34 @@ Corrected several stale session-memory assumptions:
   `ConversationTurnExecutor` (1,628 LOC) + `ConversationRuntime` are the hottest-churn files,
   mixing features and race-fixes, co-changing 12× (a false 2-file boundary).
 - **Tooling is a clean absorber; agentic orchestration is not.** Adding a tool = conform
-  `ToolExecutor` + register. But multi-agent/planning/autonomous runs land squarely on the
+  `ToolExecutor` + register. But resumable/multi-step orchestration lands squarely on the
   un-refined `ConversationTurnExecutor`, which has **no turn-strategy/driver abstraction**.
 
 ## Moat thesis (triangulated)
 
-Three independent lenses — historical churn, modality-ripple, agentic-ripple — converge on
-the same conclusion:
+Four lenses — historical churn, modality-ripple, agentic-ripple, and DX/reliability —
+converge:
 
-1. **The backend / tool / connector seams are strong absorbers. Protect, don't polish.**
-   New models, engines, tools, consumers, and (per the WWDC analysis) a new Apple *text*
-   surface all plug in at the edge. This is the industry-standard kernel shape — table
-   stakes, not differentiation.
-2. **The defensible moat is the on-device-first normalization + batteries-included runtime**
-   (MLX/Llama/Foundation behind one capability-negotiated contract, plus persistence + UI).
-   This is precisely what Semantic Kernel / LangChain *lack*.
-3. **The single highest-leverage refinement is cracking the engine turn-loop monolith into a
-   pluggable driver seam over a resumable `Run`.** It is the chokepoint where *every*
-   expansion axis collides — modality, multi-agent, planning. One refinement, compounding
-   returns.
+1. **The backend / tool / connector seams are strong absorbers. Protect them.** New models,
+   engines, tools, consumers, and (per the WWDC analysis) a new Apple *text* surface all plug
+   in at the edge. This is the industry-standard kernel *shape*.
+2. **The kernel shape is table stakes — but the *quality* of the shape is not.** Reliability
+   and DX (the one-import promise, a `quickStart()` that actually chats, a clean error
+   surface) are where MK out-competes Semantic Kernel / LangChain, which are rough to operate.
+   The usability work below is **moat investment, not cleanup.**
+3. **The defensible moat is the on-device-first normalization + batteries-included runtime**
+   (MLX/Llama/Foundation behind one capability-negotiated contract, plus persistence + UI) —
+   precisely what SK/LangChain lack.
+4. **The single highest-leverage refinement is cracking the engine turn-loop monolith into a
+   pluggable driver seam over a resumable `ConversationRun`.** It is the chokepoint where
+   modality, resumable runs, and (future, optional) richer orchestration all collide. One
+   refinement, compounding returns.
 
 ## Target structure — concentric tiers (structure == consumption)
 
 Dependencies point inward to the Contract, so *how deep an adopter imports is how much they
 opt in.* The four rings are simultaneously the internal layering and the consumption ladder.
-Each component below carries: **Responsibility · Owns · Public surface · Edges · Invariants ·
+Each component carries: **Responsibility · Owns · Public surface · Edges · Invariants ·
 Absorbs / Amplifies · Evolution.**
 
 ---
@@ -109,170 +120,148 @@ The stable, SemVer-critical public API. Everything connects here; versioned most
 - **Owns:** `InferenceBackend`, `BackendCapabilities`, `GenerationConfig`, `GenerationEvent`,
   `EmbeddingBackend`, the media-gen backend protocol(s), `ToolDefinition`/`ToolCall`/
   `ToolResult`/`ToolChoice`/`ToolOutputPolicy`, `MessagePart`/`MessageKind`/`MessageRole`/
-  `Message`, `ConversationRecords` (records, not ports), `BackendRegistrar`, `Agent`/
-  `AgentHandoff` value types, `Citation`.
-- **Public surface:** the entire module is API. Treat additive enum cases + additive struct
-  fields as minor; any protocol-requirement or signature change is major.
-- **Edges:** depends on nothing (except the `@ToolSchema` macro plugin under the `Macros`
-  trait). Depended on by *everything*.
+  `Message`, `ConversationRecords` (records, not ports), `BackendRegistrar`, `Citation`.
+- **Public surface:** the entire module is API. Additive enum cases + additive struct fields
+  are minor; any protocol-requirement or signature change is major.
+- **Edges:** depends on nothing (except the `@ToolSchema` macro under `Macros`). Depended on
+  by *everything*.
 - **Invariants:** no SwiftData, no SwiftUI, no networking, no persistence ports, no
   orchestration. Records live here; ports do not.
-- **Absorbs:** new models/engines (conform `InferenceBackend`); new tools (`ToolDefinition`);
-  additive capability flags; additive `GenerationEvent` *payloads*.
+- **Absorbs:** new models/engines; new tools; additive capability flags; additive
+  `GenerationEvent` *payloads*.
 - **Amplifies (to fix):** `GenerationEvent` *cases* are source-breaking across ~14 consumers;
   `MessagePart` cases force exhaustive-switch + schema churn; `ToolResult.content` is
   `String`-only (blocks typed/multimodal tool output before a 1.0 freeze).
-- **Evolution:** stay thin — evict the ~86% non-contract mass (infra, GGUF, device, catalog,
-  discovery, HF probe) to utility leaves and adapters. Keep pushing backend variation into
-  *additive `BackendCapabilities` flags* (the pressure-relief valve) rather than new protocol
-  requirements. Decide the additive shape for non-text `ToolResult` and run/agent events
-  *before* 1.0 locks them.
+- **Evolution:** stay thin — evict the ~86% non-contract mass to utility leaves and adapters.
+  Keep pushing backend variation into *additive `BackendCapabilities` flags*. Decide the
+  additive shape for non-text `ToolResult` and run-level events *before* 1.0 locks them.
 
 ---
 
 ### RING 1 — ENGINE  ·  product: `ManifoldEngine` (merges today's `ManifoldRuntime` + the orchestration evicted from the kernel)
 
-The engine is detailed as **three** components, because the leverage lives in separating
-them. Cut by *"is it orchestration,"* not *"does it touch persistence."*
+Detailed as **three** components, because the leverage lives in separating them. Cut by
+*"is it orchestration,"* not *"does it touch persistence."*
 
 #### 1a — Orchestration core
 - **Responsibility:** own the public conversation API and the per-turn machinery.
 - **Owns:** `ConversationRuntime` (`send`/`regenerate`/`edit`/`branch`/`cancel`), prompt
-  assembly (`PromptAssembler`/`PromptTemplate`/`PromptSlot`), context budgeting
-  (`ContextWindowManager`/`ContextBudgetPlanner`/`GenerationPreflightTrimmer`), the
-  generation queue (`GenerationQueue`), transcript healing, streaming, the event subsystem
-  (`ConversationEvent`/`EventTapRegistry`/`ConversationEventRecorder`).
+  assembly, context budgeting, the generation queue, transcript healing, streaming, the event
+  subsystem (`ConversationEvent`/`EventTapRegistry`/`ConversationEventRecorder`).
 - **Public surface:** `ConversationRuntime`'s verb API + the event stream + the public
   `ConversationEventRecorder` (Glass Box, #1531).
 - **Edges:** depends on Contract; consumes persistence + tool + driver via ports.
 - **Invariants:** no SwiftData, no SwiftUI, no concrete backend.
-- **Absorbs:** new consumers (read the event stream), new hooks, new tool sources.
-- **Amplifies (to fix):** today persistence-writes and event-emission are tangled *inside*
-  `ConversationTurnExecutor` (co-change 7× and 5×) — they must move behind narrow ports.
-- **Evolution:** shrink `ConversationTurnExecutor` from a 1,100-LOC monolith to a thin
-  per-turn executor that the **driver** calls; lift persistence + event-emit to ports.
+- **Amplifies (to fix):** persistence-writes and event-emission are tangled *inside*
+  `ConversationTurnExecutor` (co-change 7× and 5×) — move them behind narrow ports.
+- **Evolution:** shrink `ConversationTurnExecutor` from a monolith to a thin per-turn executor
+  the **driver** calls.
 
-#### 1b — Turn-Driver seam  ·  *NEW first-class component*
-- **Responsibility:** decide *how* a goal becomes turns/agent-steps. This is the pluggable
-  strategy the agentic commitment requires.
+#### 1b — Turn-Driver seam  ·  *NEW first-class component (the enabler)*
+- **Responsibility:** decide *how* a goal becomes turns/steps. The pluggable strategy.
 - **Owns:** a `TurnDriver` protocol + conformers:
-  - `SingleTurnDriver` — today's linear behavior (default, always available).
-  - `PlanExecuteDriver` — goal decomposition / ReAct-style plan→act phases.
-  - `MultiAgentDriver` — concurrent / collaborating sub-agents, agent-as-tool, handoff.
-  - `AutonomousRunDriver` — long-running, checkpointed, resumable runs.
-- **Public surface:** `TurnDriver` (conform to add an orchestration shape); driver selection
-  on the run/turn input.
-- **Edges:** sits between `ConversationRuntime` (orchestration) and the per-turn executor;
-  uses the Contract's tool/agent types; reconciles the **current Inference/Runtime dispatch
-  split** (the reactive tool loop in `GenerationToolDispatchLoop` vs agent/handoff
-  orchestration in the executor) so "agent-as-tool" can re-enter the runtime cleanly.
-- **Invariants:** drivers are additive — adding one must be EDGE (conform + register), never
-  engine surgery. Single-turn behavior must remain the zero-config default.
-- **Absorbs (by design):** multi-agent, planning, autonomous runs — the whole agentic axis.
-- **Evolution:** this seam *is* MK's answer to SK's Agent Framework + Process Framework,
-  built MK-shaped. Ship `SingleTurnDriver` first (refactor-in-place), then add drivers.
+  - `SingleTurnDriver` — today's linear behavior (default, always available). **Committed.**
+  - `ResumableRunDriver` — long-running, checkpointed, resumable runs. **Committed** (the
+    on-device-shaped agentic bet).
+  - `MultiAgentDriver`, `PlanExecuteDriver` — **seam-enabled but NOT committed.** Built only
+    on explicit adopter demand. The seam guarantees they can be added as EDGE conformers.
+- **Public surface:** `TurnDriver` (conform to add a strategy); driver selection on the
+  run/turn input.
+- **Edges:** sits between the orchestration core and the per-turn executor; reconciles the
+  current Inference/Runtime dispatch split so a future agent-as-tool could re-enter cleanly.
+- **Invariants:** drivers are additive — adding one is EDGE, never engine surgery. Single-turn
+  remains the zero-config default.
+- **Absorbs (by design):** resumable runs now; richer orchestration later without re-cutting
+  the engine.
+- **Evolution:** this seam is MK's lightweight, MK-shaped answer to SK's orchestration
+  layers — ship `SingleTurnDriver` (refactor-in-place) then `ResumableRunDriver`.
 
-#### 1c — Run model + ports  ·  *NEW, required by the stateful/resumable commitment*
-- **Responsibility:** represent a `Run` (a multi-step unit above a turn) with persisted,
-  resumable state and checkpoints.
-- **Owns:** `Run`/`RunStep` value types, run-level events (started/step/paused/resumed/
-  completed), and the **`RunStore` port** + checkpoint records. Agent state generalises from
-  a single `activeAgentID` to an **agent stack/tree**.
-- **Public surface:** the `Run` API on `ConversationRuntime` (start/pause/resume/cancel a
-  run); `RunStore` port for hosts.
-- **Edges:** persistence ports (Ring 2 SwiftData implements `RunStore`); the driver executes
-  a `Run`.
-- **Invariants:** **run/agent events must NOT be added as `GenerationEvent` cases** — they
-  ride their own event type (precedent: `ImageRuntimeEvent` is deliberately separate from
-  the text-path `ConversationEvent` so exhaustive switches stay closed). This is the modality
-  lesson applied to agentic.
+#### 1c — Run model + ports  ·  *NEW, the committed stateful/resumable capability*
+- **Responsibility:** represent a `ConversationRun` (a multi-step unit above a turn) with
+  persisted, resumable state and checkpoints.
+- **Owns:** `ConversationRun`/`RunStep` value types, run-level events (started/step/paused/
+  resumed/completed), and the **`RunStore` port** + checkpoint records.
+- **Public surface:** the run API on `ConversationRuntime` (start/pause/resume/cancel a run);
+  `RunStore` for hosts.
+- **Edges:** persistence ports (Ring 2 SwiftData implements `RunStore`); the driver executes a
+  `ConversationRun`.
+- **Invariants:** **run-level events must NOT be added as `GenerationEvent` cases** — they
+  ride their own event type (precedent: `ImageRuntimeEvent` is deliberately separate from the
+  text-path event vocabulary so exhaustive switches stay closed).
 - **Absorbs:** resumable/long-running/checkpointed orchestration without touching the text
   event vocabulary.
-- **Evolution:** the persistence layer must gain run/checkpoint storage (SwiftData schema
-  bump) — sequence this with the driver work.
+- **Evolution:** persistence gains run/checkpoint storage (schema bump). *Agent stack/tree
+  state is part of the deferred multi-agent track — not built now.*
 
 Also in the Engine tier: **ports** (`MessageStore`, `SessionStore`, `EndpointStore`,
 `SamplerPresetStore`, `VectorStore`, `DocumentStore`, `UsageStore`, `RunStore`), **hooks**
-(`HookRegistry`/`PreToolUseHook`/`GenerationHook` — expand coverage to `postToolUse`/
-`onTurnComplete`/`onHandoff`/`onRunStep` as drivers land), and **RAG/export/import** use
-cases.
+(`HookRegistry`/`PreToolUseHook`/`GenerationHook`; expand to `postToolUse`/`onTurnComplete`/
+`onRunStep` as the run model lands), and **RAG/export/import** use cases.
 
 ---
 
 ### RING 2 — ADAPTERS (à-la-carte products that plug into the Contract / Engine ports)
 
-Each depends down on the Contract (and Engine ports where relevant), never on each other —
-the "provider package" model expressed as SwiftPM products.
+Each depends down on the Contract (and Engine ports where relevant), never on each other.
 
 #### Inference backends (inlets)
 - **Products:** `ManifoldMLX`, `ManifoldLlama`, `ManifoldFoundation`, `ManifoldCloud`
   (+ `ManifoldCloudCore`).
-- **Responsibility:** implement `InferenceBackend` for one engine/provider.
-- **Public surface:** the conformer + its `BackendRegistrar`.
-- **Edges:** Contract only (Cloud also CloudCore). Heavy deps (MLX, LlamaSwift) stay
-  trait-gated.
-- **Invariants:** never import Runtime/Engine or each other; never import UI.
 - **Absorbs:** new engine/provider = conform + register (EDGE).
-- **Amplifies (to fix):** `APIProvider` is an enum behind ~14 exhaustive switches — adding a
-  cloud provider ripples. **Evolution:** make provider selection registry/descriptor-driven
-  (the registrar already uses a factory closure — extend it to encoding/extraction) so a new
-  provider is "register a descriptor," not "edit 14 switches."
+- **Amplifies (to fix):** `APIProvider` enum behind ~14 exhaustive switches.
+  **Evolution / acceptance metric:** make provider selection registry/descriptor-driven so
+  *adding a cloud provider drops from editing ~14 switches to registering 1 descriptor*.
+- **Invariants:** never import Runtime/Engine or each other; never import UI. Heavy deps
+  trait-gated.
 
 #### Media-generation backends (generic seam) — *decided refactor*
-- **Responsibility:** image / video / **audio (incl. realtime)** generation behind ONE
-  generic seam, replacing the per-modality vertical clones.
-- **Owns (target):** `MediaGeneration<Output>` backend + `MediaGenerationService<Output>` +
-  `MediaGenerationRuntime<Output>` over a `GeneratedMediaPayload` protocol, with a shared
-  media event type (allowing both one-shot `progress→completed` *and* a streaming/duplex
-  variant for realtime audio).
-- **Edges:** Contract; MLX-family diffusion impls under the `MLX` trait.
+- **Responsibility:** image / video / **audio (incl. realtime)** behind ONE generic seam.
+- **Owns (target):** `MediaGeneration<Output>` + `MediaGenerationService<Output>` +
+  `MediaGenerationRuntime<Output>` over a `GeneratedMediaPayload` protocol, with a shared media
+  event type (one-shot *and* a streaming/duplex variant for realtime audio). **Provide
+  concrete typealiases** (`ImageGeneration`, `VideoGeneration`, `AudioGeneration`) so adopters
+  rarely write the generic.
 - **Invariants:** generated media funnels through a single `MessagePart.generatedMedia
-  (GeneratedMediaPayload)` case (not per-type cases) — one Codable key, one UI render branch.
-  Media events stay OFF the text-path `GenerationEvent` switch.
-- **Absorbs (by design):** a new modality = conform the generic seam (~3 EDGE files), not a
-  ~14-file 5-module clone. This is the WWDC hedge against an Apple on-device *media* surface.
+  (GeneratedMediaPayload)` case; media events stay OFF the text-path switch.
+- **Absorbs (acceptance metric):** *a new modality = conform the generic seam in ≤3 EDGE
+  files*, not a ~14-file 5-module clone. This is the WWDC hedge against an Apple on-device
+  *media* surface.
 
-#### Tool sources / agentic side-ports
+#### Tool sources / data side-ports
 - **Products:** `ManifoldMCP`, `ManifoldMCPHost`, `ManifoldAppIntents`, `ManifoldHuggingFace`
   (+ RAG in the Engine).
-- **Responsibility:** contribute tools/agents/data into the registry.
-- **Public surface:** `ToolExecutor`/`ToolRegistry` (the live dispatch seam) and
-  `SessionToolSource` (advertising/allow-listing).
-- **Invariants:** external tool universes (MCP, AppIntents) collapse onto `ToolExecutor`.
+- **Public surface:** `ToolExecutor`/`ToolRegistry` (live dispatch) and `SessionToolSource`
+  (advertising/allow-listing).
 - **Absorbs:** new tool / MCP server / AppIntent = conform + register (EDGE). Approval,
   streaming progress, cancellation already first-class.
 - **Amplifies / debt (to fix):** **`SessionToolSource.resolve` is dead in the dispatch path**
-  — `generate_image`/`generate_video`/`web_search` are advertised but unreachable (no
-  `SessionToolSource → ToolExecutor` adapter). Either wire it per-turn or make
-  `SessionToolSource` advertising-only by design and route execution through `ToolExecutor`.
-  Also: parallel tool dispatch is *declared* (`supportsConcurrentDispatch`) but not wired.
+  — `generate_image`/`generate_video`/`web_search` are advertised but unreachable. Wire it or
+  make `SessionToolSource` advertising-only by design. Parallel tool dispatch is declared but
+  not wired.
 
 #### Persistence (bottom port)
 - **Product:** `ManifoldPersistenceSwiftData`.
-- **Responsibility:** implement the Engine ports against SwiftData; own schema + `Bootstrap`.
-- **Edges:** Engine ports + Contract records.
 - **Invariants:** the only place SwiftData lives.
-- **Evolution:** must implement the new `RunStore` + checkpoint records (schema bump) for the
-  stateful/resumable commitment.
+- **Evolution:** implement the new `RunStore` + checkpoint records (schema bump).
 
 ---
 
 ### RING 3 — APP LAYER (batteries-included)  ·  `ManifoldUI`, `ManifoldUIModelManagement`, `ManifoldVoice`, bootstrap, `ManifoldKit` umbrella
 
-- **Responsibility:** drop-in SwiftUI chat + model-management UI + the one-import umbrella.
 - **Public surface:** `ChatView`/`ChatViewModel`, `ManifoldBootstrap`, `quickStart()`.
 - **Edges:** Engine + Contract; CloudCore under `CloudSaaS`. **Never** a backend (CI-lint).
 - **Absorbs:** new consumer = read the event stream + ports (CORE-free).
-- **Amplifies / debt (usability, to fix in target):** `quickStart()` yields a chat that
-  can't chat (registers backends, selects/loads none); cloud is off-by-default behind a trait
-  edit; "one import" is contradicted by examples importing `ManifoldUI` too; 9 `configure*`
-  overloads. The target bakes in: umbrella genuinely one-import; `quickStart()` brings a
-  default inlet live; cloud not a silent wall.
+- **Amplifies / moat work (was "debt"):** `quickStart()` yields a chat that can't chat
+  (registers backends, selects/loads none); cloud is off-by-default behind a trait edit;
+  "one import" is contradicted by examples; 9 `configure*` overloads. **The target fixes
+  these as moat investment** — incl. a defined first-launch **backend-selection policy**
+  (prefer Foundation Models if available → first registered local backend → a clearly-labeled
+  empty state), so a fresh install is never a blank composer.
 
 ---
 
 ### Utility leaves (evicted from the kernel)
-- `ManifoldNet` — networking policy/factory + CloudCore SSE/TLS/DNS infra.
+- `ManifoldNetworking` — networking policy/factory + CloudCore SSE/TLS/DNS infra.
 - `ManifoldSecrets` — `Security/` + `KeychainService`.
 - Device-capability + GGUF readers → adapter-side (MLX/Llama only).
 - Model discovery / catalog / benchmark → their own products.
@@ -281,8 +270,9 @@ the "provider package" model expressed as SwiftPM products.
 
 | Axis | Today | Target seam | Cost after refactor |
 |---|---|---|---|
-| **Modality** (img/video/**audio/realtime**) | per-modality 5-module clone (~14 files) | generic `MediaGeneration<Output>` + single `MessagePart.generatedMedia` | ~3 EDGE files |
-| **Agentic** (multi-agent, plan-execute, autonomous) | single-active-agent + handoff on a monolith | pluggable **TurnDriver** seam over a resumable **Run** | conform a driver (EDGE) |
+| **Modality** (img/video/**audio/realtime**) | per-modality 5-module clone (~14 files) | generic `MediaGeneration<Output>` + single `MessagePart.generatedMedia` | ≤3 EDGE files |
+| **Resumable runs** (committed) | none; single linear turn | `ResumableRunDriver` over `ConversationRun` + `RunStore` | conform a driver (EDGE) |
+| **Richer orchestration** (multi-agent / plan-execute — deferred) | n/a | the same `TurnDriver` seam (door kept open) | conform a driver, when an adopter needs it |
 | **Models / providers** | `InferenceBackend` clean, but `APIProvider` in ~14 switches | registry/descriptor-driven provider selection | register a descriptor |
 | **Consumers** | already clean | event stream + ports | CORE-free |
 
@@ -300,14 +290,15 @@ the "provider package" model expressed as SwiftPM products.
 3. Records in the Contract; ports in the Engine; adapters implement ports.
 4. Heavy-dependency traits stay traits; product-selection-equivalent traits retire.
 5. The Contract is the SemVer surface — breaking it is a major bump; adapters may churn.
-6. **New modality/agentic events ride their own event types — never new `GenerationEvent`
-   cases on the text path.**
-7. **Adding a driver or a modality is EDGE, never engine surgery.**
+6. **New modality/run-level events ride their own event types — never new `GenerationEvent`
+   cases on the text path.** *(Needs a tripwire audit test — see migration plan.)*
+7. **Adding a driver or a modality is EDGE, never engine surgery.** *(Needs a tripwire.)*
+8. **Every adopter-affecting change ships a migration guide + `@available(deprecated,
+   renamed:)` annotations; `@_exported` shims live ≥2 minor releases.**
 
 ## Trait disposition (target)
 - **Stay:** `MLX`, `Llama`, `HuggingFace`, `Macros`, `Server`, `AnyLanguageModel`,
-  `FoundationOnly`, `Fuzz` (Xcode-scheme collision #982), WWDC stubs
-  (`SystemAIProviderExtension`, `CoreAI`).
+  `FoundationOnly`, `Fuzz` (Xcode-scheme collision #982), WWDC stubs.
 - **Retire → product opt-in (clean):** `MCP`, `Voice`, `Tools`, `AppIntents`.
 - **Retire → product, blocked on source extraction first:** `Ollama` (36 in-body `#if`),
   `CloudSaaS` (53).
@@ -315,35 +306,37 @@ the "provider package" model expressed as SwiftPM products.
 
 ## Known debts & hard problems (carry into the migration plan)
 1. **The one real refactor gate: `InferenceService.GenerationRequestToken`.** UI binds the
-   concrete `InferenceService` at ~9 declaration + 22 call sites; the nested token type is the
-   tightest knot. The engine carve needs either App-above-Engine (UI names the concrete type)
-   or a protocol-level token abstraction.
-2. **`ConversationTurnExecutor` monolith** (1,100–1,628 LOC) must be split into orchestration
-   + thin executor + driver before agentic expansion piles on.
-3. **Tool-dispatch layer split** (Inference `GenerationToolDispatchLoop` vs Runtime executor)
-   must be reconciled so agent-as-tool can re-enter cleanly.
+   concrete `InferenceService` at ~9 declaration + 22 call sites. Decision: App-above-Engine
+   (UI names the concrete type); protocol-token abstraction is later polish.
+2. **`ConversationTurnExecutor` monolith** must be split into orchestration + thin executor +
+   driver before the run model piles on.
+3. **Tool-dispatch layer split** (Inference vs Runtime) must be reconciled by the driver seam.
 4. **`SessionToolSource.resolve` dead path** — live bug; wire or redesign.
 5. **`APIProvider` exhaustive-switch sprawl** — make descriptor-driven.
-6. **Run/checkpoint persistence** — new `RunStore` + schema migration for resumable runs.
+6. **Run/checkpoint persistence** — new `RunStore` + schema migration; resumable state needs
+   injected clock/IDs to be deterministically testable.
 7. **Ollama/CloudSaaS `#if` extraction** before those traits can retire.
-8. **Module naming** — `ManifoldEngine`, `ManifoldNet`, `ManifoldSecrets`; whether the App
-   layer is one `ManifoldAppKit` or stays separate products.
-9. **Back-compat** — `@_exported import` shims on old module names during migration; retire
-   in a final breaking release.
+8. **Module naming** — `ManifoldEngine`, `ManifoldNetworking`, `ManifoldSecrets`,
+   `ConversationRun`; whether the App layer is one `ManifoldAppKit` or stays separate products.
+9. **Back-compat** — `@_exported import` shims on old module names; retire in a final breaking
+   release (≥2-minor deprecation window).
 10. **Lockstep CI** — `FeatureMatrix.swift`, cold-start gates, `PackageTraitGateAuditTest`
-    must move with any trait change.
+    move with any trait/module change.
+11. **No turn-loop characterization harness exists** — the P2/P3 "behavior-preserving" claims
+    are unprovable until one is built (migration P0c).
 
 ## Semantic Kernel orientation (where MK sits in the landscape)
 MK's inference+tooling **core** is ~60–70% the standard kernel shape SK/LangChain share
 (backends ≈ connectors, `ToolRegistry` ≈ plugins, the tool loop ≈ auto-invocation, RAG ≈
 memory, both speak MCP) — so the kernel shape is **table stakes, not the moat**. MK diverges
 as an **on-device-first Swift chat *runtime* with batteries SK omits** (persistence + SwiftUI
-UI), organised around one normalizing event stream + one turn loop. The two capabilities SK
-has and MK lacks — **formal multi-agent orchestration** and a **stateful/resumable process
-engine** — are exactly the agentic frontier this target now **commits to**, built MK-shaped
-on the TurnDriver seam + `Run` model rather than as SK-style separate frameworks.
+UI), organised around one normalizing event stream + one turn loop. Of the two capabilities SK
+has and MK lacks — multi-agent orchestration and a stateful/resumable process engine — **MK
+commits only to the latter** (resumable runs, the on-device-defensible one), built MK-shaped
+on the TurnDriver seam + `ConversationRun`. **Multi-agent is explicitly deferred**: it is a
+cloud-scale fan-out pattern poorly suited to on-device context budgets, and the seam keeps the
+option open without paying for it now.
 
 ## Explicitly out of scope here
-The sequenced migration (leaf evictions → engine carve + driver seam → modality generify →
-trait→product → usability fixes → run/checkpoint persistence), PR scoping, and issue
-creation. That is the next document, written against this target.
+The sequenced migration, PR scoping, test-infra prerequisites, and issue creation — see
+[`target-architecture-migration.md`](./target-architecture-migration.md).


### PR DESCRIPTION
Adds two planning artifacts under `docs/plans/` (decisions before code — argue with the design, not the diff). Docs-only; no source changes.

## What's here
- **`target-architecture.md`** — the end-state north-star. MK as a *manifold*: many backends in → one normalized `GenerationEvent` stream out → many consumers. Concentric tiers (Contract → Engine → Adapters → App) where *import depth = opt-in level*. Per-component detail with absorber-vs-amplifier classification.
- **`target-architecture-migration.md`** — the sequenced, incremental path (7 phases, each its own PR behind `@_exported` shims).

## Key decisions captured
- **Moat:** the kernel shape is table stakes (≈ Semantic Kernel ~60–70%); the moat is on-device-first normalization + batteries (persistence + UI) + DX/reliability.
- **Modality** → one generic `MediaGeneration<Output>` seam (no per-modality clones).
- **Agentic** → commit to **resumable runs only** (`ConversationRun` + `RunStore` + `ResumableRunDriver`); multi-agent/plan-execute deferred to adopter demand (the `TurnDriver` seam keeps the door open).
- **WWDC gate:** P0 + P1 are keynote-independent (start now); P2–P4 re-confirmed after 2026-06-08.

## Reviewed
Vetted by product + QA persona reviews. QA edits folded in: a Phase 0 turn-loop characterization/golden harness (P0c) gating the engine carve; a shim-completeness cold-start tier; per-phase Test & CI impact; new test targets + audit tripwires; enumerated trait→product lockstep assertions. Product edits: usability reframed as moat, naming, adopter SemVer/deprecation comms, acceptance metrics.

Tracking issues follow: detailed per-item issues for the WWDC-independent work (P0/P1/P6); a single umbrella for the WWDC-gated phases (P2–P5/P7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)