### PR TITLE
fix(ui): remove deprecated configure* shims — configure(bootstrap:) is the canonical entry

### DIFF
--- a/Example/Advanced/ManifoldDemoApp.swift
+++ b/Example/Advanced/ManifoldDemoApp.swift
@@ -379,8 +379,8 @@ struct ManifoldDemoApp: App {
             }
             return false
         }
-        vm.configure(runtime: runtime)
-        sessionManager.configure(runtime: runtime)
+        vm.configure(bootstrap: runtime)
+        sessionManager.configure(bootstrap: runtime)
         modelManagementViewModel.benchmarkCache = runtime.benchmarkCache
         // Use the runtime's classificationService so title generation routes
         // to the auxiliary backend (FoundationBackend on iOS 26+/macOS 26+)

--- a/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
@@ -26,30 +26,6 @@ extension ChatViewModel {
             configure(webSearchRuntime: webSearchRuntime)
         }
     }
-
-    /// Preferred bootstrap path for apps that assemble shared services through
-    /// a ``ChatRuntimeBootstrap``. Wires the persistence and endpoint stores
-    /// onto the view model.
-    ///
-    /// Behaviour preserved as a deprecation shim — pre-I6 this overload did
-    /// not wire `imageGenerationRuntime`. New callers should use
-    /// ``configure(bootstrap:)``, which wires the image runtime when present.
-    @available(*, deprecated, renamed: "configure(bootstrap:)", message: "Use configure(bootstrap:) — it also wires imageGenerationRuntime when the bootstrap exposes one.")
-    @MainActor
-    public func configure(runtime: any ChatRuntimeBootstrap) {
-        configure(persistence: runtime.persistenceStores)
-        configure(endpointStore: runtime.apiEndpointStore)
-    }
-
-    /// Wires the bootstrap's runtimes into this ``ChatViewModel``.
-    ///
-    /// Equivalent to ``configure(bootstrap:)``. Retained as a deprecation
-    /// shim for one minor while adopters migrate.
-    @available(*, deprecated, renamed: "configure(bootstrap:)", message: "Use configure(bootstrap:) — same behaviour, more explicit argument label.")
-    @MainActor
-    public func configure(_ bootstrap: any ChatRuntimeBootstrap) {
-        configure(bootstrap: bootstrap)
-    }
 }
 
 extension SessionManagerViewModel {
@@ -88,11 +64,5 @@ extension SessionManagerViewModel {
         // `sessions` array immediately after `await`. `autoLoad: false` above
         // prevents a concurrent fire-and-forget Task from racing this fetch.
         await loadSessions()
-    }
-
-    /// Deprecated shim kept for one minor.
-    @available(*, deprecated, renamed: "configure(bootstrap:)", message: "Use configure(bootstrap:) — same behaviour.")
-    public func configure(runtime: any ChatRuntimeBootstrap) {
-        configure(bootstrap: runtime)
     }
 }

--- a/Tests/ManifoldUIModelManagementTests/RuntimeBootstrapMigrationGuardTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/RuntimeBootstrapMigrationGuardTests.swift
@@ -33,8 +33,8 @@ final class RuntimeBootstrapMigrationGuardTests: XCTestCase {
 
         let chatViewModel = ChatViewModel(inferenceService: runtime.inferenceService)
         let sessionManager = SessionManagerViewModel()
-        chatViewModel.configure(runtime: runtime)
-        sessionManager.configure(runtime: runtime)
+        chatViewModel.configure(bootstrap: runtime)
+        sessionManager.configure(bootstrap: runtime)
 
         // Real architectural invariant: ManifoldBootstrap owns a single
         // SessionStore + MessageStore adapter, and both view models must
@@ -43,13 +43,13 @@ final class RuntimeBootstrapMigrationGuardTests: XCTestCase {
         // smoke check (persistence != nil) doesn't defend this — it would
         // pass even if each view model received its own independent provider,
         // which would silently break cross-view-model session visibility.
-        // Sabotage check: change `configure(runtime:)` on either view model
+        // Sabotage check: change `configure(bootstrap:)` on either view model
         // to wrap `runtime.persistence` in a fresh `SwiftDataPersistenceProvider`
         // and this identity assertion fails.
         XCTAssertNotNil(chatViewModel.persistence,
-            "ChatViewModel.configure(runtime:) must install the runtime's persistence provider")
+            "ChatViewModel.configure(bootstrap:) must install the runtime's persistence provider")
         XCTAssertNotNil(sessionManager.persistence,
-            "SessionManagerViewModel.configure(runtime:) must install the runtime's persistence provider")
+            "SessionManagerViewModel.configure(bootstrap:) must install the runtime's persistence provider")
         XCTAssertTrue((chatViewModel.persistence as AnyObject) === (sessionManager.persistence as AnyObject),
             "Both view models must share the runtime's single persistence provider instance")
 

--- a/Tests/ManifoldUITests/BootstrapConfigureImageWiringTests.swift
+++ b/Tests/ManifoldUITests/BootstrapConfigureImageWiringTests.swift
@@ -4,7 +4,7 @@ import ManifoldRuntime
 @testable import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 
-/// Defends the `ChatViewModel.configure(_:)` convenience method that wires both
+/// Defends the `ChatViewModel.configure(bootstrap:)` method that wires both
 /// runtimes into a view model in a single call (PR 9 / umbrella #1002).
 ///
 /// Tests 3 and 4 from the BootstrapImageWiring spec live here because
@@ -30,7 +30,7 @@ final class BootstrapConfigureImageWiringTests: XCTestCase {
         )
     }
 
-    // MARK: - Test 3: configure(_:) wires imageRuntime into ChatViewModel when opted in
+    // MARK: - Test 3: configure(bootstrap:) wires imageRuntime into ChatViewModel when opted in
 
     func test_configure_wiresImageRuntimeIntoViewModel_whenOptedIn() throws {
         let service = ImageGenerationService()
@@ -47,11 +47,11 @@ final class BootstrapConfigureImageWiringTests: XCTestCase {
             "chatViewModel.imageRuntime must be nil before configure(_:) is called"
         )
 
-        chatViewModel.configure(bootstrap)
+        chatViewModel.configure(bootstrap: bootstrap)
 
         // After configure — imageRuntime must be the bootstrap's runtime instance.
         // Sabotage: remove `if let imageRuntime = bootstrap.imageRuntime { configure(imageRuntime: imageRuntime) }`
-        // from RuntimeConfiguration.configure(_:) and this assertion fails.
+        // from RuntimeConfiguration.configure(bootstrap:) and this assertion fails.
         XCTAssertNotNil(
             chatViewModel.imageRuntime,
             "chatViewModel.imageRuntime must be non-nil after configure(_:) when bootstrap has an imageRuntime"
@@ -62,7 +62,7 @@ final class BootstrapConfigureImageWiringTests: XCTestCase {
         )
     }
 
-    // MARK: - Test 4: configure(_:) without image service leaves chatViewModel.imageRuntime nil
+    // MARK: - Test 4: configure(bootstrap:) without image service leaves chatViewModel.imageRuntime nil
 
     func test_configure_doesNotWireImageRuntime_whenNotOptedIn() throws {
         // A bootstrap constructed without imageGenerationService must not
@@ -74,7 +74,7 @@ final class BootstrapConfigureImageWiringTests: XCTestCase {
             conversationRuntime: bootstrap.conversationRuntime
         )
 
-        chatViewModel.configure(bootstrap)
+        chatViewModel.configure(bootstrap: bootstrap)
 
         XCTAssertNil(
             chatViewModel.imageRuntime,

--- a/Tests/ManifoldUITests/RuntimeConfigurationTests.swift
+++ b/Tests/ManifoldUITests/RuntimeConfigurationTests.swift
@@ -37,8 +37,8 @@ final class RuntimeConfigurationTests: XCTestCase {
         )
         let sessionManager = SessionManagerViewModel()
 
-        chatViewModel.configure(runtime: runtime)
-        sessionManager.configure(runtime: runtime)
+        chatViewModel.configure(bootstrap: runtime)
+        sessionManager.configure(bootstrap: runtime)
 
         guard let chatPersistence = chatViewModel.persistence else {
             XCTFail("ChatViewModel should be configured with runtime persistence")
@@ -57,7 +57,7 @@ final class RuntimeConfigurationTests: XCTestCase {
         let persistedIDs = try await runtime.persistence.fetchSessions().map(\.id)
         XCTAssertEqual(persistedIDs, [created.id])
 
-        // `configure(runtime:)` schedules a fire-and-forget `loadSessions()`
+        // `configure(bootstrap:)` schedules a fire-and-forget `loadSessions()`
         // (autoLoad: true). Drain it before the runtime / SwiftData container
         // tears down, otherwise the in-flight fetch races teardown and traps.
         await sessionManager.autoLoadTask?.value
@@ -93,10 +93,10 @@ final class RuntimeConfigurationTests: XCTestCase {
         )
         let sessionManager = SessionManagerViewModel()
 
-        chatViewModel.configure(runtime: runtime)
-        sessionManager.configure(runtime: runtime)
+        chatViewModel.configure(bootstrap: runtime)
+        sessionManager.configure(bootstrap: runtime)
         chatViewModel.refreshModels()
-        // `configure(runtime:)` schedules a fire-and-forget `loadSessions()`.
+        // `configure(bootstrap:)` schedules a fire-and-forget `loadSessions()`.
         // Drain it deterministically so the explicit reload below is the
         // observed sequence and the in-flight fetch can't race teardown.
         await sessionManager.autoLoadTask?.value
@@ -153,11 +153,11 @@ final class RuntimeConfigurationTests: XCTestCase {
         try await runtime.persistence.insertSession(session)
 
         let chatViewModel = ChatViewModel(inferenceService: runtime.inferenceService)
-        chatViewModel.configure(runtime: runtime)
+        chatViewModel.configure(bootstrap: runtime)
         await chatViewModel.endpointRefreshTask?.value
 
         XCTAssertEqual(chatViewModel.availableEndpoints.map(\.id), [endpointID],
-            "configure(runtime:) should load selectable endpoints through the runtime endpoint store")
+            "configure(bootstrap:) should load selectable endpoints through the runtime endpoint store")
 
         var freshEndpoint = originalEndpoint
         freshEndpoint.name = "Fresh Endpoint"

--- a/scripts/cold-start-tier2-bootstrap.sh
+++ b/scripts/cold-start-tier2-bootstrap.sh
@@ -18,7 +18,7 @@
 #   - `ManifoldBootstrap` → `ChatViewModel` link shape (ManifoldInference,
 #     ManifoldRuntime, ManifoldPersistenceSwiftData, ManifoldUI products
 #     must all be reachable from a single downstream consumer).
-#   - `ChatViewModel.configure(runtime:)` ergonomics — wires persistence
+#   - `ChatViewModel.configure(bootstrap:)` ergonomics — wires persistence
 #     and endpoint stores from the bootstrap in one call.
 #   - The ambient `vm.inputText = "..."; await vm.sendMessage()` pattern
 #     that all production hosts use, including the fact that `sendMessage`
@@ -64,7 +64,7 @@ cd "$WORK"
 #   - ManifoldInference            — InferenceService, InferenceBackend, BackendCapabilities, ModelLoadPlan, ModelInfo
 #   - ManifoldRuntime              — SendInput, ConversationRuntime (transitively via ManifoldPersistenceSwiftData)
 #   - ManifoldPersistenceSwiftData — ManifoldBootstrap, ModelContainerFactory, SwiftDataPersistenceProvider
-#   - ManifoldUI                   — ChatViewModel, ChatViewModel.configure(runtime:)
+#   - ManifoldUI                   — ChatViewModel, ChatViewModel.configure(bootstrap:)
 cat > Package.swift <<EOF
 // swift-tools-version: 6.2
 import PackageDescription
@@ -214,7 +214,7 @@ func run() async throws -> Int32 {
         inferenceService: bootstrap.inferenceService,
         conversationRuntime: bootstrap.conversationRuntime
     )
-    vm.configure(runtime: bootstrap)
+    vm.configure(bootstrap: bootstrap)
 
     vm.activeSession = sessionRecord
 


### PR DESCRIPTION
Closes #1614

## Summary
- Removes 3 deprecated configure* shims from ChatViewModel and SessionManagerViewModel (`configure(runtime:)` x2, `configure(_:)`)
- `configure(bootstrap:)` and `configureAndLoad(bootstrap:)` are now the only bootstrap-wiring entry points
- Per-component overloads (`configure(persistence:)`, `configure(imageRuntime:)`, etc.) kept as documented advanced escape hatches
- APIFreezeTests, ManifoldUITests, ManifoldUIModelManagementTests, Example app, and cold-start-tier2 updated to use canonical form

## Test plan
- [x] `swift build --disable-default-traits` — Build complete (814 targets)
- [x] `swift test --disable-default-traits --filter ManifoldUITests` — 633 tests, 0 failures
- [x] `swift test --disable-default-traits --filter APIFreezeTests` — 1 test, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)