### PR TITLE
perf(ci): prototype per-target xcschemes + SchemeSubgraphFreshnessTest (Tier 2, #1590)

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldInferenceTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldInferenceTests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldInference + its test target so xcodebuild
+     compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldInference"
+               BuildableName = "ManifoldInference"
+               BlueprintName = "ManifoldInference"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldInferenceTests"
+               BuildableName = "ManifoldInferenceTests"
+               BlueprintName = "ManifoldInferenceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldInferenceTests"
+               BuildableName = "ManifoldInferenceTests"
+               BlueprintName = "ManifoldInferenceTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldMCPTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldMCPTests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldMCP + its test target so xcodebuild
+     compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldMCP"
+               BuildableName = "ManifoldMCP"
+               BlueprintName = "ManifoldMCP"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldMCPTests"
+               BuildableName = "ManifoldMCPTests"
+               BlueprintName = "ManifoldMCPTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldMCPTests"
+               BuildableName = "ManifoldMCPTests"
+               BlueprintName = "ManifoldMCPTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/ManifoldCoreTests/SchemeSubgraphFreshnessTest.swift
+++ b/Tests/ManifoldCoreTests/SchemeSubgraphFreshnessTest.swift
@@ -1,0 +1,142 @@
+import XCTest
+
+/// Guards against scheme rot introduced by the Tier 2 compile-pruned selective
+/// CI initiative (issue #1590).
+///
+/// ## Why this test exists
+///
+/// The per-target `.xcscheme` files in `.swiftpm/xcode/xcshareddata/xcschemes/`
+/// reference targets by name via `BlueprintName` attributes.  If a target is
+/// renamed or removed in `Package.swift` without updating the corresponding
+/// scheme, `xcodebuild test -scheme <Name>` silently fails to resolve the
+/// target — which either errors at CI or, worse, falls back to a wider build
+/// graph than intended.
+///
+/// This test walks every `.xcscheme` file in the SwiftPM-managed scheme
+/// directory, extracts every `BlueprintName` attribute, and asserts that the
+/// named target still exists in `Package.swift`.  It catches renames and
+/// removals in the same PR that makes the Package.swift edit.
+///
+/// ## What it does NOT enforce
+///
+/// It does not enforce the *completeness* of a scheme's `BuildActionEntries`
+/// (i.e. it does not verify that the scheme lists all direct dependencies of
+/// the test target).  xcodebuild resolves transitive deps from Package.swift
+/// automatically; the scheme only needs the top-level library + test target.
+///
+/// ## Fixing a violation
+///
+/// Either update `BlueprintName` / `BlueprintIdentifier` in the relevant
+/// `.xcscheme` to match the new target name, or delete the scheme if the
+/// target no longer exists.  Do this in the same PR as the Package.swift edit.
+final class SchemeSubgraphFreshnessTest: XCTestCase {
+
+    func test_schemeBlueprintNamesReferenceExistingTargets() throws {
+        let root = try Self.locatePackageRoot()
+
+        let schemesDir = root
+            .appendingPathComponent(".swiftpm/xcode/xcshareddata/xcschemes")
+        let schemeFiles = try FileManager.default
+            .contentsOfDirectory(at: schemesDir, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "xcscheme" }
+
+        XCTAssertFalse(schemeFiles.isEmpty,
+            "Expected at least one .xcscheme file in \(schemesDir.path)")
+
+        let manifest = try String(
+            contentsOf: root.appendingPathComponent("Package.swift"),
+            encoding: .utf8)
+        let knownTargets = Self.extractTargetNames(from: manifest)
+
+        var violations: [(scheme: String, blueprint: String)] = []
+
+        for schemeURL in schemeFiles.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            let schemeXML = try String(contentsOf: schemeURL, encoding: .utf8)
+            let names = Self.extractBlueprintNames(from: schemeXML)
+            for name in names where !knownTargets.contains(name) {
+                violations.append((scheme: schemeURL.lastPathComponent, blueprint: name))
+            }
+        }
+
+        if !violations.isEmpty {
+            let lines = violations
+                .map { "  \($0.scheme): BlueprintName \"\($0.blueprint)\" not found in Package.swift" }
+                .joined(separator: "\n")
+            XCTFail("""
+                Scheme subgraph freshness check failed.
+                The following BlueprintName entries reference targets that no
+                longer exist in Package.swift.  Update or delete the affected
+                scheme in the same PR as the Package.swift change.
+
+                \(lines)
+                """)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Extracts the string values of all `BlueprintName = "..."` and
+    /// `BlueprintIdentifier = "..."` attributes from xcscheme XML.  Both
+    /// attributes name the same target; scanning both is redundant but guards
+    /// against an attribute being absent in a hand-edited scheme.
+    private static func extractBlueprintNames(from xml: String) -> Set<String> {
+        var names = Set<String>()
+        // Matches:  BlueprintName = "SomeTargetName"
+        //           BlueprintIdentifier = "SomeTargetName"
+        let pattern = #"Blueprint(?:Name|Identifier)\s*=\s*"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return names
+        }
+        let range = NSRange(xml.startIndex..., in: xml)
+        for match in regex.matches(in: xml, range: range) {
+            if let r = Range(match.range(at: 1), in: xml) {
+                names.insert(String(xml[r]))
+            }
+        }
+        return names
+    }
+
+    /// Extracts target names declared in Package.swift by scanning for
+    /// `name: "..."` occurrences that appear on a line ending in a comma or
+    /// following a `.target(` / `.testTarget(` / `.executableTarget(` opener.
+    ///
+    /// Implementation note: because target-name lines in Package.swift look
+    /// like `name: "ManifoldMCP",` (the `name:` key is always first after the
+    /// opener), a simple `name: "XYZ"` scan has an acceptably low false-
+    /// negative rate for the drift-detection purpose here.  False positives
+    /// (non-target `name:` uses) are benign — they only enlarge the known set,
+    /// never cause a false failure.
+    private static func extractTargetNames(from manifest: String) -> Set<String> {
+        var names = Set<String>()
+        let pattern = #"name:\s*"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return names
+        }
+        let range = NSRange(manifest.startIndex..., in: manifest)
+        for match in regex.matches(in: manifest, range: range) {
+            if let r = Range(match.range(at: 1), in: manifest) {
+                names.insert(String(manifest[r]))
+            }
+        }
+        return names
+    }
+
+    /// Walks upward from this test file's location to find the repo root
+    /// `Package.swift`.  Mirrors the pattern used by `PackageTraitGateAuditTest`
+    /// and `UserDefaultsStandardAuditTest`.
+    private static func locatePackageRoot(filePath: StaticString = #filePath) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(filePath)").deletingLastPathComponent()
+        while dir.path != "/" {
+            let candidate = dir.appendingPathComponent("Package.swift")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return dir
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(
+            domain: "SchemeSubgraphFreshnessTest",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate Package.swift from #filePath"]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ManifoldInferenceTests.xcscheme` and `ManifoldMCPTests.xcscheme` to `.swiftpm/xcode/xcshareddata/xcschemes/` — the per-target xcodebuild scheme prototype for the Tier 2 compile-pruned selective CI initiative (#1590)
- Adds `SchemeSubgraphFreshnessTest` (ManifoldCoreTests) — watches every committed `.xcscheme` for `BlueprintName` drift against `Package.swift`; catches target renames/removals in the same PR

## Prototype findings

This is the PR A research step from the scoping in #1590. Both schemes are correct and functional. Two blockers surface that must be resolved before PR B can wire xcodebuild into the CI gate.

### ManifoldInferenceTests.xcscheme ✅ (runs correctly, compile-prune blocked)

Runs and passes 1649 tests on macOS. `buildImplicitDependencies = YES` lets xcodebuild resolve the subgraph from `Package.swift` without listing every transitive dep in the scheme.

**Blocker — MLX Metal in the non-hardware graph:** `ManifoldTestSupport` carries `MLXLMCommon` as a trait-conditional dep (`condition: .when(traits: ["MLX"])`). xcodebuild uses the default SwiftPM trait set (MLX, Llama, HuggingFace, Skills), so `MLXLMCommon` and the full MLX + Metal shader stack compile even for `ManifoldInferenceTests` — the exact cost Tier 2 is meant to avoid.

**Required prerequisite for PR B:** Split `ManifoldTestSupport` into a hardware-free core and an MLX extension. Non-hardware test suites link only the core. This is the structural change that makes the compile-prune real.

### ManifoldMCPTests.xcscheme ⚠️ (runs with 0 tests — trait-activation needed)

The scheme XML is correct. xcodebuild silently produces an empty test bundle (0 tests) because MCP is not in the default trait set. `ManifoldMCPTests`'s `ManifoldMCP` dep has `condition: .when(traits: ["MCP"])` — without the trait active, the dep isn't linked, test source files fail to import `ManifoldMCP`, and xcodebuild silently drops them (confirmed via `empty-ManifoldMCPTests.plist` in DerivedData).

**Required prerequisite for PR B:** Either surface a way to activate specific SwiftPM traits in an xcodebuild invocation (Xcode 16+ may expose this — worth investigating before PR B), or limit the xcodebuild scheme path to test targets whose deps don't require non-default traits, keeping ManifoldMCPTests on `swift test --traits MCP`.

### SWIFT_ACTIVE_COMPILATION_CONDITIONS workaround ruled out

Passing `SWIFT_ACTIVE_COMPILATION_CONDITIONS=...` overrides — not appends to — the Debug build's `DEBUG` flag. This silences the `#if DEBUG` guard on `InferenceService(backend:name:)` and similar test-only inits, causing compile errors. Any use of this override must explicitly include `DEBUG`, AND it cannot disable the package-manifest-level MLX dep (that's a trait, not a compilation condition).

## Test plan

- [x] `SchemeSubgraphFreshnessTest` passes in `scripts/test.sh --profile ci --filter ManifoldCoreTests`
- [x] `ManifoldInferenceTests.xcscheme` runs 1649 tests via `xcodebuild test -scheme ManifoldInferenceTests -destination "platform=macOS,arch=arm64" -disableAutomaticPackageResolution`
- [x] `ManifoldMCPTests.xcscheme` exists and is recognized by `xcodebuild -list`; 0-test behaviour documented above

## What's next (PR B prerequisites)

1. **ManifoldTestSupport split** — separates MLX mocks from non-hardware mocks so `ManifoldInferenceTests` and peer suites compile without Metal
2. **xcodebuild trait-activation research** — check if Xcode 26 exposes a `SWIFT_PACKAGE_ENABLED_TRAITS` or equivalent build setting before writing off ManifoldMCPTests and similar trait-gated suites from the xcodebuild path
3. **Tier 0 activation** (#1588) — Tier 0's `affected` output feeds the selective dispatch; it needs to leave dry-run before PR B's CI wiring is useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)