### PR TITLE
feat: quickStart() applies backend-selection policy on first launch

### DIFF
--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -65,10 +65,20 @@ public enum ManifoldKit {
     }
 
     /// Internal seam used by tests to inject a custom (or throwing) model
-    /// container factory. Production callers go through ``quickStart(configuration:)``.
+    /// container factory and an optional selection policy. Production callers
+    /// go through ``quickStart(configuration:)``.
+    ///
+    /// - Parameters:
+    ///   - configuration: The framework configuration.
+    ///   - makeModelContainer: Factory closure that produces the SwiftData container.
+    ///   - selectionPolicy: An optional closure that receives the populated
+    ///     `ModelRegistry` and returns the `ModelInfo` to select, or `nil` to
+    ///     leave no model selected. When `nil` (the default), the built-in
+    ///     Foundation-first → first-local → labeled-empty-state policy runs.
     static func _quickStart(
         configuration: ManifoldConfiguration,
-        makeModelContainer: @MainActor @escaping () throws -> ModelContainer
+        makeModelContainer: @MainActor @escaping () throws -> ModelContainer,
+        selectionPolicy: (@MainActor (ModelRegistry) async -> ModelInfo?)? = nil
     ) async throws -> QuickStartResult {
         do {
             // Drive the bootstrap stream to completion. We don't surface
@@ -102,6 +112,16 @@ public enum ManifoldKit {
             )
             viewModel.configure(persistence: bootstrap.persistence)
             viewModel.configure(endpointStore: bootstrap.endpointStore)
+
+            // Wire the Foundation-model availability probe so `refresh()`
+            // prepends the built-in model when Apple Intelligence is available.
+            // Done before the selection policy so `availableModels` reflects
+            // the full local catalogue at policy-evaluation time.
+            #if canImport(FoundationModels)
+            if #available(iOS 26, macOS 26, *) {
+                viewModel.modelRegistry.foundationModelProvider = { FoundationBackend.isAvailable }
+            }
+            #endif
 
             // Wire the session manager and await its initial load so that
             // `sessionManager.sessions` is populated before this call returns
@@ -144,10 +164,70 @@ public enum ManifoldKit {
                 await viewModel.switchToSession(initialSession)
             }
 
+            // Apply the backend-selection policy (#1612). Running after session
+            // wiring means the chat surface is live regardless of whether a
+            // model is chosen; the composer enables itself once `selectedModel`
+            // becomes non-nil.
+            //
+            // `refresh()` is required before the policy runs so `availableModels`
+            // reflects on-disk GGUFs + the Foundation model (when the provider
+            // above returned true). Failure to scan the models directory is
+            // non-fatal: the empty-state path will fire, surfacing a clear
+            // placeholder rather than a silent blank composer.
+            do {
+                try viewModel.modelRegistry.refresh()
+            } catch {
+                Log.quickStart.warning("quickStart: model registry refresh failed; no model will be pre-selected: \(error, privacy: .public)")
+            }
+
+            let effectivePolicy = selectionPolicy ?? ManifoldKit.defaultSelectionPolicy
+            let chosen = await effectivePolicy(viewModel.modelRegistry)
+            if let chosen {
+                viewModel.modelRegistry.selectModel(chosen)
+            } else {
+                // Neither the built-in policy nor the host-supplied policy found
+                // a model. Leave `selectedModel` nil so the UI can surface an
+                // explicit "No model available — add one to get started" state
+                // rather than a silent blank composer.
+                Log.quickStart.info("quickStart: no model selected — host UI should prompt the user to add a model")
+            }
+
             return QuickStartResult(bootstrap: bootstrap, viewModel: viewModel, sessionManager: sessionManager)
         } catch {
             throw ManifoldKitError.from(error)
         }
+    }
+
+    // MARK: - Built-in selection policy
+
+    /// The default backend-selection policy applied by `quickStart()`.
+    ///
+    /// Priority order:
+    /// 1. Foundation model — selected when running on iOS 26+ / macOS 26+ and
+    ///    the Foundation backend is compiled in and available at runtime.
+    /// 2. First local model — the first entry in `availableModels` (populated
+    ///    by `refresh()`), which skips cloud/endpoint-configured backends that
+    ///    have no `ModelInfo` representation in the registry.
+    /// 3. Nil — no model is pre-selected; the UI must prompt the user to add one.
+    @MainActor
+    static func defaultSelectionPolicy(_ registry: ModelRegistry) async -> ModelInfo? {
+        // Foundation-first: on Apple-Intelligence-capable devices the built-in
+        // model is always the lowest-friction starting point — no download, no
+        // disk space, no endpoint configuration required.
+        #if canImport(FoundationModels)
+        if #available(iOS 26, macOS 26, *) {
+            if DefaultBackends.canLoad(modelType: .foundation),
+               let provider = registry.foundationModelProvider, provider() {
+                return .builtInFoundation
+            }
+        }
+        #endif
+
+        // Fall back to the first local model discovered on disk. All ModelType
+        // cases (.gguf, .mlx, .foundation) represent local backends — there is
+        // no "remote" ModelType in the registry (cloud backends are addressed
+        // through APIEndpointRecord + APIProvider, not ModelInfo).
+        return registry.availableModels.first
     }
 }
 

--- a/Sources/ManifoldModelCatalog/Logging.swift
+++ b/Sources/ManifoldModelCatalog/Logging.swift
@@ -16,4 +16,5 @@ public enum Log {
     public static var network: Logger { Logger(subsystem: subsystem, category: "network") }
     public static var download: Logger { Logger(subsystem: subsystem, category: "download") }
     public static var security: Logger { Logger(subsystem: subsystem, category: "security") }
+    public static var quickStart: Logger { Logger(subsystem: subsystem, category: "quickStart") }
 }

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -236,6 +236,101 @@ final class QuickStartTests: XCTestCase {
     }
 
     private func _requireSendable<T: Sendable>(_: T.Type) {}
+
+    // MARK: - Selection Policy tests (#1612)
+
+    /// A custom `selectionPolicy` that returns a `ModelInfo` must result in
+    /// `modelRegistry.selectedModel` equalling that info. This exercises the
+    /// override seam so hosts can inject their own policy.
+    ///
+    /// The policy must register the model in `availableModels` before returning
+    /// it — `ModelRegistry.selectModel` validates that the chosen model is
+    /// present in the registry (or is `builtInFoundation`). A real host policy
+    /// would only return models it discovered or registered.
+    func test_quickStart_customPolicy_selectsReturnedModel() async throws {
+        let sentinel = ModelInfo(
+            id: UUID(),
+            name: "Sentinel Model",
+            fileName: "sentinel.gguf",
+            url: URL(fileURLWithPath: "/tmp/sentinel.gguf"),
+            fileSize: 1_000_000,
+            modelType: .gguf
+        )
+
+        let result = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { registry in
+                // Policies are responsible for ensuring selected models are in
+                // availableModels — selectModel() validates presence. A host
+                // policy that discovers its own models would add them here.
+                registry.availableModels = [sentinel]
+                return sentinel
+            }
+        )
+
+        // The policy returned a model — `selectedModel` must reflect it.
+        XCTAssertEqual(result.viewModel.modelRegistry.selectedModel?.id, sentinel.id,
+            "Custom selectionPolicy return value must be applied to modelRegistry.selectedModel (#1612)")
+
+        // Sabotage: a different model ID must NOT match.
+        XCTAssertNotEqual(result.viewModel.modelRegistry.selectedModel?.id, UUID(),
+            "Sabotage: selectedModel.id must not be a random UUID")
+    }
+
+    /// A `selectionPolicy` returning `nil` must leave `selectedModel` nil
+    /// without crashing — the empty-state path must be silent and stable.
+    func test_quickStart_nilReturningPolicy_leavesSelectedModelNil() async throws {
+        let result = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { _ in nil }
+        )
+
+        XCTAssertNil(result.viewModel.modelRegistry.selectedModel,
+            "nil selectionPolicy must leave selectedModel nil — no crash, no fallback (#1612)")
+    }
+
+    /// When the built-in policy is in effect (selectionPolicy: nil) and
+    /// `availableModels` contains a local model but no Foundation model is
+    /// available, the first local model must be selected.
+    ///
+    /// We exercise this via a custom policy that:
+    /// 1. Clears `foundationModelProvider` to ensure the Foundation-first branch
+    ///    is skipped (guards against test machines where Apple Intelligence is
+    ///    available and would win the priority race).
+    /// 2. Seeds `availableModels` with the local model.
+    /// 3. Delegates to `defaultSelectionPolicy` to exercise its logic directly.
+    func test_quickStart_defaultPolicy_selectsFirstLocalModel_whenAvailable() async throws {
+        let localModel = ModelInfo(
+            id: UUID(),
+            name: "Test GGUF",
+            fileName: "test.gguf",
+            url: URL(fileURLWithPath: "/tmp/test.gguf"),
+            fileSize: 500_000,
+            modelType: .gguf
+        )
+
+        let result = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { registry in
+                // Suppress Foundation availability so we reach the "first local
+                // model" fallback branch regardless of what hardware the test
+                // runner is on.
+                registry.foundationModelProvider = { false }
+                // Seed the registry so availableModels is non-empty.
+                registry.availableModels = [localModel]
+                // Delegate to the built-in policy so we exercise its logic.
+                return await ManifoldKit.defaultSelectionPolicy(registry)
+            }
+        )
+
+        // The default policy must select the first available local model.
+        XCTAssertEqual(result.viewModel.modelRegistry.selectedModel?.id, localModel.id,
+            "Default policy must select the first local model when Foundation is unavailable (#1612)")
+        XCTAssertEqual(result.viewModel.modelRegistry.selectedModel?.modelType, .gguf)
+    }
 }
 
 private final class QuickStartCloudBackend: InferenceBackend, CloudBackendURLModelConfigurable, @unchecked Sendable {


### PR DESCRIPTION
Closes #1612

## Summary
- Adds `selectionPolicy` parameter to `_quickStart` (the internal test seam) with Foundation-first → first-local → labeled-empty-state built-in policy
- Wires `foundationModelProvider` on `modelRegistry` before the policy runs so `refresh()` includes the built-in Foundation model in the candidate list
- Adds `Log.quickStart` logging category to `ManifoldModelCatalog/Logging.swift`
- Three new tests in `QuickStartTests`: custom policy sets `selectedModel`, nil policy leaves it nil, default policy selects first local model when Foundation unavailable

## Test plan
- [x] `swift build --build-tests --disable-default-traits` — build complete
- [x] `swift test --disable-default-traits --filter ManifoldKitTests` — 17/17 pass
- [x] `swift test --disable-default-traits --filter ManifoldCoreTests` — 182/182 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)