### PR TITLE
feat(cloud): configurable per-request idle timeout for slow LAN/local prefill

### DIFF
--- a/Sources/ManifoldCloud/OllamaBackend.swift
+++ b/Sources/ManifoldCloud/OllamaBackend.swift
@@ -70,6 +70,16 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
         withStateLock { _isThinkingModel }
     }
 
+    /// Default per-request idle timeout for Ollama connections.
+    ///
+    /// Large models may need several minutes to load into VRAM and prefill a
+    /// long prompt before any response byte arrives. This generous default
+    /// prevents the connection from being killed during that load phase.
+    /// Matches the ``keepAlive`` default of 30 minutes.
+    ///
+    /// Override via ``SSECloudBackend/requestIdleTimeout`` after init.
+    public static let defaultRequestIdleTimeout: TimeInterval = 1800
+
     /// Conservative floor for `num_ctx` when the caller did not plumb a real
     /// context budget via `ModelLoadPlan` (`.cloud()` default is `1`).
     /// Ollama's server-side `OLLAMA_CONTEXT_LENGTH` defaults to 2048 tokens,
@@ -152,6 +162,10 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
             urlSession: urlSession ?? URLSessionProvider.unpinned,
             payloadHandler: CloudPayloadHandler.ollama
         )
+        // Ollama servers often need time to load a model into VRAM before the
+        // first response byte arrives. Set a generous HTTP-layer idle timeout
+        // so that cold-start latency isn't misreported as a network failure.
+        requestIdleTimeout = OllamaBackend.defaultRequestIdleTimeout
 
         // Phase 3/Ollama — install adapter routing so the stream loop runs
         // in `CloudRoutedStreamParser` driving a fresh
@@ -559,9 +573,10 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
     // visible caps reach the extractor.
     //
     // TODO: (#189) Detect Ollama model-loading state and set GenerationStream
-    // phase to .loading. Requires the monitoring task pattern from
-    // GenerationStream to detect the pre-first-token stall that indicates
-    // Ollama is loading the model into VRAM.
+    // phase to .loading. The pre-first-token stall is no longer killed by a
+    // short HTTP timeout (see `defaultRequestIdleTimeout`), but the phase
+    // still shows as .streaming during the load window. Requires a monitoring
+    // task that detects the stall and surfaces it as .loading.
 
     public override func parseResponseStream(
         bytes: URLSession.AsyncBytes,

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -175,6 +175,23 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     /// `nil` disables idle detection (default).
     public var streamIdleTimeout: Duration?
 
+    /// Per-request HTTP idle timeout, applied as `URLRequest.timeoutInterval`
+    /// on every generation request.
+    ///
+    /// When non-nil, overrides the session-level `timeoutIntervalForRequest`
+    /// from ``URLSessionProvider`` for each generation call. Use a generous
+    /// value for LAN/local backends where the server may need time to load a
+    /// model into VRAM before producing the first byte.
+    ///
+    /// `nil` (default) leaves `URLRequest.timeoutInterval` unset, so the
+    /// session configuration's `timeoutIntervalForRequest` governs idle behavior.
+    ///
+    /// Distinct from ``streamIdleTimeout``, which is an application-level gate
+    /// that fires when no SSE *event* arrives within a window after the
+    /// connection is already open and streaming. This property controls the
+    /// HTTP-layer idle window before the first byte.
+    public var requestIdleTimeout: TimeInterval?
+
     /// Per-backend override for the SSE / NDJSON stream caps that defend
     /// against hostile upstream servers. When `nil` (default), the value
     /// from `ManifoldConfiguration.shared.sseStreamLimits` is used at
@@ -551,6 +568,10 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         generationID: UInt64,
         eventIDTracker: SSEEventIDTracker
     ) -> SSEGenerationTaskContext {
+        var request = request
+        if let timeout = requestIdleTimeout {
+            request.timeoutInterval = timeout
+        }
         let capturedStrategy = retryStrategy
         let capturedBaseURL = baseURL
         return SSEGenerationTaskContext(

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -1731,6 +1731,71 @@ struct OllamaBackendTests {
                     "tag '\(tag)' contains 'cloud' but does not end in ':cloud' — must load normally")
         }
     }
+
+    // MARK: - requestIdleTimeout (slow cold-load protection)
+
+    @Test func requestIdleTimeout_defaultMatchesConstant() {
+        // Sabotage: removing the `requestIdleTimeout = defaultRequestIdleTimeout`
+        // line in OllamaBackend.init causes this to return nil.
+        let backend = OllamaBackend(urlSession: makeMockSession())
+        #expect(backend.requestIdleTimeout == OllamaBackend.defaultRequestIdleTimeout,
+                "OllamaBackend must default requestIdleTimeout to defaultRequestIdleTimeout so cold-loading servers aren't killed")
+    }
+
+    @Test func requestIdleTimeout_defaultIsGenerous() {
+        // 1800s matches the 30-min keepAlive default; anything below 600s
+        // would kill large models during a realistic VRAM load.
+        #expect(OllamaBackend.defaultRequestIdleTimeout >= 600,
+                "defaultRequestIdleTimeout must be at least 600s to survive slow model cold-loads")
+    }
+
+    @Test func requestIdleTimeout_stampsGenerationRequest() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+        MockURLProtocol.stub(url: showURL, response: .immediate(data: apiShowBody(capabilities: []), statusCode: 200))
+        defer { MockURLProtocol.unstub(url: showURL) }
+        try await loadBackend(backend)
+
+        let doneChunk = ndjsonLine("""
+        {"model":"llama3.2","message":{"role":"assistant","content":"hi"},"done":true}
+        """)
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: [doneChunk], statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
+        for try await _ in stream.events {}
+
+        let captured = MockURLProtocol.capturedRequests.last { $0.url?.absoluteString.contains("api/chat") == true }
+        // Sabotage: removing the `request.timeoutInterval = timeout` line in
+        // SSECloudBackend.makeGenerationTaskContext causes the captured request
+        // to carry the URLRequest default (60s) rather than our 1800s.
+        #expect(
+            captured?.timeoutInterval == OllamaBackend.defaultRequestIdleTimeout,
+            "Generation request must carry requestIdleTimeout as URLRequest.timeoutInterval"
+        )
+    }
+
+    @Test func requestIdleTimeout_overridePropagates() async throws {
+        let (backend, chatURL, showURL) = makeConfiguredBackendWithShow()
+        backend.requestIdleTimeout = 42
+        MockURLProtocol.stub(url: showURL, response: .immediate(data: apiShowBody(capabilities: []), statusCode: 200))
+        defer { MockURLProtocol.unstub(url: showURL) }
+        try await loadBackend(backend)
+
+        let doneChunk = ndjsonLine("""
+        {"model":"llama3.2","message":{"role":"assistant","content":"ok"},"done":true}
+        """)
+        MockURLProtocol.stub(url: chatURL, response: .sse(chunks: [doneChunk], statusCode: 200))
+        defer { MockURLProtocol.unstub(url: chatURL) }
+
+        let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
+        for try await _ in stream.events {}
+
+        let captured = MockURLProtocol.capturedRequests.last { $0.url?.absoluteString.contains("api/chat") == true }
+        // Sabotage: changing backend.requestIdleTimeout = 42 to any other value
+        // or removing the wiring in makeGenerationTaskContext causes this to fail.
+        #expect(captured?.timeoutInterval == 42,
+                "Overriding requestIdleTimeout must propagate to URLRequest.timeoutInterval")
+    }
 }
 
 // MARK: - OllamaModelListService Tests


### PR DESCRIPTION
## Summary

- Adds `SSECloudBackend.requestIdleTimeout: TimeInterval?` — when non-nil, sets `URLRequest.timeoutInterval` on every generation request, overriding the session-level idle timeout on a per-backend basis
- `OllamaBackend` defaults to `defaultRequestIdleTimeout = 1800` (30 min), matching the `keepAlive` default, so cold-loading large models are no longer killed before the first byte arrives
- All other backends default to `nil` (existing session-level 300s behavior unchanged)
- Updates the `#189` TODO comment now that the connection is preserved during the load phase

## Test plan

- [x] `requestIdleTimeout_defaultMatchesConstant` — `OllamaBackend().requestIdleTimeout == defaultRequestIdleTimeout`
- [x] `requestIdleTimeout_defaultIsGenerous` — `defaultRequestIdleTimeout >= 600`
- [x] `requestIdleTimeout_stampsGenerationRequest` — captured `URLRequest.timeoutInterval == defaultRequestIdleTimeout` (sabotage-checked)
- [x] `requestIdleTimeout_overridePropagates` — setting `backend.requestIdleTimeout = 42` propagates to captured request (sabotage-checked)
- [x] Full-traits build clean: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Macros`
- [x] 72 Ollama suite tests pass under `--traits Ollama`

Closes #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)