### PR TITLE
test: add turn-loop characterization harness (closes #1607)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,13 +336,13 @@ jobs:
       # neither) — traits only ADD compiled code, so no suite's behavior changes.
       # Keep all three in sync; diverging the traits silently reintroduces the
       # redundant rebuilds.
-      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Inference, parallel)
+      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Inference + TurnLoopCharacterization, parallel)
         id: test-xctest-suites
         timeout-minutes: 30
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --disable-default-traits --traits MCP,CloudSaaS --skip-update --parallel
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --traits MCP,CloudSaaS --skip-update --parallel
 
       # ManifoldBackendsTests is intentionally NOT included in the --parallel batch
       # above. Under --parallel, swift-test schedules XCTest classes across workers

--- a/Package.swift
+++ b/Package.swift
@@ -836,6 +836,25 @@ let package = Package(
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
+        // Turn-loop golden-transcript harness — gates the P2 engine carve.
+        // Snapshots the ConversationEvent stream + persisted records for every
+        // ConversationRuntime verb (send/regenerate/edit/cancel/branch) plus
+        // tool round-trip and tool-forwarded-no-registry cases. Runs in CI
+        // (both the XCTest and local profiles) so any turn-loop behaviour
+        // change surfaces as a snapshot diff before it lands. Will relocate
+        // into ManifoldEngineTests when P2 creates that target; golden files
+        // travel with the test.
+        .testTarget(
+            name: "ManifoldTurnLoopCharacterizationTests",
+            dependencies: [
+                "ManifoldRuntime",
+                "ManifoldInference",
+                "ManifoldPersistenceSwiftData",
+                "ManifoldTestSupport",
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ],
+            exclude: ["__Snapshots__"]
+        ),
         // Fuzzing engine: corpus, runner, capture, detectors, sink. Backend-agnostic.
         // Trait-free so it never pulls MLX/Llama transitively — backend selection
         // happens in `ManifoldFuzzBackends` (importable real-backend factories),

--- a/Tests/ManifoldTurnLoopCharacterizationTests/EventTraceCanonicalizer.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/EventTraceCanonicalizer.swift
@@ -1,0 +1,111 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - EventTraceCanonicalizer
+
+/// Produces a stable, human-readable text serialization of a
+/// ``ConversationEvent`` sequence for snapshot comparison.
+///
+/// UUIDs are replaced by positional labels (`<uuid:N>`) in order of first
+/// appearance so goldens are deterministic across runs. Timestamps and other
+/// volatile values are omitted. The canonicalizer is stateful — share one
+/// instance across the event and records snapshots for a single test so UUID
+/// labels are consistent between the two files.
+struct EventTraceCanonicalizer {
+
+    private var uuidLabels: [UUID: String] = [:]
+    private var counter = 0
+
+    // MARK: - Public API
+
+    /// Serializes a sequence of events to a newline-separated string.
+    mutating func serialize(events: [ConversationEvent]) -> String {
+        events.enumerated().map { i, e in "\(i)  \(describe(e))" }
+            .joined(separator: "\n")
+    }
+
+    /// Serializes persisted ``ChatMessageRecord`` values to a newline-separated
+    /// string. Use the same instance that serialized the events so UUID labels
+    /// are shared.
+    mutating func serialize(records: [ChatMessageRecord]) -> String {
+        records.enumerated().map { i, r in
+            let text = r.content
+            let c = text.isEmpty ? "(empty)" : "\"\(text.prefix(80))\""
+            let extra = r.contentParts.count > 1 ? " parts:\(r.contentParts.count)" : ""
+            return "\(i)  id:\(label(r.id)) role:\(r.role.rawValue) content:\(c)\(extra)"
+        }.joined(separator: "\n")
+    }
+
+    // MARK: - Private helpers
+
+    private mutating func label(_ uuid: UUID) -> String {
+        if let l = uuidLabels[uuid] { return l }
+        counter += 1
+        let l = "<uuid:\(counter)>"
+        uuidLabels[uuid] = l
+        return l
+    }
+
+    private mutating func describe(_ event: ConversationEvent) -> String {
+        switch event {
+        case let .beforeContextAssembly(prompt, request):
+            let p = prompt.map { "\"\($0)\"" } ?? "nil"
+            return "beforeContextAssembly  session:\(label(request.sessionID)) prompt:\(p) msgCount:\(request.messageCount)"
+        case let .contextAssembled(slots):
+            return "contextAssembled  slots:\(slots.count)"
+        case let .messageInserted(msg):
+            let text = msg.content
+            let c = text.isEmpty ? "(empty)" : "\"\(text.prefix(40))\""
+            return "messageInserted  id:\(label(msg.id)) role:\(msg.role.rawValue) content:\(c)"
+        case let .messageRemoved(id):
+            return "messageRemoved  id:\(label(id))"
+        case let .messageUpdated(msg):
+            let text = msg.content
+            let c = text.isEmpty ? "(empty)" : "\"\(text.prefix(40))\""
+            return "messageUpdated  id:\(label(msg.id)) role:\(msg.role.rawValue) content:\(c)"
+        case let .sessionBranched(newSessionID, copiedCount):
+            return "sessionBranched  newSession:\(label(newSessionID)) copiedCount:\(copiedCount)"
+        case let .streamStarted(id):
+            return "streamStarted  id:\(label(id))"
+        case let .tokenEmitted(id, delta):
+            return "tokenEmitted  id:\(label(id)) delta:\"\(delta)\""
+        case let .tokenUsageRecorded(id, prompt, completion):
+            return "tokenUsageRecorded  id:\(label(id)) prompt:\(prompt) completion:\(completion)"
+        case let .thinkingStarted(id):
+            return "thinkingStarted  id:\(label(id))"
+        case let .thinkingUpdated(id, partial):
+            return "thinkingUpdated  id:\(label(id)) partial:\"\(partial.prefix(40))\""
+        case let .thinkingFinalized(id, text, _):
+            return "thinkingFinalized  id:\(label(id)) text:\"\(text.prefix(40))\""
+        case let .loopDetected(id):
+            return "loopDetected  id:\(label(id))"
+        case let .streamFinished(id, reason):
+            return "streamFinished  id:\(label(id)) reason:\(reason)"
+        case let .errorRaised(error):
+            return "errorRaised  \(String(error.localizedDescription.prefix(80)))"
+        case let .sessionTouchFailed(sid):
+            return "sessionTouchFailed  session:\(label(sid))"
+        case let .historyShaped(sid, diagnostics):
+            return "historyShaped  session:\(label(sid)) count:\(diagnostics.count)"
+        case let .afterGeneration(id, finalText):
+            return "afterGeneration  id:\(label(id)) finalText:\"\(finalText.prefix(80))\""
+        case let .compressionTriggered(removed, reason):
+            return "compressionTriggered  removed:\(removed.count) reason:\(reason)"
+        case let .historyCompressed(sid, records):
+            return "historyCompressed  session:\(label(sid)) inserted:\(records.count)"
+        case let .toolCallRequested(call):
+            return "toolCallRequested  callId:\(call.id) tool:\(call.toolName)"
+        case let .toolCallApproved(callID):
+            return "toolCallApproved  callId:\(callID)"
+        case let .toolCallCompleted(callID, result):
+            return "toolCallCompleted  callId:\(callID) status:\(result.errorKind == nil ? "ok" : "err")"
+        case let .agentHandoff(from, to):
+            return "agentHandoff  from:\(from.map { label($0) } ?? "nil") to:\(label(to))"
+        case let .skillInvoked(name, _):
+            return "skillInvoked  name:\(name)"
+        case let .hookFired(event, _):
+            return "hookFired  event:\(event)"
+        }
+    }
+}

--- a/Tests/ManifoldTurnLoopCharacterizationTests/ScriptedEchoTool.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/ScriptedEchoTool.swift
@@ -1,0 +1,32 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - ScriptedEchoTool
+
+/// Minimal ``ToolExecutor`` that returns a fixed scripted response.
+///
+/// Registered directly in ``ToolRegistry`` for the tool round-trip
+/// characterization test. Using the registry dispatch path (not
+/// ``SessionToolSource``) keeps the golden stable across the #1606
+/// dead-path bug fix — a SessionToolSource-based golden would change
+/// intentionally when that fix lands.
+struct ScriptedEchoTool: ToolExecutor, @unchecked Sendable {
+
+    let toolName: String
+    let response: String
+
+    var definition: ToolDefinition {
+        ToolDefinition(
+            name: toolName,
+            description: "Scripted echo tool — returns a fixed response.",
+            parameters: .object([:])
+        )
+    }
+
+    var supportsConcurrentDispatch: Bool { false }
+    var requiresApproval: Bool { false }
+
+    func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        ToolResult(callId: "", content: response)
+    }
+}

--- a/Tests/ManifoldTurnLoopCharacterizationTests/TurnLoopCharacterizationTests.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/TurnLoopCharacterizationTests.swift
@@ -1,0 +1,431 @@
+import XCTest
+import SnapshotTesting
+@testable import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - EventTapDrain
+
+/// Actor that buffers ``ConversationEvent`` values from a tap and serves them
+/// on demand via ``next()``.
+///
+/// Swift 6 disallows calling a `mutating` async function (like
+/// `AsyncIteratorProtocol.next()`) on an actor-isolated stored property because
+/// the borrow would span a suspension point. The workaround: a background task
+/// drains the raw `AsyncStream` and enqueues events here; `next()` then returns
+/// them from the buffer without holding any across-suspension borrow.
+actor EventTapDrain {
+    private var buffer: [ConversationEvent] = []
+    private var waiters: [CheckedContinuation<ConversationEvent?, Never>] = []
+    private var isDone = false
+
+    /// Start consuming `tap` in the background. Returns the draining Task so the
+    /// caller can cancel it during tearDown.
+    func start(consuming tap: AsyncStream<ConversationEvent>) -> Task<Void, Never> {
+        Task { [weak self] in
+            for await event in tap {
+                await self?.enqueue(event)
+            }
+            await self?.finish()
+        }
+    }
+
+    /// Suspends until the next event is available or the tap has finished.
+    func next() async -> ConversationEvent? {
+        if !buffer.isEmpty { return buffer.removeFirst() }
+        if isDone { return nil }
+        return await withCheckedContinuation { cont in
+            waiters.append(cont)
+        }
+    }
+
+    private func enqueue(_ event: ConversationEvent) {
+        if let waiter = waiters.first {
+            waiters.removeFirst()
+            waiter.resume(returning: event)
+        } else {
+            buffer.append(event)
+        }
+    }
+
+    private func finish() {
+        isDone = true
+        for waiter in waiters { waiter.resume(returning: nil) }
+        waiters.removeAll()
+    }
+}
+
+// MARK: - TurnLoopCharacterizationTests
+
+/// Golden-transcript harness for the ``ConversationRuntime`` turn loop.
+///
+/// Each test drives `send` / `regenerate` / `edit` / `cancel` / `branch`
+/// against ``MockInferenceBackend`` + an in-memory SwiftData store, then
+/// snapshots the ``ConversationEvent`` sequence and the final persisted
+/// ``ChatMessageRecord`` list using a UUID-canonicalizing serializer.
+///
+/// **Purpose.** P2 (engine carve) and P3a (`SingleTurnDriver`) both claim
+/// "behaviour-preserving / byte-identical turns." These goldens are the
+/// only falsifiable proof of that claim. Record them on `main` **before**
+/// P2 lands; P2/P3a prove behaviour-preservation by diffing against them.
+///
+/// **Non-regression.** Adding these suites to the CI XCTest filter ensures
+/// any turn-loop behaviour change — intentional or accidental — surfaces
+/// as a snapshot diff rather than a silent regression.
+///
+/// **Sensitivity note.** Changing ``MockInferenceBackend/tokensToYield``
+/// to a different value and re-running any test that snapshots token events
+/// will produce a diff, confirming the harness catches turn-loop behaviour
+/// changes. (Verified during development for `test_send_plainTurn`.)
+@MainActor
+final class TurnLoopCharacterizationTests: XCTestCase {
+
+    // MARK: - Per-test state
+
+    private var persistenceStack: InMemoryPersistenceHarness.Stack!
+    private var backend: MockInferenceBackend!
+    private var runtime: ConversationRuntime!
+    private var tapDrain: EventTapDrain!
+    private var tapDrainTask: Task<Void, Never>?
+    private var sessionID: UUID!
+
+    // MARK: - setUp / tearDown
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistenceStack = try InMemoryPersistenceHarness.make()
+        backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hello", " world"]
+        let service = InferenceService(backend: backend, name: "CharacterizationMock")
+        runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service
+        )
+        tapDrain = EventTapDrain()
+        tapDrainTask = await tapDrain.start(consuming: runtime.addEventTap())
+        sessionID = UUID()
+    }
+
+    override func tearDown() async throws {
+        tapDrainTask?.cancel()
+        tapDrainTask = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Drain helpers
+
+    /// Drains `tapIterator` until `predicate` returns `true` or the deadline elapses.
+    private func drain(
+        until predicate: (ConversationEvent) -> Bool,
+        deadline: Duration = .seconds(5)
+    ) async -> [ConversationEvent] {
+        var events: [ConversationEvent] = []
+        let end = ContinuousClock.now.advanced(by: deadline)
+        while let event = await tapDrain.next() {
+            events.append(event)
+            if predicate(event) { break }
+            if ContinuousClock.now > end { break }
+        }
+        return events
+    }
+
+    /// Drains until the true terminal event for any generation-producing turn.
+    ///
+    /// Event ordering in `ConversationTurnExecutor`:
+    /// - Happy path (.stop / .empty): `streamFinished` → `afterGeneration`  ← TERMINAL
+    /// - Cancelled: `streamFinished(.cancelled)`  ← TERMINAL (no afterGeneration follows)
+    /// - Error: `errorRaised` → `streamFinished`  ← TERMINAL (no afterGeneration follows)
+    ///
+    /// Stopping at `afterGeneration` captures the complete event sequence for the
+    /// happy path; stopping at `.cancelled` / `errorRaised` handles the early-exit
+    /// paths where `afterGeneration` is never emitted.
+    private func drainTurn() async -> [ConversationEvent] {
+        await drain {
+            switch $0 {
+            case .afterGeneration: return true
+            case .errorRaised: return true
+            case .streamFinished(_, let reason):
+                return reason == .cancelled || reason == .length
+            default: return false
+            }
+        }
+    }
+
+    /// Drains until `sessionBranched` — the terminal event for a branch-without-generate turn.
+    private func drainBranch() async -> [ConversationEvent] {
+        await drain { if case .sessionBranched = $0 { return true }; return false }
+    }
+
+    // MARK: - Snapshot helper
+
+    private func assertGolden(
+        events: [ConversationEvent],
+        records: [ChatMessageRecord],
+        file: StaticString = #filePath,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        var c = EventTraceCanonicalizer()
+        assertSnapshot(
+            of: c.serialize(events: events),
+            as: .lines,
+            named: "events",
+            record: .missing,
+            file: file,
+            testName: testName,
+            line: line
+        )
+        assertSnapshot(
+            of: c.serialize(records: records),
+            as: .lines,
+            named: "records",
+            record: .missing,
+            file: file,
+            testName: testName,
+            line: line
+        )
+    }
+
+    // MARK: - Verb: send
+
+    func test_send_plainTurn() async throws {
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Hello"))
+        )
+        let events = await drainTurn()
+        await handle?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: events, records: records)
+    }
+
+    // MARK: - Verb: regenerate
+
+    func test_regenerate() async throws {
+        // Turn 1: send
+        let s1 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Hello"))
+        )
+        var allEvents = await drainTurn()
+        await s1?.outcome
+
+        // Turn 2: regenerate — replaces the assistant message
+        let s2 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .regenerate)
+        )
+        allEvents += await drainTurn()
+        await s2?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: allEvents, records: records)
+    }
+
+    // MARK: - Verb: edit
+
+    func test_edit_userMessage() async throws {
+        // Turn 1: send to establish a user + assistant message
+        let s1 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Original text"))
+        )
+        var allEvents = await drainTurn()
+        await s1?.outcome
+
+        // Fetch user message ID for edit target
+        let msgs1 = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        let userMsg = try XCTUnwrap(msgs1.first(where: { $0.role == .user }),
+                                    "Expected a persisted user message after send")
+
+        // Turn 2: edit the user message (produces a new assistant reply)
+        backend.tokensToYield = ["Edited", " reply"]
+        let s2 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .edit(messageID: userMsg.id, text: "Edited text"))
+        )
+        allEvents += await drainTurn()
+        await s2?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: allEvents, records: records)
+    }
+
+    // MARK: - Verb: branch
+
+    func test_branch_withoutGenerate() async throws {
+        // Turn 1: send to create messages to branch from
+        let s1 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Branch source"))
+        )
+        var allEvents = await drainTurn()
+        await s1?.outcome
+
+        // Get the user message ID to branch at
+        let msgs = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        let userMsg = try XCTUnwrap(msgs.first(where: { $0.role == .user }),
+                                    "Expected a persisted user message")
+
+        // Branch: fork at the user message (inclusive), no generation on the fork
+        let branchSessionID = UUID()
+        try await runtime.processTurn(
+            TurnInput(sessionID: sessionID, kind: .branch(
+                messageID: userMsg.id,
+                newSessionID: branchSessionID,
+                generateAfter: false
+            ))
+        )
+        allEvents += await drainBranch()
+
+        let sourceRecords = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        let branchRecords = try await persistenceStack.provider.fetchMessages(for: branchSessionID)
+
+        var c = EventTraceCanonicalizer()
+        assertSnapshot(
+            of: c.serialize(events: allEvents),
+            as: .lines, named: "events", record: .missing
+        )
+        assertSnapshot(
+            of: c.serialize(records: sourceRecords),
+            as: .lines, named: "source-records", record: .missing
+        )
+        assertSnapshot(
+            of: c.serialize(records: branchRecords),
+            as: .lines, named: "branch-records", record: .missing
+        )
+    }
+
+    // MARK: - Verb: cancel mid-stream
+
+    func test_cancel_midStream() async throws {
+        // Gate controls token emission so we can cancel after the first token
+        // and before the second, making the truncation deterministic.
+        let gate = TokenEmissionGate()
+        backend.tokensToYield = ["Hello", " world"]
+        backend.tokenEmissionGate = gate
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(
+                sessionID: sessionID,
+                kind: .send(text: "Cancel me"),
+                config: TurnConfig(streamingBatchCharacterLimit: 1)
+            )
+        )
+
+        // Drain events; cancel after the first tokenEmitted event.
+        // For cancel, streamFinished(.cancelled) is the terminal — afterGeneration
+        // does not fire on cancelled turns.
+        let drainTask = Task { @MainActor [self] in
+            var events: [ConversationEvent] = []
+            var didCancel = false
+            while let event = await tapDrain.next() {
+                events.append(event)
+                if case .tokenEmitted = event, !didCancel, let h = handle {
+                    didCancel = true
+                    await runtime.cancel(h.streamHandle)
+                }
+                if case .streamFinished(_, .cancelled) = event { break }
+                if case .errorRaised = event { break }
+            }
+            return events
+        }
+
+        await gate.advance()    // release "Hello" so the first tokenEmitted fires
+        let events = await drainTask.value
+        await gate.release()    // allow the mock's generation Task to clean up
+        await handle?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: events, records: records)
+    }
+
+    // MARK: - Tool: real two-turn round-trip
+
+    func test_tool_roundTrip() async throws {
+        // Use a backend that declares supportsToolCalling so GenerationQueue
+        // includes tool definitions in the request (required for the dispatch loop
+        // to wire the registry). Default capabilities have supportsToolCalling: false.
+        let toolBackend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        ))
+        toolBackend.isModelLoaded = true
+
+        // Build a dedicated runtime with a ToolRegistry.
+        // Register ScriptedEchoTool directly in the registry (not via
+        // SessionToolSource) to keep the golden stable across the #1606 fix.
+        let registry = ToolRegistry()
+        registry.register(ScriptedEchoTool(toolName: "echo", response: "Echo: hello"))
+        let service = InferenceService(backend: toolBackend, name: "CharacterizationMock", toolRegistry: registry)
+        let toolRuntime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service
+        )
+        let toolDrain = EventTapDrain()
+        let toolDrainTask = await toolDrain.start(consuming: toolRuntime.addEventTap())
+
+        // Turn 1: backend emits a tool call; no visible text
+        // Turn 2: backend emits the final answer after the tool result is fed back
+        toolBackend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "tool-1", toolName: "echo", arguments: "{\"q\":\"hello\"}")]
+        ]
+        toolBackend.tokensToYieldPerTurn = [
+            [],        // turn 1: no visible tokens (tool call only)
+            ["Done"]   // turn 2: final response after tool result
+        ]
+
+        let toolSessionID = UUID()
+        let handle = try await toolRuntime.processTurnWithOutcome(
+            TurnInput(sessionID: toolSessionID, kind: .send(text: "Use the echo tool"))
+        )
+
+        // The tool dispatch loop produces ONE streamFinished covering both turns
+        var events: [ConversationEvent] = []
+        let end = ContinuousClock.now.advanced(by: .seconds(10))
+        while let event = await toolDrain.next() {
+            events.append(event)
+            if case .afterGeneration = event { break }
+            if case .errorRaised = event { break }
+            if case .streamFinished(_, let r) = event, r == .cancelled { break }
+            if ContinuousClock.now > end { break }
+        }
+        await handle?.outcome
+
+        toolDrainTask.cancel()
+
+        let records = try await persistenceStack.provider.fetchMessages(for: toolSessionID)
+        var c = EventTraceCanonicalizer()
+        assertSnapshot(
+            of: c.serialize(events: events),
+            as: .lines, named: "events", record: .missing
+        )
+        assertSnapshot(
+            of: c.serialize(records: records),
+            as: .lines, named: "records", record: .missing
+        )
+    }
+
+    // MARK: - Tool: forwarded without registry
+
+    func test_tool_forwarded_noRegistry() async throws {
+        // No ToolRegistry wired → tool call is forwarded upstream verbatim;
+        // the dispatch loop exits without executing the tool or re-prompting.
+        backend.scriptedToolCalls = [ToolCall(id: "tool-fwd-1", toolName: "search", arguments: "{}")]
+        backend.tokensToYield = []  // no visible text; tool call only
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Forward a tool call"))
+        )
+        let events = await drainTurn()
+        await handle?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: events, records: records)
+    }
+}

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_branch_withoutGenerate.branch-records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_branch_withoutGenerate.branch-records.txt
@@ -1,0 +1,1 @@
+0  id:<uuid:5> role:user content:"Branch source"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_branch_withoutGenerate.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_branch_withoutGenerate.events.txt
@@ -1,0 +1,9 @@
+0  messageInserted  id:<uuid:1> role:user content:"Branch source"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Branch source" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"Hello world"
+5  messageInserted  id:<uuid:3> role:assistant content:"Hello world"
+6  streamFinished  id:<uuid:3> reason:stop
+7  afterGeneration  id:<uuid:3> finalText:"Hello world"
+8  sessionBranched  newSession:<uuid:4> copiedCount:1

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_branch_withoutGenerate.source-records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_branch_withoutGenerate.source-records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Branch source"
+1  id:<uuid:3> role:assistant content:"Hello world"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_cancel_midStream.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_cancel_midStream.events.txt
@@ -1,0 +1,7 @@
+0  messageInserted  id:<uuid:1> role:user content:"Cancel me"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Cancel me" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"Hello"
+5  messageInserted  id:<uuid:3> role:assistant content:"Hello"
+6  streamFinished  id:<uuid:3> reason:cancelled

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_cancel_midStream.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_cancel_midStream.records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Cancel me"
+1  id:<uuid:3> role:assistant content:"Hello"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_edit_userMessage.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_edit_userMessage.events.txt
@@ -1,0 +1,17 @@
+0  messageInserted  id:<uuid:1> role:user content:"Original text"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Original text" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"Hello world"
+5  messageInserted  id:<uuid:3> role:assistant content:"Hello world"
+6  streamFinished  id:<uuid:3> reason:stop
+7  afterGeneration  id:<uuid:3> finalText:"Hello world"
+8  messageUpdated  id:<uuid:1> role:user content:"Edited text"
+9  messageRemoved  id:<uuid:3>
+10  beforeContextAssembly  session:<uuid:2> prompt:nil msgCount:1
+11  contextAssembled  slots:0
+12  streamStarted  id:<uuid:4>
+13  tokenEmitted  id:<uuid:4> delta:"Edited reply"
+14  messageInserted  id:<uuid:4> role:assistant content:"Edited reply"
+15  streamFinished  id:<uuid:4> reason:stop
+16  afterGeneration  id:<uuid:4> finalText:"Edited reply"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_edit_userMessage.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_edit_userMessage.records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Edited text"
+1  id:<uuid:4> role:assistant content:"Edited reply"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_regenerate.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_regenerate.events.txt
@@ -1,0 +1,16 @@
+0  messageInserted  id:<uuid:1> role:user content:"Hello"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Hello" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"Hello world"
+5  messageInserted  id:<uuid:3> role:assistant content:"Hello world"
+6  streamFinished  id:<uuid:3> reason:stop
+7  afterGeneration  id:<uuid:3> finalText:"Hello world"
+8  messageRemoved  id:<uuid:3>
+9  beforeContextAssembly  session:<uuid:2> prompt:nil msgCount:1
+10  contextAssembled  slots:0
+11  streamStarted  id:<uuid:4>
+12  tokenEmitted  id:<uuid:4> delta:"Hello world"
+13  messageInserted  id:<uuid:4> role:assistant content:"Hello world"
+14  streamFinished  id:<uuid:4> reason:stop
+15  afterGeneration  id:<uuid:4> finalText:"Hello world"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_regenerate.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_regenerate.records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Hello"
+1  id:<uuid:4> role:assistant content:"Hello world"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_send_plainTurn.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_send_plainTurn.events.txt
@@ -1,0 +1,8 @@
+0  messageInserted  id:<uuid:1> role:user content:"Hello"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Hello" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"Hello world"
+5  messageInserted  id:<uuid:3> role:assistant content:"Hello world"
+6  streamFinished  id:<uuid:3> reason:stop
+7  afterGeneration  id:<uuid:3> finalText:"Hello world"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_send_plainTurn.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_send_plainTurn.records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Hello"
+1  id:<uuid:3> role:assistant content:"Hello world"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_forwarded_noRegistry.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_forwarded_noRegistry.events.txt
@@ -1,0 +1,8 @@
+0  messageInserted  id:<uuid:1> role:user content:"Forward a tool call"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Forward a tool call" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  toolCallRequested  callId:tool-fwd-1 tool:search
+5  messageInserted  id:<uuid:3> role:assistant content:(empty)
+6  streamFinished  id:<uuid:3> reason:stop
+7  afterGeneration  id:<uuid:3> finalText:""

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_forwarded_noRegistry.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_forwarded_noRegistry.records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Forward a tool call"
+1  id:<uuid:3> role:assistant content:(empty)

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_roundTrip.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_roundTrip.events.txt
@@ -1,0 +1,10 @@
+0  messageInserted  id:<uuid:1> role:user content:"Use the echo tool"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Use the echo tool" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  toolCallRequested  callId:tool-1 tool:echo
+5  toolCallCompleted  callId:tool-1 status:ok
+6  tokenEmitted  id:<uuid:3> delta:"Done"
+7  messageInserted  id:<uuid:3> role:assistant content:"Done"
+8  streamFinished  id:<uuid:3> reason:stop
+9  afterGeneration  id:<uuid:3> finalText:"Done"

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_roundTrip.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/TurnLoopCharacterizationTests/test_tool_roundTrip.records.txt
@@ -1,0 +1,2 @@
+0  id:<uuid:1> role:user content:"Use the echo tool"
+1  id:<uuid:3> role:assistant content:"Done" parts:3

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -220,6 +220,7 @@ PROFILE_CI_XCTEST_FILTERS=(
     ManifoldTestSupportTests
     ManifoldAppIntentsTests
     ManifoldServerTests
+    ManifoldTurnLoopCharacterizationTests
 )
 # Local-profile filters extend the CI list with the suites PR #1382 proved
 # we need to hit when traits are on (KV cache reuse race, etc.).


### PR DESCRIPTION
## Summary

- New `ManifoldTurnLoopCharacterizationTests` target (no-trait, CI-gated from day 1) snapshot-tests the `ConversationEvent` stream and final persisted `ChatMessageRecord` list for every `ConversationRuntime` verb.
- 7 golden-transcript tests cover: `send`, `regenerate`, `edit`, `branch` (no-generate), cancel mid-stream, tool round-trip (real two-turn dispatch loop), and tool-forwarded-no-registry.
- 15 golden `.txt` files recorded on `main` — P2 (engine carve) and P3a (`SingleTurnDriver`) prove behaviour-preservation by diffing against them.
- Wired into `scripts/test.sh` CI + local profiles and `ci.yml` `test-xctest-suites` step.

## Closes

Closes #1607.

## Design notes

**Dedicated target, not `ManifoldSnapshotTests`.** The existing snapshot target carries UI/SwiftUI deps and isn't in the CI filter — view snapshots are environment-sensitive. This harness is data-only, no UI dep, must be CI-gated.

**`EventTapDrain` actor.** Swift 6 disallows calling `mutating next()` on an actor-isolated stored property across a suspension. Wrapping the iterator in an actor that buffers via a background drain `Task` sidesteps the restriction cleanly.

**Drain terminal is `afterGeneration`, not `streamFinished`.** In `ConversationTurnExecutor` the happy-path order is `streamFinished` → `afterGeneration`. Stopping at `streamFinished` misses the terminal event. For cancelled turns `afterGeneration` doesn't fire; the drain falls back to `streamFinished(.cancelled)`.

**`ScriptedEchoTool` in `ToolRegistry`, not `SessionToolSource`.** The #1606 dead-path bug means `SessionToolSource.resolve` is currently unreachable. Registry dispatch keeps the golden stable across that fix — a `SessionToolSource`-based golden would intentionally diff when #1606 lands.

**UUID canonicalisation, no injected clock/IDs.** All UUIDs are replaced by positional `<uuid:N>` labels in order of first appearance. No production changes required. Injectable clock/ID sources are deferred to P3 where production needs them for resumable run checkpoints.

**Relocation plan.** This target will move into `ManifoldEngineTests` when P2 creates it; the golden files travel with the test.

## Test plan

- [x] `swift test --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --skip-update` — 7/7 pass (verified on two consecutive runs after initial golden recording)
- [x] `swift build --build-tests --disable-default-traits` — clean
- [x] `git diff --stat` — 3 config files + new test directory only; `Package.resolved` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)