### PR TITLE
refactor: enforce cross-cutting invariants structurally (#1623)

### DIFF
--- a/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
+++ b/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
@@ -87,10 +87,23 @@ public enum DefaultBackends {
         FoundationBackends.self,
     ]
 
+    /// Registers every compiled-in backend family with `service` and returns
+    /// how many backend capabilities (local model types + cloud providers) were
+    /// actually wired.
+    ///
+    /// Each registrar is trait-gated internally, so a minimal build can register
+    /// nothing — the returned count lets the caller fail fast on an empty,
+    /// never-generating service instead of launching a dead app (the footgun
+    /// audit's class D — "silent degradation where a fail-fast boundary check
+    /// belongs"). ``ManifoldKit/ManifoldKit/quickStart(configuration:)`` does
+    /// exactly this; hosts driving ``ManifoldBootstrap`` directly should check
+    /// the result too.
     @MainActor
-    public static func register(with service: InferenceService) {
+    @discardableResult
+    public static func register(with service: InferenceService) -> Int {
         for registrar in registrars {
             registrar.register(with: service)
         }
+        return service.registeredBackendSnapshot().count
     }
 }

--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -485,9 +485,9 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBack
             throw CloudBackendError.providerOverloaded(provider: "Claude", retryAfter: retryAfter)
         default:
             let sanitized = await drainAndSanitizeErrorBody(bytes)
-            throw CloudBackendError.serverError(
+            throw CloudBackendError.sanitizedServerError(
                 statusCode: statusCode,
-                message: sanitized
+                rawMessage: sanitized
             )
         }
     }

--- a/Sources/ManifoldCloud/ClaudeStreamEventExtractor.swift
+++ b/Sources/ManifoldCloud/ClaudeStreamEventExtractor.swift
@@ -191,7 +191,7 @@ enum ClaudePayloadParser {
               let message = error["message"] as? String else {
             return nil
         }
-        return .parseError(CloudErrorSanitizer.sanitize(message))
+        return .sanitizedParseError(message)
     }
 
     private static func parseObject(_ json: String) -> [String: Any]? {

--- a/Sources/ManifoldCloud/CloudPayloadHandler.swift
+++ b/Sources/ManifoldCloud/CloudPayloadHandler.swift
@@ -251,7 +251,7 @@ enum OpenAIResponsesPayloadParsing {
         }
         guard envelope.name == "response.error" else { return nil }
         let message = OpenAIResponsesBackend.parseErrorMessage(from: envelope.data)
-        return CloudBackendError.serverError(statusCode: 500, message: CloudErrorSanitizer.sanitize(message))
+        return CloudBackendError.sanitizedServerError(statusCode: 500, rawMessage: message)
     }
 }
 #endif // CloudSaaS

--- a/Sources/ManifoldCloud/OllamaBackend.swift
+++ b/Sources/ManifoldCloud/OllamaBackend.swift
@@ -599,7 +599,7 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
                 bytes,
                 extractor: { OllamaModelProbe.extractErrorMessage(from: $0) }
             )
-            throw CloudBackendError.serverError(statusCode: statusCode, message: message)
+            throw CloudBackendError.sanitizedServerError(statusCode: statusCode, rawMessage: message)
         }
     }
 

--- a/Sources/ManifoldCloudCore/CloudBackendError+Sanitized.swift
+++ b/Sources/ManifoldCloudCore/CloudBackendError+Sanitized.swift
@@ -1,0 +1,46 @@
+import Foundation
+import ManifoldInference
+
+public extension CloudBackendError {
+
+    /// Construction chokepoint for the two `CloudBackendError` cases that carry
+    /// free-form, upstream-controlled text (`serverError`'s message and
+    /// `parseError`'s detail).
+    ///
+    /// An upstream error can reach the UI by two paths — a non-2xx HTTP body and
+    /// an error event delivered *inside* a 200-OK SSE stream — and the footgun
+    /// audit (2026-06-05) found the sanitize invariant wired into only the first
+    /// (class A, "two paths, one guard"). Routing every upstream-text
+    /// construction through `sanitizedServerError`/`sanitizedParseError` makes
+    /// the invariant uniform and greppable: a raw `.serverError(message:)` /
+    /// `.parseError(_:)` in the cloud modules now means the text is a trusted
+    /// literal, and any new error path reaches for the `sanitized*` factory
+    /// rather than re-deriving sanitization and risking a bypass.
+    ///
+    /// `CloudErrorSanitizer.sanitize` is pure and idempotent, so it is safe for
+    /// callers that already sanitized (e.g. the HTTP path's
+    /// ``SSECloudBackend/drainAndSanitizeErrorBody(_:extractor:)``, which adds
+    /// host-aware fallbacks the static stream paths cannot) to route through the
+    /// factory as a second, no-op pass.
+    ///
+    /// These factories live in `ManifoldCloudCore` rather than beside
+    /// `CloudBackendError` (declared in the `ManifoldInference` kernel) because
+    /// the sanitizer lives here — the kernel must not depend on `CloudCore`.
+    static func sanitizedServerError(
+        statusCode: Int,
+        rawMessage: String?,
+        host: String? = nil
+    ) -> CloudBackendError {
+        .serverError(statusCode: statusCode, message: CloudErrorSanitizer.sanitize(rawMessage, host: host))
+    }
+
+    /// In-stream counterpart to ``sanitizedServerError(statusCode:rawMessage:host:)``
+    /// for upstream error text surfaced as a parse failure. See that factory for
+    /// the chokepoint rationale.
+    static func sanitizedParseError(
+        _ rawMessage: String?,
+        host: String? = nil
+    ) -> CloudBackendError {
+        .parseError(CloudErrorSanitizer.sanitize(rawMessage, host: host))
+    }
+}

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -747,7 +747,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
             throw CloudBackendError.rateLimited(retryAfter: retryAfter)
         default:
             let message = await drainAndSanitizeErrorBody(bytes)
-            throw CloudBackendError.serverError(statusCode: statusCode, message: message)
+            throw CloudBackendError.sanitizedServerError(statusCode: statusCode, rawMessage: message)
         }
     }
 

--- a/Sources/ManifoldInference/ManifoldKitError.swift
+++ b/Sources/ManifoldInference/ManifoldKitError.swift
@@ -45,6 +45,13 @@ public enum ManifoldKitError: Error, Sendable, LocalizedError, Equatable {
     /// is a short, PII-free description of where decoding failed (e.g.
     /// `"missing field: choices"`).
     case decodingFailure(String)
+    /// No inference backend was compiled into the binary for the active trait /
+    /// OS combination, so the assembled service can never generate. Raised at
+    /// the assembly boundary (``ManifoldKit/ManifoldKit/quickStart(configuration:)``)
+    /// as a fail-fast diagnostic rather than letting the app launch dead and
+    /// throw on the first turn.
+    case noBackendsRegistered
+
     /// Catch-all for errors that did not match any of the more specific cases.
     /// The underlying error is reduced to a string at construction time to
     /// keep the rim `Sendable`.
@@ -77,6 +84,8 @@ public enum ManifoldKitError: Error, Sendable, LocalizedError, Equatable {
             return "Keychain is unavailable. Unlock the device and try again."
         case .decodingFailure(let detail):
             return "Couldn't read the server response: \(detail)"
+        case .noBackendsRegistered:
+            return "No inference backends are compiled into this build. quickStart() needs at least one backend trait enabled (MLX, Llama, CloudSaaS, Ollama, or Foundation). Check the package traits / build settings."
         case .unknown(let underlyingDescription):
             if underlyingDescription.isEmpty {
                 return "An unexpected error occurred."

--- a/Sources/ManifoldInference/Protocols/InferenceBackend+CapabilityGate.swift
+++ b/Sources/ManifoldInference/Protocols/InferenceBackend+CapabilityGate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public extension InferenceBackend {
+
+    /// Enforces ``GenerationConfig/requiredCapabilities`` against this backend's
+    /// advertised ``InferenceBackend/capabilities`` and then generates.
+    ///
+    /// The capability gate previously lived **only** in ``RouterBackend`` — the
+    /// footgun audit's class A ("cross-cutting invariant wired into one branch
+    /// only"). A host that set `requiredCapabilities` and ran against a single
+    /// concrete backend (no router) had the constraint silently ignored: the
+    /// backend would generate anyway, downgrading (e.g. dropping tool calls or
+    /// thinking) with no error. Routing every non-router dispatch through this
+    /// wrapper makes fail-fast the default — the same `noBackendSatisfiesRequirements`
+    /// error the router raises, raised at the single-backend boundary too.
+    ///
+    /// The guard is a no-op when `requiredCapabilities` is empty (the standard
+    /// chat path), so it adds nothing to normal generation. When this backend is
+    /// itself a ``RouterBackend``, its merged capabilities pass the gate whenever
+    /// some child can satisfy the request, and the router then performs precise
+    /// per-child selection — the double check is benign.
+    func generateEnforcingCapabilities(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        try enforceRequiredCapabilities(config.requiredCapabilities)
+        return try generate(prompt: prompt, systemPrompt: systemPrompt, config: config)
+    }
+
+    /// Throws ``InferenceError/noBackendSatisfiesRequirements(_:)`` listing the
+    /// unmet requirements (sorted for deterministic diagnostics) when this
+    /// backend cannot satisfy `requirements`. No-op for an empty set.
+    func enforceRequiredCapabilities(_ requirements: Set<GenerationCapabilityRequirement>) throws {
+        guard !requirements.isEmpty, !capabilities.satisfies(requirements) else { return }
+        let unmet = requirements
+            .filter { !capabilities.satisfies($0) }
+            .sorted { $0.sortKey < $1.sortKey }
+        throw InferenceError.noBackendSatisfiesRequirements(unmet)
+    }
+}

--- a/Sources/ManifoldInference/Services/CachingTokenizer.swift
+++ b/Sources/ManifoldInference/Services/CachingTokenizer.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-/// A ``TokenizerProvider`` that memoizes token counts for the lifetime of this instance.
+/// A ``TokenizerProvider`` that memoizes token counts. Messages whose content
+/// does not change between subsystem calls pay the tokenization cost exactly
+/// once — subsequent lookups for the same string return the cached count.
 ///
-/// Construct one per generation cycle and discard it afterward. Messages whose content
-/// does not change between subsystem calls pay the tokenization cost exactly once —
-/// subsequent lookups for the same string return the cached count.
+/// The cache may be reused across generation cycles (identity-based
+/// invalidation on model swap is the caller's job); it is therefore bounded by
+/// ``maxEntries`` so a long-lived session can't grow it without limit.
 ///
 /// Thread-safe: concurrent reads and writes from different actors are safe.
 ///
@@ -14,6 +16,12 @@ import Foundation
 /// // Pass tok wherever a TokenizerProvider is accepted.
 /// ```
 package final class CachingTokenizer: TokenizerProvider, @unchecked Sendable {
+
+    /// Upper bound on memoized entries. Keys are raw message content, so without
+    /// a cap a long-lived (reused) instance grows unbounded. On overflow we
+    /// flush wholesale rather than track recency: token counting tolerates a
+    /// cold cache, and the flush is amortized O(1) across `maxEntries` inserts.
+    static let maxEntries = 10_000
 
     private let base: TokenizerProvider
     private var cache: [String: Int] = [:]
@@ -28,6 +36,9 @@ package final class CachingTokenizer: TokenizerProvider, @unchecked Sendable {
         defer { lock.unlock() }
         if let cached = cache[text] { return cached }
         let count = base.tokenCount(text)
+        if cache.count >= Self.maxEntries {
+            cache.removeAll(keepingCapacity: true)
+        }
         cache[text] = count
         return count
     }

--- a/Sources/ManifoldInference/Services/FrameworkCapabilityService.swift
+++ b/Sources/ManifoldInference/Services/FrameworkCapabilityService.swift
@@ -32,6 +32,15 @@ public struct EnabledBackends: Sendable, Equatable {
     /// Whether any cloud API backend is available.
     public var supportsCloudInference: Bool { !cloudProviders.isEmpty }
 
+    /// `true` when no local model type and no cloud provider is registered —
+    /// the assembled backend set is dead for the active trait / OS combination.
+    public var isEmpty: Bool { localModelTypes.isEmpty && cloudProviders.isEmpty }
+
+    /// Total registered backend capabilities (local model types + cloud
+    /// providers). Used by ``DefaultBackends/register(with:)`` to report how
+    /// many backends the build actually wired.
+    public var count: Int { localModelTypes.count + cloudProviders.count }
+
     public init(
         localModelTypes: Set<ModelType> = [],
         cloudProviders: Set<APIProvider> = []

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -410,7 +410,7 @@ final class GenerationQueue {
                 config: config
             )
             GenerationHistoryInstaller.installHistory(on: backend, structuredMessages: result.trimmedMessages)
-            return try backend.generate(
+            return try backend.generateEnforcingCapabilities(
                 prompt: result.prompt,
                 systemPrompt: nil,
                 config: config
@@ -440,7 +440,7 @@ final class GenerationQueue {
 
         GenerationHistoryInstaller.installHistory(on: backend, structuredMessages: messages)
 
-        return try backend.generate(
+        return try backend.generateEnforcingCapabilities(
             prompt: assembledPrompt,
             systemPrompt: effectiveSystemPrompt,
             config: config

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -816,7 +816,7 @@ public final class InferenceService {
 
         if preferFast, let fast = fastBackend {
             do {
-                return try fast.generate(
+                return try fast.generateEnforcingCapabilities(
                     prompt: prompt,
                     systemPrompt: systemPrompt,
                     config: config
@@ -832,7 +832,7 @@ public final class InferenceService {
         guard let primary = lifecycle.backend else {
             throw InferenceError.inferenceFailure("No model loaded")
         }
-        return try primary.generate(
+        return try primary.generateEnforcingCapabilities(
             prompt: prompt,
             systemPrompt: systemPrompt,
             config: config

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -86,7 +86,15 @@ public enum ManifoldKit {
 
             let bootstrap = try await task.value
 
-            DefaultBackends.register(with: bootstrap.inferenceService)
+            // Fail fast when the build compiled in zero backends for the active
+            // trait / OS combination. Without this the app launches fully wired
+            // — persistence, session list, composer enabled — then throws on the
+            // first turn with a confusing "No model loaded". Surfacing it here,
+            // at the assembly boundary, names the actual cause (missing traits).
+            let registeredBackends = DefaultBackends.register(with: bootstrap.inferenceService)
+            guard registeredBackends > 0 else {
+                throw ManifoldKitError.noBackendsRegistered
+            }
 
             let viewModel = ChatViewModel(
                 inferenceService: bootstrap.inferenceService,

--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -236,10 +236,6 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         // in memory so words can match across non-adjacent parts of a message.
         let terms = Self.messageSearchTerms(from: trimmed)
         let needle = terms[0]
-        var descriptor = FetchDescriptor<ChatMessage>(
-            predicate: #Predicate { $0.content.localizedStandardContains(needle) },
-            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
-        )
         // Bound the store fetch on EVERY branch. Multi-term queries previously
         // had no limit and matched only the first term in-store, then filtered
         // the rest in Swift — a common first word on a large history loaded all
@@ -247,7 +243,11 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         // enough to survive the in-memory all-terms filter below, so multi-term
         // queries fetch a widened cap rather than the exact `limit`; single-term
         // queries need exactly `limit` because the in-memory filter is a no-op.
-        descriptor.fetchLimit = terms.count == 1 ? limit : limit * Self.multiTermFetchMultiplier
+        let descriptor = boundedMessageFetch(
+            predicate: #Predicate { $0.content.localizedStandardContains(needle) },
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)],
+            limit: terms.count == 1 ? limit : limit * Self.multiTermFetchMultiplier
+        )
 
         let results = try modelContext.fetch(descriptor)
         var hits: [MessageSearchHit] = []
@@ -281,6 +281,28 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         query.split(whereSeparator: \.isWhitespace).map(String.init)
     }
 
+    /// Absolute safety ceiling for "fetch the whole session" reads
+    /// (``fetchMessages(for:)``). High enough that no realistic conversation is
+    /// truncated, low enough that a pathological session can't load unbounded
+    /// rows into RAM.
+    static let maxSessionMessageFetch = 10_000
+
+    /// Single builder for every `ChatMessage` *read* fetch. The `limit`
+    /// parameter is required, so no read path can construct a message fetch that
+    /// forgets to bound the store query — the footgun audit's class A
+    /// ("cross-cutting invariant wired into one branch only") applied to fetch
+    /// limits. Bulk-delete paths deliberately do not route through here: capping
+    /// a delete would leave orphaned rows, so they own their unbounded fetch.
+    private func boundedMessageFetch(
+        predicate: Predicate<ChatMessage>,
+        sortBy: [SortDescriptor<ChatMessage>],
+        limit: Int
+    ) -> FetchDescriptor<ChatMessage> {
+        var descriptor = FetchDescriptor<ChatMessage>(predicate: predicate, sortBy: sortBy)
+        descriptor.fetchLimit = limit
+        return descriptor
+    }
+
     // MARK: - Messages
 
     public func insertMessage(_ record: ChatMessageRecord) async throws {
@@ -308,31 +330,42 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     }
 
     public func fetchMessages(for sessionID: UUID) async throws -> [ChatMessageRecord] {
-        let descriptor = FetchDescriptor<ChatMessage>(
+        // "Whole session" read. Bounded to the newest `maxSessionMessageFetch`
+        // rows so a pathological session can't load unbounded rows into RAM;
+        // fetched newest-first under the cap then reversed to ascending so that
+        // when the ceiling *is* hit we keep recent context (silently dropping the
+        // oldest beats dropping the newest for chat) — and we log, because a
+        // silently truncated session would corrupt prompt assembly and export.
+        let descriptor = boundedMessageFetch(
             predicate: #Predicate { $0.sessionID == sessionID },
-            sortBy: [SortDescriptor(\.timestamp)]
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)],
+            limit: Self.maxSessionMessageFetch
         )
-        return try modelContext.fetch(descriptor).map { $0.toRecord() }
+        let results = try modelContext.fetch(descriptor)
+        if results.count == Self.maxSessionMessageFetch {
+            Log.persistence.warning("fetchMessages(for:) hit the \(Self.maxSessionMessageFetch, privacy: .public)-row ceiling for a session; older messages were not loaded. Paginate via fetchMessages(for:before:limit:).")
+        }
+        return results.reversed().map { $0.toRecord() }
     }
 
     public func fetchRecentMessages(for sessionID: UUID, limit: Int) async throws -> [ChatMessageRecord] {
         // Fetch newest-first, take `limit`, then reverse to ascending order.
-        var descriptor = FetchDescriptor<ChatMessage>(
+        let descriptor = boundedMessageFetch(
             predicate: #Predicate { $0.sessionID == sessionID },
-            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)],
+            limit: limit
         )
-        descriptor.fetchLimit = limit
         let results = try modelContext.fetch(descriptor)
         return results.reversed().map { $0.toRecord() }
     }
 
     public func fetchMessages(for sessionID: UUID, before: Date, limit: Int) async throws -> [ChatMessageRecord] {
         // Fetch messages older than `before`, newest-first, take `limit`, then reverse.
-        var descriptor = FetchDescriptor<ChatMessage>(
+        let descriptor = boundedMessageFetch(
             predicate: #Predicate { $0.sessionID == sessionID && $0.timestamp < before },
-            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)],
+            limit: limit
         )
-        descriptor.fetchLimit = limit
         let results = try modelContext.fetch(descriptor)
         return results.reversed().map { $0.toRecord() }
     }

--- a/Tests/ManifoldBackendsTests/CloudBackendErrorSanitizedFactoryTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudBackendErrorSanitizedFactoryTests.swift
@@ -1,0 +1,62 @@
+#if CloudSaaS
+import XCTest
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+
+/// Tests for the ``CloudBackendError`` sanitizing factories
+/// (``CloudBackendError/sanitizedServerError(statusCode:rawMessage:host:)`` and
+/// ``CloudBackendError/sanitizedParseError(_:host:)``).
+///
+/// The footgun audit found cloud error text reaching the UI unsanitized on the
+/// in-stream SSE path because the sanitize invariant was wired into only the
+/// non-2xx HTTP branch (class A — "two paths, one guard"). These factories are
+/// the construction chokepoint that closes that class: every upstream-text
+/// `CloudBackendError` now routes through `CloudErrorSanitizer` at construction,
+/// so no current or future error path can surface raw HTML / tokens / URLs.
+///
+/// XCTest (not Swift Testing) so this file stays clear of the `SwiftTestingAuditTest`
+/// merged-filter allowlist (#681).
+final class CloudBackendErrorSanitizedFactoryTests: XCTestCase {
+
+    func test_serverErrorFactory_stripsHTML_beforeErrorDescription() {
+        let error = CloudBackendError.sanitizedServerError(
+            statusCode: 500,
+            rawMessage: "<img src=x onerror=alert(1)>",
+            host: "api.example.com"
+        )
+        let description = error.errorDescription ?? ""
+        XCTAssertFalse(description.contains("<img"))
+        XCTAssertFalse(description.contains("onerror"))
+        // HTML-shaped bodies collapse to the host-aware generic fallback.
+        XCTAssertTrue(description.contains("api.example.com"))
+    }
+
+    func test_serverErrorFactory_redactsLeakedJWT() {
+        let error = CloudBackendError.sanitizedServerError(
+            statusCode: 502,
+            rawMessage: "auth failed for eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig"
+        )
+        XCTAssertFalse((error.errorDescription ?? "").contains("eyJ"))
+    }
+
+    func test_parseErrorFactory_sanitizesInStreamErrorText() {
+        let error = CloudBackendError.sanitizedParseError("see https://evil.example/callback?token=abc")
+        let description = error.errorDescription ?? ""
+        XCTAssertFalse(description.contains("https://"))
+        XCTAssertFalse(description.contains("evil.example"))
+    }
+
+    func test_benignMessage_survivesBoundedButIntact() {
+        let error = CloudBackendError.sanitizedServerError(statusCode: 503, rawMessage: "Service temporarily unavailable")
+        let description = error.errorDescription ?? ""
+        XCTAssertTrue(description.contains("Service temporarily unavailable"))
+        XCTAssertTrue(description.contains("503"))
+    }
+
+    func test_sanitization_isIdempotent_onAlreadyCleanText() {
+        let once = CloudErrorSanitizer.sanitize("Rate limit reached", host: nil)
+        let viaFactory = CloudBackendError.sanitizedServerError(statusCode: 429, rawMessage: once)
+        XCTAssertEqual(viaFactory.errorDescription?.contains(once), true)
+    }
+}
+#endif

--- a/Tests/ManifoldInferenceTests/BackendDeinitSymmetryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/BackendDeinitSymmetryAuditTest.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+/// Source-scan guard for the footgun audit's **class C — "asymmetric
+/// siblings"**: a fix applied to one of N parallel implementations that never
+/// propagates to the others.
+///
+/// The motivating regression (#1622/#1627): `MLXBackend` shipped with **no
+/// `deinit`** while its sibling `LlamaBackend` released its C resources in
+/// `deinit`. A dropped `MLXBackend` therefore leaked its per-UUID claim in
+/// `MLXResourceArbiter` forever — and because the arbiter only fires
+/// `MLX.Memory.clearCache()` on the *last* release, that guarantee then never
+/// fired again and Metal buffers never returned to the OS.
+///
+/// The backend-level proof ("dropping the instance releases the claim") needs a
+/// real Metal load and lives in `ManifoldMLXIntegrationTests` (Xcode-only). This
+/// audit is the cheap, trait-independent CI tripwire that runs everywhere: each
+/// backend that acquires a **process-global** resource must keep a `deinit`,
+/// and that `deinit` must reference its release mechanism (so a no-op `deinit {}`
+/// can't silence the guard). It would have failed the day the MLX `deinit` was
+/// missing.
+///
+/// Lives in `ManifoldInferenceTests` (no traits) rather than
+/// `ManifoldBackendsTests` (MLX/Llama-gated) so it runs in the default CI lane
+/// regardless of which backend traits are enabled.
+final class BackendDeinitSymmetryAuditTest: XCTestCase {
+
+    /// A backend that acquires a process-global resource, plus the token that
+    /// proves its `deinit` releases that resource.
+    private struct ResourceReleasingBackend {
+        let relativePath: String
+        /// A substring that must appear in the file's `deinit` block, proving
+        /// the teardown actually releases (not an empty `deinit {}`).
+        let releaseToken: String
+        let rationale: String
+    }
+
+    private static let backends: [ResourceReleasingBackend] = [
+        ResourceReleasingBackend(
+            relativePath: "ManifoldMLX/MLXBackend.swift",
+            releaseToken: "MLXResourceArbiter.shared.release",
+            rationale: "MLXBackend must release its MLXResourceArbiter claim in deinit, or the process-global cacheLimit/clearCache guarantee never fires again and Metal buffers never return to the OS (#1627)."
+        ),
+        ResourceReleasingBackend(
+            relativePath: "ManifoldLlama/LlamaBackend.swift",
+            releaseToken: "LlamaBackendProcessLifecycle.release",
+            rationale: "LlamaBackend must release the process-global llama_backend latch (LlamaBackendProcessLifecycle.release) and free its C resources (unloadModel) in deinit — the sibling release path MLXBackend was missing."
+        ),
+    ]
+
+    func test_resourceReleasingBackends_releaseInDeinit() throws {
+        let sourcesURL = try Self.locateSourcesDirectory()
+
+        for backend in Self.backends {
+            let fileURL = sourcesURL.appendingPathComponent(backend.relativePath)
+            guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                XCTFail("""
+                    Could not read \(backend.relativePath). If the backend was renamed or moved, update \
+                    BackendDeinitSymmetryAuditTest.backends so the deinit-symmetry guard keeps tracking it.
+                    """)
+                continue
+            }
+
+            guard let deinitBody = Self.deinitBody(in: content) else {
+                XCTFail("""
+                    \(backend.relativePath) declares no `deinit`.
+                    \(backend.rationale)
+                    A sibling resource-releasing backend lost its deinit — exactly the class-C asymmetry the footgun audit flagged.
+                    """)
+                continue
+            }
+
+            XCTAssertTrue(
+                deinitBody.contains(backend.releaseToken),
+                """
+                \(backend.relativePath) has a `deinit` but it does not reference `\(backend.releaseToken)` — \
+                it looks like a no-op teardown that does not release the process-global resource.
+                \(backend.rationale)
+                """
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Returns the text of the first `deinit { ... }` block in `content`,
+    /// matched by brace balancing from the `deinit` keyword. Returns `nil` when
+    /// no `deinit` is declared.
+    private static func deinitBody(in content: String) -> String? {
+        guard let deinitRange = content.range(of: #"\bdeinit\b"#, options: .regularExpression) else {
+            return nil
+        }
+        guard let openBrace = content[deinitRange.upperBound...].firstIndex(of: "{") else {
+            return nil
+        }
+        var depth = 0
+        var idx = openBrace
+        while idx < content.endIndex {
+            let ch = content[idx]
+            if ch == "{" { depth += 1 }
+            else if ch == "}" {
+                depth -= 1
+                if depth == 0 {
+                    return String(content[content.index(after: openBrace)..<idx])
+                }
+            }
+            idx = content.index(after: idx)
+        }
+        return nil
+    }
+
+    private static func locateSourcesDirectory(filePath: StaticString = #filePath) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(filePath)").deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent("Sources")
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDir), isDir.boolValue {
+                return candidate
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(domain: "BackendDeinitSymmetryAuditTest", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate Sources/ from #filePath"
+        ])
+    }
+}

--- a/Tests/ManifoldInferenceTests/CachingTokenizerTests.swift
+++ b/Tests/ManifoldInferenceTests/CachingTokenizerTests.swift
@@ -145,4 +145,33 @@ final class CachingTokenizerTests: XCTestCase {
         let provider: any TokenizerProvider = CachingTokenizer(wrapping: HeuristicTokenizer())
         XCTAssertEqual(provider.tokenCount("abcdefgh"), 2)
     }
+
+    // MARK: Bounded cache
+
+    /// The single-use contract was relaxed to reusable, so the cache is no
+    /// longer naturally lifetime-bounded. It must flush wholesale at
+    /// `maxEntries` so a long-lived instance can't grow without limit.
+    func test_cacheIsBoundedAndFlushesAtMaxEntries() {
+        let base = CountingTokenizer()
+        let cache = CachingTokenizer(wrapping: base)
+
+        // Fill exactly to the cap — each distinct string is a miss.
+        for i in 0..<CachingTokenizer.maxEntries {
+            _ = cache.tokenCount("s\(i)")
+        }
+        XCTAssertEqual(base.callCount, CachingTokenizer.maxEntries)
+
+        // At the cap (not over) the earliest key is still cached.
+        _ = cache.tokenCount("s0")
+        XCTAssertEqual(base.callCount, CachingTokenizer.maxEntries, "s0 should still be cached at the cap")
+
+        // One more distinct key trips the wholesale flush (count >= maxEntries),
+        // evicting s0 — re-querying it recomputes, proving the bound holds.
+        _ = cache.tokenCount("overflow")
+        _ = cache.tokenCount("s0")
+        XCTAssertEqual(
+            base.callCount, CachingTokenizer.maxEntries + 2,
+            "'overflow' and the re-query of evicted 's0' both recompute after the flush"
+        )
+    }
 }

--- a/Tests/ManifoldInferenceTests/InferenceBackendCapabilityGateTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceBackendCapabilityGateTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for ``InferenceBackend/generateEnforcingCapabilities(prompt:systemPrompt:config:)``
+/// — the capability gate that the footgun audit promoted from a RouterBackend-only
+/// check to the single-backend dispatch boundary (class A — "two paths, one guard").
+///
+/// Without it, a host that set ``GenerationConfig/requiredCapabilities`` and ran
+/// against a single concrete backend had the constraint silently ignored: the
+/// backend generated anyway, downgrading the request with no error.
+final class InferenceBackendCapabilityGateTests: XCTestCase {
+
+    private func minimalCaps() -> BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 2048,
+            supportsToolCalling: false,
+            supportsThinking: false
+        )
+    }
+
+    private func toolCapableCaps() -> BackendCapabilities {
+        BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 8192,
+            supportsToolCalling: true
+        )
+    }
+
+    func test_throwsWhenBackendCannotSatisfyRequirement_withoutCallingGenerate() throws {
+        let backend = MockInferenceBackend(capabilities: minimalCaps())
+        backend.isModelLoaded = true
+        let config = GenerationConfig(requiredCapabilities: [.toolCalling])
+
+        XCTAssertThrowsError(
+            try backend.generateEnforcingCapabilities(prompt: "hi", systemPrompt: nil, config: config)
+        ) { error in
+            guard case InferenceError.noBackendSatisfiesRequirements(let unmet) = error else {
+                return XCTFail("Expected .noBackendSatisfiesRequirements, got \(error)")
+            }
+            XCTAssertEqual(unmet, [.toolCalling])
+        }
+        // The gate must fail fast BEFORE dispatching to the backend — a silently
+        // downgraded generation is exactly the bug this closes.
+        XCTAssertEqual(backend.generateCallCount, 0, "generate must not run when requirements are unmet")
+    }
+
+    func test_passesWhenBackendSatisfiesRequirement() throws {
+        let backend = MockInferenceBackend(capabilities: toolCapableCaps())
+        backend.isModelLoaded = true
+        let config = GenerationConfig(requiredCapabilities: [.toolCalling])
+
+        XCTAssertNoThrow(
+            try backend.generateEnforcingCapabilities(prompt: "hi", systemPrompt: nil, config: config)
+        )
+        XCTAssertEqual(backend.generateCallCount, 1)
+    }
+
+    func test_emptyRequirements_isNoOp_andDispatches() throws {
+        let backend = MockInferenceBackend(capabilities: minimalCaps())
+        backend.isModelLoaded = true
+        let config = GenerationConfig() // requiredCapabilities defaults empty
+
+        XCTAssertNoThrow(
+            try backend.generateEnforcingCapabilities(prompt: "hi", systemPrompt: nil, config: config)
+        )
+        XCTAssertEqual(backend.generateCallCount, 1, "the standard chat path must be unaffected")
+    }
+
+    func test_reportsAllUnmetRequirements_sortedDeterministically() throws {
+        let backend = MockInferenceBackend(capabilities: minimalCaps())
+        backend.isModelLoaded = true
+        let config = GenerationConfig(requiredCapabilities: [.toolCalling, .thinking])
+
+        XCTAssertThrowsError(
+            try backend.generateEnforcingCapabilities(prompt: "hi", systemPrompt: nil, config: config)
+        ) { error in
+            guard case InferenceError.noBackendSatisfiesRequirements(let unmet) = error else {
+                return XCTFail("Expected .noBackendSatisfiesRequirements, got \(error)")
+            }
+            // Both are unmet; order is deterministic (sortKey) so logs/diffs are stable.
+            XCTAssertEqual(Set(unmet), [.toolCalling, .thinking])
+            XCTAssertEqual(unmet, unmet.sorted { $0.sortKey < $1.sortKey })
+        }
+    }
+}


### PR DESCRIPTION
Closes part of #1623 — the footgun audit's third leg (security #1621 and correctness #1622 already shipped). Converts the highest-value per-site guards and prose contracts into **structural** enforcement so the next backend or branch inherits correctness by construction.

Two items the issue listed were already done since it was filed and are dropped from scope: `maxOutputTokens` doc reconciliation (commit `3ee1740c`) and the `EmbeddingBackend` unsafe call sites (fixed in #1627).

## What changed, by root-cause pattern

**Class A — "two paths, one guard" (chokepoints)**
- **Cloud error sanitize** — new `CloudBackendError.sanitized{Server,Parse}Error` factory in `ManifoldCloudCore` (the kernel can't see `CloudErrorSanitizer`). All five upstream-text construction sites route through it, so a raw `.serverError`/`.parseError` in the cloud modules now means *trusted literal* and no future error path can bypass the sanitizer.
- **Message fetch limit** — `boundedMessageFetch` builder *requires* a limit on every `ChatMessage` read; fixes the unbounded `fetchMessages(for:)`. The "whole session" read is now newest-N with a logged ceiling, so truncation is bounded and visible, never silent.
- **`requiredCapabilities`** — `generateEnforcingCapabilities` wrapper enforces the capability gate at the `InferenceService` dispatch boundary (per maintainer call), not only inside `RouterBackend`. No-op when the requirement set is empty, so the standard chat path is unaffected.

**Class D — silent degradation (fail-fast viability)**
- `DefaultBackends.register` now returns the registered count; `quickStart()` throws `ManifoldKitError.noBackendsRegistered` instead of launching a fully-wired but dead app for an empty trait/OS combination. (`ManifoldBootstrap` itself can't host this check — it has no ML deps — so it lands at the assembly boundary.)

**Class B — prose into types**
- `CachingTokenizer` cache is bounded (flush at `maxEntries`); the single-use contract had been relaxed to reusable, leaving it unbounded.

**Class C — asymmetric siblings**
- `BackendDeinitSymmetryAuditTest` fails in CI if a resource-releasing backend (MLX/Llama) loses its `deinit`-time release — the exact MLX arbiter-leak class from #1627. The backend-level proof needs Metal and stays in the Xcode-only integration suite.

## Not in this PR (tracked follow-up on #1623)
The full **cross-backend conformance-matrix generalization** — running the same contract suite against every family for every cross-cutting invariant — is genuinely multi-PR; the issue says to pace it. This PR delivers the CI-runnable keystone guard (the deinit-symmetry audit) and leaves the matrix on the issue.

## Tests
New: `InferenceBackendCapabilityGateTests` (4), `CachingTokenizerTests` bounded-cache case, `CloudBackendErrorSanitizedFactoryTests` (5), `BackendDeinitSymmetryAuditTest` (1). All new + affected suites green under `scripts/test.sh --profile local` (XCTest 4796/0, Swift Testing 83/0, 60 expected skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)