### PR TITLE
refactor(test): move MockMLXModelContainer to ManifoldBackendsTests + drop MLX dep from ManifoldTestSupport

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -541,7 +541,6 @@ let package = Package(
                 "ManifoldRuntime",
                 "ManifoldPersistenceSwiftData",
                 "ManifoldInference",
-                .product(name: "MLXLMCommon", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
             ],
             path: "Sources/ManifoldTestSupport",
             exclude: ["FuzzCalibrationCorpus"],

--- a/Tests/ManifoldBackendsTests/MLXBackendGenerationTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXBackendGenerationTests.swift
@@ -11,21 +11,21 @@ import ManifoldInference
 // Conform MockMLXModelContainer to the internal protocol in this test target,
 // where both the internal protocol and the public mock type are visible.
 extension MockMLXModelContainer: MLXModelContainerProtocol {
-    public func prepare(messages: [[String : String]]) async throws -> MLXPreparedInput {
+    func prepare(messages: [[String : String]]) async throws -> MLXPreparedInput {
         let promptTokenIds = try await prepareForGeneration(messages: messages)
         return MLXPreparedInput(promptTokenIds: promptTokenIds)
     }
 
-    public func prepare(chat: SendableChatMessages) async throws -> MLXPreparedInput {
+    func prepare(chat: SendableChatMessages) async throws -> MLXPreparedInput {
         let promptTokenIds = try await prepareForGeneration(chat: chat.value)
         return MLXPreparedInput(promptTokenIds: promptTokenIds)
     }
 
-    public func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache {
+    func makeCache(parameters: GenerateParameters) async throws -> MLXPromptCache {
         MLXPromptCache(makeCacheForGeneration(parameters: parameters))
     }
 
-    public func generate(
+    func generate(
         input: MLXPreparedInput,
         cache: MLXPromptCache?,
         parameters: GenerateParameters

--- a/Tests/ManifoldBackendsTests/MockMLXModelContainer.swift
+++ b/Tests/ManifoldBackendsTests/MockMLXModelContainer.swift
@@ -9,18 +9,18 @@ import MLXLMCommon
 /// This is `@unchecked Sendable` because `LMInput` holds `MLXArray` values that are not
 /// marked `Sendable`. The wrapper is safe when access to the underlying value is
 /// serialised — e.g. produced and consumed within the same `Task`.
-public struct SendableLMInput: @unchecked Sendable {
-    public let value: LMInput
+struct SendableLMInput: @unchecked Sendable {
+    let value: LMInput
 
-    public init(_ value: LMInput) {
+    init(_ value: LMInput) {
         self.value = value
     }
 }
 
-public struct SendableKVCacheList: @unchecked Sendable {
-    public let value: [any KVCache]
+struct SendableKVCacheList: @unchecked Sendable {
+    let value: [any KVCache]
 
-    public init(_ value: [any KVCache]) {
+    init(_ value: [any KVCache]) {
         self.value = value
     }
 }
@@ -29,18 +29,18 @@ public struct SendableKVCacheList: @unchecked Sendable {
 
 /// Fake model container for unit-testing `MLXBackend` generation without hardware.
 ///
-/// Conforms to `MLXModelContainerProtocol` via an extension declared in
-/// `ManifoldBackendsTests` (where the internal protocol is visible). This avoids
-/// importing `ManifoldBackends` from `ManifoldTestSupport`.
-public final class MockMLXModelContainer: @unchecked Sendable {
+/// Conforms to `MLXModelContainerProtocol` via an extension below (where the
+/// internal protocol is visible). This avoids importing `ManifoldBackends` from
+/// `ManifoldTestSupport`.
+final class MockMLXModelContainer: @unchecked Sendable {
 
     // MARK: - Configuration
 
     /// Tokens the mock yields from `generate`. Defaults to a two-token sequence.
-    public var tokensToYield: [String] = ["Hello", " world"]
+    var tokensToYield: [String] = ["Hello", " world"]
 
     /// When set, `generate` throws this error instead of yielding tokens.
-    public var generateError: Error?
+    var generateError: Error?
 
     /// Simulates a chat-template / tokenizer rejection at `apply_chat_template` time.
     ///
@@ -50,59 +50,59 @@ public final class MockMLXModelContainer: @unchecked Sendable {
     /// or the template rejects the supplied message set (e.g. missing
     /// `<|assistant|>` marker, wrong role ordering). The error surfaces unwrapped
     /// through `MLXBackend.generate`'s GenerationStream — see issue #551.
-    public var simulatedTokenizerApplyFailure: Error?
+    var simulatedTokenizerApplyFailure: Error?
 
     /// Optional stand-in for the tokenizer's `chat_template` field. The mock does
     /// NOT itself apply a Jinja template — production MLXModelContainer does that
     /// internally — but tests can set this to document which template shape they
     /// are exercising and assert the backend hands compatible messages along.
-    public var simulatedChatTemplate: String?
+    var simulatedChatTemplate: String?
 
     /// Prepared prompt-token batches returned by successive `prepare` calls.
     ///
     /// When empty, the mock synthesizes a small token sequence from the message count.
-    public var preparedTokenBatches: [[Int]] = []
+    var preparedTokenBatches: [[Int]] = []
 
     /// Factory used to create the explicit cache passed to generation.
-    public var cacheFactory: @Sendable () -> [any KVCache] = { [KVCacheSimple()] }
+    var cacheFactory: @Sendable () -> [any KVCache] = { [KVCacheSimple()] }
 
     /// Extra tail tokens the mock appends to the cache during generation to model
     /// completion tokens extending beyond the prompt.
-    public var simulatedCacheCompletionTokenCount = 0
+    var simulatedCacheCompletionTokenCount = 0
 
     // MARK: - Observation
 
     /// Number of times prepared generation was called.
-    public private(set) var generateCallCount = 0
+    private(set) var generateCallCount = 0
 
     /// Number of times `prepare(messages:)` was called.
-    public private(set) var prepareCallCount = 0
+    private(set) var prepareCallCount = 0
 
     /// Number of times `makeCache(parameters:)` was called.
-    public private(set) var makeCacheCallCount = 0
+    private(set) var makeCacheCallCount = 0
 
     /// Last messages passed to `prepare`.
-    public private(set) var lastMessages: [[String: String]]?
+    private(set) var lastMessages: [[String: String]]?
 
     /// Last structured chat messages passed to `prepare(chat:)`.
-    public private(set) var lastChatMessages: [Chat.Message]?
+    private(set) var lastChatMessages: [Chat.Message]?
 
     /// Last `GenerateParameters` value passed to generation. Useful for asserting
     /// that `MLXBackend` forwards `temperature` / `topP` / `topK` / `minP` /
     /// `repetitionPenalty` from the caller's `GenerationConfig`.
-    public private(set) var lastParameters: GenerateParameters?
+    private(set) var lastParameters: GenerateParameters?
 
     /// Last prepared prompt-token batch returned by `prepare`.
-    public private(set) var lastPreparedTokenIds: [Int]?
+    private(set) var lastPreparedTokenIds: [Int]?
 
     /// Cache offsets observed at the start of generation.
-    public private(set) var lastInitialCacheOffsets: [Int]?
+    private(set) var lastInitialCacheOffsets: [Int]?
 
-    public init() {}
+    init() {}
 
-    // MARK: - Public helpers consumed by ManifoldBackendsTests conformance
+    // MARK: - Helpers consumed by MLXModelContainerProtocol conformance
 
-    public func prepareForGeneration(
+    func prepareForGeneration(
         messages: [[String: String]]
     ) async throws -> [Int] {
         prepareCallCount += 1
@@ -119,7 +119,7 @@ public final class MockMLXModelContainer: @unchecked Sendable {
         return promptTokens
     }
 
-    public func prepareForGeneration(
+    func prepareForGeneration(
         chat: [Chat.Message]
     ) async throws -> [Int] {
         prepareCallCount += 1
@@ -136,12 +136,12 @@ public final class MockMLXModelContainer: @unchecked Sendable {
         return promptTokens
     }
 
-    public func makeCacheForGeneration(parameters: GenerateParameters) -> [any KVCache] {
+    func makeCacheForGeneration(parameters: GenerateParameters) -> [any KVCache] {
         makeCacheCallCount += 1
         return cacheFactory()
     }
 
-    public func generatePreparedInput(
+    func generatePreparedInput(
         promptTokenIds: [Int],
         cache: SendableKVCacheList?,
         parameters: GenerateParameters


### PR DESCRIPTION
## Summary

- **ManifoldTestSupport split**: `MockMLXModelContainer` (the only MLX-dependent symbol) moves from `Sources/ManifoldTestSupport/` to `Tests/ManifoldBackendsTests/` — its sole consumer. Removes the `MLXLMCommon` product dep from `ManifoldTestSupport`.
- **Conformance access level fix**: Conformance extension methods dropped from `public` to `internal` — `public` methods on an `internal` type fail Swift 6 strict mode.
- **Research finding (xcodebuild trait activation)**: No `SWIFT_PACKAGE_ENABLED_TRAITS` or equivalent CLI flag exists in Xcode 26 build settings. xcodebuild has no way to activate or deactivate SwiftPM traits from the command line. `ManifoldMCPTests` must stay on `swift test --traits MCP`.

## Why this matters

`ManifoldTestSupport` had a `condition: .when(traits: ["MLX"])` dep on `MLXLMCommon`. Because `MLX` is a default xcodebuild trait, every suite importing `ManifoldTestSupport` — including `ManifoldInferenceTests` — pulled in full Metal shader compilation even when none of its tests touch MLX. This blocked the per-target `ManifoldInferenceTests.xcscheme` (landed in #1631) from pruning the Metal subgraph.

After this change, `ManifoldInferenceTests.xcscheme` will compile only the `ManifoldInference` + `ManifoldInferenceTests` subgraph. The MLX Metal subtree is no longer reachable.

## Impact on PR B planning

The xcodebuild trait-activation research concludes that `ManifoldMCPTests` (and any other trait-gated suite) **cannot** be driven by xcodebuild schemes. PR B should wire only non-trait-gated suites into xcodebuild. The MCP suite stays on the `swift test --traits MCP` path.

## Prerequisite for

Issue #1590 — Tier 2 compile-pruned selective CI, PR B.

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — clean build ✅
- [x] `swift build --build-tests --traits MLX,Llama,MCP,MCPBuiltinCatalog,CloudSaaS,Ollama,HuggingFace,Fuzz` — clean build ✅
- [x] `scripts/test.sh --profile ci --skip-update` — PASSED ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)