### PR TITLE
perf(ci): Tier 0 selective-testing resolver (dry-run mode) (#1588)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/check-foundation-only-bundle.sh"
       - "scripts/test-ios-simulator.sh"
       - "scripts/lint-no-new-force-unwraps.sh"
+      - "scripts/ci-affected-suites.py"
   pull_request:
     branches: [main]
     paths:
@@ -31,6 +32,7 @@ on:
       - "scripts/check-foundation-only-bundle.sh"
       - "scripts/test-ios-simulator.sh"
       - "scripts/lint-no-new-force-unwraps.sh"
+      - "scripts/ci-affected-suites.py"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -103,9 +105,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # paths-filter needs the parent commit to diff against on `push` events;
-          # `pull_request` works with the default shallow clone.
-          fetch-depth: 2
+          # fetch-depth: 0 so the Tier 0 selective-test resolver can compute the
+          # PR's merge-base diff (base...HEAD). The deps paths-filter below only
+          # needs the parent commit, but the three-dot diff needs both histories.
+          fetch-depth: 0
 
       - name: Detect dependency-graph changes
         id: deps-changed
@@ -290,6 +293,49 @@ jobs:
           swift package resolve
           git diff --exit-code Package.resolved || \
             (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
+
+      # Tier 0 selective-testing resolver (#1588) — DRY-RUN PHASE.
+      # Computes the affected-suite set from the PR diff and LOGS it (a
+      # `TIER0_DRYRUN ...` marker per run), but the test steps below still run
+      # the full hardcoded list. scripts/ci-tier0-dryrun-report.sh aggregates a
+      # week of these markers; once the projected ~15-20% reduction is confirmed
+      # against live traffic, wire steps 1-3 to these outputs (Phase 2).
+      # Fails open: any diff/describe error forces a full run, never an empty one.
+      - name: Resolve affected suites (dry-run)
+        id: suites
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Full suite always on push to main + nightly — selective is PR-only.
+            python3 scripts/ci-affected-suites.py --force-full
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          if ! git diff --name-only "$base"...HEAD > /tmp/tier0-changed.txt; then
+            echo "::warning::Tier 0 resolver: diff against base failed — forcing full run"
+            python3 scripts/ci-affected-suites.py --force-full
+            exit 0
+          fi
+          echo "Changed files in this PR:"; cat /tmp/tier0-changed.txt
+          python3 scripts/ci-affected-suites.py --changed-files /tmp/tier0-changed.txt
+
+      # Surface the dry-run decision in the job summary for at-a-glance review
+      # without digging into step logs. Removed when Phase 2 lands.
+      - name: Tier 0 dry-run summary
+        if: always() && steps.suites.outcome == 'success'
+        run: |
+          {
+            echo "### Tier 0 selective-testing (dry-run)"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| would force full | ${{ steps.suites.outputs.full }} |"
+            echo "| selected suites | ${{ steps.suites.outputs.suites }} |"
+            echo "| run backends | ${{ steps.suites.outputs.run_backends }} |"
+            echo "| run swift-testing | ${{ steps.suites.outputs.run_swift_testing }} |"
+            echo ""
+            echo "_Dry-run only — the full suite still ran this PR._"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs ManifoldCoreTests + ManifoldRuntimeTests + ManifoldPersistenceSwiftDataTests

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ scripts/dx-walkthrough/runs/**/RUN-CONFIG.md
 # vulnerability maps with file paths and line numbers.
 SECURITY_REMEDIATION_PLAN*.md
 SECURITY_AUDIT*.md
+
+# Python bytecode from scripts/*.py
+scripts/__pycache__/

--- a/scripts/ci-affected-suites.py
+++ b/scripts/ci-affected-suites.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""scripts/ci-affected-suites.py — Tier 0 selective-testing resolver (issue #1588).
+
+Given the set of files changed in a PR, compute which of the per-PR `test`-job
+suites actually need to run, using the SwiftPM target dependency graph.
+
+`swift test --filter X` only prunes *execution*, not *compile* (the whole test
+bundle still builds — see #1588 / #1590), so this saves the execution half only.
+Realistic win: a narrow PR ~16m -> ~12-13m. Compile pruning is Tier 2 (#1590).
+
+Design (matches #1588):
+  1. Read the maximal target graph from `swift package --enable-all-traits
+     describe --type json`. The `--enable-all-traits` is LOAD-BEARING: plain
+     `describe` reflects only default-ON traits, so trait-gated test targets
+     (ManifoldVoiceTests, ManifoldAppIntentsTests, ...) report incomplete deps
+     and we would UNDER-include suites -> false green. We always want the
+     conservative (maximal) closure.
+  2. Map each changed file to a target via longest-prefix match on the target's
+     real `.path` (NOT `Sources/<name>` — `ManifoldBackends` lives in
+     `Sources/ManifoldBackendsUmbrella/`).
+  3. A changed source target selects every CI suite whose transitive dependency
+     closure includes it (reverse closure). A changed CI test target selects
+     itself.
+
+Safety net (fail OPEN — when in doubt, run everything):
+  - Force-full when any changed path matches FORCE_FULL_PATTERNS (manifests,
+    .github/**, the test harness, this resolver itself, or a hub module).
+  - Force-full when a path under Sources/ or Tests/ maps to no known target.
+  - Force-full when describe fails or the graph can't be built.
+  - Force-full when the computed set is empty but real source/test code changed.
+
+Outputs (GitHub Actions `$GITHUB_OUTPUT` if set, else stdout):
+  full=true|false              # true => run the entire hardcoded suite list
+  step1_filters=<args>         # e.g. "--filter ManifoldCoreTests --filter ..."
+  run_backends=true|false      # ManifoldBackendsTests (serial step)
+  run_swift_testing=true|false # ManifoldInferenceSwiftTestingTests (isolated step)
+  suites=<comma list>          # human-readable selected set
+  reason=<text>                # why full was forced (when full=true)
+
+A human-readable log always goes to stderr so it shows up in the CI step.
+
+Usage:
+  ci-affected-suites.py --changed-files PATH [--describe-json PATH]
+  printf 'Sources/ManifoldMLX/Foo.swift\n' | ci-affected-suites.py --changed-files -
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# CI-runnable suites in the per-PR `test` job, partitioned by how the workflow
+# runs them. Keep in sync with .github/workflows/ci.yml `test` job.
+STEP1_SUITES = [
+    "ManifoldCoreTests",
+    "ManifoldRuntimeTests",
+    "ManifoldPersistenceSwiftDataTests",
+    "ManifoldUITests",
+    "ManifoldUIModelManagementTests",
+    "ManifoldMCPTests",
+    "ManifoldTestSupportTests",
+    "ManifoldAppIntentsTests",
+    "ManifoldInferenceTests",
+    "ManifoldNetworkingTests",
+    "ManifoldTurnLoopCharacterizationTests",
+]
+SERIAL_SUITE = "ManifoldBackendsTests"            # claims-registry race -> serial (#1601)
+SWIFT_TESTING_SUITE = "ManifoldInferenceSwiftTestingTests"  # isolated process (#681)
+
+CI_RUNNABLE = STEP1_SUITES + [SERIAL_SUITE, SWIFT_TESTING_SUITE]
+
+# Any changed path matching these forces a full run. The hub modules are listed
+# explicitly even though their reverse-closure fanout is already ~13/13: it makes
+# the intent legible and covers the 12/13 near-hubs (TestSupport, Runtime,
+# Persistence) whose one missing suite we never want to skip.
+FORCE_FULL_PATTERNS = [
+    re.compile(r"^Package\.swift$"),
+    re.compile(r"^Package\.resolved$"),
+    re.compile(r"^\.github/"),
+    re.compile(r"^scripts/test\.sh$"),
+    re.compile(r"^scripts/ci-test-with-watchdog\.sh$"),
+    re.compile(r"^scripts/ci-affected-suites\.py$"),  # the resolver gates itself
+    re.compile(r"^Sources/ManifoldInference/"),
+    re.compile(r"^Sources/ManifoldRuntime/"),
+    re.compile(r"^Sources/ManifoldPersistenceSwiftData/"),
+    re.compile(r"^Sources/ManifoldTestSupport/"),
+    re.compile(r"^Sources/ManifoldNetworking/"),
+]
+
+# Roots whose changes must map to a known target or we fail open.
+CODE_ROOTS = ("Sources/", "Tests/")
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def load_describe(describe_json: str | None) -> dict:
+    if describe_json:
+        with open(describe_json) as fh:
+            return json.load(fh)
+    out = subprocess.run(
+        ["swift", "package", "--enable-all-traits", "describe", "--type", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(out.stdout)
+
+
+def build_graph(pkg: dict):
+    targets = {t["name"]: t for t in pkg["targets"]}
+    deps = {n: set(t.get("target_dependencies") or []) for n, t in targets.items()}
+    # (path, name) sorted longest-path-first for prefix matching.
+    paths = sorted(
+        ((t["path"].rstrip("/"), t["name"]) for t in pkg["targets"]),
+        key=lambda pn: len(pn[0]),
+        reverse=True,
+    )
+    return targets, deps, paths
+
+
+def closure(name: str, deps: dict, seen: set | None = None) -> set:
+    if seen is None:
+        seen = set()
+    for d in deps.get(name, ()):
+        if d not in seen:
+            seen.add(d)
+            closure(d, deps, seen)
+    return seen
+
+
+def reverse_map(deps: dict) -> dict:
+    """source target -> set of CI_RUNNABLE suites whose closure includes it."""
+    rev: dict[str, set] = {}
+    for suite in CI_RUNNABLE:
+        for member in closure(suite, deps) | {suite}:
+            rev.setdefault(member, set()).add(suite)
+    return rev
+
+
+def path_to_target(path: str, paths) -> str | None:
+    for tpath, name in paths:
+        if path == tpath or path.startswith(tpath + "/"):
+            return name
+    return None
+
+
+def emit(outputs: dict) -> None:
+    gh = os.environ.get("GITHUB_OUTPUT")
+    lines = [f"{k}={v}" for k, v in outputs.items()]
+    if gh:
+        with open(gh, "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+    # Stable, greppable telemetry marker for the dry-run aggregator
+    # (scripts/ci-tier0-dryrun-report.sh scans CI logs for this prefix). One
+    # line per resolver run; do not reformat without updating the aggregator.
+    suites = outputs.get("suites", "")
+    selected = 0 if not suites else len(suites.split(","))
+    log(f"TIER0_DRYRUN full={outputs.get('full')} "
+        f"selected={selected} total={len(CI_RUNNABLE)}")
+
+
+def full_run(reason: str) -> dict:
+    log(f"FORCE-FULL: {reason}")
+    log(f"Running all {len(CI_RUNNABLE)} CI suites.")
+    return {
+        "full": "true",
+        "step1_filters": " ".join(f"--filter {s}" for s in STEP1_SUITES),
+        "run_backends": "true",
+        "run_swift_testing": "true",
+        "suites": ",".join(CI_RUNNABLE),
+        "reason": reason,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--changed-files",
+                    help="file with newline-separated changed paths, or '-' for stdin")
+    ap.add_argument("--describe-json", default=None,
+                    help="precomputed `swift package describe` JSON (testing); "
+                         "otherwise invokes swift")
+    ap.add_argument("--force-full", action="store_true",
+                    help="unconditionally select every CI suite (push to main / "
+                         "nightly / any event where selective testing must not apply)")
+    args = ap.parse_args()
+
+    if args.force_full:
+        emit(full_run("--force-full requested (non-PR event)"))
+        return 0
+
+    if not args.changed_files:
+        ap.error("--changed-files is required unless --force-full is given")
+
+    if args.changed_files == "-":
+        raw = sys.stdin.read()
+    else:
+        with open(args.changed_files) as fh:
+            raw = fh.read()
+    changed = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+
+    if not changed:
+        # Empty diff should not happen on a real PR; fail open.
+        emit(full_run("empty changed-files list"))
+        return 0
+
+    log(f"Changed files: {len(changed)}")
+
+    for path in changed:
+        for pat in FORCE_FULL_PATTERNS:
+            if pat.search(path):
+                emit(full_run(f"changed path '{path}' matches force-full rule"))
+                return 0
+
+    try:
+        pkg = load_describe(args.describe_json)
+        targets, deps, paths = build_graph(pkg)
+    except Exception as exc:  # noqa: BLE001 — any describe failure fails open
+        emit(full_run(f"could not build package graph: {exc}"))
+        return 0
+
+    rev = reverse_map(deps)
+    selected: set[str] = set()
+
+    for path in changed:
+        if path.startswith(CODE_ROOTS):
+            tgt = path_to_target(path, paths)
+            if tgt is None:
+                emit(full_run(f"changed code path '{path}' maps to no known target"))
+                return 0
+            if targets[tgt].get("type") == "test":
+                if tgt in CI_RUNNABLE:
+                    selected.add(tgt)
+                # A non-CI test target (E2E, Server, MLXIntegration, ...) is
+                # handled by its own gated job / nightly — it adds nothing here.
+            else:
+                selected |= rev.get(tgt, set())
+        # Non-code paths (docs, etc.) that slipped the workflow path filter
+        # contribute nothing; if they are the ONLY changes we fail open below.
+
+    if not selected:
+        emit(full_run("no CI suite mapped from the changed set"))
+        return 0
+
+    selected_step1 = [s for s in STEP1_SUITES if s in selected]
+    log(f"Selected {len(selected)}/{len(CI_RUNNABLE)} suites: {sorted(selected)}")
+
+    emit({
+        "full": "false",
+        "step1_filters": " ".join(f"--filter {s}" for s in selected_step1),
+        "run_backends": "true" if SERIAL_SUITE in selected else "false",
+        "run_swift_testing": "true" if SWIFT_TESTING_SUITE in selected else "false",
+        "suites": ",".join(sorted(selected)),
+        "reason": "",
+    })
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-tier0-dryrun-report.sh
+++ b/scripts/ci-tier0-dryrun-report.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# scripts/ci-tier0-dryrun-report.sh — aggregate Tier 0 selective-testing dry-run
+# telemetry (issue #1588) across recent CI runs.
+#
+# The `Resolve affected suites (dry-run)` step in ci.yml emits one greppable
+# `TIER0_DRYRUN full=<bool> selected=<n> total=<n>` marker per PR run. This
+# script scans recent successful `test`-job logs for those markers and tallies:
+#   - how many PRs would have run selectively vs forced-full,
+#   - the distribution of selected-suite counts,
+#   - the aggregate fraction of suite-executions that would have been skipped.
+#
+# That fraction is the validate-before-commit signal the issue requires before
+# flipping Phase 2: the projected win is ~15-20% of CI minutes (execution half
+# only — `swift test --filter` never prunes compile; see #1588 / #1590).
+#
+# Usage:
+#   scripts/ci-tier0-dryrun-report.sh [--limit N] [--branch B]
+#     --limit N   number of recent CI runs to scan (default 80)
+#     --branch B  only runs for this base branch (default: all)
+#
+# Per [[feedback_gh_log_investigation]] each run's log is fetched ONCE into a
+# cache dir and grepped locally; re-runs reuse the cache.
+
+set -euo pipefail
+
+LIMIT=80
+BRANCH=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --limit) LIMIT="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null || { echo "gh CLI required" >&2; exit 1; }
+
+CACHE="${TMPDIR:-/tmp}/tier0-dryrun-cache"
+mkdir -p "$CACHE"
+
+echo "Fetching up to $LIMIT recent CI runs…" >&2
+runs_json=$(gh run list --workflow CI --event pull_request --limit "$LIMIT" \
+  --json databaseId,headBranch,conclusion,createdAt)
+
+# Filter to runs we care about (optionally by base branch). We only need the run
+# IDs; conclusion can be anything — the resolver step runs before the tests, so
+# even a later-failed run carries a valid marker.
+ids=$(echo "$runs_json" | jq -r --arg b "$BRANCH" \
+  '.[] | select($b=="" or .headBranch==$b) | .databaseId')
+
+total=0; full=0; selective=0
+declare -a selected_counts=()
+suite_total=0          # sum of `total` field (denominator: suites that ran today)
+suite_would_run=0      # sum of selected (numerator: suites the resolver would run)
+
+for id in $ids; do
+  logf="$CACHE/$id.log"
+  if [ ! -s "$logf" ]; then
+    # Fetch once; some runs may have expired logs — skip those quietly.
+    gh run view "$id" --log > "$logf" 2>/dev/null || { rm -f "$logf"; continue; }
+  fi
+  marker=$(grep -h "TIER0_DRYRUN" "$logf" | tail -n 1 || true)
+  [ -n "$marker" ] || continue
+
+  is_full=$(echo "$marker" | sed -E 's/.*full=([a-z]+).*/\1/')
+  sel=$(echo "$marker" | sed -E 's/.*selected=([0-9]+).*/\1/')
+  tot=$(echo "$marker" | sed -E 's/.*total=([0-9]+).*/\1/')
+
+  total=$((total + 1))
+  suite_total=$((suite_total + tot))
+  suite_would_run=$((suite_would_run + sel))
+  if [ "$is_full" = "true" ]; then
+    full=$((full + 1))
+  else
+    selective=$((selective + 1))
+    selected_counts+=("$sel")
+  fi
+done
+
+if [ "$total" -eq 0 ]; then
+  echo "No TIER0_DRYRUN markers found in the scanned runs." >&2
+  echo "(Either the dry-run step hasn't landed yet, or logs have expired.)" >&2
+  exit 0
+fi
+
+skipped=$((suite_total - suite_would_run))
+pct_selective=$(( selective * 100 / total ))
+pct_suites_skipped=$(( skipped * 100 / suite_total ))
+
+echo "=========================================================="
+echo " Tier 0 selective-testing — dry-run report (#1588)"
+echo "=========================================================="
+echo "PR runs analyzed:        $total"
+echo "  would run selectively: $selective (${pct_selective}%)"
+echo "  would force full:      $full"
+echo ""
+echo "Suite-executions (denominator = suites that actually ran today):"
+echo "  ran today:             $suite_total"
+echo "  resolver would run:    $suite_would_run"
+echo "  would SKIP:            $skipped (${pct_suites_skipped}% of executions)"
+echo ""
+if [ "${#selected_counts[@]}" -gt 0 ]; then
+  echo "Selected-suite count distribution (selective PRs only):"
+  printf '%s\n' "${selected_counts[@]}" | sort -n | uniq -c \
+    | awk '{printf "  %2d suite(s): %d PR(s)\n", $2, $1}'
+fi
+echo ""
+echo "NOTE: % suites skipped ≈ upper bound on the EXECUTION-time win only."
+echo "      Compile is never pruned by --filter (#1588/#1590), so wall-clock"
+echo "      savings are smaller. Target signal: ~15-20% of total CI minutes."


### PR DESCRIPTION
## What

Ships the **Tier 0 selective-testing resolver** from #1588 in **dry-run mode**: it computes which per-PR `test`-job suites a diff actually affects (from the SwiftPM dependency graph) and **logs** the decision, but the test steps still run the full hardcoded list. No behavior change to what executes — this PR cannot regress coverage.

Phase 2 (wiring the test steps to consume the resolver's outputs) lands in a follow-up **after ~1 week of dry-run data confirms the projected payoff**, per the issue's validate-before-commit requirement.

## Why dry-run first

`swift test --filter` prunes **execution only, not compile** (measured: clean filtered run still builds the whole bundle — see #1588/#1590). So the realistic Tier 0 win is the execution half: a narrow PR ~16m → ~12–13m, **~15–20% of total CI minutes**. We want to confirm that against live traffic before flipping the switch.

## Changes

- `scripts/ci-affected-suites.py` — the resolver:
  - Reads the **maximal** graph via `swift package --enable-all-traits describe` (load-bearing: plain `describe` drops trait-off test targets → under-include → false green).
  - Maps changed files to targets by longest-prefix on the real `.path` (`ManifoldBackends` lives in `Sources/ManifoldBackendsUmbrella/`).
  - Reverse-closure: a changed source target selects every CI suite whose dependency closure includes it; a changed CI test target selects itself.
  - **Fails open**: manifest / `.github/` / hub-module / unknown-path / describe-error all force a full run. Never an empty one.
- `.github/workflows/ci.yml`:
  - `test`-job checkout → `fetch-depth: 0` (needed for the `base...HEAD` merge-base diff).
  - New **"Resolve affected suites (dry-run)"** + **"Tier 0 dry-run summary"** steps (PR-only; `--force-full` on push/nightly).
  - Resolver script added to both `paths:` filters so editing it re-triggers CI.
- `scripts/ci-tier0-dryrun-report.sh` — aggregates the `TIER0_DRYRUN` markers across recent runs: % selective-vs-full and % of suite-executions that would be skipped (the go/no-go signal for Phase 2).

## How payoff is measured

After ~1 week of PRs, run:

```
scripts/ci-tier0-dryrun-report.sh --limit 120
```

Flip Phase 2 only if it shows the projected ~15–20% execution-time reduction.

## Test impact

CI-only (no Swift sources touched). The dry-run step + YAML are exercised by this PR's own CI run; resolver logic validated locally against the live package graph (leaf→1 suite, hub/manifest/unknown→force-full, umbrella path-mismatch handled).

Refs #1588. Tier 1 (#1608) and Tier 2 (#1590) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)