### PR TITLE
fix: dispatch advertised SessionToolSource tools via ToolRegistry

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -734,6 +734,16 @@ struct ConversationTurnExecutor: Sendable {
             sessionRecord: sessionRecord
         )
 
+        // Wire dispatch for the session tools we just advertised. Without this
+        // the model can *call* `generate_image` / `web_search` / etc. but the
+        // dispatch loop finds no registry executor and returns `unknownTool`
+        // (#1606). Registered after `advertisedTools` is computed so advertising
+        // is unaffected; unregistered once the stream fully drains below.
+        let registeredSessionToolNames = await registerSessionToolExecutors(
+            sources: turnSessionToolSources,
+            sessionRecord: sessionRecord
+        )
+
         let token: InferenceService.GenerationRequestToken
         let stream: GenerationStream
         do {
@@ -750,6 +760,7 @@ struct ConversationTurnExecutor: Sendable {
                 sessionID: sessionID
             )
         } catch {
+            await unregisterSessionToolExecutors(registeredSessionToolNames)
             let conversationError = ConversationError.inference(error)
             emit(.errorRaised(conversationError))
             await completeOutcome(
@@ -892,6 +903,14 @@ struct ConversationTurnExecutor: Sendable {
                 streamFailed = .inference(error)
             }
         }
+
+        // Tool dispatch is complete once the stream has drained — the dispatch
+        // loop runs on the producer side as we consume events. Unregister the
+        // session-scoped executors now so the shared registry doesn't carry a
+        // stale ``ChatSessionRecord`` binding into the next turn (#1606). All
+        // remaining exit paths below are post-stream, so this is the single
+        // cleanup point alongside the enqueue-failure path above.
+        await unregisterSessionToolExecutors(registeredSessionToolNames)
 
         // Flush remaining buffered tokens (normal end, error, or cancellation).
         if let batch = batcher.flush(now: ContinuousClock.now) {
@@ -1598,6 +1617,67 @@ struct ConversationTurnExecutor: Sendable {
             return Array(unioned.prefix(cap))
         }
         return unioned
+    }
+
+    /// Registers a ``ToolExecutor`` adapter for each session-source-advertised
+    /// tool so a model tool call actually reaches the source's `resolve`
+    /// instead of coming back as ``ToolResult/ErrorKind/unknownTool`` (#1606).
+    ///
+    /// Returns the set of tool names this call registered so the caller can
+    /// unregister exactly those when the turn ends — leaving a session-scoped
+    /// executor in the shared registry would bind later turns to a stale
+    /// ``ChatSessionRecord``.
+    ///
+    /// A tool already present in the registry (a host-installed executor) is
+    /// left untouched: the registry executor wins, matching the
+    /// advertising-path de-dupe in ``readAdvertisedToolDefinitions``. Like the
+    /// per-turn `setHandoffDetector` / `setPreToolUseHook` wiring, this mutates
+    /// shared `InferenceService` state and assumes one turn per service at a
+    /// time; concurrent turns on the same service are last-writer-wins.
+    private func registerSessionToolExecutors(
+        sources: [any SessionToolSource],
+        sessionRecord: ChatSessionRecord?
+    ) async -> Set<String> {
+        guard let sessionRecord, !sources.isEmpty else { return [] }
+
+        // Gather (source, definition) pairs off the main actor so the
+        // per-source async `toolDefinitions(for:)` calls don't pin MainActor.
+        var pairs: [(source: any SessionToolSource, definition: ToolDefinition)] = []
+        for source in sources {
+            let defs = await source.toolDefinitions(for: sessionRecord)
+            for def in defs {
+                pairs.append((source, def))
+            }
+        }
+        guard !pairs.isEmpty else { return [] }
+
+        return await MainActor.run {
+            guard let registry = inferenceService.toolRegistry else { return Set<String>() }
+            var registered: Set<String> = []
+            for pair in pairs {
+                // Don't clobber a host-installed executor of the same name.
+                guard registry.contains(name: pair.definition.name) == false else { continue }
+                registry.register(
+                    SessionToolSourceExecutor(
+                        definition: pair.definition,
+                        source: pair.source,
+                        session: sessionRecord
+                    )
+                )
+                registered.insert(pair.definition.name)
+            }
+            return registered
+        }
+    }
+
+    private func unregisterSessionToolExecutors(_ names: Set<String>) async {
+        guard !names.isEmpty else { return }
+        await MainActor.run {
+            guard let registry = inferenceService.toolRegistry else { return }
+            for name in names {
+                registry.unregister(name: name)
+            }
+        }
     }
 
     @MainActor

--- a/Sources/ManifoldRuntime/Services/SessionToolSourceExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/SessionToolSourceExecutor.swift
@@ -1,0 +1,82 @@
+import Foundation
+import ManifoldInference
+
+/// Bridges a ``SessionToolSource`` into the ``ToolExecutor`` protocol so an
+/// advertised session tool actually *dispatches* when the model calls it.
+///
+/// ## Why this exists (#1606)
+///
+/// `SessionToolSource` advertises tool definitions (`toolDefinitions(for:)`)
+/// *and* declares a `resolve(toolName:arguments:session:)` dispatch hook. The
+/// turn loop's advertising path (`ConversationTurnExecutor`) wires the former
+/// onto the wire, but nothing ever called `resolve`: tool dispatch flows
+/// exclusively through ``ToolRegistry`` → ``ToolExecutor``. A source such as
+/// ``ImageGenerationToolSource`` therefore advertised `generate_image` to the
+/// model, but when the model called it the dispatch loop looked the name up in
+/// the registry, found no executor, and returned
+/// ``ToolResult/ErrorKind/unknownTool`` — the source's `resolve` was dead code.
+///
+/// This adapter closes that gap: ``ConversationTurnExecutor`` registers one
+/// `SessionToolSourceExecutor` per advertised session-source tool at the top of
+/// a turn and unregisters it when the turn ends, so a model tool call lands on
+/// the source's `resolve` and returns a real result.
+///
+/// Handoff sources (``HandoffToolSource``) are unaffected: their
+/// `transfer_to_<agent>` tools are intercepted upstream by the dispatch loop's
+/// `HandoffDetector` before the registry is consulted, so the executor this
+/// adapter installs for them is never invoked.
+struct SessionToolSourceExecutor: ToolExecutor {
+
+    let definition: ToolDefinition
+
+    /// Session-source tools are treated as side-effecting by default: the
+    /// runtime relies on the source's own `resolve` to decide what to do, and
+    /// dispatch must reach it without a UI approval hop (matching the
+    /// "no user interaction" contract of ``ImageGenerationToolSource`` and
+    /// friends). Sources that want approval gating can model it inside
+    /// `resolve` directly.
+    var requiresApproval: Bool { false }
+
+    private let source: any SessionToolSource
+    private let session: ChatSessionRecord
+
+    init(
+        definition: ToolDefinition,
+        source: any SessionToolSource,
+        session: ChatSessionRecord
+    ) {
+        self.definition = definition
+        self.source = source
+        self.session = session
+    }
+
+    func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        // `SessionToolSource.resolve` takes the raw JSON argument *string* the
+        // model emitted; ``ToolRegistry`` hands executors an already-parsed
+        // ``JSONSchemaValue`` (after optional coercion), so re-serialise it
+        // back to a compact JSON string for the source. A `nil`/encode failure
+        // is surfaced as an empty object so the source still gets a
+        // well-formed payload rather than garbage.
+        let argumentString = encodeArguments(arguments)
+        return try await source.resolve(
+            toolName: definition.name,
+            arguments: argumentString,
+            session: session
+        )
+    }
+
+    private func encodeArguments(_ arguments: JSONSchemaValue) -> String {
+        do {
+            let data = try JSONEncoder().encode(arguments)
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            // JSONSchemaValue is always encodable, but degrade to an empty
+            // object instead of throwing so a serialisation hiccup never turns
+            // a real tool call into a permanent failure before the source runs.
+            Log.inference.warning(
+                "SessionToolSourceExecutor: failed to re-encode arguments for '\(definition.name, privacy: .public)'; passing empty object"
+            )
+            return "{}"
+        }
+    }
+}

--- a/Tests/ManifoldTurnLoopCharacterizationTests/SessionToolSourceDispatchTest.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/SessionToolSourceDispatchTest.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - StubGenerateImageToolSource
+
+/// Minimal ``SessionToolSource`` that both *advertises* a `generate_image`
+/// tool and *resolves* it to a fixed result.
+///
+/// Stands in for the production ``ImageGenerationToolSource`` /
+/// `VideoGenerationToolSource` / `WebSearchToolSource` without dragging in
+/// `ManifoldUI`'s `ChatViewModel`. The only behaviour under test is that an
+/// advertised session tool reaches `resolve` — the body just proves the call
+/// arrived and carried the model's arguments through.
+private struct StubGenerateImageToolSource: SessionToolSource {
+    static let toolName = "generate_image"
+    static let successContent = "image-generated"
+
+    func toolDefinitions(for session: ChatSessionRecord) async -> [ToolDefinition] {
+        [
+            ToolDefinition(
+                name: Self.toolName,
+                description: "Generate an image from a text prompt.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "prompt": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("prompt")])
+                ])
+            )
+        ]
+    }
+
+    func resolve(
+        toolName: String,
+        arguments: String,
+        session: ChatSessionRecord
+    ) async throws -> ToolResult {
+        guard toolName == Self.toolName else {
+            return ToolResult(callId: toolName, content: "unexpected tool", errorKind: .unknownTool)
+        }
+        // Echo the round-tripped arguments back so the test can confirm the
+        // model's JSON survived the JSONSchemaValue → string re-encode.
+        return ToolResult(callId: toolName, content: "\(Self.successContent):\(arguments)")
+    }
+}
+
+// MARK: - SessionToolSourceDispatchTest
+
+/// Tripwire for #1606: an advertised ``SessionToolSource`` tool must actually
+/// dispatch to its `resolve` when the model calls it, instead of falling
+/// through ``ToolRegistry`` as ``ToolResult/ErrorKind/unknownTool``.
+///
+/// Integration test — it drives the real ``ConversationRuntime`` turn loop
+/// against ``MockInferenceBackend`` and an in-memory SwiftData store.
+@MainActor
+final class SessionToolSourceDispatchTest: XCTestCase {
+
+    private static func toolCapableBackend() -> MockInferenceBackend {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportedParameters: [.temperature, .topP, .repeatPenalty],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: false,
+            supportsSystemPrompt: true,
+            supportsToolCalling: true,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: false
+        ))
+        backend.isModelLoaded = true
+        return backend
+    }
+
+    /// A model tool call for a session-source-advertised tool dispatches and
+    /// returns a real result. Before the #1606 fix this came back as
+    /// `unknownTool` because nothing registered the source's `resolve` into the
+    /// ``ToolRegistry`` — reverting the fix makes the `unknownTool` assertion
+    /// below fail, which is the falsifiability the tripwire exists for.
+    func test_advertisedSessionTool_dispatchesToResolve_notUnknownTool() async throws {
+        let stack = try InMemoryPersistenceHarness.make()
+        let session = ChatSessionRecord(id: UUID(), title: "dispatch")
+        try await stack.provider.insertSession(session)
+
+        let backend = Self.toolCapableBackend()
+        // Turn 1: emit the tool call only. Turn 2: final answer after the
+        // tool result is fed back to the model.
+        backend.scriptedToolCallsPerTurn = [
+            [ToolCall(id: "img-1", toolName: StubGenerateImageToolSource.toolName, arguments: "{\"prompt\":\"a cat\"}")]
+        ]
+        backend.tokensToYieldPerTurn = [[], ["Done"]]
+
+        // Empty registry — there is NO host-installed executor for
+        // `generate_image`. The only way the call resolves is through the
+        // per-turn SessionToolSource → ToolExecutor bridge.
+        let registry = ToolRegistry()
+        let service = InferenceService(backend: backend, name: "DispatchMock", toolRegistry: registry)
+        let runtime = ConversationRuntime(
+            messageStore: stack.provider,
+            sessionStore: stack.provider,
+            inferenceService: service
+        )
+        await runtime.updateSessionToolSources([StubGenerateImageToolSource()])
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: session.id, kind: .send(text: "make me an image"))
+        )
+        _ = await handle?.outcome
+
+        // The assistant turn persists the dispatched tool result as a
+        // `.toolResult` content part.
+        let records = try await stack.provider.fetchMessages(for: session.id)
+        let toolResults: [ToolResult] = records
+            .flatMap(\.contentParts)
+            .compactMap { part in
+                if case .toolResult(let result) = part { return result }
+                return nil
+            }
+
+        guard let result = toolResults.first(where: { $0.callId == "img-1" }) else {
+            XCTFail("expected a dispatched tool result for the generate_image call; got \(toolResults)")
+            return
+        }
+        XCTAssertNotEqual(
+            result.errorKind,
+            .unknownTool,
+            "advertised session tool must dispatch to resolve, not fall through ToolRegistry as unknownTool"
+        )
+        XCTAssertTrue(
+            result.content.hasPrefix(StubGenerateImageToolSource.successContent),
+            "tool result content should come from the source's resolve, got: \(result.content)"
+        )
+        XCTAssertTrue(
+            result.content.contains("a cat"),
+            "the model's JSON arguments should survive the round-trip to resolve, got: \(result.content)"
+        )
+    }
+
+    /// The per-turn session executor must not leak into the shared registry:
+    /// once the turn ends, `generate_image` is gone again so the next turn
+    /// re-binds it to a fresh ``ChatSessionRecord`` rather than reusing a stale
+    /// one.
+    func test_sessionToolExecutor_unregisteredAfterTurn() async throws {
+        let stack = try InMemoryPersistenceHarness.make()
+        let session = ChatSessionRecord(id: UUID(), title: "leak-check")
+        try await stack.provider.insertSession(session)
+
+        let backend = Self.toolCapableBackend()
+        backend.tokensToYieldPerTurn = [["Hi"]]  // plain turn, no tool call
+
+        let registry = ToolRegistry()
+        let service = InferenceService(backend: backend, name: "DispatchMock", toolRegistry: registry)
+        let runtime = ConversationRuntime(
+            messageStore: stack.provider,
+            sessionStore: stack.provider,
+            inferenceService: service
+        )
+        await runtime.updateSessionToolSources([StubGenerateImageToolSource()])
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: session.id, kind: .send(text: "hello"))
+        )
+        _ = await handle?.outcome
+
+        let leaked = service.toolRegistry?.contains(name: StubGenerateImageToolSource.toolName) ?? false
+        XCTAssertFalse(
+            leaked,
+            "session-scoped executor must be unregistered when the turn ends; a leak would bind later turns to a stale session"
+        )
+    }
+}


### PR DESCRIPTION
## Problem (#1606)

`SessionToolSource.resolve(toolName:arguments:session:)` was dead in the dispatch path. `ConversationTurnExecutor` consumed only `toolDefinitions` + `allowedToolNames` (advertising / allow-listing); tool *dispatch* flowed exclusively through `ToolRegistry` → `ToolExecutor`, and there was no `SessionToolSource → ToolExecutor` adapter anywhere in `Sources/`.

Net effect: `ImageGenerationToolSource` / `VideoGenerationToolSource` / `WebSearchToolSource` advertised `generate_image` / `generate_video` / `web_search` to the model, but when the model called one the request hit `ToolRegistry`, found no executor, and returned `.unknownTool`. Their `resolve` bodies never ran.

## Decision — option (a)

The product intent is clearly that these sources should *work* (e.g. `ImageGenerationToolSource.resolve` forwards to `ChatViewModel.generateImage`), so I made advertised session tools actually dispatch rather than deleting `resolve`:

- New `SessionToolSourceExecutor` (ManifoldRuntime) bridges a `SessionToolSource` + one `ToolDefinition` + the `ChatSessionRecord` into the `ToolExecutor` protocol. `execute` re-encodes the registry's parsed `JSONSchemaValue` arguments back to the JSON string `resolve` expects.
- `ConversationTurnExecutor.runGenerationTurn` registers one executor per advertised session-source tool right **before** `enqueueAsync` (so advertising is unchanged) and unregisters them once the stream fully drains — plus on the enqueue-failure path. Reliable unregister prevents a session-scoped executor leaking a stale `ChatSessionRecord` into the next turn.
- Tools already in the registry (host-installed executors) are skipped — the registry executor wins, matching the existing advertising de-dupe.
- `HandoffToolSource`'s `transfer_to_*` tools are unaffected: the dispatch loop's `HandoffDetector` still intercepts them upstream before the registry is consulted, so the executor installed for them is never invoked.

This follows the established per-turn `setHandoffDetector` / `setPreToolUseHook` pattern on the shared `InferenceService` (one turn per service at a time; concurrent turns are last-writer-wins, documented in-code).

`SessionToolSource.resolve` and its contract test stay — the protocol is unchanged, the dispatch path is now wired.

## Test

`SessionToolSourceDispatchTest` (integration, in-memory SwiftData + `MockInferenceBackend`):
- `test_advertisedSessionTool_dispatchesToResolve_notUnknownTool` — an empty `ToolRegistry` + a `generate_image` session source; the model emits a `generate_image` call; the dispatched result is **not** `.unknownTool`, carries the source's content, and round-trips the model's JSON args. Reverting the fix makes the `unknownTool` assertion fail.
- `test_sessionToolExecutor_unregisteredAfterTurn` — after a turn the registry no longer contains the session tool, so later turns re-bind a fresh session.

## Local gate (scoped — four workers share the machine)

- `swift build --build-tests --disable-default-traits` — clean (deprecation warnings only).
- `swift test --disable-default-traits --filter SessionToolSourceDispatchTest` — 2/2 pass.
- `swift test --disable-default-traits --filter ManifoldTurnLoopCharacterizationTests` — 9/9 pass; the `test_tool_roundTrip` golden is unchanged.
- `swift test --disable-default-traits --filter ManifoldRuntimeTests` — 420 pass, 2 skipped.

No switched-enum / `GenerationEvent`-shaped types touched, so the all-traits sweep was not required. `Package.resolved` left untouched.

Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)