### PR TITLE
perf(ci): wire Tier 0→Tier 2 selective xcodebuild CI with 8 new xcschemes (#1590)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ on:
       # logging — otherwise a change to the gate would bypass the gate.
       - "scripts/affected-suites.sh"
       - "scripts/affected-suites-graph.json"
+      # Tier 2 selective CI (issue #1590). Listed so edits to the selective
+      # runner or the xcscheme files re-trigger CI — otherwise a change to
+      # the gate would bypass it (per CI path-filter self-validation rule).
+      - "scripts/ci-selective-test.sh"
+      - ".swiftpm/xcode/xcshareddata/xcschemes/**"
   pull_request:
     branches: [main]
     paths:
@@ -41,6 +46,9 @@ on:
       # logging — otherwise a change to the gate would bypass the gate.
       - "scripts/affected-suites.sh"
       - "scripts/affected-suites-graph.json"
+      # Tier 2 selective CI (issue #1590). See push section above.
+      - "scripts/ci-selective-test.sh"
+      - ".swiftpm/xcode/xcshareddata/xcschemes/**"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -156,11 +164,12 @@ jobs:
               echo "Would run **${n}** affected test-job suite(s): \`${affected}\`"
             fi
             echo ""
-            echo "_Execution is unchanged — the \`test\` job still runs its full hard-coded \`--filter\` list. Tier 0 addresses the ~136s execution half only; compile (~127s) is Tier 2._"
+            echo "_Tier 0 (execution routing) + Tier 2 (compile pruning, issue #1590) are now wired. When mode=selective the \`test\` job runs only the affected suites via xcodebuild per-target instead of the full swift-test bundle._"
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Tier 0 dry-run: affected=${affected}"
 
   test:
+    needs: [changes]
     runs-on: macos-15  # Apple Silicon (arm64) standard runner to reduce spend
 
     steps:
@@ -405,6 +414,54 @@ jobs:
       # The XCTest batch below compiles the test bundle on first invocation,
       # so a separate `swift build --build-tests` step would be duplicate work.
 
+      # ── Tier 2 selective path (issue #1590) ─────────────────────────────────
+      # When Tier 0 returns a bounded affected-suite list (pull_request only),
+      # route each suite to the fastest correct test path via ci-selective-test.sh:
+      #   - Suite has an xcscheme AND is not trait-gated → xcodebuild (subgraph compile)
+      #   - ManifoldMCPTests → swift test --traits MCP (no xcodebuild trait activation)
+      #   - ManifoldBackendsTests → serial swift test (hardware dep in subgraph)
+      # Saves ~127s full-bundle compile by compiling only the affected subgraph(s).
+      # When Tier 0 returns FULL (hub-module change, push to main) or NONE (no
+      # test-job suites affected), fall through to the existing full swift-test batch.
+      - name: Compute test mode (Tier 2 selective or full)
+        id: test-mode
+        run: |
+          set -euo pipefail
+          affected="${{ needs.changes.outputs.affected }}"
+          # Helper: emit "full" with a reason and exit
+          emit_full() { echo "mode=full" >> "$GITHUB_OUTPUT"; echo "Test mode: full ($1)"; exit 0; }
+          [[ "$affected" == "FULL" || "$affected" == "NONE" || -z "$affected" ]] \
+            && emit_full "affected=${affected:-unset}"
+          # Count suites that require a full swift-test bundle compile (can't use xcodebuild):
+          # ManifoldMCPTests (MCP trait not in defaults) and ManifoldBackendsTests
+          # (ManifoldMLX/ManifoldLlama in subgraph → Metal shaders with xcodebuild defaults).
+          # Running 2+ such suites separately compiles the full bundle twice, which is always
+          # slower than one full run. Also fall back if total suite count is large (≥8)
+          # to avoid excessive sequential xcodebuild overhead outweighing the compile savings.
+          swift_test_count=0
+          for s in $affected; do
+            case "$s" in ManifoldMCPTests|ManifoldBackendsTests) ((swift_test_count++)) ;; esac
+          done
+          total_count=$(printf '%s\n' $affected | wc -w | tr -d ' ')
+          [[ $swift_test_count -ge 2 ]] \
+            && emit_full "2+ swift-test suites (${affected}) would compile full bundle twice"
+          [[ $total_count -ge 8 ]] \
+            && emit_full "${total_count} suites — xcodebuild overhead exceeds full-run savings"
+          echo "mode=selective" >> "$GITHUB_OUTPUT"
+          echo "suites=$affected" >> "$GITHUB_OUTPUT"
+          echo "Test mode: selective — ${total_count} suite(s): $affected"
+
+      # ── SELECTIVE PATH (Tier 2) ──────────────────────────────────────────────
+      - name: Test — Selective (Tier 2 compile-pruned xcodebuild)
+        id: test-selective
+        if: steps.test-mode.outputs.mode == 'selective'
+        timeout-minutes: 30
+        env:
+          MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-selective.log
+          STALL_SECONDS: "240"
+        run: scripts/ci-selective-test.sh ${{ steps.test-mode.outputs.suites }}
+
+      # ── FULL PATH — existing swift-test batch (unchanged) ────────────────────
       # Run the full XCTest batch with --parallel. Every test that read or wrote
       # `UserDefaults.standard` has been migrated to a per-suite
       # `UserDefaults(suiteName:)` instance — see
@@ -436,8 +493,9 @@ jobs:
       # neither) — traits only ADD compiled code, so no suite's behavior changes.
       # Keep all three in sync; diverging the traits silently reintroduces the
       # redundant rebuilds.
-      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Inference + TurnLoopCharacterization, parallel)
+      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Inference + Networking + TurnLoopCharacterization, parallel) [full]
         id: test-xctest-suites
+        if: steps.test-mode.outputs.mode == 'full'
         timeout-minutes: 30
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
@@ -452,21 +510,24 @@ jobs:
       # check fails (see CLAUDE.md "BackendContractChecks" note). Running this suite
       # alone in a separate serial invocation guarantees every backend class loads and
       # registers before any meta-contract assertion executes.
-      - name: Test — ManifoldBackendsTests (serial, claims-registry safe)
+      # In selective mode this suite runs via ci-selective-test.sh when it appears in
+      # the affected set; the full-mode step below is therefore scoped to full runs.
+      - name: Test — ManifoldBackendsTests (serial, claims-registry safe) [full]
         id: test-backends
-        if: always()
+        if: ${{ steps.test-mode.outputs.mode == 'full' && (success() || failure()) }}
         timeout-minutes: 30
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-backends.log
           STALL_SECONDS: "240"
         run: scripts/ci-test-with-watchdog.sh --filter ManifoldBackendsTests --disable-default-traits --traits MCP,CloudSaaS --skip-update
 
-      # `if: always()` so a failing XCTest step still surfaces Swift Testing
-      # failures in the same run — otherwise breakage in both harnesses costs
-      # two re-push cycles to triage. The job still fails because step 1 failed.
-      - name: Test — Inference (Swift Testing, isolated process)
+      # `if: (success() || failure())` so a failing XCTest step still surfaces
+      # Swift Testing failures in the same run — otherwise breakage in both
+      # harnesses costs two re-push cycles to triage. In selective mode this
+      # suite runs via ci-selective-test.sh when it appears in the affected set.
+      - name: Test — Inference (Swift Testing, isolated process) [full]
         id: test-inference-swift-testing
-        if: always()
+        if: ${{ steps.test-mode.outputs.mode == 'full' && (success() || failure()) }}
         timeout-minutes: 30
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-swift-testing.log
@@ -503,6 +564,7 @@ jobs:
         # overwrite a previous failing step's diagnostics.
         if: failure()
         env:
+          SELECTIVE_FAILED: ${{ steps.test-selective.outcome == 'failure' }}
           XCTEST_SUITES_FAILED: ${{ steps.test-xctest-suites.outcome == 'failure' }}
           BACKENDS_FAILED: ${{ steps.test-backends.outcome == 'failure' }}
           INFERENCE_SWIFT_TESTING_FAILED: ${{ steps.test-inference-swift-testing.outcome == 'failure' }}
@@ -513,6 +575,7 @@ jobs:
             echo "run-id=${{ github.run_id }}"
             echo "run-attempt=${{ github.run_attempt }}"
             echo "job=test"
+            echo "selective-failed=${SELECTIVE_FAILED}"
             echo "xctest-suites-failed=${XCTEST_SUITES_FAILED}"
             echo "backends-failed=${BACKENDS_FAILED}"
             echo "inference-swift-testing-failed=${INFERENCE_SWIFT_TESTING_FAILED}"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldCoreTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldCoreTests.xcscheme
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     ManifoldCoreTests spans ManifoldInference + ManifoldRuntime +
+     ManifoldPersistenceSwiftData — no single primary library. Lists only the
+     test target; buildImplicitDependencies resolves the subgraph from
+     Package.swift. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldCoreTests"
+               BuildableName = "ManifoldCoreTests"
+               BlueprintName = "ManifoldCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldCoreTests"
+               BuildableName = "ManifoldCoreTests"
+               BlueprintName = "ManifoldCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldInferenceSwiftTestingTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldInferenceSwiftTestingTests.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldInference + ManifoldInferenceSwiftTestingTests
+     so xcodebuild compiles only the subgraph.
+     Separate scheme from ManifoldInferenceTests because this target uses
+     Swift Testing syntax (not XCTest); xcodebuild handles both harnesses. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldInference"
+               BuildableName = "ManifoldInference"
+               BlueprintName = "ManifoldInference"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldInferenceSwiftTestingTests"
+               BuildableName = "ManifoldInferenceSwiftTestingTests"
+               BlueprintName = "ManifoldInferenceSwiftTestingTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldInferenceSwiftTestingTests"
+               BuildableName = "ManifoldInferenceSwiftTestingTests"
+               BlueprintName = "ManifoldInferenceSwiftTestingTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldNetworkingTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldNetworkingTests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldNetworking + its test target so xcodebuild
+     compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldNetworking"
+               BuildableName = "ManifoldNetworking"
+               BlueprintName = "ManifoldNetworking"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldNetworkingTests"
+               BuildableName = "ManifoldNetworkingTests"
+               BlueprintName = "ManifoldNetworkingTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldNetworkingTests"
+               BuildableName = "ManifoldNetworkingTests"
+               BlueprintName = "ManifoldNetworkingTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldRuntimeTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldRuntimeTests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldRuntime + its test target so xcodebuild
+     compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldRuntime"
+               BuildableName = "ManifoldRuntime"
+               BlueprintName = "ManifoldRuntime"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldRuntimeTests"
+               BuildableName = "ManifoldRuntimeTests"
+               BlueprintName = "ManifoldRuntimeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldRuntimeTests"
+               BuildableName = "ManifoldRuntimeTests"
+               BlueprintName = "ManifoldRuntimeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldTestSupportTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldTestSupportTests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldTestSupport + its test target so xcodebuild
+     compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldTestSupport"
+               BuildableName = "ManifoldTestSupport"
+               BlueprintName = "ManifoldTestSupport"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldTestSupportTests"
+               BuildableName = "ManifoldTestSupportTests"
+               BlueprintName = "ManifoldTestSupportTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldTestSupportTests"
+               BuildableName = "ManifoldTestSupportTests"
+               BlueprintName = "ManifoldTestSupportTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldTurnLoopCharacterizationTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldTurnLoopCharacterizationTests.xcscheme
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     ManifoldTurnLoopCharacterizationTests exercises ConversationRuntime end-to-end
+     across ManifoldInference + ManifoldRuntime + ManifoldPersistenceSwiftData.
+     Lists only the test target; buildImplicitDependencies resolves the subgraph. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldTurnLoopCharacterizationTests"
+               BuildableName = "ManifoldTurnLoopCharacterizationTests"
+               BlueprintName = "ManifoldTurnLoopCharacterizationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldTurnLoopCharacterizationTests"
+               BuildableName = "ManifoldTurnLoopCharacterizationTests"
+               BlueprintName = "ManifoldTurnLoopCharacterizationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldUIModelManagementTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldUIModelManagementTests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldUIModelManagement + its test target so
+     xcodebuild compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldUIModelManagement"
+               BuildableName = "ManifoldUIModelManagement"
+               BlueprintName = "ManifoldUIModelManagement"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldUIModelManagementTests"
+               BuildableName = "ManifoldUIModelManagementTests"
+               BlueprintName = "ManifoldUIModelManagementTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldUIModelManagementTests"
+               BuildableName = "ManifoldUIModelManagementTests"
+               BlueprintName = "ManifoldUIModelManagementTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldUITests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ManifoldUITests.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Per-target scheme for compile-pruned selective CI (Tier 2, issue #1590).
+     Scopes the build to ManifoldUI + its test target so xcodebuild
+     compiles only the subgraph instead of the full bundle. -->
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldUI"
+               BuildableName = "ManifoldUI"
+               BlueprintName = "ManifoldUI"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldUITests"
+               BuildableName = "ManifoldUITests"
+               BlueprintName = "ManifoldUITests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ManifoldUITests"
+               BuildableName = "ManifoldUITests"
+               BlueprintName = "ManifoldUITests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/affected-suites.sh
+++ b/scripts/affected-suites.sh
@@ -65,6 +65,7 @@ TEST_JOB_SUITES=(
   ManifoldTestSupportTests
   ManifoldAppIntentsTests
   ManifoldInferenceTests
+  ManifoldNetworkingTests
   ManifoldTurnLoopCharacterizationTests
   ManifoldBackendsTests
   ManifoldInferenceSwiftTestingTests
@@ -152,6 +153,7 @@ FORCE_FULL_EXACT=(
   "scripts/affected-suites-graph.json"
   "scripts/test.sh"
   "scripts/ci-test-with-watchdog.sh"
+  "scripts/ci-selective-test.sh"
 )
 for p in "${CHANGED[@]}"; do
   case "$p" in

--- a/scripts/ci-selective-test.sh
+++ b/scripts/ci-selective-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scripts/ci-selective-test.sh — Tier 2 compile-pruned selective CI runner.
+#
+# Receives the space-separated affected-suite list from Tier 0
+# (affected-suites.sh) and routes each suite to the fastest correct test path.
+#
+# Routing rules:
+#   - Suite has a .xcscheme AND is not trait-gated
+#       → xcodebuild test -scheme (compiles only the subgraph, not the full bundle)
+#   - ManifoldMCPTests
+#       → swift test --traits MCP  (xcodebuild cannot activate non-default traits;
+#         running without MCP silently drops all test sources → 0 compiled tests)
+#   - ManifoldBackendsTests
+#       → swift test --disable-default-traits (has ManifoldMLX/ManifoldLlama in its
+#         dep graph; xcodebuild default traits trigger Metal shader compilation;
+#         must run serial — no --parallel — because the claims-registry meta-contract
+#         check requires all backend classes to register before it fires)
+#   - ManifoldInferenceSwiftTestingTests
+#       → xcodebuild test -scheme (separate scheme = separate process; avoids the
+#         libmalloc SIGABRT that fires when XCTest + Swift Testing share one process)
+#
+# Usage:
+#   scripts/ci-selective-test.sh <suite1> [suite2] ...
+#
+# Exit codes:
+#   0 — all suites passed
+#   1 — one or more suites failed
+
+set -euo pipefail
+
+PACKAGE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCHEMES_DIR="$PACKAGE_DIR/.swiftpm/xcode/xcshareddata/xcschemes"
+DESTINATION="platform=macOS,arch=arm64"
+
+PASSED=()
+FAILED=()
+
+run_xcodebuild() {
+  local suite="$1"
+  local scheme="$SCHEMES_DIR/${suite}.xcscheme"
+  if [[ ! -f "$scheme" ]]; then
+    echo "::error::No xcscheme found for $suite — expected $scheme"
+    FAILED+=("$suite (no-scheme)")
+    return
+  fi
+  echo ""
+  echo "══════ xcodebuild test -scheme $suite ══════"
+  local exit_code=0
+  xcodebuild test \
+    -scheme "$suite" \
+    -destination "$DESTINATION" \
+    2>&1 || exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    PASSED+=("$suite")
+  else
+    FAILED+=("$suite")
+  fi
+}
+
+run_swift_test() {
+  local suite="$1"
+  shift
+  echo ""
+  echo "══════ swift test --filter $suite ══════"
+  local exit_code=0
+  "$PACKAGE_DIR/scripts/test.sh" \
+    --filter "$suite" \
+    --skip-update \
+    "$@" || exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    PASSED+=("$suite")
+  else
+    FAILED+=("$suite")
+  fi
+}
+
+for suite in "$@"; do
+  case "$suite" in
+    ManifoldMCPTests)
+      run_swift_test "$suite" --disable-default-traits --traits MCP,CloudSaaS
+      ;;
+    ManifoldBackendsTests)
+      run_swift_test "$suite" --disable-default-traits --traits MCP,CloudSaaS
+      ;;
+    *)
+      run_xcodebuild "$suite"
+      ;;
+  esac
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  SELECTIVE RESULTS"
+echo "  Passed ${#PASSED[@]}: ${PASSED[*]:-(none)}"
+echo "  Failed ${#FAILED[@]}: ${FAILED[*]:-(none)}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **8 new per-target xcschemes** (`ManifoldCoreTests`, `ManifoldRuntimeTests`, `ManifoldUITests`, `ManifoldUIModelManagementTests`, `ManifoldTestSupportTests`, `ManifoldNetworkingTests`, `ManifoldInferenceSwiftTestingTests`, `ManifoldTurnLoopCharacterizationTests`) — each uses `buildImplicitDependencies=YES` so xcodebuild compiles only the affected subgraph instead of the full 836-file bundle
- **`scripts/ci-selective-test.sh`** — routes each affected suite to xcodebuild (subgraph compile) or swift test (special cases: `ManifoldMCPTests` needs `--traits MCP`; `ManifoldBackendsTests` needs `--disable-default-traits` to avoid Metal); falls back to full mode when 2+ swift-test suites or 8+ suites total
- **`ci.yml`** — `test` job now depends on `changes` job; new "Compute test mode" step reads the Tier 0 affected output and selects `mode=selective` or `mode=full`; existing test steps scoped to `[full]`; new selective step runs `ci-selective-test.sh` with the affected-suite list
- **`affected-suites.sh`** — adds `ManifoldNetworkingTests` to `TEST_JOB_SUITES` (was missing) and `scripts/ci-selective-test.sh` to `FORCE_FULL_EXACT`

## What this saves

On a narrow 1–3 source-file PR touching `ManifoldUI` or `ManifoldNetworking`, the selective path compiles ~50–200 files instead of 836, saving ~127s of compile time per run on the macOS runner. The affected-suite list from Tier 0 was already being published as a dry-run output (PR #1619) — this PR wires it to actually change execution.

## Threshold / fallback logic

The "Compute test mode" step falls back to `mode=full` when:
- `affected` is `FULL`, `NONE`, or empty (Tier 0 conservative fallback)
- 2+ suites require `swift test` (two full-bundle compiles > one full run)
- 8+ suites total (xcodebuild overhead exceeds savings)

## Routing rules for selective mode

| Suite | Runner | Reason |
|---|---|---|
| `ManifoldMCPTests` | `swift test --traits MCP` | Can't activate non-default traits via xcodebuild |
| `ManifoldBackendsTests` | `swift test --disable-default-traits` | MLX/Llama in subgraph trigger Metal; must be serial for claims-registry |
| Everything else | `xcodebuild test -scheme <Suite>` | Subgraph compile only |

## Test plan

- [ ] CI green on this PR (triggers full mode since `ci.yml` is in `FORCE_FULL_EXACT`)
- [ ] Verify a follow-up UI-only PR routes to selective mode with 1–3 suites
- [ ] `scripts/ci-selective-test.sh ManifoldUITests` runs locally without error

Closes part of #1590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)