### PR TITLE
fix: resource-correctness bugs (MLX deinit leak, RAG crash/orphans, search OOM, MCP timeout leak)

### DIFF
--- a/Sources/ManifoldLlama/LlamaBackend.swift
+++ b/Sources/ManifoldLlama/LlamaBackend.swift
@@ -376,12 +376,17 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
         let reuseLen = max(0, min(commonPrefixLen, tokens.count - 2))
 
         // Trim the KV cache tail beyond the reuse prefix before flipping
-        // isGenerating. The context pointer is safe to snapshot here: the outer
-        // guard already verified context != nil, and unloadModel() can only nil
-        // it after acquiring stateLock — which we hold during the flip below.
-        if reuseLen > 0, let ctx = withStateLock({ context }),
-           let mem = llama_get_memory(ctx) {
-            llama_memory_seq_rm(mem, 0, Int32(reuseLen), -1)
+        // isGenerating. The C KV mutation must run *inside* stateLock, not after
+        // a snapshot-then-release: unloadModel()/secureWipe() nil and free
+        // `context` under the same lock, so a snapshot read followed by an
+        // unlocked `llama_memory_seq_rm` could touch a freed context
+        // (use-after-free) if teardown raced in between.
+        if reuseLen > 0 {
+            withStateLock {
+                if let ctx = context, let mem = llama_get_memory(ctx) {
+                    llama_memory_seq_rm(mem, 0, Int32(reuseLen), -1)
+                }
+            }
         }
 
         // Reset the cancellation flag and flip isGenerating atomically under the
@@ -531,14 +536,17 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// cancelled turn preserves the prefix so the model can continue from
     /// where it left off on the next `generate()`.
     public func resetConversation() {
-        let capturedContext = withStateLock { () -> OpaquePointer? in
+        // Run the C KV flush inside stateLock alongside the sessionKVState reset.
+        // Snapshotting `context` and releasing the lock before calling
+        // llama_memory_clear() would let a concurrent unloadModel()/secureWipe()
+        // free the context between the read and the C call (use-after-free).
+        withStateLock {
             sessionKVState = nil
-            return context
-        }
-        // Also flush the actual KV cache in the C context so any leftover
-        // positional state is gone before the next turn decodes from position 0.
-        if let ctx = capturedContext, let mem = llama_get_memory(ctx) {
-            llama_memory_clear(mem, false)
+            // Also flush the actual KV cache in the C context so any leftover
+            // positional state is gone before the next turn decodes from position 0.
+            if let ctx = context, let mem = llama_get_memory(ctx) {
+                llama_memory_clear(mem, false)
+            }
         }
     }
 
@@ -552,14 +560,16 @@ public final class LlamaBackend: InferenceBackend, @unchecked Sendable {
     /// The KV state cache pointer is also nil-ed so the next
     /// ``generate(_:config:)`` call starts with a fresh context.
     public func secureWipe() {
-        let capturedContext = withStateLock { () -> OpaquePointer? in
+        // C KV zeroing runs inside stateLock with the sessionKVState reset for
+        // the same use-after-free reason as resetConversation(): teardown frees
+        // `context` under this lock.
+        withStateLock {
             sessionKVState = nil
-            return context
-        }
-        if let ctx = capturedContext, let mem = llama_get_memory(ctx) {
-            // true = zero the actual KV tensor data (key + value matrices),
-            // not just the positional/sequence metadata.
-            llama_memory_clear(mem, true)
+            if let ctx = context, let mem = llama_get_memory(ctx) {
+                // true = zero the actual KV tensor data (key + value matrices),
+                // not just the positional/sequence metadata.
+                llama_memory_clear(mem, true)
+            }
         }
     }
 

--- a/Sources/ManifoldMCP/InternalMCPSession.swift
+++ b/Sources/ManifoldMCP/InternalMCPSession.swift
@@ -105,6 +105,8 @@ internal actor MCPSession {
                         )
                     }
                 }
+            } onTimeout: { [weak self] in
+                await self?.handleRequestTimeout(id: id)
             }
         } onCancel: { [weak self] in
             guard let session = self else { return }
@@ -232,6 +234,27 @@ internal actor MCPSession {
         continuation.resume(throwing: error)
     }
 
+    /// Cleanup invoked when the request timeout wins the race in ``withTimeout``.
+    ///
+    /// Without this, a server that accepts a request but never answers its id
+    /// leaks both the inner continuation and the `pendingRequests[id]`
+    /// concurrency slot permanently — after `maxConcurrentRequests` such events
+    /// every `sendRequest` throws "Exceeded max concurrent MCP requests" until
+    /// reconnect. Evict the entry (resuming the leaked continuation so the slot
+    /// is reclaimed) and tell the server to stop wasting work on the abandoned
+    /// call.
+    private func handleRequestTimeout(id: MCPRequestID) async {
+        failPendingRequest(id: id, error: MCPError.requestTimeout)
+        let cancelParams: JSONSchemaValue = .object([
+            "requestId": .string(id.description),
+            "reason": .string("Request timed out"),
+        ])
+        await sendNotificationIgnoringErrors(
+            method: "notifications/cancelled",
+            params: cancelParams
+        )
+    }
+
     private func registerPendingAndSend(
         id: MCPRequestID,
         request: MCPJSONRPCMessage,
@@ -249,7 +272,8 @@ internal actor MCPSession {
 
     private func withTimeout<T: Sendable>(
         _ timeout: Duration,
-        operation: @escaping @Sendable () async throws -> T
+        operation: @escaping @Sendable () async throws -> T,
+        onTimeout: @escaping @Sendable () async -> Void = {}
     ) async throws -> T {
         // Use unstructured tasks so the timeout race doesn't wait for the operation
         // task to drain. withThrowingTaskGroup waits for ALL child tasks on exit;
@@ -259,21 +283,20 @@ internal actor MCPSession {
         try await withCheckedThrowingContinuation { continuation in
             let resumed = OSAllocatedUnfairLock(initialState: false)
 
-            func tryResume(_ body: @Sendable () -> Void) {
-                let shouldResume = resumed.withLock { flag -> Bool in
+            func claimResume() -> Bool {
+                resumed.withLock { flag -> Bool in
                     guard !flag else { return false }
                     flag = true
                     return true
                 }
-                if shouldResume { body() }
             }
 
-            Task {
+            let operationTask = Task {
                 do {
                     let value = try await operation()
-                    tryResume { continuation.resume(returning: value) }
+                    if claimResume() { continuation.resume(returning: value) }
                 } catch {
-                    tryResume { continuation.resume(throwing: error) }
+                    if claimResume() { continuation.resume(throwing: error) }
                 }
             }
 
@@ -283,7 +306,17 @@ internal actor MCPSession {
                 } catch {
                     return
                 }
-                tryResume { continuation.resume(throwing: MCPError.requestTimeout) }
+                // The timeout won. Claim the resume slot first so the operation
+                // task's own completion becomes a no-op, then cancel it, run the
+                // caller's cleanup (evict the pending entry + notify the server —
+                // see `handleRequestTimeout`), and finally surface the timeout.
+                // Cancelling alone is not enough: the operation is suspended in a
+                // continuation awaiting a server reply, which cancellation cannot
+                // resume; the cleanup resumes it explicitly.
+                guard claimResume() else { return }
+                operationTask.cancel()
+                await onTimeout()
+                continuation.resume(throwing: MCPError.requestTimeout)
             }
         }
     }

--- a/Sources/ManifoldMLX/MLXBackend.swift
+++ b/Sources/ManifoldMLX/MLXBackend.swift
@@ -203,6 +203,39 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
         self.enableKVCacheReuse = enableKVCacheReuse
     }
 
+    deinit {
+        // A dropped instance (VM teardown, error path, A/B model swap) must
+        // release its per-UUID claim in `MLXResourceArbiter`. The arbiter only
+        // fires `MLX.Memory.clearCache()` on the *last* release, so a leaked
+        // claim means that guarantee never fires again and Metal buffers never
+        // return to the OS. `LlamaBackend.deinit` releases its C resources the
+        // same way (`LlamaBackend.swift:170`).
+        //
+        // deinit cannot be async and must never block (CLAUDE.md: no
+        // `DispatchSemaphore.wait()` under @MainActor ownership). Mirror
+        // `LlamaBackend`'s retain/detach/release pattern: snapshot the identity
+        // + chained cleanup under the lock, then hop off-actor in a detached
+        // task that captures only locals — never `self`.
+        //
+        // Guard on `_hasInitializedRuntime`: the arbiter's last release calls
+        // `MLX.Memory.clearCache()`, which traps with "Failed to load default
+        // metallib" when no real load ever initialized the runtime (injected
+        // test doubles). `_hasInitializedRuntime` is the container-presence
+        // proxy CLAUDE.md's MLX.Memory guard rule requires. It is also false
+        // after `unloadModel()` already ran, so the guard doubles as a
+        // double-release guard for the normal teardown path.
+        let snapshot: (hadRuntime: Bool, previousCleanup: Task<Void, Never>?, id: MLXResourceArbiter.BackendID) = withStateLock {
+            (_hasInitializedRuntime, _cleanupTask, backendID)
+        }
+        guard snapshot.hadRuntime else { return }
+        let previousCleanup = snapshot.previousCleanup
+        let id = snapshot.id
+        Task.detached {
+            await previousCleanup?.value
+            await MLXResourceArbiter.shared.release(backendID: id)
+        }
+    }
+
     /// Forwards to `MLXGenerationDriver.resolveThinkingMarkers(...)`.
     ///
     /// The canonical implementation moved into the driver as part of Phase

--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -240,9 +240,14 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
             predicate: #Predicate { $0.content.localizedStandardContains(needle) },
             sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
         )
-        if terms.count == 1 {
-            descriptor.fetchLimit = limit
-        }
+        // Bound the store fetch on EVERY branch. Multi-term queries previously
+        // had no limit and matched only the first term in-store, then filtered
+        // the rest in Swift — a common first word on a large history loaded all
+        // matching rows into RAM (OOM/stall). The store fetch must over-fetch
+        // enough to survive the in-memory all-terms filter below, so multi-term
+        // queries fetch a widened cap rather than the exact `limit`; single-term
+        // queries need exactly `limit` because the in-memory filter is a no-op.
+        descriptor.fetchLimit = terms.count == 1 ? limit : limit * Self.multiTermFetchMultiplier
 
         let results = try modelContext.fetch(descriptor)
         var hits: [MessageSearchHit] = []
@@ -264,6 +269,13 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         }
         return hits
     }
+
+    /// Over-fetch factor for multi-term search. The store predicate matches only
+    /// the first term; the remaining terms are required in memory. A common first
+    /// term can knock out many candidates, so we fetch `limit * multiplier` rows
+    /// before the in-memory filter to keep recall high — while still bounding the
+    /// fetch so a common word on a huge history can't load every matching row.
+    private static let multiTermFetchMultiplier = 10
 
     private static func messageSearchTerms(from query: String) -> [String] {
         query.split(whereSeparator: \.isWhitespace).map(String.init)

--- a/Sources/ManifoldRuntime/Services/RAGService.swift
+++ b/Sources/ManifoldRuntime/Services/RAGService.swift
@@ -77,7 +77,22 @@ public actor RAGService {
             chunkCount: chunks.count,
             indexedAt: Date()
         )
-        try await documentStore.insertDocument(record)
+        do {
+            try await documentStore.insertDocument(record)
+        } catch {
+            // Two-store ingest is not atomic: the vectors above are already in
+            // the flat-file index, but the SwiftData metadata row failed. The
+            // UI lists documents from `documentStore`, so without a compensating
+            // rollback the orphaned chunks would pollute search/citations
+            // forever while being invisible and undeletable. Best-effort delete
+            // the vector write, then surface the original failure.
+            do {
+                try await vectorStore.delete(documentID: documentID)
+            } catch let rollbackError {
+                Log.inference.error("RAGService: failed to roll back vector write for orphaned document \(documentID, privacy: .public): \(rollbackError.localizedDescription, privacy: .public)")
+            }
+            throw error
+        }
         return record
     }
 
@@ -140,7 +155,14 @@ public actor RAGService {
         let hits: [VectorSearchHit]
         if let backend = embeddingBackend, backend.isModelLoaded {
             do {
-                let queryEmbedding = try await backend.embed([cappedQuery])[0]
+                // `EmbeddingBackend.embed` does not guarantee output count ==
+                // input count. Subscripting `[0]` on an empty/short return is a
+                // runtime *trap* that the surrounding catch (designed to fall
+                // back to keyword search) cannot intercept — route the empty
+                // case through `throw` so it lands in the keyword fallback.
+                guard let queryEmbedding = try await backend.embed([cappedQuery]).first else {
+                    throw RAGError.embeddingFailed(underlying: InferenceError.inferenceFailure("Embedding backend returned no vectors for query"))
+                }
                 hits = try await vectorStore.search(embedding: queryEmbedding, limit: limit)
             } catch {
                 Log.inference.warning("RAGService: embedding query failed, falling back to keyword search: \(error.localizedDescription)")

--- a/Tests/ManifoldMCPTests/MCPSessionTests.swift
+++ b/Tests/ManifoldMCPTests/MCPSessionTests.swift
@@ -204,6 +204,74 @@ final class MCPSessionTests: XCTestCase {
         await session.close()
     }
 
+    // #1622: a request whose id is never answered must, on timeout, evict its
+    // pending entry (reclaiming the concurrency slot) and send
+    // notifications/cancelled. Previously the timeout resumed the outer
+    // continuation but leaked both the inner continuation and the slot, so after
+    // `maxConcurrentRequests` such events every sendRequest threw
+    // "Exceeded max concurrent" until reconnect.
+    func test_sendRequestTimeoutReleasesSlotAndNotifiesCancelled() async throws {
+        let descriptor = MCPServerDescriptor(
+            displayName: "Session Test",
+            transport: .streamableHTTP(endpoint: URL(string: "https://example.com/mcp")!, headers: [:]),
+            dataDisclosure: "test"
+        )
+
+        let codec = MCPJSONRPCCodec(maxMessageBytes: 4096, maxJSONNestingDepth: 8)
+        let transport = MockSessionTransport(codec: codec)
+        await transport.setRequestHandler { id, method, _ in
+            switch method {
+            case "initialize":
+                return .result(id: id, result: .object([
+                    "protocolVersion": .string("2025-03-26"),
+                    "serverInfo": .object(["name": .string("Demo"), "version": .string("1")]),
+                    "capabilities": .object([:]),
+                ]))
+            default:
+                // Never answer tools/list — force the timeout path.
+                return nil
+            }
+        }
+
+        let session = MCPSession(
+            descriptor: descriptor,
+            transport: transport,
+            codec: codec,
+            requestTimeout: .milliseconds(150),
+            maxConcurrentRequests: 1
+        )
+        _ = try await session.start()
+
+        do {
+            _ = try await session.sendRequest(method: "tools/list", params: nil)
+            XCTFail("Expected requestTimeout")
+        } catch let error as MCPError {
+            XCTAssertEqual(error, .requestTimeout)
+        }
+
+        // The slot must have been reclaimed. With maxConcurrentRequests == 1, a
+        // leaked slot would make this throw .transportFailure instead of timing
+        // out again.
+        do {
+            _ = try await session.sendRequest(method: "tools/list", params: nil)
+            XCTFail("Expected requestTimeout on the second request")
+        } catch let error as MCPError {
+            XCTAssertEqual(error, .requestTimeout,
+                           "Pending slot leaked: second request hit max-concurrency instead of timing out")
+        }
+
+        let sent = await transport.sentMessages()
+        XCTAssertTrue(sent.contains { message in
+            if case .notification(let method, _) = message {
+                return method == "notifications/cancelled"
+            }
+            return false
+        }, "Timeout path must send notifications/cancelled so the server stops working on the abandoned call")
+        // Sabotage: removing the failPendingRequest(id:) call in handleRequestTimeout would leak the slot, making the second request throw .transportFailure and failing the equality assertion above.
+
+        await session.close()
+    }
+
     func test_sendRequestEnforcesMaxConcurrentRequests() async throws {
         let descriptor = MCPServerDescriptor(
             displayName: "Session Test",

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderSearchTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderSearchTests.swift
@@ -109,6 +109,30 @@ final class SwiftDataPersistenceProviderSearchTests: XCTestCase {
         XCTAssertEqual(hits.count, 10, "Limit should cap result count")
     }
 
+    // #1622: the multi-term branch previously set NO fetchLimit, so a common
+    // first term loaded every matching row into RAM before the in-memory
+    // all-terms filter (OOM/stall on large histories). The store fetch is now
+    // bounded on all branches; this verifies the multi-term path still honours
+    // the caller's result limit when many rows match every term.
+    func test_searchMessages_multiTermRespectsLimit() async throws {
+        let session = ChatSessionRecord(title: "Multi Term Limit")
+        try await provider.insertSession(session)
+        for i in 0..<25 {
+            try await provider.insertMessage(ChatMessageRecord(
+                role: .user,
+                content: "dragon treasure row \(i)",
+                timestamp: Date(timeIntervalSince1970: Double(1_000 + i)),
+                sessionID: session.id
+            ))
+        }
+
+        let hits = try await provider.searchMessages(query: "dragon treasure", limit: 10)
+        XCTAssertEqual(hits.count, 10, "Multi-term search must cap results at the requested limit")
+        // Recent-first ordering must survive the bounded fetch.
+        XCTAssertTrue(hits.first?.snippet.contains("row 24") ?? false,
+                      "Most recent matching row should sort first under the bounded fetch")
+    }
+
     func test_searchMessages_snippetCentersOnMatchAndElides() async throws {
         let session = ChatSessionRecord(title: "Snippet")
         try await provider.insertSession(session)

--- a/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
+++ b/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
@@ -68,6 +68,38 @@ private final class CapturingEmbeddingBackend: EmbeddingBackend, @unchecked Send
     func unloadModel() { isModelLoaded = false }
 }
 
+/// Returns *fewer* vectors than inputs (here: none), reproducing a backend
+/// that does not guarantee output-count == input-count. Drives the
+/// `embed([...]).first else { throw }` fallback path.
+private final class EmptyResultEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var dimensions: Int = 4
+    var embedCallCount = 0
+
+    func loadModel(from url: URL) async throws { isModelLoaded = true }
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        embedCallCount += 1
+        return []  // shorter than `texts` — `[0]` would trap
+    }
+    func unloadModel() { isModelLoaded = false }
+}
+
+/// A document store whose `insertDocument` always throws, simulating a
+/// SwiftData metadata-row write failure after the vector write has landed.
+@MainActor
+private final class ThrowingDocumentStore: DocumentStore {
+    struct InsertFailure: Error {}
+    var insertCallCount = 0
+
+    func insertDocument(_ record: DocumentRecord) throws {
+        insertCallCount += 1
+        throw InsertFailure()
+    }
+    func fetchDocuments() throws -> [DocumentRecord] { [] }
+    func fetchDocument(id: UUID) throws -> DocumentRecord? { nil }
+    func deleteDocument(id: UUID) throws {}
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -314,6 +346,58 @@ final class RAGServiceTests: XCTestCase {
         }
         XCTAssertEqual(capturedTexts[0].utf8.count, maxBytes,
                        "query at exactly the limit must not be truncated")
+    }
+
+    // MARK: - #1622: embed empty result must fall back, not trap
+
+    /// When `embed` returns fewer vectors than inputs (here: empty), the old
+    /// `[0]` subscript was a runtime trap the surrounding do/catch could not
+    /// intercept. The `.first else { throw }` form must route the failure into
+    /// the keyword-search fallback instead.
+    func test_retrieve_embedReturnsEmpty_fallsBackToKeyword() async throws {
+        let vectorStore = FakeVectorStore()
+        let chunk = DocumentChunk(documentID: UUID(), text: "keyword fallback hit", chunkIndex: 0)
+        await vectorStore.setKeywordResults([VectorSearchHit(chunk: chunk, documentTitle: "Doc", score: 1.0)])
+
+        let backend = EmptyResultEmbeddingBackend()
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: backend
+        )
+
+        let result = try await sut.retrieve(query: "anything")
+
+        XCTAssertEqual(backend.embedCallCount, 1, "embed must have been attempted before falling back")
+        XCTAssertEqual(result.slots.count, 1)
+        XCTAssertTrue(result.slots[0].content.contains("keyword fallback hit"),
+                      "empty embed result must route into keyword fallback, not crash")
+    }
+
+    // MARK: - #1622: non-atomic ingest rollback
+
+    /// If the SwiftData metadata insert throws after the vectors were already
+    /// written, the orphaned chunks must be rolled back so they do not pollute
+    /// search/citations invisibly (the UI lists from `documentStore`).
+    func test_ingest_metadataInsertFails_rollsBackVectorWrite() async throws {
+        let vectorStore = FakeVectorStore()
+        let docStore = ThrowingDocumentStore()
+        let sut = RAGService(documentStore: docStore, vectorStore: vectorStore)
+
+        let url = try writeTempFile(content: "Some content to chunk and embed.")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            _ = try await sut.ingest(url: url)
+            XCTFail("ingest must rethrow the metadata-insert failure")
+        } catch is ThrowingDocumentStore.InsertFailure {
+            // expected — the original failure is surfaced
+        }
+
+        let inserted = await vectorStore.insertedChunks
+        XCTAssertFalse(inserted.isEmpty, "vectors were written before the metadata insert failed")
+        let deleted = await vectorStore.deletedDocumentIDs
+        XCTAssertEqual(deleted.count, 1, "the orphaned vector write must be rolled back exactly once")
     }
 
     func testDeleteDocumentRemovesFromBothStores() async throws {


### PR DESCRIPTION
Closes #1622

Batch of genuine crash / leak / OOM fixes from the 2026-06-05 footgun audit. One PR per the "fewer, larger units of work" rule.

## What changed

- [x] **MLX GPU-memory leak — `MLXBackend` had no `deinit`.** Added a `deinit` mirroring `LlamaBackend`'s retain/detach/release pattern: it snapshots identity + chained cleanup under the state lock, then hops off-actor in a `Task.detached` (capturing only locals, never `self`) to release the per-UUID `MLXResourceArbiter` claim. Without the release the arbiter never reaches its last-release `MLX.Memory.clearCache()` and Metal buffers never return to the OS. Guarded on `_hasInitializedRuntime` so `MLX.Memory` is never touched without a real load (avoids the "Failed to load default metallib" trap) and so the normal `unloadModel()` path can't double-release.
- [x] **RAG crash instead of fallback — `embed(...)[0]`.** `EmbeddingBackend.embed` does not guarantee output-count == input-count; `[0]` on an empty return was a trap the surrounding `do/catch` couldn't intercept. Changed to `.first else { throw }` so the empty case routes into the existing keyword-search fallback.
- [x] **RAG non-atomic two-store ingest → invisible orphans.** Vectors are written before the SwiftData metadata row; on `insertDocument` failure the orphaned chunks were invisible/undeletable in the UI. Added a compensating `vectorStore.delete(documentID:)` rollback before rethrowing the original error.
- [x] **Multi-term message search OOM.** `fetchLimit` was set only for single-term queries; multi-word search matched the first term with no limit, loading every matching row into RAM. Now bounded on all branches — single-term fetches exactly `limit`; multi-term fetches `limit * 10` (over-fetch keeps recall high for the in-memory all-terms filter while still bounding memory).
- [x] **MCP request-timeout leaked continuation + concurrency slot.** `withTimeout` resumed the outer continuation but never cancelled the op task or evicted `pendingRequests[id]`, so a server that accepted but never answered an id leaked the slot until reconnect. `withTimeout` now takes an `onTimeout` hook; on timeout it claims the resume slot, cancels the op task, evicts the pending entry (resuming the leaked inner continuation), sends `notifications/cancelled`, then surfaces `MCPError.requestTimeout`.
- [x] **(fold-in) Llama KV C-mutation lock scope.** `llama_memory_seq_rm` / `llama_memory_clear` ran after releasing `stateLock`, racing teardown that frees `context` under that same lock (use-after-free). Widened the lock to cover the C KV mutations in the generate prefix-trim, `resetConversation()`, and `secureWipe()`.

## Skipped (with rationale)

- **`maxOutputTokens` default vs doc** — already resolved. Commit `3ee1740c` updated the doc at `InferenceBackend.swift:189` to describe the real `2048` default; nothing to change. Default left at `2048` per maintainer call.
- **(fold-in) `URLSessionProvider.pinned`/`.unpinned` precondition trap** — skipped. The `precondition` is a deliberate fail-closed behaviour of a security kill-switch (`networkDisabled`). A non-throwing `URLSession` getter has no clean non-trapping fallback (returning a session anyway would silently defeat the kill-switch). Throwing variants already exist for callers that want graceful degradation. Changing the fail-closed semantics is a maintainer call, not a low-risk drive-by.

## Tests

New regression tests (in-memory SwiftData / fakes, no mocked persistence):
- `RAGServiceTests.test_retrieve_embedReturnsEmpty_fallsBackToKeyword`
- `RAGServiceTests.test_ingest_metadataInsertFails_rollsBackVectorWrite`
- `SwiftDataPersistenceProviderSearchTests.test_searchMessages_multiTermRespectsLimit`
- `MCPSessionTests.test_sendRequestTimeoutReleasesSlotAndNotifiesCancelled`

The MLX `deinit` is exercised only on real Apple Silicon with the metallib (`MLXResourceArbiter.shared` is process-global and not injectable from `swift test`), so it has no standalone unit test; existing `MLXResourceArbiterTests` cover the release accounting it relies on.

## Gate

- `scripts/test.sh --profile local` — green (XCTest 4594 passed / 0 failed / 60 skipped; Swift Testing 169 + 83 passed / 0 failed). New MCP test verified passing in a direct `--traits ...MCP...` run (it was absent from a stale incremental manifest in the combined gate run).
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — Build complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)