### PR TITLE
fix(docs): import ManifoldKit is sufficient — remove redundant ManifoldUI import

### DIFF
--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import SwiftData // needed for .modelContainer modifier type inference
 import ManifoldKit
-import ManifoldUI
 
 /// The simplest possible ManifoldKit app.
 ///

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Add the package, then drop this into your app entry point. `ManifoldKit.quickSta
 import SwiftUI
 import SwiftData
 import ManifoldKit
-import ManifoldUI
 
 @main
 struct MyChatApp: App {

--- a/docs/LAUNCH-BRIEF.md
+++ b/docs/LAUNCH-BRIEF.md
@@ -223,7 +223,6 @@ persistence + multi-backend inference into one drop-in chat product.**
 ```swift
 import SwiftUI
 import ManifoldKit
-import ManifoldUI
 
 @main
 struct MyChatApp: App {

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,7 +39,6 @@ The umbrella re-exports `ManifoldRuntime`, `ManifoldPersistenceSwiftData`, `Mani
 import SwiftUI
 import SwiftData
 import ManifoldKit
-import ManifoldUI
 
 @main
 struct MyChatApp: App {
@@ -118,7 +117,6 @@ Add this to the `Hello World` example so the moment `result` is non-nil, you als
 import SwiftUI
 import SwiftData
 import ManifoldKit
-import ManifoldUI
 #if canImport(ManifoldFoundation)
 import ManifoldFoundation
 #endif
@@ -163,7 +161,6 @@ For cloud / LAN backends (Ollama, OpenAI Chat Completions, OpenAI Responses, Ant
 ```swift,no-build
 import SwiftUI
 import ManifoldKit
-import ManifoldUI
 import ManifoldInference
 
 @main
@@ -217,7 +214,6 @@ The canonical surface is `ModelManagementSheet` from the **`ManifoldUIModelManag
 ```swift,no-build
 import SwiftUI
 import ManifoldKit
-import ManifoldUI
 import ManifoldUIModelManagement
 
 @main

--- a/docs/SWIFTUI-MULTI-SESSION.md
+++ b/docs/SWIFTUI-MULTI-SESSION.md
@@ -303,7 +303,6 @@ Target dependencies (add what you need):
 ```swift,no-build
 import SwiftUI
 import ManifoldKit
-import ManifoldUI
 import ManifoldUIModelManagement   // optional — omit if you don't want the model browser
 
 @main
@@ -396,7 +395,6 @@ struct MyChatApp: App {
 ```swift,no-build
 import SwiftUI
 import ManifoldKit
-import ManifoldUI
 import ManifoldUIModelManagement
 
 struct RootView: View {


### PR DESCRIPTION
Closes #1613

## Summary
- Removes redundant `import ManifoldUI` from README Hello World, MinimalExampleApp, and docs snippets that pair it with `import ManifoldKit`
- `ManifoldKit` already does `@_exported import ManifoldUI` in `Exports.swift`; the double-import was fiction
- Files that import `ManifoldUI` without `ManifoldKit` (Advanced example, SWIFTUI-MULTI-SESSION direct-consumer block, QUICKSTART-VIDEO-GEN section 5) are left unchanged — they are correct direct consumers
- cold-start-human gate verifies the README snippet compiles with a single import

**Files changed:** `README.md`, `Example/Examples/MinimalExample/MinimalExampleApp.swift`, `docs/QUICKSTART.md`, `docs/LAUNCH-BRIEF.md`, `docs/SWIFTUI-MULTI-SESSION.md`

## Test plan
- [x] `swift build --disable-default-traits` — Build complete
- [x] `bash scripts/cold-start-human.sh` — Cold-start conformance (tier 4 — human path): OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)