### PR TITLE
fix(dx): OllamaBackend registrar warning, EndpointBackend rename, GenerationStream AsyncSequence, thinking-token sample fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ await source.register(in: registry)
 
 For a complete walkthrough (descriptor setup, lifecycle, and built-in catalog), see `Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md`.
 
+ManifoldKit also supports running as an **MCP server** — exposing your app's live state and tools to external MCP clients such as Claude Desktop, other agents, or any MCP-aware host. Import `ManifoldMCPHost` and follow the setup guide at `Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md`. This is the entry point for agent-platform builders who want to surface their app's capabilities to the broader MCP ecosystem rather than consuming external tools.
+
 ## Skills, Handoffs, and Hooks
 
 Three session-scoped extension points complement MCP for non-MCP hosts:

--- a/Sources/ManifoldBackendsUmbrella/CloudBackends.swift
+++ b/Sources/ManifoldBackendsUmbrella/CloudBackends.swift
@@ -16,7 +16,7 @@ public enum CloudBackends: BackendRegistrar {
         PinnedSessionDelegate.loadDefaultPins()
         #endif
 
-        service.registerCloudBackendFactory { provider in
+        service.registerEndpointBackendFactory { provider in
             switch provider {
             #if CloudSaaS
             case .claude:                     return ClaudeBackend()
@@ -24,12 +24,7 @@ public enum CloudBackends: BackendRegistrar {
             case .openAIResponses:            return OpenAIResponsesBackend()
             #endif
             #if Ollama
-            // FIXME(#714): expected deprecation warning until the next major
-            // release flips `Ollama` out of default traits. This internal
-            // registration is the supported migration path consumers are
-            // pointed at — silencing the warning here would defeat the
-            // signal it sends to direct callers of `OllamaBackend()`.
-            case .ollama:                     return OllamaBackend()
+            case .ollama:                     return OllamaBackend(_registrar: ())
             #endif
             default: return nil
             }

--- a/Sources/ManifoldCloud/OllamaBackend.swift
+++ b/Sources/ManifoldCloud/OllamaBackend.swift
@@ -132,6 +132,62 @@ public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigura
 
     // MARK: - Init
 
+    /// Internal initializer used by registrar and framework-internal infrastructure.
+    ///
+    /// This path is identical to the public `init(urlSession:)` with a `nil` session
+    /// but is NOT marked deprecated, so framework-internal callers
+    /// (``CloudBackends``, ``TraitAwareServerBackendProvider``, etc.) don't generate
+    /// deprecation warnings when following the recommended migration path.
+    /// External consumers building `OllamaBackend` directly should use the public
+    /// init or register via `DefaultBackends.register(_:)`.
+    internal init(_registrar: Void) {
+        self.adapter = OllamaAdapter(
+            capabilities: Self.defaultAdapterCapabilities,
+            requestBuilder: { _, _, _, _ in
+                throw CloudBackendError.invalidURL(
+                    "OllamaAdapter.requestBuilder is not the live path; the OllamaBackend installs a CloudAdapterRouting that delegates to its own buildRequest override."
+                )
+            }
+        )
+        super.init(
+            defaultModelName: "llama3.2",
+            urlSession: URLSessionProvider.unpinned,
+            payloadHandler: CloudPayloadHandler.ollama
+        )
+        requestIdleTimeout = OllamaBackend.defaultRequestIdleTimeout
+        let weakSelfBox = WeakOllamaBackendBox(self)
+        let routing = CloudAdapterRouting(
+            payloadHandler: adapter.payloadHandler,
+            framedTransport: adapter.framedTransport,
+            streamFinalizer: adapter.streamFinalizer,
+            errorBodyDecoder: adapter.errorBodyDecoder,
+            buildRequest: { prompt, systemPrompt, config in
+                guard let backend = weakSelfBox.value else {
+                    throw CloudBackendError.backendDeallocated
+                }
+                return try backend.buildRequest(
+                    prompt: prompt,
+                    systemPrompt: systemPrompt,
+                    config: config
+                )
+            },
+            streamConsumerFactory: {
+                guard let backend = weakSelfBox.value else {
+                    return OllamaStreamEventExtractor(
+                        config: GenerationConfig(),
+                        autoDetectedMarkers: nil
+                    )
+                }
+                let (config, markers) = backend.snapshotForExtractor()
+                return OllamaStreamEventExtractor(
+                    config: config,
+                    autoDetectedMarkers: markers
+                )
+            }
+        )
+        self.configure(adapterRouting: routing)
+    }
+
     /// Creates an Ollama backend.
     ///
     /// - Parameter urlSession: Custom URLSession for testing. Pass `nil` to use the default.

--- a/Sources/ManifoldFuzzBackends/OllamaFuzzFactory.swift
+++ b/Sources/ManifoldFuzzBackends/OllamaFuzzFactory.swift
@@ -41,11 +41,7 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
                 "No Ollama model installed. Pull one with: ollama pull qwen3.5:4b"
             )
         }
-        // FIXME(#714): expected deprecation warning until the next major
-        // release flips `Ollama` out of default traits. The fuzz harness
-        // is internal infrastructure that exercises the trait-gated init
-        // directly.
-        let backend = OllamaBackend()
+        let backend = OllamaBackend(_registrar: ())
         backend.configure(baseURL: baseURL, modelName: model)
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
         let markers = RunRecord.MarkerSnapshot(open: "<think>", close: "</think>")

--- a/Sources/ManifoldInference/Services/GenerationStream.swift
+++ b/Sources/ManifoldInference/Services/GenerationStream.swift
@@ -180,6 +180,21 @@ public final class GenerationStream: Sendable {
     }
 }
 
+// MARK: - AsyncSequence Conformance
+
+extension GenerationStream: AsyncSequence {
+    public typealias Element = GenerationEvent
+    public typealias AsyncIterator = AsyncThrowingStream<GenerationEvent, Error>.AsyncIterator
+
+    /// Returns an iterator over the generation events in this stream.
+    ///
+    /// Allows idiomatic iteration with `for try await event in stream { … }`
+    /// instead of `for try await event in stream.events { … }`.
+    public nonisolated func makeAsyncIterator() -> AsyncThrowingStream<GenerationEvent, Error>.AsyncIterator {
+        events.makeAsyncIterator()
+    }
+}
+
 // MARK: - Thread-safe Atomics
 
 /// Lock-protected boolean for cross-task signaling.

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -5,9 +5,14 @@ import Observation
 /// Return `nil` if this factory does not handle the given type.
 public typealias BackendFactory = @MainActor (ModelType) -> (any InferenceBackend)?
 
+/// A factory closure that creates an endpoint-based inference backend for the given API provider.
+/// Return `nil` if this factory does not handle the given provider.
+public typealias EndpointBackendFactory = @MainActor (APIProvider) -> (any InferenceBackend)?
+
 /// A factory closure that creates a cloud inference backend for the given API provider.
 /// Return `nil` if this factory does not handle the given provider.
-public typealias CloudBackendFactory = @MainActor (APIProvider) -> (any InferenceBackend)?
+@available(*, deprecated, renamed: "EndpointBackendFactory")
+public typealias CloudBackendFactory = EndpointBackendFactory
 
 /// Readiness state for the primary model managed by ``InferenceService``.
 public enum ModelLoadReadinessState: Equatable, Sendable {
@@ -113,11 +118,15 @@ public final class InferenceService {
 
     public var capabilities: BackendCapabilities? { lifecycle.capabilities }
 
-    /// The currently-loaded cloud backend, if any. Host apps can use this to
-    /// call ``SSECloudBackend/configure(baseURL:tokenProvider:modelName:)``
-    /// after ``loadCloudBackend(from:)`` to inject a rotating token provider
+    /// The currently-loaded endpoint-based backend, if any. Host apps can use
+    /// this to call ``SSECloudBackend/configure(baseURL:tokenProvider:modelName:)``
+    /// after ``loadEndpointBackend(from:)`` to inject a rotating token provider
     /// without going through the static Keychain path.
-    public var currentCloudBackend: (any InferenceBackend)? { lifecycle.backend }
+    public var currentEndpointBackend: (any InferenceBackend)? { lifecycle.backend }
+
+    /// The currently-loaded cloud backend, if any.
+    @available(*, deprecated, renamed: "currentEndpointBackend")
+    public var currentCloudBackend: (any InferenceBackend)? { currentEndpointBackend }
 
     // MARK: - Deny Policy
 
@@ -154,8 +163,13 @@ public final class InferenceService {
         lifecycle.registerBackendFactory(factory)
     }
 
-    public func registerCloudBackendFactory(_ factory: @escaping CloudBackendFactory) {
+    public func registerEndpointBackendFactory(_ factory: @escaping EndpointBackendFactory) {
         lifecycle.registerCloudBackendFactory(factory)
+    }
+
+    @available(*, deprecated, renamed: "registerEndpointBackendFactory(_:)")
+    public func registerCloudBackendFactory(_ factory: @escaping CloudBackendFactory) {
+        registerEndpointBackendFactory(factory)
     }
 
     public func declareSupport(for modelType: ModelType) {
@@ -185,13 +199,22 @@ public final class InferenceService {
         pressureBroadcaster.send(.didReload(modelID: modelInfo.id))
     }
 
-    /// Loads a cloud API backend from an `APIEndpointRecord` configuration.
+    /// Loads an endpoint-based backend (cloud SaaS, Ollama, LM Studio, etc.)
+    /// from an ``APIEndpointRecord`` configuration.
     ///
     /// Follows the same latest-wins/stale-suppression semantics as `loadModel`.
-    public func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
+    public func loadEndpointBackend(from endpoint: APIEndpointRecord) async throws {
         ensureProviderWired()
         generation.stopGeneration()
         try await lifecycle.loadCloudBackend(from: endpoint)
+    }
+
+    /// Loads a cloud API backend from an `APIEndpointRecord` configuration.
+    ///
+    /// Follows the same latest-wins/stale-suppression semantics as `loadModel`.
+    @available(*, deprecated, renamed: "loadEndpointBackend(from:)")
+    public func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
+        try await loadEndpointBackend(from: endpoint)
     }
 
     /// Unloads the current model and frees all associated memory.

--- a/Sources/ManifoldModelCatalog/APIEndpointRecord.swift
+++ b/Sources/ManifoldModelCatalog/APIEndpointRecord.swift
@@ -37,4 +37,23 @@ public struct APIEndpointRecord: Sendable, Hashable, Identifiable {
         self.createdAt = createdAt
         self.isEnabled = isEnabled
     }
+
+    /// Convenience initializer for headless / CLI consumers that only need to
+    /// call ``InferenceService/loadEndpointBackend(from:)`` and don't have a
+    /// persistence layer to supply the full set of metadata fields.
+    ///
+    /// Sets `name` to `modelName`, derives `keychainAccount` from a freshly
+    /// generated `id`, and uses sensible defaults for `createdAt` and
+    /// `isEnabled`.
+    public init(provider: APIProvider, baseURL: String, modelName: String) {
+        let id = UUID()
+        self.id = id
+        self.provider = provider
+        self.baseURL = baseURL
+        self.modelName = modelName
+        self.name = modelName
+        self.keychainAccount = id.uuidString
+        self.createdAt = Date()
+        self.isEnabled = true
+    }
 }

--- a/Sources/ManifoldPersistenceSwiftData/Adapters/InferenceService+APIEndpoint.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/InferenceService+APIEndpoint.swift
@@ -2,7 +2,7 @@ import Foundation
 import ManifoldInference
 
 // Source-compatibility shim: lets callers continue to pass the SwiftData
-// `@Model APIEndpoint` directly to `InferenceService.loadCloudBackend(from:)`.
+// `@Model APIEndpoint` directly to `InferenceService.loadEndpointBackend(from:)`.
 // The underlying inference API now operates on the storage-agnostic
 // `APIEndpointRecord`; this extension converts the @Model to a record.
 extension APIEndpoint {
@@ -31,15 +31,22 @@ extension APIEndpoint {
 
 extension InferenceService {
 
-    /// Loads a cloud API backend from a SwiftData `APIEndpoint`.
+    /// Loads an endpoint-based backend from a SwiftData `APIEndpoint`.
     ///
     /// Convenience overload that validates the endpoint URL using the canonical
     /// ``APIEndpoint/validate()`` check — blocking private/link-local SSRF targets,
     /// insecure schemes, and malformed URLs — before converting to an
     /// `APIEndpointRecord` and delegating to the storage-agnostic core API.
     @MainActor
-    public func loadCloudBackend(from endpoint: APIEndpoint) async throws {
+    public func loadEndpointBackend(from endpoint: APIEndpoint) async throws {
         try endpoint.validate().get()
-        try await loadCloudBackend(from: endpoint.record)
+        try await loadEndpointBackend(from: endpoint.record)
+    }
+
+    /// Loads a cloud API backend from a SwiftData `APIEndpoint`.
+    @available(*, deprecated, renamed: "loadEndpointBackend(from:)")
+    @MainActor
+    public func loadCloudBackend(from endpoint: APIEndpoint) async throws {
+        try await loadEndpointBackend(from: endpoint)
     }
 }

--- a/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
+++ b/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
@@ -226,7 +226,7 @@ internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
         guard let baseURL = URL(string: selection.ollamaBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             throw ServerError.invalidConfiguration("--ollama-base-url must be a valid URL.")
         }
-        let backend = OllamaBackend()
+        let backend = OllamaBackend(_registrar: ())
         backend.configure(baseURL: baseURL, modelName: modelName)
         try await backend.loadModel(from: baseURL, plan: .cloud(requestedContextSize: 8192))
         return backend

--- a/Sources/ManifoldUI/ViewModels/ModelLoadCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ModelLoadCoordinator.swift
@@ -202,7 +202,7 @@ final class ModelLoadCoordinator {
         }
 
         do {
-            try await inferenceService.loadCloudBackend(from: endpoint)
+            try await inferenceService.loadEndpointBackend(from: endpoint)
         } catch is CancellationError {
             return
         } catch {

--- a/Sources/manifold-tools/main.swift
+++ b/Sources/manifold-tools/main.swift
@@ -376,11 +376,7 @@ func makeBackend(cli: CLI, scenario: Scenario, model: String) async throws -> an
         return MockFactory.make(for: scenario)
     case .ollama:
         #if Ollama
-        // FIXME(#714): expected deprecation warning until the next major
-        // release flips `Ollama` out of default traits. manifold-tools is internal
-        // infrastructure that intentionally exercises the trait-gated init
-        // directly.
-        let backend = OllamaBackend()
+        let backend = OllamaBackend(_registrar: ())
         backend.configure(baseURL: cli.ollamaBaseURL, modelName: model)
         try await backend.loadModel(from: cli.ollamaBaseURL, plan: .cloud())
         return backend

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -434,10 +434,25 @@ struct ChatCLICloud {
         try await inference.loadCloudBackend(from: endpoint)
 
         let stream = try inference.generate(messages: [("user", "Say hello in five words.")])
+
+        // Reasoning-tuned models (Qwen3, DeepSeek-R1, etc.) emit `.thinkingToken`
+        // events before — or instead of — `.token` events. A bare `if case .token`
+        // pattern drops all thinking content silently, producing zero stdout output
+        // when pointed at one of these models. Route thinking tokens to stderr so
+        // they don't pollute piped output; response tokens go to stdout as normal.
+        // If you see nothing on stdout, check stderr for thinking content — that
+        // confirms the model is responding but its response is reasoning-only.
+        // Generation errors surface as thrown errors from the async sequence itself,
+        // not as a GenerationEvent case — the outer `try` handles them.
         for try await event in stream.events {
-            if case .token(let text) = event {
+            switch event {
+            case .token(let text):
                 print(text, terminator: "")
                 fflush(stdout)
+            case .thinkingToken(let text):
+                FileHandle.standardError.write(Data(text.utf8))
+            default:
+                break
             }
         }
         print("")


### PR DESCRIPTION
## Summary

Fixes five DX friction points surfaced by two independent external cold-start audits (Grok and Anti-gravity):

- **OllamaBackend self-deprecation** — The registrar in `CloudBackends.swift` called the deprecated `OllamaBackend()` init unconditionally, firing a migration-notice warning on consumers who were already on the correct path (Ollama trait + `DefaultBackends.register`). Added `internal init(_registrar:)` so the registrar bypasses the warning; the public deprecated init still fires for any consumer calling it directly. Also cleaned up three other internal callers (`TraitAwareServerBackendProvider`, `OllamaFuzzFactory`, `manifold-tools`).

- **`loadCloudBackend` → `loadEndpointBackend` (deprecation cycle)** — "Cloud" is wrong for Ollama at localhost and LM Studio. Added `loadEndpointBackend(from:)`, `currentEndpointBackend`, `registerEndpointBackendFactory`, and `EndpointBackendFactory`; deprecated the `Cloud*` names with `renamed:` so existing consumers get a fixable warning, not a break.

- **`APIEndpointRecord` convenience init** — Added `init(provider:baseURL:modelName:)` so headless/CLI consumers don't have to supply `id`, `name`, `createdAt`, `isEnabled` just to call `loadEndpointBackend`. The persistence-tier fields get sensible defaults.

- **`GenerationStream: AsyncSequence`** — Added conformance so `for try await event in stream` works without the `.events` indirection. `makeAsyncIterator()` is `nonisolated` and delegates to the existing `nonisolated events` property.

- **CLI quickstart thinking-token example** — Both auditors followed `docs/QUICKSTART-CLI.md` §3 and got blank output when pointing at a reasoning-tuned model (qwen3.5:4b). The bare `if case .token` pattern silently discards all `.thinkingToken` events. Replaced with a full `switch` that routes thinking tokens to stderr, so the CLI works correctly with modern local models and doesn't hang silently.

- **MCP server mode visibility** — `ManifoldMCPHost` had zero README presence. Added a pointer in the MCP section so agent-platform builders know the capability exists and where to look.

## Test plan

- [ ] Build with `swift build --build-tests --disable-default-traits` — no new errors
- [ ] Check that `OllamaBackend()` still emits the deprecation warning when called directly (not via registrar)
- [ ] Verify `for try await event in stream { }` compiles alongside `for try await event in stream.events { }` (both should work)
- [ ] Run `docs/QUICKSTART-CLI.md` §3 example against a reasoning-tuned Ollama model — should see thinking on stderr, response on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)