### PR TITLE
perf(ci): Tier 0 selective-testing resolver (dry-run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
             elif [ "$affected" = "NONE" ]; then
               echo "Would run **no** test-job suites (change covered by sibling jobs or non-code paths)."
             else
-              n=$(printf '%s\n' $affected | wc -w | tr -d ' ')
+              n=$(printf '%s\n' "$affected" | wc -w | tr -d ' ')
               echo "Would run **${n}** affected test-job suite(s): \`${affected}\`"
             fi
             echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ on:
       - "scripts/check-foundation-only-bundle.sh"
       - "scripts/test-ios-simulator.sh"
       - "scripts/lint-no-new-force-unwraps.sh"
+      # Tier 0 selective-testing gate (issue #1588). Listed so edits to the
+      # resolver or its committed graph snapshot re-trigger CI and the dry-run
+      # logging — otherwise a change to the gate would bypass the gate.
+      - "scripts/affected-suites.sh"
+      - "scripts/affected-suites-graph.json"
   pull_request:
     branches: [main]
     paths:
@@ -31,6 +36,11 @@ on:
       - "scripts/check-foundation-only-bundle.sh"
       - "scripts/test-ios-simulator.sh"
       - "scripts/lint-no-new-force-unwraps.sh"
+      # Tier 0 selective-testing gate (issue #1588). Listed so edits to the
+      # resolver or its committed graph snapshot re-trigger CI and the dry-run
+      # logging — otherwise a change to the gate would bypass the gate.
+      - "scripts/affected-suites.sh"
+      - "scripts/affected-suites-graph.json"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -51,6 +61,10 @@ jobs:
       cold-start: ${{ steps.filter.outputs.cold-start }}
       persistence: ${{ steps.filter.outputs.persistence }}
       foundation-only: ${{ steps.filter.outputs.foundation-only }}
+      # Tier 0 (issue #1588): the affected per-PR test-job suite list, or the
+      # sentinel FULL / NONE. DRY-RUN — published for a later PR to wire into the
+      # test --filter; nothing consumes it to change execution yet.
+      affected: ${{ steps.affected.outputs.affected }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -58,7 +72,13 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          # `list-files: json` exposes the full changed-file list as
+          # `steps.filter.outputs.all_files` (via the catch-all `all` filter
+          # below) for the Tier 0 resolver to map to affected suites.
+          list-files: json
           filters: |
+            all:
+              - '**'
             server:
               - 'Sources/ManifoldServer*/**'
               - 'Tests/ManifoldServerTests/**'
@@ -95,6 +115,50 @@ jobs:
               - 'Sources/ManifoldFoundation/**'
               - 'scripts/check-foundation-only-bundle.sh'
               - '.github/workflows/ci.yml'
+
+      # Tier 0 selective testing — DRY-RUN ONLY (issue #1588).
+      #
+      # Maps the diff to the subset of per-PR `test`-job suites it could affect,
+      # using the committed SwiftPM target-graph snapshot
+      # (scripts/affected-suites-graph.json) so this 1×-billed ubuntu job needs
+      # only jq — no Swift toolchain (ubuntu-latest has none; resolving the graph
+      # on Linux fails on the Apple-only MLX/llama deps anyway). The snapshot is
+      # derived purely from Package.swift and its freshness is guarded in the
+      # `test` job.
+      #
+      # This step changes NOTHING about what executes: the `test` job below still
+      # runs its full hard-coded --filter list. It only logs what a selective run
+      # WOULD do and publishes the result as the `affected` job output, so a later
+      # PR can wire it to --filter once a week of this data confirms the projected
+      # ~15–20% reduction. On push to main (and nightly) the resolver returns FULL
+      # — selective applies to pull_request only.
+      - name: Tier 0 — affected-suite resolver (dry-run, informational)
+        id: affected
+        env:
+          ALL_FILES: ${{ steps.filter.outputs.all_files }}
+          MANIFOLD_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+          files="${ALL_FILES:-[]}"
+          # Never let a resolver hiccup fail the cheap changes job; fall back to FULL.
+          affected="$(printf '%s' "$files" | jq -r '.[]?' | bash scripts/affected-suites.sh)" || affected=FULL
+          [ -z "$affected" ] && affected=FULL
+          echo "affected=$affected" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Tier 0 selective-testing — dry-run (issue #1588)"
+            echo ""
+            if [ "$affected" = "FULL" ]; then
+              echo "Would run the **full** test-job suite list (no narrowing)."
+            elif [ "$affected" = "NONE" ]; then
+              echo "Would run **no** test-job suites (change covered by sibling jobs or non-code paths)."
+            else
+              n=$(printf '%s\n' $affected | wc -w | tr -d ' ')
+              echo "Would run **${n}** affected test-job suite(s): \`${affected}\`"
+            fi
+            echo ""
+            echo "_Execution is unchanged — the \`test\` job still runs its full hard-coded \`--filter\` list. Tier 0 addresses the ~136s execution half only; compile (~127s) is Tier 2._"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Tier 0 dry-run: affected=${affected}"
 
   test:
     runs-on: macos-15  # Apple Silicon (arm64) standard runner to reduce spend
@@ -290,6 +354,24 @@ jobs:
           swift package resolve
           git diff --exit-code Package.resolved || \
             (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
+
+      - name: Verify Tier 0 affected-suites graph snapshot is up to date
+        # The Tier 0 resolver (scripts/affected-suites.sh, issue #1588) reads a
+        # committed snapshot of the SwiftPM target graph so the ubuntu `changes`
+        # job can resolve affected suites with jq alone (no Swift on Linux). The
+        # snapshot is derived purely from Package.swift, so it can only drift when
+        # the manifest changes — gate on deps-changed (same as the lockfile check
+        # above) and fail if the committed copy is stale so it is regenerated in
+        # the same PR.
+        if: steps.deps-changed.outputs.deps == 'true'
+        run: |
+          set -euo pipefail
+          scripts/affected-suites.sh --generate > /tmp/affected-suites-graph.json
+          diff -u scripts/affected-suites-graph.json /tmp/affected-suites-graph.json || {
+            echo "::error::scripts/affected-suites-graph.json is stale — run 'scripts/affected-suites.sh --generate > scripts/affected-suites-graph.json' and commit."
+            exit 1
+          }
+          echo "Tier 0 affected-suites graph snapshot OK."
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs ManifoldCoreTests + ManifoldRuntimeTests + ManifoldPersistenceSwiftDataTests

--- a/Package.swift
+++ b/Package.swift
@@ -411,6 +411,12 @@ let package = Package(
             dependencies: [
                 "ManifoldInference",
                 "ManifoldCloudCore",
+                // DefaultWebSearchRuntime conforms to the WebSearchRuntime port
+                // declared in ManifoldRuntime. This is a library→library edge
+                // (not a consumer→family edge) so it stays un-gated per the
+                // trait-gating rule. ManifoldRuntime is SwiftData-free, so this
+                // does not drag SwiftData into the family target.
+                "ManifoldRuntime",
             ],
             path: "Sources/ManifoldCloud",
             swiftSettings: [

--- a/scripts/affected-suites-graph.json
+++ b/scripts/affected-suites-graph.json
@@ -7,11 +7,17 @@
       "path": "Sources/ManifoldMacrosPlugin",
       "deps": []
     },
+    "ManifoldNetworking": {
+      "type": "regular",
+      "path": "Sources/ManifoldNetworking",
+      "deps": []
+    },
     "ManifoldInference": {
       "type": "regular",
       "path": "Sources/ManifoldInference",
       "deps": [
-        "ManifoldMacrosPlugin"
+        "ManifoldMacrosPlugin",
+        "ManifoldNetworking"
       ]
     },
     "ManifoldMCP": {
@@ -238,6 +244,15 @@
       "path": "Tests/ManifoldInferenceSwiftTestingTests",
       "deps": [
         "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldNetworkingTests": {
+      "type": "test",
+      "path": "Tests/ManifoldNetworkingTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldNetworking",
         "ManifoldTestSupport"
       ]
     },

--- a/scripts/affected-suites-graph.json
+++ b/scripts/affected-suites-graph.json
@@ -97,7 +97,8 @@
       "path": "Sources/ManifoldCloud",
       "deps": [
         "ManifoldCloudCore",
-        "ManifoldInference"
+        "ManifoldInference",
+        "ManifoldRuntime"
       ]
     },
     "ManifoldBackends": {

--- a/scripts/affected-suites-graph.json
+++ b/scripts/affected-suites-graph.json
@@ -1,0 +1,492 @@
+{
+  "generatedBy": "scripts/affected-suites.sh --generate (swift package dump-package)",
+  "note": "Committed snapshot of the SwiftPM target graph. Regenerate when Package.swift changes; CI guards freshness.",
+  "targets": {
+    "ManifoldMacrosPlugin": {
+      "type": "macro",
+      "path": "Sources/ManifoldMacrosPlugin",
+      "deps": []
+    },
+    "ManifoldInference": {
+      "type": "regular",
+      "path": "Sources/ManifoldInference",
+      "deps": [
+        "ManifoldMacrosPlugin"
+      ]
+    },
+    "ManifoldMCP": {
+      "type": "regular",
+      "path": "Sources/ManifoldMCP",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldMCPHost": {
+      "type": "regular",
+      "path": "Sources/ManifoldMCPHost",
+      "deps": [
+        "ManifoldMCP",
+        "ManifoldRuntime"
+      ]
+    },
+    "ManifoldRuntime": {
+      "type": "regular",
+      "path": "Sources/ManifoldRuntime",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldSkills": {
+      "type": "regular",
+      "path": "Sources/ManifoldSkills",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldRuntime"
+      ]
+    },
+    "ManifoldPersistenceSwiftData": {
+      "type": "regular",
+      "path": "Sources/ManifoldPersistenceSwiftData",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldRuntime"
+      ]
+    },
+    "StableDiffusion": {
+      "type": "regular",
+      "path": "Sources/StableDiffusion",
+      "deps": []
+    },
+    "ManifoldCloudCore": {
+      "type": "regular",
+      "path": "Sources/ManifoldCloudCore",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldMLX": {
+      "type": "regular",
+      "path": "Sources/ManifoldMLX",
+      "deps": [
+        "FluxSwift",
+        "ManifoldInference",
+        "StableDiffusion"
+      ]
+    },
+    "FluxSwift": {
+      "type": "regular",
+      "path": "Sources/FluxSwift",
+      "deps": []
+    },
+    "ManifoldLlama": {
+      "type": "regular",
+      "path": "Sources/ManifoldLlama",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldFoundation": {
+      "type": "regular",
+      "path": "Sources/ManifoldFoundation",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldCloud": {
+      "type": "regular",
+      "path": "Sources/ManifoldCloud",
+      "deps": [
+        "ManifoldCloudCore",
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldBackends": {
+      "type": "regular",
+      "path": "Sources/ManifoldBackendsUmbrella",
+      "deps": [
+        "ManifoldCloud",
+        "ManifoldCloudCore",
+        "ManifoldFoundation",
+        "ManifoldInference",
+        "ManifoldLlama",
+        "ManifoldMLX"
+      ]
+    },
+    "ManifoldUI": {
+      "type": "regular",
+      "path": "Sources/ManifoldUI",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldRuntime"
+      ]
+    },
+    "ManifoldUIModelManagement": {
+      "type": "regular",
+      "path": "Sources/ManifoldUIModelManagement",
+      "deps": [
+        "ManifoldHuggingFace",
+        "ManifoldInference",
+        "ManifoldRuntime",
+        "ManifoldUI"
+      ]
+    },
+    "ManifoldHuggingFace": {
+      "type": "regular",
+      "path": "Sources/ManifoldHuggingFace",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldKit": {
+      "type": "regular",
+      "path": "Sources/ManifoldKit",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldSkills",
+        "ManifoldUI"
+      ]
+    },
+    "ManifoldVoice": {
+      "type": "regular",
+      "path": "Sources/ManifoldVoice",
+      "deps": [
+        "ManifoldUI"
+      ]
+    },
+    "ManifoldTestSupport": {
+      "type": "regular",
+      "path": "Sources/ManifoldTestSupport",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime"
+      ]
+    },
+    "ManifoldContractTestSupport": {
+      "type": "regular",
+      "path": "Sources/ManifoldContractTestSupport",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldCoreTests": {
+      "type": "test",
+      "path": "Tests/ManifoldCoreTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldRuntimeTests": {
+      "type": "test",
+      "path": "Tests/ManifoldRuntimeTests",
+      "deps": [
+        "ManifoldContractTestSupport",
+        "ManifoldInference",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldSkillsTests": {
+      "type": "test",
+      "path": "Tests/ManifoldSkillsTests",
+      "deps": [
+        "ManifoldContractTestSupport",
+        "ManifoldInference",
+        "ManifoldRuntime",
+        "ManifoldSkills"
+      ]
+    },
+    "ManifoldPersistenceSwiftDataTests": {
+      "type": "test",
+      "path": "Tests/ManifoldPersistenceSwiftDataTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldTestSupportTests": {
+      "type": "test",
+      "path": "Tests/ManifoldTestSupportTests",
+      "deps": [
+        "ManifoldContractTestSupport",
+        "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldInferenceTests": {
+      "type": "test",
+      "path": "Tests/ManifoldInferenceTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldMacrosPlugin",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldInferenceSwiftTestingTests": {
+      "type": "test",
+      "path": "Tests/ManifoldInferenceSwiftTestingTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldMCPTests": {
+      "type": "test",
+      "path": "Tests/ManifoldMCPTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldMCP",
+        "ManifoldMCPHost",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldMCPE2ETests": {
+      "type": "test",
+      "path": "Tests/ManifoldMCPE2ETests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldMCP",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldBackendsTests": {
+      "type": "test",
+      "path": "Tests/ManifoldBackendsTests",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldCloud",
+        "ManifoldCloudCore",
+        "ManifoldFoundation",
+        "ManifoldInference",
+        "ManifoldLlama",
+        "ManifoldMLX",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport",
+        "ManifoldUI"
+      ]
+    },
+    "ManifoldUITests": {
+      "type": "test",
+      "path": "Tests/ManifoldUITests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport",
+        "ManifoldUI"
+      ]
+    },
+    "ManifoldVoiceTests": {
+      "type": "test",
+      "path": "Tests/ManifoldVoiceTests",
+      "deps": [
+        "ManifoldVoice"
+      ]
+    },
+    "ManifoldUIModelManagementTests": {
+      "type": "test",
+      "path": "Tests/ManifoldUIModelManagementTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport",
+        "ManifoldUI",
+        "ManifoldUIModelManagement"
+      ]
+    },
+    "ManifoldHuggingFaceTests": {
+      "type": "test",
+      "path": "Tests/ManifoldHuggingFaceTests",
+      "deps": [
+        "ManifoldHuggingFace",
+        "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldServer": {
+      "type": "executable",
+      "path": "Sources/ManifoldServer",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldServerTests": {
+      "type": "test",
+      "path": "Tests/ManifoldServerTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldServer",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldE2ETests": {
+      "type": "test",
+      "path": "Tests/ManifoldE2ETests",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldCloud",
+        "ManifoldCloudCore",
+        "ManifoldFoundation",
+        "ManifoldHuggingFace",
+        "ManifoldInference",
+        "ManifoldLlama",
+        "ManifoldMLX",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport",
+        "ManifoldTools",
+        "ManifoldUI"
+      ]
+    },
+    "ManifoldSnapshotTests": {
+      "type": "test",
+      "path": "Tests/ManifoldSnapshotTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport",
+        "ManifoldUI",
+        "ManifoldUIModelManagement"
+      ]
+    },
+    "ManifoldTurnLoopCharacterizationTests": {
+      "type": "test",
+      "path": "Tests/ManifoldTurnLoopCharacterizationTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldFuzz": {
+      "type": "regular",
+      "path": "Sources/ManifoldFuzz",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldFuzzBackends": {
+      "type": "regular",
+      "path": "Sources/ManifoldFuzzBackends",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldFuzz",
+        "ManifoldInference"
+      ]
+    },
+    "fuzz-chat": {
+      "type": "executable",
+      "path": "Sources/fuzz-chat",
+      "deps": [
+        "ManifoldFuzz",
+        "ManifoldFuzzBackends",
+        "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldFuzzTests": {
+      "type": "test",
+      "path": "Tests/ManifoldFuzzTests",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldFuzz",
+        "ManifoldFuzzBackends",
+        "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldTools": {
+      "type": "regular",
+      "path": "Sources/ManifoldTools",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "manifold-tools": {
+      "type": "executable",
+      "path": "Sources/manifold-tools",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldInference",
+        "ManifoldTools"
+      ]
+    },
+    "ManifoldToolsTests": {
+      "type": "test",
+      "path": "Tests/ManifoldToolsTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldTestSupport",
+        "ManifoldTools"
+      ]
+    },
+    "ManifoldAppIntents": {
+      "type": "regular",
+      "path": "Sources/ManifoldAppIntents",
+      "deps": [
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldAppIntentsTests": {
+      "type": "test",
+      "path": "Tests/ManifoldAppIntentsTests",
+      "deps": [
+        "ManifoldAppIntents",
+        "ManifoldInference"
+      ]
+    },
+    "ManifoldMLXIntegrationTests": {
+      "type": "test",
+      "path": "Tests/ManifoldMLXIntegrationTests",
+      "deps": [
+        "ManifoldBackends",
+        "ManifoldInference",
+        "ManifoldMLX",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "APIFreezeTests": {
+      "type": "test",
+      "path": "Tests/APIFreezeTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldPersistenceSwiftData",
+        "ManifoldRuntime",
+        "ManifoldTestSupport"
+      ]
+    },
+    "ManifoldKitTests": {
+      "type": "test",
+      "path": "Tests/ManifoldKitTests",
+      "deps": [
+        "ManifoldKit"
+      ]
+    },
+    "ManifoldAuditSabotageSuiteTests": {
+      "type": "test",
+      "path": "Tests/ManifoldAuditSabotageSuiteTests",
+      "deps": [
+        "ManifoldInference",
+        "ManifoldTestSupport"
+      ]
+    }
+  }
+}

--- a/scripts/affected-suites.sh
+++ b/scripts/affected-suites.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# Tier 0 selective-testing resolver — maps a set of changed paths to the
+# subset of per-PR `test`-job suites that could be affected, using the SwiftPM
+# target dependency graph.
+#
+# STATUS: DRY-RUN. The `test` job in .github/workflows/ci.yml still executes its
+# full hard-coded `--filter` list. This script only *computes and logs* what a
+# selective run WOULD execute and publishes it as a `changes`-job output, so a
+# later PR can wire it to `--filter` once a week of live data confirms the
+# projected ~15–20% reduction (see issue #1588). Nothing here changes what runs.
+#
+# WHY a committed graph snapshot instead of `swift package describe` in CI:
+#   The `changes` job runs on ubuntu-latest (1× billing) specifically to AVOID a
+#   10×-billed macOS runner. ubuntu-latest ships no Swift toolchain, and
+#   resolving ManifoldKit's graph on Linux would fail anyway (MLX / llama.cpp are
+#   Apple-only). The target dependency graph is derived *purely* from the
+#   manifest (`swift package dump-package` reads Package.swift, no dependency
+#   resolution, no network), and it can only change when Package.swift changes.
+#   So we commit a normalized snapshot (`affected-suites-graph.json`), read it in
+#   CI with nothing but `jq`, and keep it honest two ways:
+#     1. Any Package.swift edit FORCES a full run (the manifest is in the
+#        force-full set below), so a stale snapshot can never cause an
+#        under-selection on the PR that changed the graph.
+#     2. A CI guard step (gated on the deps-changed filter, mirroring the
+#        Package.resolved freshness check) regenerates the snapshot and fails on
+#        drift, so the committed copy is updated in the same PR.
+#
+# USAGE
+#   Resolve (default): changed paths on stdin (one per line) → one line on stdout
+#       printf '%s\n' Sources/ManifoldUI/Foo.swift | scripts/affected-suites.sh
+#     stdout is exactly one of:
+#       - a space-separated subset of the test-job suite names, or
+#       - "FULL"  (run everything — manifest/CI/hub/gate change or unmapped path), or
+#       - "NONE"  (no test-job suite is affected; sibling jobs cover the change)
+#     Human-readable reasoning goes to stderr.
+#
+#   Regenerate the snapshot (needs Swift + jq, run on macOS / locally):
+#       scripts/affected-suites.sh --generate > scripts/affected-suites-graph.json
+#
+# Robustness: the resolve path never exits non-zero for "I don't know" — it
+# falls back to FULL. The CI step treats any hard failure as FULL too. Selective
+# narrowing must never be able to SKIP a suite that should have run.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GRAPH_FILE="${MANIFOLD_GRAPH_FILE:-$SCRIPT_DIR/affected-suites-graph.json}"
+
+# ---------------------------------------------------------------------------
+# Suites the per-PR `test` job actually executes (the hard-coded --filter set in
+# ci.yml). The resolver only ever emits names from THIS set: suites that run in
+# sibling jobs (server / macros / cold-start / iOS file-protection) or not at all
+# in per-PR CI have their own paths filters and are never this gate's concern.
+# PinnedSessionDelegateTests is a class-level --filter inside ManifoldBackendsTests,
+# so at suite granularity it is covered by ManifoldBackendsTests.
+# ---------------------------------------------------------------------------
+TEST_JOB_SUITES=(
+  ManifoldCoreTests
+  ManifoldRuntimeTests
+  ManifoldPersistenceSwiftDataTests
+  ManifoldUITests
+  ManifoldUIModelManagementTests
+  ManifoldMCPTests
+  ManifoldTestSupportTests
+  ManifoldAppIntentsTests
+  ManifoldInferenceTests
+  ManifoldTurnLoopCharacterizationTests
+  ManifoldBackendsTests
+  ManifoldInferenceSwiftTestingTests
+)
+
+# ---------------------------------------------------------------------------
+# --generate: rebuild the committed snapshot from the live manifest.
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--generate" ]]; then
+  if ! command -v swift >/dev/null 2>&1; then
+    echo "error: --generate needs the Swift toolchain on PATH" >&2
+    exit 2
+  fi
+  # dump-package reads only Package.swift (no resolution / no network). We
+  # normalize it to { targets: { name: { type, path, deps:[local targets] } } }.
+  # path defaults: Sources/<name> for non-test targets, Tests/<name> for tests
+  # (SwiftPM's own default layout) when the manifest leaves .path null.
+  swift package --package-path "$SCRIPT_DIR/.." dump-package \
+    | jq '
+        [.targets[].name] as $local
+        | {
+            generatedBy: "scripts/affected-suites.sh --generate (swift package dump-package)",
+            note: "Committed snapshot of the SwiftPM target graph. Regenerate when Package.swift changes; CI guards freshness.",
+            targets: (reduce .targets[] as $t ({}; .[$t.name] = {
+                type: $t.type,
+                path: ($t.path // (if $t.type == "test" then "Tests/\($t.name)" else "Sources/\($t.name)" end)),
+                deps: ([$t.dependencies[]? | (.byName[0] // .target[0]) | select(. != null)]
+                       | map(select(. as $d | $local | index($d))) | unique)
+            }))
+          }'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve mode.
+# ---------------------------------------------------------------------------
+log() { printf '%s\n' "$*" >&2; }
+
+emit() { # print result to stdout and stop
+  printf '%s\n' "$1"
+  exit 0
+}
+
+# Selective testing applies to pull_request only. Pushes to main and the nightly
+# workflow always run the full suite (safety net per #1588).
+EVENT_NAME="${MANIFOLD_EVENT_NAME:-pull_request}"
+if [[ "$EVENT_NAME" != "pull_request" ]]; then
+  log "event=$EVENT_NAME → full suite (selective applies to pull_request only)"
+  emit FULL
+fi
+
+if [[ ! -f "$GRAPH_FILE" ]]; then
+  log "graph snapshot not found at $GRAPH_FILE → FULL (conservative)"
+  emit FULL
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  log "jq not available → FULL (conservative)"
+  emit FULL
+fi
+
+# Read changed paths from stdin.
+mapfile -t CHANGED < <(grep -v '^[[:space:]]*$' || true)
+# `${arr[*]:-}` is the set -u-safe emptiness test: an empty (hence "unset") array
+# would make a bare `${#arr[@]}` trip nounset, so guard with the `:-` form.
+if [[ -z "${CHANGED[*]:-}" ]]; then
+  log "no changed paths on stdin → NONE"
+  emit NONE
+fi
+
+# ---- Force-full surface -----------------------------------------------------
+# Hub modules fan out to nearly every suite; the manifest / lockfile / CI config
+# can change build or trait semantics globally; the gate's own script + snapshot
+# and the shared test harness scripts change how everything runs. Any of these
+# → full run. (Hubs are also force-full so we never rely on closure completeness
+# for the highest-fan-out modules.)
+HUB_PREFIXES=(
+  "Sources/ManifoldInference/"
+  "Sources/ManifoldRuntime/"
+  "Sources/ManifoldPersistenceSwiftData/"
+)
+FORCE_FULL_EXACT=(
+  "Package.swift"
+  "Package.resolved"
+  "scripts/affected-suites.sh"
+  "scripts/affected-suites-graph.json"
+  "scripts/test.sh"
+  "scripts/ci-test-with-watchdog.sh"
+)
+for p in "${CHANGED[@]}"; do
+  case "$p" in
+    .github/*) log "force-full: $p (CI config)"; emit FULL ;;
+  esac
+  for ex in "${FORCE_FULL_EXACT[@]}"; do
+    [[ "$p" == "$ex" ]] && { log "force-full: $p (manifest/gate/harness)"; emit FULL; }
+  done
+  for hub in "${HUB_PREFIXES[@]}"; do
+    [[ "$p" == "$hub"* ]] && { log "force-full: $p (hub module)"; emit FULL; }
+  done
+done
+
+# ---- Load the committed graph into bash maps --------------------------------
+declare -A TYPE TPATH DEPS
+while IFS=$'\t' read -r name type tpath deps; do
+  TYPE["$name"]="$type"
+  TPATH["$name"]="$tpath"
+  DEPS["$name"]="$deps"   # comma-separated local target names
+done < <(jq -r '.targets | to_entries[] | "\(.key)\t\(.value.type)\t\(.value.path)\t\(.value.deps | join(","))"' "$GRAPH_FILE")
+
+if [[ ${#TYPE[@]} -eq 0 ]]; then
+  log "graph snapshot parsed to 0 targets → FULL (conservative)"
+  emit FULL
+fi
+
+# ---- Map each changed path to its owning target (longest path-prefix match) --
+declare -A CHANGED_TARGETS
+for p in "${CHANGED[@]}"; do
+  # Only Sources/ and Tests/ paths can map to a target. Anything else (docs,
+  # READMEs, …) cannot affect compiled test outcomes and is ignored.
+  case "$p" in
+    Sources/*|Tests/*) ;;
+    *) continue ;;
+  esac
+  best=""; best_len=-1
+  for name in "${!TPATH[@]}"; do
+    tp="${TPATH[$name]}"
+    if [[ "$p" == "$tp/"* || "$p" == "$tp" ]]; then
+      len=${#tp}
+      if (( len > best_len )); then best="$name"; best_len=$len; fi
+    fi
+  done
+  if [[ -z "$best" ]]; then
+    log "force-full: $p maps to no known target (conservative)"
+    emit FULL
+  fi
+  CHANGED_TARGETS["$best"]=1
+  log "changed: $p → target $best"
+done
+
+if [[ -z "${CHANGED_TARGETS[*]:-}" ]]; then
+  log "no changed path maps to a target → NONE"
+  emit NONE
+fi
+
+# Partition changed targets into directly-changed test suites vs source targets.
+declare -A CHANGED_SOURCES
+declare -A DIRECT_SUITES
+for t in "${!CHANGED_TARGETS[@]}"; do
+  if [[ "${TYPE[$t]}" == "test" ]]; then
+    DIRECT_SUITES["$t"]=1
+  else
+    CHANGED_SOURCES["$t"]=1
+  fi
+done
+
+# ---- Forward closure of a test target over local deps (BFS) -----------------
+# Returns (via global CLOSURE assoc array) every local target reachable from the
+# given test target, including itself.
+declare -A CLOSURE
+closure_of() {
+  local start="$1"
+  CLOSURE=()
+  local -a queue=("$start")
+  CLOSURE["$start"]=1
+  while (( ${#queue[@]} > 0 )); do
+    local cur="${queue[0]}"
+    queue=("${queue[@]:1}")
+    local deps="${DEPS[$cur]:-}"
+    [[ -z "$deps" ]] && continue
+    local IFS=','
+    local d
+    for d in $deps; do
+      [[ -z "$d" ]] && continue
+      if [[ -z "${CLOSURE[$d]:-}" ]]; then
+        CLOSURE["$d"]=1
+        queue+=("$d")
+      fi
+    done
+  done
+}
+
+# ---- Reverse mapping: which test-job suites are affected --------------------
+declare -A AFFECTED
+for suite in "${TEST_JOB_SUITES[@]}"; do
+  # A directly-changed test suite always runs.
+  if [[ -n "${DIRECT_SUITES[$suite]:-}" ]]; then
+    AFFECTED["$suite"]=1
+    continue
+  fi
+  # Otherwise the suite is affected if its dependency closure includes any
+  # changed source target.
+  [[ -z "${TYPE[$suite]:-}" ]] && continue   # suite not in graph; skip defensively
+  closure_of "$suite"
+  for src in "${!CHANGED_SOURCES[@]}"; do
+    if [[ -n "${CLOSURE[$src]:-}" ]]; then
+      AFFECTED["$suite"]=1
+      break
+    fi
+  done
+done
+
+if [[ -z "${AFFECTED[*]:-}" ]]; then
+  log "no test-job suite affected (change covered by sibling jobs or no test) → NONE"
+  emit NONE
+fi
+
+# Stable, deterministic ordering for the output line. Safe to expand AFFECTED
+# unguarded here: the emptiness check above already returned for the empty case.
+result="$(printf '%s\n' "${!AFFECTED[@]}" | sort | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+log "affected ${#AFFECTED[@]}/${#TEST_JOB_SUITES[@]} test-job suites: $result"
+emit "$result"


### PR DESCRIPTION
## What

Lands the **dry-run** half of Tier 0 execution-only selective testing. A new resolver maps a PR's diff to the subset of per-PR `test`-job suites it could affect, using the SwiftPM target dependency graph. It **logs what a selective run would do** and publishes the result as a `changes`-job output — **without changing what the `test` job executes**. A later PR wires it to `--filter` once ~1 week of live data confirms the projected reduction.

Part of #1588 (the switch-flip to actually narrow `--filter` is the deliberate follow-up the issue mandates).

## How

- **`scripts/affected-suites.sh`** — resolver + `--generate` mode. Reverse-closures each per-PR `test`-job suite over the SwiftPM target graph and prints the affected suite list, or a `FULL` / `NONE` sentinel. Reasoning goes to stderr; the single result line to stdout.
- **`scripts/affected-suites-graph.json`** — committed, normalized snapshot of the target graph (54 targets). The 1×-billed ubuntu `changes` job resolves with **`jq` alone** — ubuntu-latest has no Swift toolchain, and the Apple-only MLX/llama deps cannot resolve on Linux anyway. The graph is derived *purely* from `Package.swift`, so it can only drift when the manifest changes.
- **`.github/workflows/ci.yml`**:
  - `changes` job: enables `list-files: json` + a catch-all `all` filter, runs the resolver, writes a step-summary, and exports `affected` as a job output.
  - `test` job: a **freshness guard** (gated on `deps-changed`, mirroring the `Package.resolved` check) regenerates the snapshot and fails on drift, so a stale graph is regenerated in the same PR.
  - The resolver script + graph are added to the top-level `paths:` filters so **edits to the gate cannot bypass the gate** (`[[feedback_ci_path_filter_self_validation]]`).

## Safety net (designed in, dormant during dry-run)

- **`pull_request` only** — push to `main` / nightly resolve to `FULL`.
- **Force-full** on `Package.swift`, `Package.resolved`, `.github/**`, hub modules (`ManifoldInference` / `ManifoldRuntime` / `ManifoldPersistenceSwiftData`), the gate's own script + snapshot, and the shared test-harness scripts.
- **Conservative**: a changed `Sources/**` or `Tests/**` path that maps to no known target → `FULL`.

## Known ceiling (no over-claim)

`swift test --filter X` from clean still **compiles the whole bundle** — Tier 0 saves the **execution** half (~136s), not compile (~127s). Realistic narrow-PR win **~16m → ~12–13m (~15–20% of total CI minutes)**. Compile pruning is Tier 2.

## Validation done locally

- `swift package dump-package` parses; `--generate` is **idempotent** (committed snapshot == fresh regeneration).
- Resolver desk-checked against representative diffs: UI-only → `ManifoldBackendsTests ManifoldUIModelManagementTests ManifoldUITests` (the UI→Backends edge is real in the manifest); MCP-test-only → `ManifoldMCPTests`; `Package.swift` / hub / `.github` / unmapped-path / gate-self-edit → `FULL`; docs-only / server-only / voice-only → `NONE`; `push` event → `FULL`.
- `bash -n` + `shellcheck -S warning` clean; `ci.yml` parses; **no `test`-job `--filter` invocation changed** (verified via diff).

## Not validated without live CI

Cannot run GitHub Actions locally, so the `changes`-job wiring (dorny `all_files` JSON shape, `$GITHUB_OUTPUT` / `$GITHUB_STEP_SUMMARY` plumbing) and the macOS freshness-guard step are desk-checked only. The resolver step is wrapped to fall back to `FULL` on any hiccup and never fails the cheap `changes` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also fixes: ManifoldCloud→ManifoldRuntime missing dependency edge (latent build-ordering bug)

`Sources/ManifoldCloud/WebSearch/DefaultWebSearchRuntime.swift` `import`s `ManifoldRuntime` and conforms to the `WebSearchRuntime` port declared there, but the `ManifoldCloud` target only declared `ManifoldInference` + `ManifoldCloudCore` as dependencies. On a clean checkout, `swift build --build-tests --traits Llama` (Llama trait alone) failed with *"no such module ManifoldRuntime"* — it only built when `ManifoldRuntime` happened to be compiled first via the default-trait graph. Two independent workers hit this build-ordering flake.

**Fix (Option A — add the edge):** added `"ManifoldRuntime"` to the `ManifoldCloud` target's `dependencies`. This is a **library→library** edge (not a consumer→family edge), so per the trait-gating rule it is **not** trait-gated. `ManifoldRuntime` is SwiftData-free (verified), so the family target stays free of SwiftData. The relevant audits (`PackageTopologyAuditTest`, `PackageTraitGateAuditTest`, `TrafficBoundaryAuditTest`) do not forbid this edge — none assert a family-target deps-only-`ManifoldInference` rule — so the lower-risk Option A applies; no port relocation needed.

The Tier 0 graph snapshot (`scripts/affected-suites-graph.json`) was regenerated to reflect the new dependency and re-verified idempotent.

**Gate (scoped):** `swift build --build-tests --traits Llama` (the repro) ✅ clean; all-traits `--build-tests` sweep ✅ clean; `PackageTopologyAuditTest` / `PackageTraitGateAuditTest` / `TrafficBoundaryAuditTest` / `AuditSabotageSuiteTests` ✅ green.
