### PR TITLE
fix(api): pre-v1 naming pass — EndpointBackend protocols, GenerationEvent normalization, requestGroupID, AsyncSequence conformances

### DIFF
--- a/Sources/ManifoldCloud/ClaudeBackend.swift
+++ b/Sources/ManifoldCloud/ClaudeBackend.swift
@@ -9,7 +9,7 @@ import ManifoldCloudCore
 /// Streams completions from the Anthropic Messages API (`/v1/messages`).
 /// Handles Claude-specific SSE event types (`content_block_delta`, etc.)
 /// and authentication via `x-api-key` header.
-public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, CloudBackendKeychainConfigurable, StructuredHistoryReceiver, ToolCallingHistoryReceiver, @unchecked Sendable {
+public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointBackendKeychainConfigurable, StructuredHistoryReceiver, ToolCallingHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Adapter composition (Phase 3/Claude)
     //

--- a/Sources/ManifoldCloud/ClaudeStreamEventExtractor.swift
+++ b/Sources/ManifoldCloud/ClaudeStreamEventExtractor.swift
@@ -226,7 +226,7 @@ enum ClaudePayloadParser {
 /// surface can only emit the events whose decision is local to one frame
 /// (`.token`, `.thinkingToken`). The full Claude event vocabulary —
 /// `.toolCallStart` / `.toolCallArgumentsDelta` / `.toolCall`,
-/// `.thinkingSignature`, `.thinkingComplete` transition, `.usage` — requires
+/// `.thinkingSignature`, `.thinkingCompleted` transition, `.usage` — requires
 /// cross-frame state (index-keyed tool-use accumulator, the open-thinking
 /// flag, the once-only tool-call finalisation guard).
 /// `ClaudeStreamEventExtractor` owns that state.
@@ -443,7 +443,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
     }
 
     /// Flushes pending state at stream end. Yields a trailing
-    /// `.thinkingComplete` if a thinking block is still open, and finalises
+    /// `.thinkingCompleted` if a thinking block is still open, and finalises
     /// any tool_use indices that never received their own
     /// `content_block_stop` (truncated upstream, hangup).
     ///
@@ -464,7 +464,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
 
     private func flushThinking(into out: inout [GenerationEvent]) {
         guard thinking.isOpen else { return }
-        out.append(.thinkingComplete)
+        out.append(.thinkingCompleted)
         thinking = ThinkingBlockManager()
     }
 

--- a/Sources/ManifoldCloud/OllamaBackend.swift
+++ b/Sources/ManifoldCloud/OllamaBackend.swift
@@ -21,7 +21,7 @@ import ManifoldCloudCore
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
 /// for try await event in stream.events { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
-public final class OllamaBackend: SSECloudBackend, CloudBackendURLModelConfigurable, ToolCallingHistoryReceiver, @unchecked Sendable {
+public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfigurable, ToolCallingHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Adapter composition (Phase 3/Ollama)
     //

--- a/Sources/ManifoldCloud/OllamaStreamEventExtractor.swift
+++ b/Sources/ManifoldCloud/OllamaStreamEventExtractor.swift
@@ -108,7 +108,7 @@ enum OllamaPayloadParser {
     /// This method only surfaces visible content; reasoning-model `thinking`
     /// fields are handled inline by ``parseResponseStream(bytes:config:continuation:)``
     /// so they can be emitted as ``GenerationEvent/thinkingToken(_:)`` with
-    /// proper ``GenerationEvent/thinkingComplete`` bracketing. Kept for the
+    /// proper ``GenerationEvent/thinkingCompleted`` bracketing. Kept for the
     /// ``SSEPayloadHandler`` protocol conformance and external callers.
     static func extractToken(from json: String) -> String? {
         guard let parsed = parseLine(json) else { return nil }
@@ -124,7 +124,7 @@ enum OllamaPayloadParser {
     /// one. Exposed for symmetry with ``extractToken(from:)``; streaming
     /// callers use the inline logic in
     /// ``parseResponseStream(bytes:config:continuation:)`` to bracket
-    /// thinking emissions with ``GenerationEvent/thinkingComplete``.
+    /// thinking emissions with ``GenerationEvent/thinkingCompleted``.
     static func extractThinking(from json: String) -> String? {
         guard let parsed = parseLine(json),
               let thinking = parsed.thinking,
@@ -220,7 +220,7 @@ enum OllamaPayloadParser {
 /// emit events whose decision is local to one frame (`.token`,
 /// `.thinkingToken`). The full Ollama event vocabulary —
 /// `.toolCallStart` / `.toolCallArgumentsDelta` / `.toolCall`, `.usage`,
-/// the implicit `.thinkingComplete` transition, the inline `<think>`-tag
+/// the implicit `.thinkingCompleted` transition, the inline `<think>`-tag
 /// fallback parser, and the per-stream visible/thinking caps — requires
 /// cross-frame state that lives here.
 ///
@@ -360,7 +360,7 @@ public final class OllamaStreamEventExtractor: CloudStreamEventConsumer, @unchec
         // (no done-chunk, no empty-thinking transition), close it out so
         // consumers don't hang in a thinking-only state.
         if thinkingOpen && !cancelled {
-            out.append(.thinkingComplete)
+            out.append(.thinkingCompleted)
             thinkingOpen = false
         }
         return out
@@ -394,13 +394,13 @@ public final class OllamaStreamEventExtractor: CloudStreamEventConsumer, @unchec
             thinkingTokenCount += 1
             return
         }
-        // Transition from thinking → content. Fire `.thinkingComplete`
+        // Transition from thinking → content. Fire `.thinkingCompleted`
         // exactly once on the first empty-thinking line we see after any
         // non-empty thinking was emitted. Skipped when the fallback parser
         // is driving state — the parser closes its own thinking block via
-        // its own `.thinkingComplete`.
+        // its own `.thinkingCompleted`.
         if thinkingOpen && contentParser == nil {
-            out.append(.thinkingComplete)
+            out.append(.thinkingCompleted)
             thinkingOpen = false
         }
     }
@@ -451,10 +451,10 @@ public final class OllamaStreamEventExtractor: CloudStreamEventConsumer, @unchec
         }
         // Ollama can terminate with `"done":true` while thinking is still
         // the only content emitted (reasoning model hits num_predict mid-
-        // think). Flush `.thinkingComplete` so consumers don't leave the
+        // think). Flush `.thinkingCompleted` so consumers don't leave the
         // thinking block open.
         if thinkingOpen {
-            out.append(.thinkingComplete)
+            out.append(.thinkingCompleted)
             thinkingOpen = false
         }
     }
@@ -476,7 +476,7 @@ public final class OllamaStreamEventExtractor: CloudStreamEventConsumer, @unchec
     /// Emit one parser-produced event while honouring per-stream caps.
     /// Returns `false` when the visible-token cap was hit (caller stops
     /// producing further events on this line). Only handles
-    /// `.token`/`.thinkingToken`/`.thinkingComplete` — anything else is
+    /// `.token`/`.thinkingToken`/`.thinkingCompleted` — anything else is
     /// forwarded verbatim.
     private func emit(_ event: GenerationEvent, into out: inout [GenerationEvent]) -> Bool {
         switch event {
@@ -488,8 +488,8 @@ public final class OllamaStreamEventExtractor: CloudStreamEventConsumer, @unchec
             thinkingOpen = true
             thinkingTokenCount += 1
             return true
-        case .thinkingComplete:
-            out.append(.thinkingComplete)
+        case .thinkingCompleted:
+            out.append(.thinkingCompleted)
             thinkingOpen = false
             return true
         case .token(let text):

--- a/Sources/ManifoldCloud/OpenAIBackend.swift
+++ b/Sources/ManifoldCloud/OpenAIBackend.swift
@@ -21,7 +21,7 @@ import ManifoldCloudCore
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
 /// for try await event in stream.events { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
-public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, StructuredHistoryReceiver, ToolCallingHistoryReceiver, @unchecked Sendable {
+public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, EndpointBackendURLModelConfigurable, EndpointBackendKeychainConfigurable, StructuredHistoryReceiver, ToolCallingHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Adapter composition (Phase 2/B/ii)
     //

--- a/Sources/ManifoldCloud/OpenAIResponsesBackend.swift
+++ b/Sources/ManifoldCloud/OpenAIResponsesBackend.swift
@@ -29,7 +29,7 @@ import ManifoldCloudCore
 /// ```
 ///
 /// Reasoning summaries surface as ``GenerationEvent/thinkingToken(_:)``
-/// values, with a single ``GenerationEvent/thinkingComplete`` injected on
+/// values, with a single ``GenerationEvent/thinkingCompleted`` injected on
 /// the transition to visible output. This routing mirrors the convention
 /// used by ``ClaudeBackend`` and ``OpenAIBackend`` so consumers can stay
 /// agnostic of the wire format.
@@ -52,7 +52,7 @@ import ManifoldCloudCore
 ///     }
 /// }
 /// ```
-public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, CloudBackendURLModelConfigurable, CloudBackendKeychainConfigurable, ToolCallingHistoryReceiver, @unchecked Sendable {
+public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, EndpointBackendURLModelConfigurable, EndpointBackendKeychainConfigurable, ToolCallingHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Adapter composition (Phase 3/Responses)
     //

--- a/Sources/ManifoldCloud/OpenAIResponsesStreamEventExtractor.swift
+++ b/Sources/ManifoldCloud/OpenAIResponsesStreamEventExtractor.swift
@@ -33,7 +33,7 @@ import ManifoldCloudCore
 /// the next tool-use turn), the Responses API exposes reasoning as a
 /// post-hoc *summary* the server generates and discards. Emit it as
 /// ``GenerationEvent/thinkingToken(_:)`` (and a single
-/// ``GenerationEvent/thinkingComplete`` on the transition to visible
+/// ``GenerationEvent/thinkingCompleted`` on the transition to visible
 /// content) — there is no signature to preserve.
 ///
 /// ### Lifecycle
@@ -101,7 +101,7 @@ public final class OpenAIResponsesStreamEventExtractor: CloudStreamEventConsumer
     }
 
     /// Flushes pending state at stream end. Yields a trailing
-    /// `.thinkingComplete` if a thinking block is still open and finalises
+    /// `.thinkingCompleted` if a thinking block is still open and finalises
     /// any buffered tool calls the upstream didn't accompany with a
     /// `response.completed`.
     ///
@@ -194,7 +194,7 @@ public final class OpenAIResponsesStreamEventExtractor: CloudStreamEventConsumer
 
     private func flushThinking(into out: inout [GenerationEvent]) {
         guard thinking.isOpen else { return }
-        out.append(.thinkingComplete)
+        out.append(.thinkingCompleted)
         thinking = ThinkingBlockManager()
     }
 

--- a/Sources/ManifoldCloud/OpenAIStreamEventExtractor.swift
+++ b/Sources/ManifoldCloud/OpenAIStreamEventExtractor.swift
@@ -10,7 +10,7 @@ import ManifoldCloudCore
 /// can only emit the events whose decision is local to one frame
 /// (`.token`, `.thinkingToken`). The full OpenAI Chat Completions event
 /// vocabulary — `.toolCallStart` / `.toolCallArgumentsDelta` / `.toolCall`,
-/// `.usage`, `.prefillProgress`, and the implicit `.thinkingComplete`
+/// `.usage`, `.prefillProgress`, and the implicit `.thinkingCompleted`
 /// transition — requires cross-frame state (index-keyed tool-call delta
 /// buffers, the open-thinking flag, the once-only tool-call finalisation
 /// guard). `OpenAIStreamEventExtractor` owns that state.
@@ -69,8 +69,8 @@ public final class OpenAIStreamEventExtractor: CloudStreamEventConsumer, @unchec
 
         if let progress = OpenAIChatCompletionsPayloadParsing.parsePrefillProgress(from: payload) {
             out.append(.prefillProgress(
-                nPast: progress.nPast,
-                nTotal: progress.nTotal,
+                tokensProcessed: progress.nPast,
+                tokensTotal: progress.nTotal,
                 tokensPerSecond: progress.tokensPerSecond
             ))
             return out
@@ -150,7 +150,7 @@ public final class OpenAIStreamEventExtractor: CloudStreamEventConsumer, @unchec
     }
 
     /// Flushes pending state at stream end. Yields a trailing
-    /// `.thinkingComplete` if a thinking block is still open, and finalises
+    /// `.thinkingCompleted` if a thinking block is still open, and finalises
     /// any buffered tool calls that arrived without an explicit
     /// `finish_reason` (compat servers that close the stream silently).
     ///
@@ -170,7 +170,7 @@ public final class OpenAIStreamEventExtractor: CloudStreamEventConsumer, @unchec
 
     private func flushThinking(into out: inout [GenerationEvent]) {
         guard thinking.isOpen else { return }
-        out.append(.thinkingComplete)
+        out.append(.thinkingCompleted)
         thinking = ThinkingBlockManager()
     }
 

--- a/Sources/ManifoldCloudCore/CloudRoutedStreamParser.swift
+++ b/Sources/ManifoldCloudCore/CloudRoutedStreamParser.swift
@@ -121,12 +121,12 @@ package struct CloudRoutedStreamParser: Sendable {
             case .thinkingToken:
                 wasThinking = true
                 continuation.yield(event)
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 wasThinking = false
                 continuation.yield(event)
             case .token:
                 if wasThinking {
-                    continuation.yield(.thinkingComplete)
+                    continuation.yield(.thinkingCompleted)
                     wasThinking = false
                 }
                 continuation.yield(event)

--- a/Sources/ManifoldCloudCore/CloudStreamEventConsumer.swift
+++ b/Sources/ManifoldCloudCore/CloudStreamEventConsumer.swift
@@ -27,7 +27,7 @@ public protocol CloudStreamEventConsumer: AnyObject, Sendable {
     func consume(payload: String) -> [GenerationEvent]
 
     /// Flushes pending state at stream end. Implementations yield any
-    /// open-thinking close (`.thinkingComplete`) and any buffered tool
+    /// open-thinking close (`.thinkingCompleted`) and any buffered tool
     /// calls the upstream never accompanied with an explicit
     /// `finish_reason`. Pass `cancelled: true` to suppress phantom tool
     /// emissions when the consumer is being dropped mid-stream.

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -284,7 +284,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     /// The default implementation forwards to ``payloadHandler``'s
     /// ``SSEPayloadHandler/extractEvents(from:)``. The base
     /// ``parseResponseStream(bytes:continuation:)`` loop iterates the
-    /// returned events and injects ``GenerationEvent/thinkingComplete``
+    /// returned events and injects ``GenerationEvent/thinkingCompleted``
     /// on the first non-thinking-token event after one or more
     /// thinking-token events, so handlers stay stateless.
     open func extractEvents(from payload: String) -> [GenerationEvent] {
@@ -676,7 +676,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
         )
         // Tracks whether the last emitted content event was a
         // `.thinkingToken`. When the next payload produces a `.token` (plain
-        // text), we inject a single `.thinkingComplete` so downstream
+        // text), we inject a single `.thinkingCompleted` so downstream
         // consumers see the reasoning block close exactly once, even for
         // field-based wire formats (Claude `thinking_delta`, OpenAI
         // `reasoning_content`) where the boundary is implicit.
@@ -689,7 +689,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                 case .thinkingToken:
                     wasThinking = true
                     continuation.yield(event)
-                case .thinkingComplete:
+                case .thinkingCompleted:
                     // Handler emitted the boundary itself (e.g. an inline-
                     // tag backend using `ThinkingTransform`). Clear the flag
                     // so we don't double-emit on the next `.token`.
@@ -697,7 +697,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                     continuation.yield(event)
                 case .token:
                     if wasThinking {
-                        continuation.yield(.thinkingComplete)
+                        continuation.yield(.thinkingCompleted)
                         wasThinking = false
                     }
                     continuation.yield(event)

--- a/Sources/ManifoldCloudCore/ThinkingBlockManager.swift
+++ b/Sources/ManifoldCloudCore/ThinkingBlockManager.swift
@@ -1,17 +1,17 @@
 import ManifoldInference
 
 /// Tracks whether a streaming parser is currently inside a thinking block and
-/// guarantees a single `.thinkingComplete` is emitted on the transition out.
+/// guarantees a single `.thinkingCompleted` is emitted on the transition out.
 ///
 /// Three SSE backends (`OpenAIBackend`, `ClaudeBackend`,
 /// `OpenAIResponsesBackend`) all need the same primitive: "remember that we
 /// yielded a `.thinkingToken`; the next non-thinking event — visible token,
 /// upstream `reasoning_done`, stream end, or thrown error — must yield
-/// `.thinkingComplete` exactly once before whatever comes next."
+/// `.thinkingCompleted` exactly once before whatever comes next."
 ///
 /// The state machine is intentionally minimal. Parsers keep their inline
 /// event-extraction logic; this type only owns the open-state and the
-/// `.thinkingComplete` emission so the close-rule is identical across
+/// `.thinkingCompleted` emission so the close-rule is identical across
 /// backends and survives refactors of the surrounding parsing code.
 ///
 /// ```swift
@@ -37,11 +37,11 @@ public struct ThinkingBlockManager {
     }
 
     /// If a thinking block is currently open, yields a single
-    /// `.thinkingComplete` and resets to closed. Otherwise a no-op.
+    /// `.thinkingCompleted` and resets to closed. Otherwise a no-op.
     /// Idempotent — calling twice in a row yields at most one event.
     public mutating func flushIfOpen(into continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation) {
         guard isOpen else { return }
-        continuation.yield(.thinkingComplete)
+        continuation.yield(.thinkingCompleted)
         isOpen = false
     }
 }

--- a/Sources/ManifoldFoundation/FoundationBackend.swift
+++ b/Sources/ManifoldFoundation/FoundationBackend.swift
@@ -16,7 +16,7 @@ import ManifoldInference
 /// ## Thinking / reasoning support
 ///
 /// ManifoldKit surfaces reasoning tokens from capable models via
-/// ``GenerationEvent/thinkingToken(_:)`` and ``GenerationEvent/thinkingComplete``.
+/// ``GenerationEvent/thinkingToken(_:)`` and ``GenerationEvent/thinkingCompleted``.
 /// The Ollama and Llama backends emit these events today. **FoundationBackend
 /// does not**, because Apple's public FoundationModels SDK (Xcode 26.4,
 /// module version 1.4.34) exposes no reasoning/thinking surface at all:
@@ -41,13 +41,13 @@ import ManifoldInference
 /// In other words: whatever chain-of-thought Apple's on-device model performs
 /// happens opaquely inside the generator. The SDK returns only the final
 /// user-visible answer. There is nothing for this backend to map onto
-/// `.thinkingToken` or `.thinkingComplete`, and synthesising fake thinking
+/// `.thinkingToken` or `.thinkingCompleted`, and synthesising fake thinking
 /// events from the visible content would be misleading.
 ///
 /// When Apple ships a reasoning surface (e.g. a `reasoning` case on
 /// `Transcript.Segment`, a `reasoningContent` field on `ResponseStream.Snapshot`,
 /// or a reasoning-enabled `UseCase`), this backend should be updated to emit
-/// `.thinkingToken` while reasoning is in flight and `.thinkingComplete`
+/// `.thinkingToken` while reasoning is in flight and `.thinkingCompleted`
 /// exactly once at the transition to visible content, matching the pattern
 /// already used by ``OllamaBackend``.
 ///

--- a/Sources/ManifoldFuzz/EventRecorder.swift
+++ b/Sources/ManifoldFuzz/EventRecorder.swift
@@ -93,11 +93,11 @@ public struct EventRecorder: Sendable {
             for try await event in stream.events {
                 let t = start.duration(to: ContinuousClock.now).seconds
                 switch event {
-                case .prefillProgress(let nPast, let nTotal, let tokensPerSecond):
+                case .prefillProgress(let tokensProcessed, let tokensTotal, let tokensPerSecond):
                     events.append(.init(
                         t: t,
                         kind: "prefillProgress",
-                        v: "\(nPast)/\(nTotal)@\(tokensPerSecond)"
+                        v: "\(tokensProcessed)/\(tokensTotal)@\(tokensPerSecond)"
                     ))
                 case .token(let text):
                     if firstTokenAt == nil { firstTokenAt = ContinuousClock.now }
@@ -108,13 +108,13 @@ public struct EventRecorder: Sendable {
                     thinkingRaw += text
                     thinkingBuffer += text
                     events.append(.init(t: t, kind: "thinkingToken", v: text))
-                case .thinkingComplete:
+                case .thinkingCompleted:
                     thinkingCompleteCount += 1
                     if !thinkingBuffer.isEmpty {
                         thinkingParts.append(thinkingBuffer)
                         thinkingBuffer = ""
                     }
-                    events.append(.init(t: t, kind: "thinkingComplete", v: nil))
+                    events.append(.init(t: t, kind: "thinkingCompleted", v: nil))
                 case .usage(let p, let c):
                     promptTokens = p
                     completionTokens = c
@@ -125,12 +125,12 @@ public struct EventRecorder: Sendable {
                 case .toolResult(let result):
                     toolResults.append(result)
                     events.append(.init(t: t, kind: "toolResult", v: result.callId))
-                case .toolLoopLimitReached(let iterations):
-                    events.append(.init(t: t, kind: "toolLoopLimitReached", v: "\(iterations)"))
+                case .toolIterationLimitExceeded(let iterations):
+                    events.append(.init(t: t, kind: "toolIterationLimitExceeded", v: "\(iterations)"))
                 case .kvCacheReuse(let tokens):
                     events.append(.init(t: t, kind: "kvCacheReuse", v: "\(tokens)"))
-                case .diagnosticThrottle(let reason):
-                    events.append(.init(t: t, kind: "diagnosticThrottle", v: reason))
+                case .throttleDiagnostic(let reason):
+                    events.append(.init(t: t, kind: "throttleDiagnostic", v: reason))
                 case .thinkingSignature(let signature):
                     // Provider-issued opaque token for multi-turn replay
                     // (Anthropic extended thinking). Surface in the trace so
@@ -146,8 +146,8 @@ public struct EventRecorder: Sendable {
                     events.append(.init(t: t, kind: "toolProgress", v: "\(progress.callId):\(progress.message):\(fraction)"))
                 case .toolDispatchStarted(let callId, let name, let attempt):
                     events.append(.init(t: t, kind: "toolDispatchStarted", v: "\(callId):\(name):\(attempt)"))
-                case .toolDispatchCompleted(let callId, let durationMs, let errorKind):
-                    events.append(.init(t: t, kind: "toolDispatchCompleted", v: "\(callId):\(durationMs):\(errorKind?.rawValue ?? "none")"))
+                case .toolDispatchCompleted(let callId, let durationMilliseconds, let errorKind):
+                    events.append(.init(t: t, kind: "toolDispatchCompleted", v: "\(callId):\(durationMilliseconds):\(errorKind?.rawValue ?? "none")"))
                 case .handoffRequested(let handoff):
                     // Multi-agent handoffs only surface through the runtime
                     // executor; deterministic fuzz replays never observe
@@ -166,7 +166,7 @@ public struct EventRecorder: Sendable {
         // trace in `thinkingParts`. Without this, detectors like
         // `unbalanced-thinking-events` and the `looping` thinking-loop sub-check go
         // blind on mid-stream failures. On the success path the buffer is already
-        // drained by the last `.thinkingComplete`, so this is a no-op.
+        // drained by the last `.thinkingCompleted`, so this is a no-op.
         if !thinkingBuffer.isEmpty {
             thinkingParts.append(thinkingBuffer)
             thinkingBuffer = ""

--- a/Sources/ManifoldFuzz/ManifoldFuzz.docc/RunRecordSchema.md
+++ b/Sources/ManifoldFuzz/ManifoldFuzz.docc/RunRecordSchema.md
@@ -35,7 +35,7 @@ in #490) call it before acting on a decoded record.
 | `rendered` | `String` | User-visible string produced by running `raw` through the same markdown / code-fence transform that `ManifoldUI`'s `AssistantMarkdownView` applies (see `MarkdownRendering.renderToVisibleString`). Diverges from `raw` in realistic ways: closing fences disappear, emphasis markers collapse, link targets are hidden. Records written before #543 had `rendered == raw`. |
 | `thinkingRaw` | `String` | Concatenation of all thinking-channel text. |
 | `thinkingParts` | `[String]` | Thinking deltas as a list, in stream order. |
-| `thinkingCompleteCount` | `Int` | Number of `thinkingComplete` events observed. |
+| `thinkingCompleteCount` | `Int` | Number of `thinkingCompleted` events observed. |
 | `templateMarkers` | `MarkerSnapshot?` | The `{open, close}` reasoning markers the backend/template advertises; `nil` if none. |
 | `memory` | `MemorySnapshot` | `beforeBytes`, `peakBytes`, `afterBytes` — all optional; nil when the backend/platform can't measure. |
 | `timing` | `TimingSnapshot` | `firstTokenMs?`, `totalMs`, `tokensPerSec?`. `totalMs` is always present; TPS is derived only when both token counts and first-token time are known. |

--- a/Sources/ManifoldFuzz/Scenarios/CancelDuringThinkingScenario.swift
+++ b/Sources/ManifoldFuzz/Scenarios/CancelDuringThinkingScenario.swift
@@ -6,10 +6,10 @@ import ManifoldInference
 ///
 /// 1. The stream terminates cleanly (no thrown error on the normal cancel
 ///    path — the backend's cancellation style is cooperative).
-/// 2. No `.thinkingComplete` event lands *after* cancellation. An unmatched
-///    `.thinkingComplete` would leave downstream UI holding a phantom
+/// 2. No `.thinkingCompleted` event lands *after* cancellation. An unmatched
+///    `.thinkingCompleted` would leave downstream UI holding a phantom
 ///    ``ManifoldInference/MessagePart/thinking`` container.
-/// 3. The number of `.thinkingComplete` events is at most the number of
+/// 3. The number of `.thinkingCompleted` events is at most the number of
 ///    `.thinkingToken` events — the invariant "complete must follow at least
 ///    one token" holds across cancellation too.
 public struct CancelDuringThinkingScenario: FuzzScenario {
@@ -27,7 +27,7 @@ public struct CancelDuringThinkingScenario: FuzzScenario {
             ],
             emitThinkingComplete: true,
             // Give the consumer a deterministic window between the first
-            // thinking token and the thinkingComplete event to land its
+            // thinking token and the thinkingCompleted event to land its
             // cancel. Without this pause the backend would race through the
             // thinking burst before the scenario's cancel reached it.
             pauseBeforeThinkingComplete: .milliseconds(50)
@@ -74,7 +74,7 @@ public struct CancelDuringThinkingScenario: FuzzScenario {
             return false
         }
         let thinkingCompleteIdxs = observed.indices.filter {
-            if case .thinkingComplete = observed[$0] { return true }
+            if case .thinkingCompleted = observed[$0] { return true }
             return false
         }
 
@@ -87,15 +87,15 @@ public struct CancelDuringThinkingScenario: FuzzScenario {
             )
         }
 
-        // `.thinkingComplete` is permitted iff it came before cancellation
+        // `.thinkingCompleted` is permitted iff it came before cancellation
         // landed (we've already emitted at least one thinking token by then).
-        // What must *not* happen: a dangling `.thinkingComplete` with zero
-        // preceding thinking tokens, or multiple `.thinkingComplete`s.
+        // What must *not* happen: a dangling `.thinkingCompleted` with zero
+        // preceding thinking tokens, or multiple `.thinkingCompleted`s.
         if thinkingCompleteIdxs.count > 1 {
             return ScenarioOutcome(
                 scenarioId: id,
                 invariantHeld: false,
-                failureReason: "multiple .thinkingComplete events across a cancelled stream",
+                failureReason: "multiple .thinkingCompleted events across a cancelled stream",
                 events: observed
             )
         }
@@ -106,7 +106,7 @@ public struct CancelDuringThinkingScenario: FuzzScenario {
                 return ScenarioOutcome(
                     scenarioId: id,
                     invariantHeld: false,
-                    failureReason: "dangling .thinkingComplete with no preceding .thinkingToken",
+                    failureReason: "dangling .thinkingCompleted with no preceding .thinkingToken",
                     events: observed
                 )
             }

--- a/Sources/ManifoldFuzz/Scenarios/ScenarioTestBackend.swift
+++ b/Sources/ManifoldFuzz/Scenarios/ScenarioTestBackend.swift
@@ -11,10 +11,10 @@ import ManifoldInference
 ///
 /// - `tokensToYield` — the visible tokens emitted after thinking (if any).
 /// - `thinkingTokensToYield` — reasoning tokens emitted before visible output.
-/// - `emitThinkingComplete` — whether to emit a `.thinkingComplete` event after
+/// - `emitThinkingComplete` — whether to emit a `.thinkingCompleted` event after
 ///   the thinking burst. Scenarios covering disable-thinking flip this off.
 /// - `pauseBeforeThinkingComplete` — optional sleep *before* emitting
-///   `.thinkingComplete`, giving scenarios a cancellation / retry window that
+///   `.thinkingCompleted`, giving scenarios a cancellation / retry window that
 ///   lands mid-thinking rather than after it.
 /// - `cancelAfterFirstThinkingToken` — when true, the backend observes
 ///   `Task.isCancelled` cooperatively and stops the stream once cancellation
@@ -139,7 +139,7 @@ public final class ScenarioTestBackend: InferenceBackend, @unchecked Sendable {
                             try? await Task.sleep(for: pause)
                         }
                         if !Task.isCancelled && emitComplete {
-                            continuation.yield(.thinkingComplete)
+                            continuation.yield(.thinkingCompleted)
                         }
                     }
                 }

--- a/Sources/ManifoldFuzz/Scenarios/ThinkingAcrossRetryScenario.swift
+++ b/Sources/ManifoldFuzz/Scenarios/ThinkingAcrossRetryScenario.swift
@@ -6,9 +6,9 @@ import ManifoldInference
 /// and the second attempt produces a clean stream.
 ///
 /// Asserts that across the whole user-visible interaction (merged retry
-/// timeline), at most **one** `.thinkingComplete` event reaches the consumer.
+/// timeline), at most **one** `.thinkingCompleted` event reaches the consumer.
 /// Double-complete would signal the retry handler re-replayed the partial
-/// thinking block without invalidating the earlier `.thinkingComplete`,
+/// thinking block without invalidating the earlier `.thinkingCompleted`,
 /// leaving downstream consumers double-closing the thinking container.
 ///
 /// The retry shape is intentionally minimal — this scenario operates at the
@@ -18,7 +18,7 @@ import ManifoldInference
 /// sees whatever a retry-shaped composition of two streams yields.
 public struct ThinkingAcrossRetryScenario: FuzzScenario {
     public let id = "thinking-across-retry"
-    public let humanName = "Retry after mid-thinking failure yields at most one .thinkingComplete"
+    public let humanName = "Retry after mid-thinking failure yields at most one .thinkingCompleted"
 
     public init() {}
 
@@ -67,7 +67,7 @@ public struct ThinkingAcrossRetryScenario: FuzzScenario {
 
         // The retry policy must also invalidate any thinking events it
         // already surfaced to the consumer before retrying, otherwise a
-        // second `.thinkingComplete` from the fresh stream would ride on top
+        // second `.thinkingCompleted` from the fresh stream would ride on top
         // of the first one. The canonical shape for this is "drop any
         // partial-stream events from the pre-retry attempt". We model that
         // here by resetting `merged` before consuming the retry — a real
@@ -80,7 +80,7 @@ public struct ThinkingAcrossRetryScenario: FuzzScenario {
         }
 
         let thinkingCompleteCount = merged.reduce(0) { acc, e in
-            if case .thinkingComplete = e { return acc + 1 }
+            if case .thinkingCompleted = e { return acc + 1 }
             return acc
         }
         let thinkingTokenCount = merged.reduce(0) { acc, e in
@@ -92,7 +92,7 @@ public struct ThinkingAcrossRetryScenario: FuzzScenario {
             return ScenarioOutcome(
                 scenarioId: id,
                 invariantHeld: false,
-                failureReason: "retry surfaced \(thinkingCompleteCount) .thinkingComplete events",
+                failureReason: "retry surfaced \(thinkingCompleteCount) .thinkingCompleted events",
                 events: merged
             )
         }
@@ -100,7 +100,7 @@ public struct ThinkingAcrossRetryScenario: FuzzScenario {
             return ScenarioOutcome(
                 scenarioId: id,
                 invariantHeld: false,
-                failureReason: ".thinkingComplete emitted after retry without any .thinkingToken",
+                failureReason: ".thinkingCompleted emitted after retry without any .thinkingToken",
                 events: merged
             )
         }

--- a/Sources/ManifoldFuzz/Scenarios/ThinkingBudgetZeroScenario.swift
+++ b/Sources/ManifoldFuzz/Scenarios/ThinkingBudgetZeroScenario.swift
@@ -5,7 +5,7 @@ import ManifoldInference
 /// that:
 ///
 /// 1. Zero `.thinkingToken` events ever fire.
-/// 2. Zero `.thinkingComplete` events fire (since no reasoning was emitted).
+/// 2. Zero `.thinkingCompleted` events fire (since no reasoning was emitted).
 /// 3. Visible output still appears.
 ///
 /// Once P4 wires Ollama's `think: false` through, this scenario replays
@@ -45,7 +45,7 @@ public struct ThinkingBudgetZeroScenario: FuzzScenario {
             return acc
         }
         let thinkingCompleteCount = observed.reduce(0) { acc, e in
-            if case .thinkingComplete = e { return acc + 1 }
+            if case .thinkingCompleted = e { return acc + 1 }
             return acc
         }
         let visibleCount = observed.reduce(0) { acc, e in
@@ -65,7 +65,7 @@ public struct ThinkingBudgetZeroScenario: FuzzScenario {
             return ScenarioOutcome(
                 scenarioId: id,
                 invariantHeld: false,
-                failureReason: "emitted .thinkingComplete despite zero thinking tokens",
+                failureReason: "emitted .thinkingCompleted despite zero thinking tokens",
                 events: observed
             )
         }

--- a/Sources/ManifoldFuzz/SessionScriptRunner.swift
+++ b/Sources/ManifoldFuzz/SessionScriptRunner.swift
@@ -28,12 +28,12 @@ public actor SessionScriptRunner {
         public var topP: Float
         public var repeatPenalty: Float
         public var maxOutputTokens: Int?
-        /// Session id applied to every enqueue. When the script carries
+        /// Request group ID applied to every enqueue. When the script carries
         /// multiple logical sessions, use ``SessionScriptRunner/execute(_:)``
         /// per-script and compose captures externally; within a single script
-        /// the `sessionLabel` field pins the id so the service's session-scoped
+        /// the `sessionLabel` field pins the id so the service's request-scoped
         /// discard/cancel semantics apply.
-        public var sessionID: UUID?
+        public var requestGroupID: UUID?
 
         public init(
             modelId: String = "mock-model",
@@ -44,7 +44,7 @@ public actor SessionScriptRunner {
             topP: Float = 0.9,
             repeatPenalty: Float = 1.1,
             maxOutputTokens: Int? = 256,
-            sessionID: UUID? = nil
+            requestGroupID: UUID? = nil
         ) {
             self.modelId = modelId
             self.modelURL = modelURL
@@ -54,7 +54,7 @@ public actor SessionScriptRunner {
             self.topP = topP
             self.repeatPenalty = repeatPenalty
             self.maxOutputTokens = maxOutputTokens
-            self.sessionID = sessionID
+            self.requestGroupID = requestGroupID
         }
     }
 
@@ -89,7 +89,7 @@ public actor SessionScriptRunner {
         // into the next enqueue. Edits/deletes mutate it in-place.
         var messages: [ChatMessage] = []
         var steps: [SessionCapture.StepResult] = []
-        let scriptSessionID: UUID = options.sessionID ?? UUID()
+        let scriptSessionID: UUID = options.requestGroupID ?? UUID()
 
         for (index, step) in script.steps.enumerated() {
             let t0 = ContinuousClock.now
@@ -99,7 +99,7 @@ public actor SessionScriptRunner {
                 let record = await runTurn(
                     messages: messages,
                     systemPrompt: script.systemPrompt,
-                    sessionID: scriptSessionID,
+                    requestGroupID: scriptSessionID,
                     stepIndex: index,
                     step: step
                 )
@@ -124,7 +124,7 @@ public actor SessionScriptRunner {
                 let record = await runTurn(
                     messages: messages,
                     systemPrompt: script.systemPrompt,
-                    sessionID: scriptSessionID,
+                    requestGroupID: scriptSessionID,
                     stepIndex: index,
                     step: step
                 )
@@ -201,7 +201,7 @@ public actor SessionScriptRunner {
     private func runTurn(
         messages: [ChatMessage],
         systemPrompt: String?,
-        sessionID: UUID,
+        requestGroupID: UUID,
         stepIndex: Int,
         step: SessionScript.Step
     ) async -> RunRecord {
@@ -230,7 +230,7 @@ public actor SessionScriptRunner {
                         maxOutputTokens: options.maxOutputTokens
                     ),
                     priority: .normal,
-                    sessionID: sessionID
+                    requestGroupID: requestGroupID
                 )
                 return .success((r.token, r.stream))
             } catch {

--- a/Sources/ManifoldHardware/BackendCapabilities.swift
+++ b/Sources/ManifoldHardware/BackendCapabilities.swift
@@ -88,7 +88,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     public let supportsGrammarConstrainedSampling: Bool
 
     /// If true, the backend can emit ``GenerationEvent/thinkingToken(_:)`` and
-    /// ``GenerationEvent/thinkingComplete`` events for reasoning content. Consumers use this
+    /// ``GenerationEvent/thinkingCompleted`` events for reasoning content. Consumers use this
     /// static capability flag to gate thinking-related UI (reasoning disclosure group,
     /// thinking budget slider) rather than inferring it from the active `PromptTemplate`.
     ///

--- a/Sources/ManifoldInference/ManifoldInference.docc/Extensions/OutputParserSession.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/Extensions/OutputParserSession.md
@@ -11,7 +11,7 @@ backend used to maintain independently (`ThinkingParser`, `MLXToolCallParser`,
 chain of transforms**: each chunk is wrapped as `[.token(chunk)]` and piped
 through the stages in declaration order. Every stage re-scans **only the
 `.token` payloads** it receives and passes structured events
-(``GenerationEvent/thinkingToken(_:)``, ``GenerationEvent/thinkingComplete``,
+(``GenerationEvent/thinkingToken(_:)``, ``GenerationEvent/thinkingCompleted``,
 ``GenerationEvent/toolCall(_:)``, …) straight through untouched.
 
 ```swift,no-build
@@ -39,7 +39,7 @@ tagged ``GenerationEvent`` case, exactly as each backend already emitted:
 |-------------|---------------|
 | Text outside any marker block | ``GenerationEvent/token(_:)`` |
 | Text inside a thinking block | ``GenerationEvent/thinkingToken(_:)`` |
-| Thinking block close (depth 1→0) | ``GenerationEvent/thinkingComplete`` |
+| Thinking block close (depth 1→0) | ``GenerationEvent/thinkingCompleted`` |
 | Completed tool-call body | ``GenerationEvent/toolCall(_:)`` |
 
 ### Stage order is chain order

--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -166,7 +166,7 @@ for try await event in stream {
         responseText += chunk
     case .thinkingToken(let chunk):
         thinkingText += chunk
-    case .thinkingComplete:
+    case .thinkingCompleted:
         showThinkingBubble(thinkingText)
     case .toolCall(let call):
         let result = try await myToolRegistry.dispatch(call)

--- a/Sources/ManifoldInference/Models/GenerationEvent.swift
+++ b/Sources/ManifoldInference/Models/GenerationEvent.swift
@@ -12,7 +12,7 @@
 /// ### Queue-emitted lifecycle events
 ///
 /// ``toolDispatchStarted(callId:name:attempt:)`` and
-/// ``toolDispatchCompleted(callId:durationMs:errorKind:)`` are emitted by the
+/// ``toolDispatchCompleted(callId:durationMilliseconds:errorKind:)`` are emitted by the
 /// **queue** (`GenerationQueue`), not by individual backends.
 /// Backends emit only ``toolCall(_:)`` (and, when
 /// streaming, ``toolCallStart(callId:name:)`` and
@@ -41,10 +41,10 @@ public enum GenerationEvent: Sendable, Equatable {
     /// Progress update while the backend is evaluating prompt tokens before the
     /// first generated content token is available.
     ///
-    /// `nPast` is how many prompt tokens have been evaluated so far, `nTotal`
-    /// is the total prompt-token count for this request, and
+    /// `tokensProcessed` is how many prompt tokens have been evaluated so far,
+    /// `tokensTotal` is the total prompt-token count for this request, and
     /// `tokensPerSecond` is the backend-reported prompt-eval throughput.
-    case prefillProgress(nPast: Int, nTotal: Int, tokensPerSecond: Double)
+    case prefillProgress(tokensProcessed: Int, tokensTotal: Int, tokensPerSecond: Double)
 
     /// A fragment of generated text (typically one token).
     case token(String)
@@ -83,7 +83,7 @@ public enum GenerationEvent: Sendable, Equatable {
     case thinkingToken(String)
 
     /// Reasoning block complete (depth 1→0 transition). Finalize accumulated thinking content.
-    case thinkingComplete
+    case thinkingCompleted
 
     /// Provider-supplied opaque signature attached to the most recent
     /// thinking block. Emitted by backends (Anthropic) whose APIs require
@@ -94,7 +94,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// same block. Consumers attach the signature to the in-flight
     /// reasoning accumulator so it lands on the persisted
     /// ``MessagePart/thinking(_:signature:)`` part once
-    /// ``thinkingComplete`` arrives. Backends without a signature concept
+    /// ``thinkingCompleted`` arrives. Backends without a signature concept
     /// (MLX inline `<think>`, OpenAI `reasoning_content`, Llama) never
     /// emit this event.
     case thinkingSignature(String)
@@ -105,7 +105,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// Emitted exactly once per turn when the loop stops for this reason. The
     /// associated value is the iteration count that ran before termination, so
     /// UI surfaces can differentiate a budget hit from an organic stop.
-    case toolLoopLimitReached(iterations: Int)
+    case toolIterationLimitExceeded(iterations: Int)
 
     /// Result of a tool dispatched by the orchestrator in response to a
     /// ``toolCall(_:)`` event.
@@ -139,7 +139,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// on every re-check tick. UI surfaces can use this to show a "device
     /// throttling — paused" hint while the loop blocks between tokens.
     /// `reason` is a short, human-readable string the UI may display verbatim.
-    case diagnosticThrottle(reason: String)
+    case throttleDiagnostic(reason: String)
 
     /// Emitted by the orchestrator immediately before it begins handling a
     /// model-emitted ``ToolCall``.
@@ -160,7 +160,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// Emitted by the orchestrator after tool-call handling settles,
     /// regardless of outcome.
     ///
-    /// Fires after the matching ``toolResult(_:)`` event. `durationMs` is the
+    /// Fires after the matching ``toolResult(_:)`` event. `durationMilliseconds` is the
     /// monotonic handling latency in milliseconds (>= 0), measured from
     /// ``toolDispatchStarted(callId:name:attempt:)`` to this event with a
     /// monotonic clock so wall-clock adjustments (NTP, user time changes) do
@@ -171,7 +171,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// when handling produced an error result and `nil` on success — its
     /// value matches the ``ToolResult/errorKind`` of the `.toolResult` event
     /// with the same `callId`.
-    case toolDispatchCompleted(callId: String, durationMs: Int, errorKind: ToolResult.ErrorKind?)
+    case toolDispatchCompleted(callId: String, durationMilliseconds: Int, errorKind: ToolResult.ErrorKind?)
 
     /// The orchestrator detected a synthetic `transfer_to_<agent>` tool call
     /// and classified it as an agent handoff. Emitted in lieu of the regular

--- a/Sources/ManifoldInference/Protocols/BackendOptInProtocols.swift
+++ b/Sources/ManifoldInference/Protocols/BackendOptInProtocols.swift
@@ -143,13 +143,13 @@ public protocol TokenUsageProvider: AnyObject {
     var lastUsage: (promptTokens: Int, completionTokens: Int)? { get }
 }
 
-/// Adopted by cloud backends configured with endpoint URL + model name.
-public protocol CloudBackendURLModelConfigurable: AnyObject {
+/// Adopted by endpoint-based backends configured with endpoint URL + model name.
+public protocol EndpointBackendURLModelConfigurable: AnyObject {
     func configure(baseURL: URL, modelName: String)
 }
 
-/// Adopted by cloud backends that resolve API keys via a Keychain account.
-public protocol CloudBackendKeychainConfigurable: AnyObject {
+/// Adopted by endpoint-based backends that resolve API keys via a Keychain account.
+public protocol EndpointBackendKeychainConfigurable: AnyObject {
     func configure(baseURL: URL, keychainAccount: String, modelName: String)
 }
 

--- a/Sources/ManifoldInference/Protocols/LocalInferenceAdapter.swift
+++ b/Sources/ManifoldInference/Protocols/LocalInferenceAdapter.swift
@@ -58,7 +58,7 @@ public protocol LocalInferenceAdapter: Sendable {
     var toolCallShape: any LocalToolCallShape { get }
 
     /// The strategy this adapter uses to detect and emit thinking-token
-    /// (`.thinkingToken`, `.thinkingComplete`) events.
+    /// (`.thinkingToken`, `.thinkingCompleted`) events.
     var thinkingMarkerStrategy: LocalThinkingMarkerStrategy { get }
 
     /// The static capability payload the owning backend declares. Used by

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -102,7 +102,7 @@ final class GenerationQueue {
     /// Session-aware handoff detector hook. The runtime sets this so the
     /// dispatch loop can intercept synthetic `transfer_to_<agent>` tool
     /// calls without the queue itself learning about ``ChatSessionRecord``.
-    /// The closure receives the in-flight request's `sessionID` (may be
+    /// The closure receives the in-flight request's `requestGroupID` (may be
     /// `nil` for sessionless flows) and the model-emitted ``ToolCall``;
     /// returning `.handoff(...)` triggers a ``GenerationEvent/handoffRequested(_:)``
     /// emission and short-circuits regular tool dispatch. `nil` (the
@@ -110,10 +110,10 @@ final class GenerationQueue {
     var handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)?
 
     /// Pre-tool-use hook installed by the runtime. Receives the in-flight
-    /// request's `sessionID` so adapters can route to per-session hook
+    /// request's `requestGroupID` so adapters can route to per-session hook
     /// registries. The dispatch loop calls this before each tool call;
     /// `nil` preserves the legacy single-host surface.
-    var preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)?
+    var preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ requestGroupID: UUID?) async -> PreToolUseOutcome)?
 
     // MARK: - Test Seam
 
@@ -160,7 +160,7 @@ final class GenerationQueue {
     private struct QueuedRequest {
         let token: GenerationRequestToken
         let priority: GenerationPriority
-        let sessionID: UUID?
+        let requestGroupID: UUID?
         /// Structured conversation history. Carries thinking signatures and
         /// tool parts intact so cloud backends with structured wire formats
         /// (Anthropic) can replay them on multi-turn requests; text-only
@@ -179,7 +179,7 @@ final class GenerationQueue {
         /// Per-request pre-tool-use hook, captured at enqueue time. See
         /// ``handoffDetector`` for the rationale. `nil` falls back to the
         /// queue-level ``preToolUseHook``.
-        let preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)?
+        let preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ requestGroupID: UUID?) async -> PreToolUseOutcome)?
     }
 
     // MARK: - Queue State (Private)
@@ -452,7 +452,7 @@ final class GenerationQueue {
     /// The single value-typed enqueue entry point.
     ///
     /// Takes a pre-built ``GenerationConfig`` plus the small non-config triple
-    /// (`priority`, `sessionID`, and the structured `messages`/`systemPrompt`).
+    /// (`priority`, `requestGroupID`, and the structured `messages`/`systemPrompt`).
     /// Every parameterized convenience overload funnels here after assembling a
     /// config, so the capability gates, queue-depth check, token/stream
     /// construction, and FIFO+priority insertion live in exactly one place.
@@ -461,9 +461,9 @@ final class GenerationQueue {
         systemPrompt: String? = nil,
         config: GenerationConfig,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil,
+        requestGroupID: UUID? = nil,
         handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)? = nil,
-        preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)? = nil
+        preToolUseHook: (@Sendable (_ toolName: String, _ arguments: String, _ requestGroupID: UUID?) async -> PreToolUseOutcome)? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         guard let backend = currentBackend, isBackendLoaded else {
             throw InferenceError.inferenceFailure("No model loaded")
@@ -501,7 +501,7 @@ final class GenerationQueue {
         let request = QueuedRequest(
             token: token,
             priority: priority,
-            sessionID: sessionID,
+            requestGroupID: requestGroupID,
             messages: messages,
             systemPrompt: systemPrompt,
             config: config,
@@ -580,7 +580,7 @@ final class GenerationQueue {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         try enqueue(
             structuredMessages: messages.map { StructuredMessage(role: $0.role, content: $0.content) },
@@ -603,7 +603,7 @@ final class GenerationQueue {
                 maxToolIterations: maxToolIterations
             ),
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 
@@ -632,7 +632,7 @@ final class GenerationQueue {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         try enqueue(
             structuredMessages: messages,
@@ -655,7 +655,7 @@ final class GenerationQueue {
                 maxToolIterations: maxToolIterations
             ),
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 
@@ -738,7 +738,7 @@ final class GenerationQueue {
     /// `.critical` thermal state. Returns immediately when thermal state is
     /// `.serious` or below, or when the surrounding task has been cancelled.
     ///
-    /// Emits `GenerationEvent.diagnosticThrottle` exactly once per pause
+    /// Emits `GenerationEvent.throttleDiagnostic` exactly once per pause
     /// cycle — on entry, before the first sleep — so UI surfaces can show
     /// "device throttling — paused" without being spammed every re-check.
     /// Generation resumes silently when thermal pressure drops; downstream
@@ -754,7 +754,7 @@ final class GenerationQueue {
         // once and the consumer keeps showing the throttle hint until the
         // next regular event flows through.
         self.continuations[token]?.yield(
-            .diagnosticThrottle(reason: "thermalState=.critical")
+            .throttleDiagnostic(reason: "thermalState=.critical")
         )
         Log.inference.warning(
             "GenerationQueue: pausing generation — ProcessInfo.thermalState == .critical"
@@ -795,9 +795,9 @@ final class GenerationQueue {
         // Bind the per-request hook closures explicitly so the type checker
         // doesn't have to infer them inside the giant init expression below.
         let boundPreToolUseHook: PreToolUseHook? = effectivePreToolUseHook.map { hook in
-            let sessionID = request.sessionID
+            let requestGroupID = request.requestGroupID
             return { @Sendable toolName, arguments, _ in
-                await hook(toolName, arguments, sessionID)
+                await hook(toolName, arguments, requestGroupID)
             }
         }
         let loop = GenerationToolDispatchLoop(
@@ -824,8 +824,8 @@ final class GenerationQueue {
                 await self?.pauseWhileThermalCritical(token: token)
             },
             handoffDetector: effectiveHandoffDetector.map { detector in
-                { [sessionID = request.sessionID] call in
-                    detector(sessionID, call)
+                { [requestGroupID = request.requestGroupID] call in
+                    detector(requestGroupID, call)
                 }
             },
             preToolUseHook: boundPreToolUseHook
@@ -865,16 +865,16 @@ final class GenerationQueue {
         }
     }
 
-    func discardRequests(notMatching sessionID: UUID) async {
+    func discardRequests(notMatching requestGroupID: UUID) async {
         requestQueue.removeAll { req in
-            guard let reqSession = req.sessionID, reqSession != sessionID else { return false }
+            guard let reqGroup = req.requestGroupID, reqGroup != requestGroupID else { return false }
             req.stream.setPhase(.failed("Session changed"))
             finishAndDiscard(req.token, error: InferenceError.inferenceFailure("Session changed"))
             return true
         }
         if let active = activeRequest,
-           let activeSession = active.sessionID,
-           activeSession != sessionID {
+           let activeGroup = active.requestGroupID,
+           activeGroup != requestGroupID {
             // Capture the active task handle before `cancel` clears it. The
             // task's `defer` block in `drainQueue` clears `activeRequest`,
             // releases `isGenerating`, and finishes the continuation; if the

--- a/Sources/ManifoldInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/ManifoldInference/Services/GenerationStreamConsumer.swift
@@ -31,7 +31,7 @@ public struct GenerationStreamConsumer: Sendable {
         case .thinkingToken(let text):
             return .appendThinkingText(text)
 
-        case .thinkingComplete:
+        case .thinkingCompleted:
             return .finalizeThinking
 
         case .thinkingSignature(let signature):
@@ -40,13 +40,13 @@ public struct GenerationStreamConsumer: Sendable {
         case .toolResult(let result):
             return .appendToolResult(result)
 
-        case .toolLoopLimitReached(let iterations):
-            return .toolLoopLimitReached(iterations: iterations)
+        case .toolIterationLimitExceeded(let iterations):
+            return .toolIterationLimitExceeded(iterations: iterations)
 
         case .kvCacheReuse:
             return .ignore
 
-        case .diagnosticThrottle:
+        case .throttleDiagnostic:
             // Throttle hints are advisory metadata; the consumer has no
             // text/usage state to mutate. UI surfaces that want to render
             // a "paused — device throttling" badge observe the raw event
@@ -112,7 +112,7 @@ public struct GenerationStreamConsumer: Sendable {
         case appendToolResult(ToolResult)
         /// The orchestrator stopped the tool-dispatch loop because the
         /// ``GenerationConfig/maxToolIterations`` budget was exhausted.
-        case toolLoopLimitReached(iterations: Int)
+        case toolIterationLimitExceeded(iterations: Int)
         /// The dispatch loop detected an agent handoff. Runtime owns the
         /// resulting session-state swap; surfacing as an action keeps the
         /// pattern-match exhaustive without forcing the consumer to know

--- a/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
+++ b/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
@@ -81,7 +81,7 @@ struct GenerationToolDispatchLoop {
                 Log.inference.warning(
                     "GenerationQueue: tool-dispatch loop hit maxToolIterations=\(limit, privacy: .public); terminating."
                 )
-                yieldEvent(.toolLoopLimitReached(iterations: limit))
+                yieldEvent(.toolIterationLimitExceeded(iterations: limit))
                 return
             }
 
@@ -194,7 +194,7 @@ struct GenerationToolDispatchLoop {
                     yieldEvent(
                         .toolDispatchCompleted(
                             callId: call.id,
-                            durationMs: dispatchDurationMs,
+                            durationMilliseconds: dispatchDurationMs,
                             errorKind: result.errorKind
                         )
                     )

--- a/Sources/ManifoldInference/Services/InferenceService+Nonisolated.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+Nonisolated.swift
@@ -42,7 +42,7 @@ extension InferenceService {
 
     // MARK: Enqueue
 
-    /// Off-main variant of ``enqueue(messages:systemPrompt:temperature:topP:repeatPenalty:maxOutputTokens:maxThinkingTokens:jsonMode:grammar:tools:toolChoice:maxToolIterations:priority:sessionID:)``.
+    /// Off-main variant of ``enqueue(messages:systemPrompt:temperature:topP:repeatPenalty:maxOutputTokens:maxThinkingTokens:jsonMode:grammar:tools:toolChoice:maxToolIterations:priority:requestGroupID:)``.
     ///
     /// Hops to the main actor to invoke the queued enqueue path. The
     /// returned ``GenerationRequestToken`` and ``GenerationStream`` are both
@@ -67,7 +67,7 @@ extension InferenceService {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil,
+        requestGroupID: UUID? = nil,
         handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)? = nil,
         preToolUseHook: PreToolUseHook? = nil
     ) async throws -> (token: GenerationRequestToken, stream: GenerationStream) {
@@ -93,7 +93,7 @@ extension InferenceService {
                     maxToolIterations: maxToolIterations
                 ),
                 priority: priority,
-                sessionID: sessionID,
+                requestGroupID: requestGroupID,
                 handoffDetector: handoffDetector,
                 preToolUseHook: preToolUseHook
             )

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -164,7 +164,7 @@ public final class InferenceService {
     }
 
     public func registerEndpointBackendFactory(_ factory: @escaping EndpointBackendFactory) {
-        lifecycle.registerCloudBackendFactory(factory)
+        lifecycle.registerEndpointBackendFactory(factory)
     }
 
     @available(*, deprecated, renamed: "registerEndpointBackendFactory(_:)")
@@ -206,7 +206,7 @@ public final class InferenceService {
     public func loadEndpointBackend(from endpoint: APIEndpointRecord) async throws {
         ensureProviderWired()
         generation.stopGeneration()
-        try await lifecycle.loadCloudBackend(from: endpoint)
+        try await lifecycle.loadEndpointBackend(from: endpoint)
     }
 
     /// Loads a cloud API backend from an `APIEndpointRecord` configuration.

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -60,9 +60,9 @@ public enum ModelLoadReadinessState: Equatable, Sendable {
 ///   The queue is processed sequentially regardless of backend type.
 /// - **Priority ordering**: `.userInitiated` > `.normal` > `.background`.
 ///   Within the same priority, requests execute in FIFO order.
-/// - **Session scoping**: requests carry an optional session ID.
+/// - **Request-group scoping**: requests carry an optional request group ID.
 ///   `discardRequests(notMatching:)` cancels all requests not belonging to the
-///   specified session. Requests with `nil` sessionID are session-agnostic.
+///   specified group. Requests with `nil` requestGroupID are group-agnostic.
 /// - **Per-request cancellation**: `cancel(_:)` removes a queued request or stops
 ///   the active one, then drains the next item.
 /// - **Max queue depth**: excess `enqueue()` calls throw. Default: 8.
@@ -429,7 +429,7 @@ public final class InferenceService {
         systemPrompt: String? = nil,
         config: GenerationConfig,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         ensureProviderWired()
         return try generation.enqueue(
@@ -437,11 +437,11 @@ public final class InferenceService {
             systemPrompt: systemPrompt,
             config: config,
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 
-    /// Structured-message variant of ``enqueue(messages:config:priority:sessionID:)``.
+    /// Structured-message variant of ``enqueue(messages:config:priority:requestGroupID:)``.
     ///
     /// Threads ``StructuredMessage`` through the queue so cloud backends
     /// with structured wire formats (Anthropic) can replay prior assistant
@@ -451,7 +451,7 @@ public final class InferenceService {
         systemPrompt: String? = nil,
         config: GenerationConfig,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil,
+        requestGroupID: UUID? = nil,
         handoffDetector: (@Sendable (UUID?, ToolCall) -> HandoffDetectionResult)? = nil,
         preToolUseHook: PreToolUseHook? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
@@ -461,7 +461,7 @@ public final class InferenceService {
             systemPrompt: systemPrompt,
             config: config,
             priority: priority,
-            sessionID: sessionID,
+            requestGroupID: requestGroupID,
             handoffDetector: handoffDetector,
             preToolUseHook: preToolUseHook
         )
@@ -470,8 +470,8 @@ public final class InferenceService {
     /// Parameterized enqueue retained as a source-compatible builder.
     ///
     /// Assembles a ``GenerationConfig`` from the individual sampling
-    /// parameters and forwards to ``enqueue(messages:config:priority:sessionID:)``.
-    @available(*, deprecated, message: "Build a GenerationConfig and call enqueue(messages:config:priority:sessionID:).")
+    /// parameters and forwards to ``enqueue(messages:config:priority:requestGroupID:)``.
+    @available(*, deprecated, message: "Build a GenerationConfig and call enqueue(messages:config:priority:requestGroupID:).")
     public func enqueue(
         messages: [Message],
         systemPrompt: String? = nil,
@@ -491,7 +491,7 @@ public final class InferenceService {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         try enqueue(
             messages: messages,
@@ -514,12 +514,12 @@ public final class InferenceService {
                 maxToolIterations: maxToolIterations
             ),
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 
     /// Tuple-shaped enqueue retained for one minor while consumers migrate
-    /// to the typed ``enqueue(messages:config:priority:sessionID:)`` overload.
+    /// to the typed ``enqueue(messages:config:priority:requestGroupID:)`` overload.
     @available(*, deprecated, message: "Use [Message] with .system/.user/.assistant and a GenerationConfig — raw role strings are typo-prone.")
     public func enqueue(
         messages: [(role: String, content: String)],
@@ -535,7 +535,7 @@ public final class InferenceService {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         ensureProviderWired()
         return try generation.enqueue(
@@ -559,12 +559,12 @@ public final class InferenceService {
                 maxToolIterations: maxToolIterations
             ),
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 
     /// Parameterized structured-message enqueue retained as a source-compatible builder.
-    @available(*, deprecated, message: "Build a GenerationConfig and call enqueue(structuredMessages:config:priority:sessionID:).")
+    @available(*, deprecated, message: "Build a GenerationConfig and call enqueue(structuredMessages:config:priority:requestGroupID:).")
     public func enqueue(
         structuredMessages messages: [StructuredMessage],
         systemPrompt: String? = nil,
@@ -584,7 +584,7 @@ public final class InferenceService {
         toolChoice: ToolChoice = .auto,
         maxToolIterations: Int = 10,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         try enqueue(
             structuredMessages: messages,
@@ -607,7 +607,7 @@ public final class InferenceService {
                 maxToolIterations: maxToolIterations
             ),
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 
@@ -620,9 +620,9 @@ public final class InferenceService {
         generation.cancel(token)
     }
 
-    public func discardRequests(notMatching sessionID: UUID) async {
+    public func discardRequests(notMatching requestGroupID: UUID) async {
         ensureProviderWired()
-        await generation.discardRequests(notMatching: sessionID)
+        await generation.discardRequests(notMatching: requestGroupID)
     }
 
     public var lastTokenUsage: (promptTokens: Int, completionTokens: Int)? {
@@ -743,7 +743,7 @@ public final class InferenceService {
     /// ``HookRegistry`` and the Inference layer. Hosts compose hooks via
     /// ``ConversationRuntime`` instead of calling this directly.
     package func setPreToolUseHook(
-        _ hook: (@Sendable (_ toolName: String, _ arguments: String, _ sessionID: UUID?) async -> PreToolUseOutcome)?
+        _ hook: (@Sendable (_ toolName: String, _ arguments: String, _ requestGroupID: UUID?) async -> PreToolUseOutcome)?
     ) {
         generation.preToolUseHook = hook
     }

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -36,7 +36,7 @@ final class ModelLifecycleCoordinator {
     // MARK: - Backend Registry
 
     private var backendFactories: [BackendFactory] = []
-    private var cloudBackendFactories: [CloudBackendFactory] = []
+    private var cloudBackendFactories: [EndpointBackendFactory] = []
     private var supportedLocalModelTypes: Set<ModelType> = []
     private var supportedCloudProviders: Set<APIProvider> = []
 
@@ -109,7 +109,7 @@ final class ModelLifecycleCoordinator {
         backendFactories.append(factory)
     }
 
-    func registerCloudBackendFactory(_ factory: @escaping CloudBackendFactory) {
+    func registerEndpointBackendFactory(_ factory: @escaping EndpointBackendFactory) {
         cloudBackendFactories.append(factory)
     }
 
@@ -272,7 +272,7 @@ final class ModelLifecycleCoordinator {
         }
     }
 
-    func loadCloudBackend(from endpoint: APIEndpointRecord) async throws {
+    func loadEndpointBackend(from endpoint: APIEndpointRecord) async throws {
         // Validate before unloading the current model so a bad endpoint doesn't
         // leave the user with no backend at all.
         try endpoint.validate()
@@ -288,7 +288,7 @@ final class ModelLifecycleCoordinator {
         guard let newBackend = createCloudBackend(for: endpoint.provider) else {
             throw InferenceError.inferenceFailure(
                 "No registered cloud backend factory can handle provider \(endpoint.provider.rawValue). "
-                + "Register a CloudBackendFactory before loading cloud backends."
+                + "Register an EndpointBackendFactory before loading endpoint backends."
             )
         }
 

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -296,7 +296,7 @@ final class ModelLifecycleCoordinator {
         case .claude, .openAI, .openAIResponses, .custom:
             guard let keychainConfigurable = newBackend as? EndpointBackendKeychainConfigurable else {
                 throw InferenceError.inferenceFailure(
-                    "Cloud backend \(type(of: newBackend)) must conform to EndpointBackendKeychainConfigurable "
+                    "Endpoint backend \(type(of: newBackend)) must conform to EndpointBackendKeychainConfigurable "
                     + "for provider \(endpoint.provider.rawValue)."
                 )
             }
@@ -309,7 +309,7 @@ final class ModelLifecycleCoordinator {
         case .ollama, .lmStudio:
             guard let urlModelConfigurable = newBackend as? EndpointBackendURLModelConfigurable else {
                 throw InferenceError.inferenceFailure(
-                    "Cloud backend \(type(of: newBackend)) must conform to EndpointBackendURLModelConfigurable "
+                    "Endpoint backend \(type(of: newBackend)) must conform to EndpointBackendURLModelConfigurable "
                     + "for provider \(endpoint.provider.rawValue)."
                 )
             }

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -294,9 +294,9 @@ final class ModelLifecycleCoordinator {
 
         switch endpoint.provider {
         case .claude, .openAI, .openAIResponses, .custom:
-            guard let keychainConfigurable = newBackend as? CloudBackendKeychainConfigurable else {
+            guard let keychainConfigurable = newBackend as? EndpointBackendKeychainConfigurable else {
                 throw InferenceError.inferenceFailure(
-                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendKeychainConfigurable "
+                    "Cloud backend \(type(of: newBackend)) must conform to EndpointBackendKeychainConfigurable "
                     + "for provider \(endpoint.provider.rawValue)."
                 )
             }
@@ -307,9 +307,9 @@ final class ModelLifecycleCoordinator {
             )
 
         case .ollama, .lmStudio:
-            guard let urlModelConfigurable = newBackend as? CloudBackendURLModelConfigurable else {
+            guard let urlModelConfigurable = newBackend as? EndpointBackendURLModelConfigurable else {
                 throw InferenceError.inferenceFailure(
-                    "Cloud backend \(type(of: newBackend)) must conform to CloudBackendURLModelConfigurable "
+                    "Cloud backend \(type(of: newBackend)) must conform to EndpointBackendURLModelConfigurable "
                     + "for provider \(endpoint.provider.rawValue)."
                 )
             }

--- a/Sources/ManifoldInference/Services/PreToolUseHook.swift
+++ b/Sources/ManifoldInference/Services/PreToolUseHook.swift
@@ -30,5 +30,5 @@ public enum PreToolUseOutcome: Sendable, Equatable {
 public typealias PreToolUseHook = @Sendable (
     _ toolName: String,
     _ arguments: String,
-    _ sessionID: UUID?
+    _ requestGroupID: UUID?
 ) async -> PreToolUseOutcome

--- a/Sources/ManifoldInference/Services/SSEStreamParser.swift
+++ b/Sources/ManifoldInference/Services/SSEStreamParser.swift
@@ -24,7 +24,7 @@ import Foundation
 /// ``extractEvents(from:)`` is the primary entry point: it maps one SSE
 /// payload to zero or more ``GenerationEvent`` values. This lets a single
 /// chunk surface ``GenerationEvent/token(_:)``, ``GenerationEvent/thinkingToken(_:)``,
-/// or ``GenerationEvent/thinkingComplete`` as the provider's wire format
+/// or ``GenerationEvent/thinkingCompleted`` as the provider's wire format
 /// requires, without forcing the base class to reinterpret a raw string.
 ///
 /// The default implementation wraps the legacy ``extractToken(from:)``
@@ -46,7 +46,7 @@ public protocol SSEPayloadHandler: Sendable {
     ///
     /// Returning multiple events from one payload lets a handler distinguish
     /// thinking/reasoning deltas from regular text deltas natively. For
-    /// lifecycle-style `.thinkingComplete` events that cannot be derived
+    /// lifecycle-style `.thinkingCompleted` events that cannot be derived
     /// from a single chunk (e.g. OpenAI's `reasoning_content` → `content`
     /// transition), the `SSECloudBackend` base loop injects the event on
     /// the first non-thinking-token event that follows one or more
@@ -54,7 +54,7 @@ public protocol SSEPayloadHandler: Sendable {
     ///
     /// Handlers that already know they are at a reasoning-block boundary
     /// (e.g. an inline-tag parser using `ThinkingTransform`) may emit
-    /// ``GenerationEvent/thinkingComplete`` themselves; the base loop's
+    /// ``GenerationEvent/thinkingCompleted`` themselves; the base loop's
     /// flag tracking is idempotent and will not duplicate the event.
     ///
     /// The default implementation wraps ``extractToken(from:)`` so existing
@@ -399,21 +399,21 @@ package struct SSEStreamParser {
                         if Task.isCancelled { break }
 
                         for event in handler.extractEvents(from: payload) {
-                            // Lifecycle: inject a single `.thinkingComplete`
+                            // Lifecycle: inject a single `.thinkingCompleted`
                             // when the stream transitions from a thinking-
                             // token run back to a plain token. Handlers that
-                            // emit `.thinkingComplete` themselves clear the
+                            // emit `.thinkingCompleted` themselves clear the
                             // flag before reaching here, so no duplicate.
                             switch event {
                             case .thinkingToken:
                                 wasThinking = true
                                 continuation.yield(event)
-                            case .thinkingComplete:
+                            case .thinkingCompleted:
                                 wasThinking = false
                                 continuation.yield(event)
                             case .token:
                                 if wasThinking {
-                                    continuation.yield(.thinkingComplete)
+                                    continuation.yield(.thinkingCompleted)
                                     wasThinking = false
                                 }
                                 continuation.yield(event)

--- a/Sources/ManifoldInference/Streaming/GrammarPhaseGate.swift
+++ b/Sources/ManifoldInference/Streaming/GrammarPhaseGate.swift
@@ -21,7 +21,7 @@
 ///
 /// ## The boundary signal
 ///
-/// `.thinkingComplete` is the one unambiguous "reasoning has ended, visible output
+/// `.thinkingCompleted` is the one unambiguous "reasoning has ended, visible output
 /// begins" signal. It fires on the depth 1→0 transition *in the same iteration*
 /// that consumes the close marker, so flipping the gate there means the **next**
 /// sampled token — the first real output token — is grammar-constrained.
@@ -33,7 +33,7 @@
 /// `<think>` block on a given turn; defaulting to strict would mask the open
 /// marker and break reasoning (the original bug). The cost: if a thinking-capable
 /// model is given a grammar but chooses *not* to think on a turn (no block, so
-/// `.thinkingComplete` never fires), its output stays unconstrained. This is an
+/// `.thinkingCompleted` never fires), its output stays unconstrained. This is an
 /// intentional trade-off — protecting the common "always reasons, `<think>` first"
 /// contract is worth more than the rare skip-thinking-with-grammar corner. Callers
 /// needing a hard grammar guarantee should disable thinking, which turns gating off
@@ -50,7 +50,7 @@ public struct GrammarPhaseGate: Sendable {
 
     /// - Parameter gateOnThinking: pass `true` only when a grammar *and* an active
     ///   thinking parser are both present. The gate then starts permissive and
-    ///   flips to strict on the first `.thinkingComplete`. Pass `false` to keep the
+    ///   flips to strict on the first `.thinkingCompleted`. Pass `false` to keep the
     ///   grammar (or absence of one) active from the first token.
     public init(gateOnThinking: Bool) {
         self.gated = gateOnThinking
@@ -63,7 +63,7 @@ public struct GrammarPhaseGate: Sendable {
     public mutating func observe(_ events: [GenerationEvent]) {
         guard gated, !isGrammarActive else { return }
         for event in events {
-            if case .thinkingComplete = event {
+            if case .thinkingCompleted = event {
                 isGrammarActive = true
                 return
             }

--- a/Sources/ManifoldInference/Streaming/StreamTransform.swift
+++ b/Sources/ManifoldInference/Streaming/StreamTransform.swift
@@ -2,7 +2,7 @@
 ///
 /// Each transform consumes a batch of `[GenerationEvent]`, re-scans **only the
 /// `.token` payloads** against its own markers, and passes every other event
-/// case (`.thinkingToken`, `.thinkingComplete`, `.toolCall`, usage, lifecycle,
+/// case (`.thinkingToken`, `.thinkingCompleted`, `.toolCall`, usage, lifecycle,
 /// …) straight through untouched. This is the composition contract that lets
 /// the drivers chain a thinking stage and a tool-call stage in either order:
 /// the upstream stage's structured output is never re-interpreted downstream,

--- a/Sources/ManifoldInference/Streaming/ThinkingTransform.swift
+++ b/Sources/ManifoldInference/Streaming/ThinkingTransform.swift
@@ -2,12 +2,12 @@
 ///
 /// Drop-in replacement for the former `ThinkingParser`. Watches a single
 /// open/close marker pair (`ThinkingMarkers`) and re-routes text inside a
-/// thinking block to `.thinkingToken`, firing `.thinkingComplete` exactly on
+/// thinking block to `.thinkingToken`, firing `.thinkingCompleted` exactly on
 /// the depth 1→0 transition. Partial markers straddling a chunk boundary are
 /// held back via the shared ``overlap(_:_:)`` primitive.
 ///
 /// As a ``StreamTransform`` it re-scans only `.token` payloads; `.thinkingToken`,
-/// `.thinkingComplete`, `.toolCall`, and every other event case pass through
+/// `.thinkingCompleted`, `.toolCall`, and every other event case pass through
 /// untouched. Behavior on a single `.token` chunk is byte-identical to the
 /// original `ThinkingParser.process`.
 public struct ThinkingTransform: StreamTransform {
@@ -50,8 +50,8 @@ public struct ThinkingTransform: StreamTransform {
                 if depth > 0 {
                     depth -= 1
                     if depth == 0 {
-                        // Only fire thinkingComplete on 1→0 transition (not nested closes).
-                        events.append(.thinkingComplete)
+                        // Only fire thinkingCompleted on 1→0 transition (not nested closes).
+                        events.append(.thinkingCompleted)
                     }
                 } else {
                     depth += 1

--- a/Sources/ManifoldLlama/LlamaGenerationDriver.swift
+++ b/Sources/ManifoldLlama/LlamaGenerationDriver.swift
@@ -127,7 +127,7 @@ struct LlamaGenerationDriver: LocalInferenceAdapter {
     ///   - maxTokens: Maximum number of new tokens to generate.
     ///   - config: Sampling parameters (temperature, topP, repeatPenalty).
     ///   - markers: Thinking markers for the active template, or nil to disable ThinkingTransform.
-    ///     When non-nil, `.thinkingToken` / `.thinkingComplete` events are emitted for reasoning
+    ///     When non-nil, `.thinkingToken` / `.thinkingCompleted` events are emitted for reasoning
     ///     content and `config.maxThinkingTokens` is enforced. When nil, every decoded chunk
     ///     surfaces as a plain `.token` event — there is no longer a sniff-mode fallback that
     ///     retroactively engages the parser on raw `<think>` substrings; auto-detection at
@@ -395,7 +395,7 @@ struct LlamaGenerationDriver: LocalInferenceAdapter {
         defer { if let thinkingSampler { llama_sampler_free(thinkingSampler) } }
 
         // Phase gate: starts permissive when gating, flips to strict on the first
-        // `.thinkingComplete`. A no-op (always strict) when not gating.
+        // `.thinkingCompleted`. A no-op (always strict) when not gating.
         var grammarGate = GrammarPhaseGate(gateOnThinking: gateGrammarOnThinking)
 
         // MARK: Chunked prompt decode
@@ -566,7 +566,7 @@ struct LlamaGenerationDriver: LocalInferenceAdapter {
             let logitIndex: Int32 = iteration == 0 ? -1 : 0
             // Phase-aware grammar (issue #1595): sample with the permissive chain
             // while the model is reasoning, and with the strict (grammar) chain once
-            // `.thinkingComplete` has flipped the gate. `thinkingSampler` is non-nil
+            // `.thinkingCompleted` has flipped the gate. `thinkingSampler` is non-nil
             // only when gating is active and grammar is inactive, so the fallback to
             // `outputSampler` covers every other case (no gating, or already strict).
             let sampler = grammarGate.isGrammarActive ? outputSampler : (thinkingSampler ?? outputSampler)
@@ -614,7 +614,7 @@ struct LlamaGenerationDriver: LocalInferenceAdapter {
                 let events = session.ingest(text)
 
                 // Advance the grammar phase gate: once the reasoning block closes
-                // (`.thinkingComplete`), the strict chain takes over for the next
+                // (`.thinkingCompleted`), the strict chain takes over for the next
                 // sampled token — the first real output token. No-op when not gating.
                 grammarGate.observe(events)
 

--- a/Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift
+++ b/Sources/ManifoldMCP/MCPNotificationLifecycleEventObserver.swift
@@ -53,3 +53,18 @@ public final class MCPNotificationLifecycleEventObserver: MCPLifecycleEventObser
         #endif
     }
 }
+
+// MARK: - AsyncSequence Conformance
+
+extension MCPNotificationLifecycleEventObserver: AsyncSequence {
+    public typealias Element = MCPLifecycleEvent
+    public typealias AsyncIterator = AsyncStream<MCPLifecycleEvent>.AsyncIterator
+
+    /// Returns an iterator over the lifecycle events emitted by this observer.
+    ///
+    /// Allows idiomatic iteration with `for await event in observer { … }`
+    /// instead of `for await event in observer.events { … }`.
+    public nonisolated func makeAsyncIterator() -> AsyncStream<MCPLifecycleEvent>.AsyncIterator {
+        events.makeAsyncIterator()
+    }
+}

--- a/Sources/ManifoldMCPHost/MCPHostStdioTransport.swift
+++ b/Sources/ManifoldMCPHost/MCPHostStdioTransport.swift
@@ -183,4 +183,19 @@ public enum MCPHostTransportError: Error, LocalizedError, Sendable {
         }
     }
 }
+
+// MARK: - AsyncSequence Conformance
+
+extension MCPHostStdioTransport: AsyncSequence {
+    public typealias Element = Data
+    public typealias AsyncIterator = AsyncThrowingStream<Data, Error>.AsyncIterator
+
+    /// Returns an iterator over the incoming framed messages on this transport.
+    ///
+    /// Allows idiomatic iteration with `for try await message in transport { … }`
+    /// instead of `for try await message in transport.incomingMessages { … }`.
+    public nonisolated func makeAsyncIterator() -> AsyncThrowingStream<Data, Error>.AsyncIterator {
+        incomingMessages.makeAsyncIterator()
+    }
+}
 #endif

--- a/Sources/ManifoldModelCatalog/APIEndpointRecord.swift
+++ b/Sources/ManifoldModelCatalog/APIEndpointRecord.swift
@@ -7,7 +7,7 @@ import ManifoldHardware
 /// `ManifoldCore` provides a SwiftData `@Model APIEndpoint` that maps to this
 /// record, but inference orchestration only depends on the record so consumers
 /// with their own persistence layer can still call
-/// ``InferenceService/loadCloudBackend(from:)``.
+/// ``InferenceService/loadEndpointBackend(from:)``.
 public struct APIEndpointRecord: Sendable, Hashable, Identifiable {
     public var id: UUID
     public var name: String

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -548,3 +548,23 @@ public final class ConversationRuntime: Sendable {
         try await processTurn(input.asTurnInput)
     }
 }
+
+// MARK: - AsyncSequence Conformance
+
+extension ConversationRuntime: AsyncSequence {
+    public typealias Element = ConversationEvent
+    public typealias AsyncIterator = AsyncStream<ConversationEvent>.AsyncIterator
+
+    /// Returns an iterator over the conversation lifecycle events emitted by
+    /// this runtime.
+    ///
+    /// Allows idiomatic iteration with `for await event in runtime { … }`
+    /// instead of `for await event in runtime.events { … }`.
+    ///
+    /// - Note: The ``events`` stream is single-consumer by design and capped at
+    ///   500 buffered events. See the type documentation for details on
+    ///   multi-consumer observation via ``addEventTap(bufferingPolicy:)``.
+    public nonisolated func makeAsyncIterator() -> AsyncStream<ConversationEvent>.AsyncIterator {
+        events.makeAsyncIterator()
+    }
+}

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -757,7 +757,7 @@ struct ConversationTurnExecutor: Sendable {
                 maxThinkingTokens: config.maxThinkingTokens,
                 tools: advertisedTools,
                 priority: .userInitiated,
-                sessionID: sessionID
+                requestGroupID: sessionID
             )
         } catch {
             await unregisterSessionToolExecutors(registeredSessionToolNames)
@@ -859,7 +859,7 @@ struct ConversationTurnExecutor: Sendable {
                     assistantMessage.contentParts.append(.toolResult(result))
                     emit(.toolCallCompleted(result.callId, result))
 
-                case .toolLoopLimitReached(let iterations):
+                case .toolIterationLimitExceeded(let iterations):
                     emit(.errorRaised(.inference(
                         InferenceError.inferenceFailure("Tool-call loop stopped after \(iterations) iterations.")
                     )))

--- a/Sources/ManifoldRuntime/Services/Hooks/PreToolUseHookAdapter.swift
+++ b/Sources/ManifoldRuntime/Services/Hooks/PreToolUseHookAdapter.swift
@@ -41,10 +41,10 @@ public enum PreToolUseHookAdapter {
     ) -> @Sendable (
         _ toolName: String,
         _ arguments: String,
-        _ sessionID: UUID?
+        _ requestGroupID: UUID?
     ) async -> PreToolUseOutcome {
-        return { toolName, arguments, sessionID in
-            let sid = sessionID ?? UUID()
+        return { toolName, arguments, requestGroupID in
+            let sid = requestGroupID ?? UUID()
             let input = HookInput(
                 event: .preToolUse,
                 sessionID: sid,

--- a/Sources/ManifoldRuntime/Services/ImageGenerationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ImageGenerationRuntime.swift
@@ -295,3 +295,18 @@ public final class ImageGenerationRuntime {
         return service.loadedModel?.id ?? "unknown"
     }
 }
+
+// MARK: - AsyncSequence Conformance
+
+extension ImageGenerationRuntime: AsyncSequence {
+    public typealias Element = ImageRuntimeEvent
+    public typealias AsyncIterator = AsyncStream<ImageRuntimeEvent>.AsyncIterator
+
+    /// Returns an iterator over the image runtime events in this stream.
+    ///
+    /// Allows idiomatic iteration with `for await event in runtime { … }`
+    /// instead of `for await event in runtime.events { … }`.
+    public nonisolated func makeAsyncIterator() -> AsyncStream<ImageRuntimeEvent>.AsyncIterator {
+        events.makeAsyncIterator()
+    }
+}

--- a/Sources/ManifoldRuntime/Services/SessionListService.swift
+++ b/Sources/ManifoldRuntime/Services/SessionListService.swift
@@ -385,7 +385,7 @@ package final class SessionListService: Sendable {
             systemPrompt: systemPrompt,
             config: GenerationConfig(temperature: 0.3, topP: 0.9, repeatPenalty: 1.0),
             priority: .background,
-            sessionID: nil
+            requestGroupID: nil
         )
         var result = ""
         for try await event in stream.events {

--- a/Sources/ManifoldRuntime/Services/VideoGenerationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/VideoGenerationRuntime.swift
@@ -275,3 +275,18 @@ public final class VideoGenerationRuntime {
         continuation.yield(event)
     }
 }
+
+// MARK: - AsyncSequence Conformance
+
+extension VideoGenerationRuntime: AsyncSequence {
+    public typealias Element = VideoRuntimeEvent
+    public typealias AsyncIterator = AsyncStream<VideoRuntimeEvent>.AsyncIterator
+
+    /// Returns an iterator over the video runtime events in this stream.
+    ///
+    /// Allows idiomatic iteration with `for await event in runtime { … }`
+    /// instead of `for await event in runtime.events { … }`.
+    public nonisolated func makeAsyncIterator() -> AsyncStream<VideoRuntimeEvent>.AsyncIterator {
+        events.makeAsyncIterator()
+    }
+}

--- a/Sources/ManifoldTestSupport/MockInferenceBackend.swift
+++ b/Sources/ManifoldTestSupport/MockInferenceBackend.swift
@@ -17,7 +17,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
     /// Multi-block reasoning script. When non-empty this **takes precedence
     /// over** ``thinkingTokensToYield``: each inner array is one reasoning
     /// block, emitted as a sequence of `.thinkingToken` events followed by
-    /// a `.thinkingComplete`. Used by tests that exercise the multi-block
+    /// a `.thinkingCompleted`. Used by tests that exercise the multi-block
     /// finalize path (#604: Anthropic emits one signature per block).
     public var thinkingBlocksToYield: [[String]] = []
 
@@ -254,7 +254,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                 if !multiBlocks.isEmpty {
                     // Multi-block reasoning script: each inner array is one
                     // `<think>…</think>` round, separated by its own
-                    // `.thinkingComplete`. Lets tests assert the per-block
+                    // `.thinkingCompleted`. Lets tests assert the per-block
                     // finalize → multi-`.thinking`-part contract.
                     for (idx, block) in multiBlocks.enumerated() {
                         for t in block {
@@ -265,7 +265,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                         if idx < signatures.count, let sig = signatures[idx] {
                             continuation.yield(.thinkingSignature(sig))
                         }
-                        continuation.yield(.thinkingComplete)
+                        continuation.yield(.thinkingCompleted)
                     }
                 } else {
                     for t in thinkingTokens {
@@ -273,7 +273,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
                         continuation.yield(.thinkingToken(t))
                     }
                     if !thinkingTokens.isEmpty && !Task.isCancelled {
-                        continuation.yield(.thinkingComplete)
+                        continuation.yield(.thinkingCompleted)
                     }
                 }
                 for token in tokens {

--- a/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
+++ b/Sources/ManifoldTestSupport/RuntimeScenarioRegistry.swift
@@ -62,11 +62,11 @@ extension RuntimeScenario {
         ]
     )
 
-    /// Verifies that a `diagnosticThrottle` advisory does not abort generation.
+    /// Verifies that a `throttleDiagnostic` advisory does not abort generation.
     public static let diagnosticThrottleAdvisory = RuntimeScenario(
         id: "diagnostic-throttle-advisory",
         displayName: "Diagnostic Throttle Advisory",
-        scenarioDescription: "Backend emits a diagnosticThrottle event before tokens. Verifies the runtime treats the advisory as informational.",
+        scenarioDescription: "Backend emits a throttleDiagnostic event before tokens. Verifies the runtime treats the advisory as informational.",
         userMessages: ["What is the throttle status?"],
         scriptedTurns: [
             .throttle(reason: "rate-limit-burst", then: ["Throttle", " noted", "."])

--- a/Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift
+++ b/Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift
@@ -54,9 +54,9 @@ public final class ScriptedGenerationBackend: InferenceBackend, @unchecked Senda
             return TurnScript(events)
         }
 
-        /// Emits a `diagnosticThrottle` event followed by text tokens.
+        /// Emits a `throttleDiagnostic` event followed by text tokens.
         public static func throttle(reason: String, then tokens: [String]) -> TurnScript {
-            var events: [ScriptedEvent] = [.emit(.diagnosticThrottle(reason: reason))]
+            var events: [ScriptedEvent] = [.emit(.throttleDiagnostic(reason: reason))]
             events += tokens.map { .emit(.token($0)) }
             return TurnScript(events)
         }

--- a/Sources/ManifoldTools/ScenarioRunner.swift
+++ b/Sources/ManifoldTools/ScenarioRunner.swift
@@ -86,16 +86,16 @@ public final class ScenarioRunner {
                 case .toolCall(let call):
                     turnToolCalls.append(call)
                     logger?.append(.toolCall(scenarioId: scenario.id, name: call.toolName, arguments: call.arguments))
-                case .prefillProgress, .usage, .thinkingToken, .thinkingComplete, .thinkingSignature:
+                case .prefillProgress, .usage, .thinkingToken, .thinkingCompleted, .thinkingSignature:
                     continue
-                case .toolResult, .toolLoopLimitReached:
+                case .toolResult, .toolIterationLimitExceeded:
                     // ScenarioRunner calls backend.generate() directly and owns
                     // dispatch below, so it never receives GenerationQueue's
                     // orchestrator events on this path. Stay exhaustive for growth.
                     continue
                 case .kvCacheReuse:
                     continue
-                case .diagnosticThrottle:
+                case .throttleDiagnostic:
                     // Advisory pause signal from the orchestrator; scenarios
                     // are deterministic replays so we just keep accumulating.
                     continue

--- a/Sources/ManifoldUI/Views/Chat/ThinkingBlockView.swift
+++ b/Sources/ManifoldUI/Views/Chat/ThinkingBlockView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 struct ThinkingBlockView: View {
     let text: String
     /// True only while the reasoning block itself is still open (i.e. no
-    /// `.thinkingComplete` event has been received yet). Distinct from the
+    /// `.thinkingCompleted` event has been received yet). Distinct from the
     /// overall message `isStreaming` flag.
     let isThinkingStreaming: Bool
 

--- a/Tests/Fixtures/backends/claude/README.md
+++ b/Tests/Fixtures/backends/claude/README.md
@@ -41,7 +41,7 @@ leaks in.
   → `content_block_stop` → `content_block_start` (text) →
   `content_block_delta` (text_delta) → `content_block_stop` →
   `message_stop`. Exercises the `.thinkingSignature` emission and the
-  open-thinking → text handoff (`.thinkingComplete`).
+  open-thinking → text handoff (`.thinkingCompleted`).
 - `usage/basic/` — `message_start` (with `input_tokens`) → text deltas
   → `message_delta` (with `output_tokens`) → `message_stop`. Exercises
   the split-usage extraction; both halves must be merged before the

--- a/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
@@ -116,7 +116,7 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     }
 
     /// `LlamaGenerationDriver` already filters thinking markers and emits
-    /// `.thinkingToken` / `.thinkingComplete`, so the capability flag must
+    /// `.thinkingToken` / `.thinkingCompleted`, so the capability flag must
     /// advertise it for consumers gating reasoning UI (#480).
     func test_llamaBackend_supportsThinking() throws {
         try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
@@ -140,7 +140,7 @@ final class BackendCapabilitiesContractTests: XCTestCase {
 
     /// MLXBackend routes generation through `ThinkingTransform` when
     /// `config.thinkingMarkers` is set, emitting `.thinkingToken` /
-    /// `.thinkingComplete` events. Capability flag must reflect that (#480).
+    /// `.thinkingCompleted` events. Capability flag must reflect that (#480).
     func test_mlxBackend_supportsThinking() throws {
         try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
                           "MLXBackend requires Apple Silicon")

--- a/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
@@ -80,14 +80,14 @@ final class ClaudeStreamEventExtractorTests: XCTestCase {
     //
     // thinking block: two thinking_delta + signature_delta + content_block_stop,
     // then a text block with one text_delta. Required events:
-    //   thinkingToken × 2, thinkingSignature, thinkingComplete (handoff),
+    //   thinkingToken × 2, thinkingSignature, thinkingCompleted (handoff),
     //   token("Answer.")
     //
-    // The exact ordering of thinkingSignature relative to thinkingComplete
+    // The exact ordering of thinkingSignature relative to thinkingCompleted
     // depends on whether the signature_delta arrives before or after the
     // first text frame. In this fixture signature_delta arrives inside the
     // thinking block (before content_block_stop), so the order is:
-    //   thinkingToken × 2 → thinkingSignature → thinkingComplete → token
+    //   thinkingToken × 2 → thinkingSignature → thinkingCompleted → token
     func test_extractor_thinkingWithSignature_yieldsHandoffAndSignature() throws {
         let events = try driveExtractor(scenario: "thinking/with-signature")
 
@@ -102,8 +102,8 @@ final class ClaudeStreamEventExtractorTests: XCTestCase {
         XCTAssertEqual(signatures, ["sig_opaque_abc123"],
                        "Anthropic signatures must round-trip verbatim — multi-turn replay is rejected if dropped")
 
-        let sawHandoff = events.contains { if case .thinkingComplete = $0 { return true } else { return false } }
-        XCTAssertTrue(sawHandoff, "extractor must emit .thinkingComplete on the thinking→text boundary")
+        let sawHandoff = events.contains { if case .thinkingCompleted = $0 { return true } else { return false } }
+        XCTAssertTrue(sawHandoff, "extractor must emit .thinkingCompleted on the thinking→text boundary")
 
         let tokens = events.compactMap { event -> String? in
             if case .token(let t) = event { return t } else { return nil }
@@ -307,20 +307,20 @@ final class ClaudeStreamEventExtractorParityTests: XCTestCase {
         switch event {
         case .token(let s): return "token(\(s))"
         case .thinkingToken(let s): return "thinkingToken(\(s))"
-        case .thinkingComplete: return "thinkingComplete"
+        case .thinkingCompleted: return "thinkingCompleted"
         case .thinkingSignature(let s): return "thinkingSignature(\(s))"
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
         case .usage(let p, let c): return "usage(\(p),\(c))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
-        case .toolLoopLimitReached(let n): return "toolLoopLimitReached(\(n))"
+        case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"
         case .toolProgress: return "toolProgress"
         case .toolDispatchStarted: return "toolDispatchStarted"
         case .toolDispatchCompleted: return "toolDispatchCompleted"
         case .kvCacheReuse: return "kvCacheReuse"
-        case .diagnosticThrottle: return "diagnosticThrottle"
+        case .throttleDiagnostic: return "throttleDiagnostic"
         case .handoffRequested(let h): return "handoffRequested(\(h.targetAgentID))"
         }
     }

--- a/Tests/ManifoldBackendsTests/ClaudeStructuredReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStructuredReplayTests.swift
@@ -223,7 +223,7 @@ final class ClaudeStructuredReplayTests: XCTestCase {
 
     /// A thinking block's `signature_delta` event must surface as a
     /// ``GenerationEvent/thinkingSignature`` event in the parsed stream,
-    /// emitted before the matching ``thinkingComplete``.
+    /// emitted before the matching ``thinkingCompleted``.
     func test_streamParse_emitsThinkingSignatureEvent() async throws {
         let (backend, url) = try await makeBackend()
         let chunks: [Data] = [
@@ -243,18 +243,18 @@ final class ClaudeStructuredReplayTests: XCTestCase {
             switch event {
             case .thinkingToken(let t): observed.append("thinkingToken:\(t)")
             case .thinkingSignature(let s): observed.append("signature:\(s)")
-            case .thinkingComplete: observed.append("thinkingComplete")
+            case .thinkingCompleted: observed.append("thinkingCompleted")
             case .token(let t): observed.append("token:\(t)")
             default: break
             }
         }
         XCTAssertTrue(observed.contains("signature:abc"),
             "Stream must surface signature_delta as `.thinkingSignature` so the UI can attach it to the persisted thinking part. Observed: \(observed)")
-        // Order check: the signature must arrive before thinkingComplete.
+        // Order check: the signature must arrive before thinkingCompleted.
         let sigIdx = observed.firstIndex(of: "signature:abc") ?? -1
-        let completeIdx = observed.firstIndex(of: "thinkingComplete") ?? -2
+        let completeIdx = observed.firstIndex(of: "thinkingCompleted") ?? -2
         XCTAssertLessThan(sigIdx, completeIdx,
-            "Signature must precede thinkingComplete so the consumer has it before applying the finalize")
+            "Signature must precede thinkingCompleted so the consumer has it before applying the finalize")
     }
 }
 #endif

--- a/Tests/ManifoldBackendsTests/ClaudeThinkingErrorPathTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeThinkingErrorPathTests.swift
@@ -9,7 +9,7 @@ import ManifoldTestSupport
 
 /// Pins the `ThinkingBlockManager.flushIfOpen` parser-error path for Claude:
 /// when an upstream `error` event interrupts an open thinking block, the
-/// stream must yield `.thinkingComplete` before the throw so consumers don't
+/// stream must yield `.thinkingCompleted` before the throw so consumers don't
 /// hang in a thinking-only state.
 ///
 /// This file uses XCTest (not Swift Testing) on purpose — see
@@ -76,7 +76,7 @@ final class ClaudeThinkingErrorPathTests: XCTestCase {
             for try await event in stream.events {
                 switch event {
                 case .thinkingToken: sawThinkingToken = true
-                case .thinkingComplete: sawThinkingComplete = true
+                case .thinkingCompleted: sawThinkingComplete = true
                 default: break
                 }
             }
@@ -87,7 +87,7 @@ final class ClaudeThinkingErrorPathTests: XCTestCase {
         XCTAssertTrue(sawThinkingToken, "expected at least one .thinkingToken before the error event")
         XCTAssertTrue(threw, "expected the upstream error event to throw out of the stream")
         XCTAssertTrue(sawThinkingComplete,
-                      ".thinkingComplete must fire before the throw so consumers don't hang in a thinking-only state")
+                      ".thinkingCompleted must fire before the throw so consumers don't hang in a thinking-only state")
     }
 }
 #endif

--- a/Tests/ManifoldBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -47,7 +47,7 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
         let localRef = localBackend!
         let cloudSessionRef = cloudSession!
         service.registerBackendFactory { _ in localRef }
-        service.registerCloudBackendFactory { _ in
+        service.registerEndpointBackendFactory { _ in
             ConfiguringOpenAICloudBackend(urlSession: cloudSessionRef)
         }
 
@@ -120,9 +120,9 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
     }
 
     /// Creates a fresh ChatViewModel wired to a custom cloud backend factory.
-    private func makeViewModel(cloudFactory: @escaping CloudBackendFactory) -> ChatViewModel {
+    private func makeViewModel(cloudFactory: @escaping EndpointBackendFactory) -> ChatViewModel {
         let service = InferenceService()
-        service.registerCloudBackendFactory(cloudFactory)
+        service.registerEndpointBackendFactory(cloudFactory)
         let viewModel = ChatViewModel(inferenceService: service)
         let persistence = SwiftDataPersistenceProvider(modelContext: context)
         viewModel.configure(persistence: persistence)

--- a/Tests/ManifoldBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -561,12 +561,12 @@ final class CloudEndpointSelectionIntegrationTests: XCTestCase {
 
 // MARK: - Backend Wrappers
 
-/// Wraps `OpenAIBackend` to conform to both `CloudBackendURLModelConfigurable`
-/// and `CloudBackendKeychainConfigurable`, matching the real app's wiring.
+/// Wraps `OpenAIBackend` to conform to both ``EndpointBackendURLModelConfigurable``
+/// and ``EndpointBackendKeychainConfigurable``, matching the real app's wiring.
 private final class ConfiguringOpenAICloudBackend: InferenceBackend,
                                                    ConversationHistoryReceiver,
-                                                   CloudBackendURLModelConfigurable,
-                                                   CloudBackendKeychainConfigurable,
+                                                   EndpointBackendURLModelConfigurable,
+                                                   EndpointBackendKeychainConfigurable,
                                                    @unchecked Sendable {
     private let backend: OpenAIBackend
     private let probeOnLoad: Bool
@@ -617,10 +617,10 @@ private final class ConfiguringOpenAICloudBackend: InferenceBackend,
     func resetConversation() { backend.resetConversation() }
 }
 
-/// Wraps `ClaudeBackend` with `CloudBackendKeychainConfigurable` conformance.
+/// Wraps `ClaudeBackend` with ``EndpointBackendKeychainConfigurable`` conformance.
 private final class ConfiguringClaudeCloudBackend: InferenceBackend,
                                                    ConversationHistoryReceiver,
-                                                   CloudBackendKeychainConfigurable,
+                                                   EndpointBackendKeychainConfigurable,
                                                    @unchecked Sendable {
     private let backend: ClaudeBackend
 

--- a/Tests/ManifoldBackendsTests/CloudThinkingTokenTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudThinkingTokenTests.swift
@@ -29,7 +29,7 @@ private let sseDone = Data("data: [DONE]\n\n".utf8)
 /// that thinking events bracket content correctly.
 private enum EventCategory: Equatable {
     case thinkingToken(String)
-    case thinkingComplete
+    case thinkingCompleted
     case token(String)
     case usage
 }
@@ -37,14 +37,14 @@ private enum EventCategory: Equatable {
 private func categorise(_ event: GenerationEvent) -> EventCategory? {
     switch event {
     case .thinkingToken(let t): return .thinkingToken(t)
-    case .thinkingComplete: return .thinkingComplete
+    case .thinkingCompleted: return .thinkingCompleted
     case .token(let t): return .token(t)
     case .usage: return .usage
     case .toolCall: return nil
     case .toolResult: return nil
-    case .toolLoopLimitReached: return nil
+    case .toolIterationLimitExceeded: return nil
     case .kvCacheReuse: return nil
-    case .diagnosticThrottle: return nil
+    case .throttleDiagnostic: return nil
     case .thinkingSignature: return nil
     case .toolCallStart, .toolCallArgumentsDelta: return nil
     case .toolProgress, .toolDispatchStarted, .toolDispatchCompleted: return nil
@@ -119,7 +119,7 @@ struct ClaudeExtendedThinkingTests {
             if let cat = categorise(event) { categories.append(cat) }
         }
 
-        // Must see the two thinking tokens, exactly one thinkingComplete before
+        // Must see the two thinking tokens, exactly one thinkingCompleted before
         // any visible token, then the two visible tokens. Usage events may be
         // interleaved but order between thinking/content is pinned.
         let contentEvents = categories.filter {
@@ -129,17 +129,17 @@ struct ClaudeExtendedThinkingTests {
         #expect(contentEvents == [
             .thinkingToken("Let me"),
             .thinkingToken(" think..."),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("The answer"),
             .token(" is 42."),
         ], "Got: \(contentEvents)")
 
-        // .thinkingComplete must fire exactly once.
-        let completeCount = categories.filter { $0 == .thinkingComplete }.count
+        // .thinkingCompleted must fire exactly once.
+        let completeCount = categories.filter { $0 == .thinkingCompleted }.count
         #expect(completeCount == 1)
     }
 
-    /// Non-thinking response (plain Claude call) must never fire .thinkingComplete
+    /// Non-thinking response (plain Claude call) must never fire .thinkingCompleted
     /// and must pass tokens through unchanged.
     @Test func nonReasoningResponse_noThinkingCompleteFires() async throws {
         let (backend, url) = makeBackend()
@@ -169,14 +169,14 @@ struct ClaudeExtendedThinkingTests {
             switch event {
             case .token(let t): tokens.append(t)
             case .thinkingToken: sawThinking = true
-            case .thinkingComplete: sawThinkingComplete = true
+            case .thinkingCompleted: sawThinkingComplete = true
             default: break
             }
         }
 
         #expect(tokens == ["Hello", " world"])
         #expect(!sawThinking, "No thinking tokens should be emitted for a non-reasoning response")
-        #expect(!sawThinkingComplete, ".thinkingComplete must not fire when no thinking was ever seen")
+        #expect(!sawThinkingComplete, ".thinkingCompleted must not fire when no thinking was ever seen")
     }
 
     /// Request wiring: when `maxThinkingTokens` is set, the outbound request
@@ -264,12 +264,12 @@ struct OpenAIReasoningTests {
         #expect(contentEvents == [
             .thinkingToken("Analysing"),
             .thinkingToken(" the prompt..."),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("The answer"),
             .token(" is 42."),
         ], "Got: \(contentEvents)")
 
-        let completeCount = categories.filter { $0 == .thinkingComplete }.count
+        let completeCount = categories.filter { $0 == .thinkingCompleted }.count
         #expect(completeCount == 1)
     }
 
@@ -300,7 +300,7 @@ struct OpenAIReasoningTests {
 
         #expect(categories == [
             .thinkingToken("Considering"),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("done"),
         ])
     }
@@ -334,14 +334,14 @@ struct OpenAIReasoningTests {
             switch event {
             case .token(let t): tokens.append(t)
             case .thinkingToken: sawThinking = true
-            case .thinkingComplete: sawThinkingComplete = true
+            case .thinkingCompleted: sawThinkingComplete = true
             default: break
             }
         }
 
         #expect(tokens == ["Hello", " there"])
         #expect(!sawThinking)
-        #expect(!sawThinkingComplete, ".thinkingComplete must not fire for plain Chat Completions streams")
+        #expect(!sawThinkingComplete, ".thinkingCompleted must not fire for plain Chat Completions streams")
     }
 }
 #endif

--- a/Tests/ManifoldBackendsTests/FixtureComparator.swift
+++ b/Tests/ManifoldBackendsTests/FixtureComparator.swift
@@ -132,14 +132,14 @@ public struct FixtureComparator {
                 ])
             case .thinkingToken(let text):
                 return .init(event: "thinkingToken", fields: ["thinking_text": text])
-            case .thinkingComplete:
-                return .init(event: "thinkingComplete", fields: [:])
+            case .thinkingCompleted:
+                return .init(event: "thinkingCompleted", fields: [:])
             case .thinkingSignature(let sig):
                 return .init(event: "thinkingSignature", fields: ["signature": sig])
-            case .toolLoopLimitReached(let n):
-                return .init(event: "toolLoopLimitReached", fields: ["iterations": String(n)])
+            case .toolIterationLimitExceeded(let n):
+                return .init(event: "toolIterationLimitExceeded", fields: ["iterations": String(n)])
             case .toolResult, .toolProgress, .toolDispatchStarted, .toolDispatchCompleted,
-                 .kvCacheReuse, .diagnosticThrottle, .prefillProgress:
+                 .kvCacheReuse, .throttleDiagnostic, .prefillProgress:
                 // Queue-emitted lifecycle events and progress signals are
                 // not part of the wire contract — drop from projection.
                 return nil

--- a/Tests/ManifoldBackendsTests/LlamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaBackendTests.swift
@@ -975,7 +975,7 @@ final class LlamaBackendTests: XCTestCase {
     /// With `thinkingMarkers = .qwen3` set on the config *and* `maxThinkingTokens = 0`,
     /// the driver must:
     ///   1. Emit zero `.thinkingToken` events — no reasoning tokens leak into the stream.
-    ///   2. Emit zero `.thinkingComplete` events — the parser never opens a thinking block.
+    ///   2. Emit zero `.thinkingCompleted` events — the parser never opens a thinking block.
     ///   3. Produce visible `.token` events — disabling thinking must not starve output.
     ///
     /// Any `<think>` / `</think>` literal the model emits surfaces as `.token`
@@ -1020,7 +1020,7 @@ final class LlamaBackendTests: XCTestCase {
         for try await event in stream.events {
             switch event {
             case .thinkingToken: thinkingTokenCount += 1
-            case .thinkingComplete: thinkingCompleteCount += 1
+            case .thinkingCompleted: thinkingCompleteCount += 1
             case .token: visibleTokenCount += 1
             default: break
             }
@@ -1030,7 +1030,7 @@ final class LlamaBackendTests: XCTestCase {
             "maxThinkingTokens=0 must suppress every .thinkingToken event (#597) — "
             + "driver must short-circuit ThinkingTransform even when thinkingMarkers is set")
         XCTAssertEqual(thinkingCompleteCount, 0,
-            "maxThinkingTokens=0 must suppress .thinkingComplete — no thinking phase entered")
+            "maxThinkingTokens=0 must suppress .thinkingCompleted — no thinking phase entered")
         XCTAssertGreaterThan(visibleTokenCount, 0,
             "Visible output must still appear when thinking is disabled — the generation loop "
             + "must not starve .token events")

--- a/Tests/ManifoldBackendsTests/MLXBackendEventOrderParityTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXBackendEventOrderParityTests.swift
@@ -52,20 +52,20 @@ final class MLXBackendEventOrderParityTests: XCTestCase {
         switch event {
         case .token: return "token"
         case .thinkingToken: return "thinkingToken"
-        case .thinkingComplete: return "thinkingComplete"
+        case .thinkingCompleted: return "thinkingCompleted"
         case .thinkingSignature: return "thinkingSignature"
         case .kvCacheReuse: return "kvCacheReuse"
         case .toolCallStart: return "toolCallStart"
         case .toolCallArgumentsDelta: return "toolCallArgumentsDelta"
         case .toolCall: return "toolCall"
         case .toolResult: return "toolResult"
-        case .toolLoopLimitReached: return "toolLoopLimitReached"
+        case .toolIterationLimitExceeded: return "toolIterationLimitExceeded"
         case .toolProgress: return "toolProgress"
         case .toolDispatchStarted: return "toolDispatchStarted"
         case .toolDispatchCompleted: return "toolDispatchCompleted"
         case .usage: return "usage"
         case .prefillProgress: return "prefillProgress"
-        case .diagnosticThrottle: return "diagnosticThrottle"
+        case .throttleDiagnostic: return "throttleDiagnostic"
         case .handoffRequested: return "handoffRequested"
         }
     }

--- a/Tests/ManifoldBackendsTests/MLXBackendThinkingTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXBackendThinkingTests.swift
@@ -83,12 +83,12 @@ final class MLXBackendThinkingTests: XCTestCase {
         XCTAssertTrue(thinkingTexts.joined().contains("reason"),
             ".thinkingToken events must contain the reasoning content")
 
-        // Verify .thinkingComplete fires
+        // Verify .thinkingCompleted fires
         let completions = allEvents.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }
         XCTAssertEqual(completions.count, 1,
-            "Exactly one .thinkingComplete must fire when </think> is encountered")
+            "Exactly one .thinkingCompleted must fire when </think> is encountered")
 
         // Verify visible token appears
         let visibleTexts = allEvents.compactMap { event -> String? in
@@ -97,20 +97,20 @@ final class MLXBackendThinkingTests: XCTestCase {
         XCTAssertTrue(visibleTexts.joined().contains("answer"),
             "Content after </think> must be emitted as .token events")
 
-        // Verify ordering: all thinkingToken events before thinkingComplete before token events
+        // Verify ordering: all thinkingToken events before thinkingCompleted before token events
         let firstThinkingIndex = allEvents.firstIndex {
             if case .thinkingToken = $0 { return true } else { return false }
         }
         let completeIndex = allEvents.firstIndex {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }
         let firstTokenIndex = allEvents.firstIndex {
             if case .token = $0 { return true } else { return false }
         }
 
         if let ti = firstThinkingIndex, let ci = completeIndex, let vi = firstTokenIndex {
-            XCTAssertLessThan(ti, ci, ".thinkingToken events must precede .thinkingComplete")
-            XCTAssertLessThan(ci, vi, ".thinkingComplete must precede .token events")
+            XCTAssertLessThan(ti, ci, ".thinkingToken events must precede .thinkingCompleted")
+            XCTAssertLessThan(ci, vi, ".thinkingCompleted must precede .token events")
         } else {
             XCTFail("Expected all three event types in the stream")
         }
@@ -182,11 +182,11 @@ final class MLXBackendThinkingTests: XCTestCase {
 
         let thinkingEvents = allEvents.filter {
             if case .thinkingToken = $0 { return true }
-            if case .thinkingComplete = $0 { return true }
+            if case .thinkingCompleted = $0 { return true }
             return false
         }
         XCTAssertTrue(thinkingEvents.isEmpty,
-            "When config.thinkingMarkers is nil, no .thinkingToken or .thinkingComplete events must be emitted")
+            "When config.thinkingMarkers is nil, no .thinkingToken or .thinkingCompleted events must be emitted")
 
         let rawTokens = allEvents.compactMap { event -> String? in
             if case .token(let t) = event { return t } else { return nil }
@@ -241,12 +241,12 @@ final class MLXBackendThinkingTests: XCTestCase {
         XCTAssertTrue(thinkingTexts.joined().contains("hmm"),
             "The reasoning body (\"hmm\") must appear inside .thinkingToken events, not raw .token events")
 
-        // Exactly one .thinkingComplete at the close marker.
+        // Exactly one .thinkingCompleted at the close marker.
         let completions = allEvents.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }
         XCTAssertEqual(completions.count, 1,
-            "Exactly one .thinkingComplete must fire when the custom close marker is encountered")
+            "Exactly one .thinkingCompleted must fire when the custom close marker is encountered")
 
         // Post-close content must emerge as visible .token events.
         let visibleTexts = allEvents.compactMap { event -> String? in
@@ -402,7 +402,7 @@ final class MLXBackendThinkingTests: XCTestCase {
         let events = try await collectAllEvents(from: stream)
         let thinkingEvents = events.filter {
             if case .thinkingToken = $0 { return true }
-            if case .thinkingComplete = $0 { return true }
+            if case .thinkingCompleted = $0 { return true }
             return false
         }
         XCTAssertTrue(thinkingEvents.isEmpty,
@@ -422,7 +422,7 @@ final class MLXBackendThinkingTests: XCTestCase {
     // MARK: - 7. maxThinkingTokens == 0 disables thinking entirely (#597)
 
     /// Verifies that `GenerationConfig.maxThinkingTokens == 0` short-circuits
-    /// the `ThinkingTransform` on MLX so zero `.thinkingToken` / `.thinkingComplete`
+    /// the `ThinkingTransform` on MLX so zero `.thinkingToken` / `.thinkingCompleted`
     /// events are emitted, and visible output still flows.
     ///
     /// Even with `thinkingMarkers = .qwen3` (which would normally activate the
@@ -432,7 +432,7 @@ final class MLXBackendThinkingTests: XCTestCase {
     func test_maxThinkingTokens_zero_disablesThinkingEntirely_regression597() async throws {
         let mock = MockMLXModelContainer()
         // A thinking-capable stream: the mock would normally have these routed
-        // through ThinkingTransform and produce `.thinkingToken` + `.thinkingComplete`.
+        // through ThinkingTransform and produce `.thinkingToken` + `.thinkingCompleted`.
         mock.tokensToYield = ["<think>", "reason", "</think>", "answer"]
 
         let backend = MLXBackend()
@@ -455,7 +455,7 @@ final class MLXBackendThinkingTests: XCTestCase {
             return acc
         }
         let thinkingCompleteCount = events.reduce(0) { acc, ev in
-            if case .thinkingComplete = ev { return acc + 1 }
+            if case .thinkingCompleted = ev { return acc + 1 }
             return acc
         }
         let visibleText = events.compactMap { ev -> String? in
@@ -465,7 +465,7 @@ final class MLXBackendThinkingTests: XCTestCase {
         XCTAssertEqual(thinkingTokenCount, 0,
             "maxThinkingTokens=0 must suppress every .thinkingToken event (#597)")
         XCTAssertEqual(thinkingCompleteCount, 0,
-            "maxThinkingTokens=0 must suppress .thinkingComplete — no thinking phase entered")
+            "maxThinkingTokens=0 must suppress .thinkingCompleted — no thinking phase entered")
         XCTAssertFalse(visibleText.isEmpty,
             "Visible output must still appear when thinking is disabled — \"answer\" should reach .token")
         XCTAssertTrue(visibleText.contains("answer"),

--- a/Tests/ManifoldBackendsTests/MockInferenceBackendThinkingTests.swift
+++ b/Tests/ManifoldBackendsTests/MockInferenceBackendThinkingTests.swift
@@ -3,7 +3,7 @@ import ManifoldInference
 import ManifoldTestSupport
 
 /// Tests verifying that `MockInferenceBackend.thinkingTokensToYield` emits
-/// events in the correct order: `.thinkingToken` × N → `.thinkingComplete` → `.token` × M.
+/// events in the correct order: `.thinkingToken` × N → `.thinkingCompleted` → `.token` × M.
 final class MockInferenceBackendThinkingTests: XCTestCase {
 
     // MARK: - Event ordering
@@ -26,9 +26,9 @@ final class MockInferenceBackendThinkingTests: XCTestCase {
         }
 
         // Expected: .thinkingToken("step1 "), .thinkingToken("step2"),
-        //           .thinkingComplete, .token("answer")
+        //           .thinkingCompleted, .token("answer")
         XCTAssertEqual(events.count, 4,
-            "Should emit 2 thinkingToken + 1 thinkingComplete + 1 token = 4 events")
+            "Should emit 2 thinkingToken + 1 thinkingCompleted + 1 token = 4 events")
 
         guard events.count == 4 else { return }
 
@@ -44,10 +44,10 @@ final class MockInferenceBackendThinkingTests: XCTestCase {
             XCTFail("events[1] must be .thinkingToken(\"step2\"), got \(events[1])")
         }
 
-        if case .thinkingComplete = events[2] {
+        if case .thinkingCompleted = events[2] {
             // expected
         } else {
-            XCTFail("events[2] must be .thinkingComplete, got \(events[2])")
+            XCTFail("events[2] must be .thinkingCompleted, got \(events[2])")
         }
 
         if case .token(let t) = events[3] {
@@ -60,7 +60,7 @@ final class MockInferenceBackendThinkingTests: XCTestCase {
         // index-based assertions at [0] and [3] would both fail.
     }
 
-    // MARK: - No thinkingComplete when thinkingTokens is empty
+    // MARK: - No thinkingCompleted when thinkingTokens is empty
 
     func test_emptyThinkingTokens_noThinkingCompleteEmitted() async throws {
         let mock = MockInferenceBackend()
@@ -80,16 +80,16 @@ final class MockInferenceBackendThinkingTests: XCTestCase {
         }
 
         let completions = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }
         XCTAssertEqual(completions.count, 0,
-            "No .thinkingComplete must be emitted when thinkingTokensToYield is empty")
+            "No .thinkingCompleted must be emitted when thinkingTokensToYield is empty")
 
-        // Sabotage check: always emitting .thinkingComplete would yield count=1
+        // Sabotage check: always emitting .thinkingCompleted would yield count=1
         // and break this assertion, exposing spurious finalize calls in the UI.
     }
 
-    // MARK: - thinkingComplete fires exactly once regardless of token count
+    // MARK: - thinkingCompleted fires exactly once regardless of token count
 
     func test_thinkingComplete_firesExactlyOnce_forMultipleThinkingTokens() async throws {
         let mock = MockInferenceBackend()
@@ -109,12 +109,12 @@ final class MockInferenceBackendThinkingTests: XCTestCase {
         }
 
         let completions = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }
         XCTAssertEqual(completions.count, 1,
-            "Exactly one .thinkingComplete must be emitted regardless of how many thinkingTokensToYield there are")
+            "Exactly one .thinkingCompleted must be emitted regardless of how many thinkingTokensToYield there are")
 
-        // Sabotage check: emitting .thinkingComplete once per thinking token would yield 5
+        // Sabotage check: emitting .thinkingCompleted once per thinking token would yield 5
         // here and cause spurious UI finalizations.
     }
 
@@ -139,7 +139,7 @@ final class MockInferenceBackendThinkingTests: XCTestCase {
 
         let thinkingEvents = allEvents.filter {
             if case .thinkingToken = $0 { return true }
-            if case .thinkingComplete = $0 { return true }
+            if case .thinkingCompleted = $0 { return true }
             return false
         }
         XCTAssertTrue(thinkingEvents.isEmpty,

--- a/Tests/ManifoldBackendsTests/NonThinkingBackendRegressionTests.swift
+++ b/Tests/ManifoldBackendsTests/NonThinkingBackendRegressionTests.swift
@@ -3,7 +3,7 @@ import ManifoldInference
 import ManifoldTestSupport
 
 /// Regression tests verifying that backends not configured for thinking do not
-/// emit `.thinkingToken` or `.thinkingComplete` events, and that the new
+/// emit `.thinkingToken` or `.thinkingCompleted` events, and that the new
 /// `GenerationEvent` cases are handled without crashes across the system.
 final class NonThinkingBackendRegressionTests: XCTestCase {
 
@@ -28,12 +28,12 @@ final class NonThinkingBackendRegressionTests: XCTestCase {
 
         let thinkingEvents = allEvents.filter { event in
             if case .thinkingToken = event { return true }
-            if case .thinkingComplete = event { return true }
+            if case .thinkingCompleted = event { return true }
             return false
         }
 
         XCTAssertTrue(thinkingEvents.isEmpty,
-            "A backend with no thinking config must emit zero .thinkingToken or .thinkingComplete events")
+            "A backend with no thinking config must emit zero .thinkingToken or .thinkingCompleted events")
 
         let visibleTokens = allEvents.compactMap { event -> String? in
             if case .token(let t) = event { return t } else { return nil }
@@ -41,7 +41,7 @@ final class NonThinkingBackendRegressionTests: XCTestCase {
         XCTAssertEqual(visibleTokens, ["hello"],
             "MockInferenceBackend with no thinking config must still emit all configured .token events")
 
-        // Sabotage check: if MockInferenceBackend always emitted .thinkingComplete after tokens,
+        // Sabotage check: if MockInferenceBackend always emitted .thinkingCompleted after tokens,
         // thinkingEvents would be non-empty and this assertion would fail.
     }
 
@@ -69,12 +69,12 @@ final class NonThinkingBackendRegressionTests: XCTestCase {
         }
 
         // Verify the expected event sequence:
-        // .thinkingToken("thought"), .thinkingComplete, .token("visible")
+        // .thinkingToken("thought"), .thinkingCompleted, .token("visible")
         let thinkingTokens = events.compactMap { e -> String? in
             if case .thinkingToken(let t) = e { return t } else { return nil }
         }
         let completions = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }
         let tokens = events.compactMap { e -> String? in
             if case .token(let t) = e { return t } else { return nil }
@@ -83,7 +83,7 @@ final class NonThinkingBackendRegressionTests: XCTestCase {
         XCTAssertEqual(completions.count, 1)
         XCTAssertEqual(tokens, ["visible"])
 
-        // Sabotage check: if the mock didn't emit .thinkingComplete after thinking tokens,
+        // Sabotage check: if the mock didn't emit .thinkingCompleted after thinking tokens,
         // the completions count would be 0 and this test would fail.
     }
 }

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -901,7 +901,7 @@ struct OllamaBackendTests {
     /// Reasoning models (qwen3, qwen3.5:4b, deepseek-r1) emit chain-of-thought in
     /// a separate `thinking` field on the `/api/chat` endpoint. The backend
     /// must surface these as `.thinkingToken` events and close with
-    /// `.thinkingComplete` when thinking transitions back to empty.
+    /// `.thinkingCompleted` when thinking transitions back to empty.
     @Test func streaming_chatEndpoint_thinkingFieldEmitsThinkingEvents() async throws {
         let (backend, chatURL) = makeConfiguredBackend()
         try await loadBackend(backend)
@@ -917,7 +917,7 @@ struct OllamaBackendTests {
         var events: [GenerationEvent] = []
         for try await event in stream.events { events.append(event) }
 
-        // Ordering: .thinkingToken → .thinkingComplete → .token
+        // Ordering: .thinkingToken → .thinkingCompleted → .token
         let thinkingTokens = events.compactMap { event -> String? in
             if case .thinkingToken(let t) = event { return t } else { return nil }
         }
@@ -925,26 +925,26 @@ struct OllamaBackendTests {
             if case .token(let t) = event { return t } else { return nil }
         }
         let completeCount = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }.count
 
         #expect(thinkingTokens == ["Reasoning step 1"])
         #expect(tokens == ["answer"])
         #expect(completeCount == 1)
 
-        // Verify event ordering: thinkingToken precedes thinkingComplete precedes token.
+        // Verify event ordering: thinkingToken precedes thinkingCompleted precedes token.
         var sawThinking = false
         var sawComplete = false
         for event in events {
             switch event {
             case .thinkingToken:
-                #expect(!sawComplete, "thinkingToken must precede thinkingComplete")
+                #expect(!sawComplete, "thinkingToken must precede thinkingCompleted")
                 sawThinking = true
-            case .thinkingComplete:
-                #expect(sawThinking, "thinkingComplete must follow at least one thinkingToken")
+            case .thinkingCompleted:
+                #expect(sawThinking, "thinkingCompleted must follow at least one thinkingToken")
                 sawComplete = true
             case .token:
-                #expect(sawComplete, "visible token must follow thinkingComplete")
+                #expect(sawComplete, "visible token must follow thinkingCompleted")
             default: break
             }
         }
@@ -974,7 +974,7 @@ struct OllamaBackendTests {
             if case .token(let t) = event { return t } else { return nil }
         }
         let completeCount = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }.count
 
         #expect(thinkingTokens == ["Thinking..."])
@@ -1004,7 +1004,7 @@ struct OllamaBackendTests {
             if case .thinkingToken(let t) = event { return t } else { return nil }
         }
         let completeCount = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }.count
 
         #expect(thinkingTokens == ["entire reasoning"])
@@ -1455,13 +1455,13 @@ struct OllamaBackendTests {
         for try await event in stream.events {
             switch event {
             case .token(let t): tokens.append(t)
-            case .thinkingComplete: sawThinkingComplete = true
+            case .thinkingCompleted: sawThinkingComplete = true
             default: break
             }
         }
 
         #expect(tokens == ["a", "b", "c"])
-        #expect(!sawThinkingComplete, "no thinking was emitted so no .thinkingComplete should fire")
+        #expect(!sawThinkingComplete, "no thinking was emitted so no .thinkingCompleted should fire")
     }
 
     /// When an Ollama-compatible server emits a running `eval_count` on
@@ -1521,7 +1521,7 @@ struct OllamaBackendTests {
     /// dedicated thinking field is ever seen on the stream and content
     /// contains `<think>`, the backend must route content through
     /// `ThinkingTransform` so callers still receive the usual thinkingToken /
-    /// thinkingComplete / token event shape instead of raw tags baked into
+    /// thinkingCompleted / token event shape instead of raw tags baked into
     /// visible output.
     @Test func streaming_thinkingInContentFallback_emitsThinkingEvents() async throws {
         let (backend, chatURL) = makeConfiguredBackend()
@@ -1549,12 +1549,12 @@ struct OllamaBackendTests {
             if case .token(let t) = event { return t } else { return nil }
         }.joined()
         let completeCount = events.filter {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }.count
 
         #expect(thinkingText == "reasoning")
         #expect(visibleText == "answer")
-        #expect(completeCount == 1, "expected exactly one .thinkingComplete (got \(completeCount))")
+        #expect(completeCount == 1, "expected exactly one .thinkingCompleted (got \(completeCount))")
 
         // No raw `<think>` tags may leak into either event type.
         for event in events {

--- a/Tests/ManifoldBackendsTests/OllamaStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaStreamEventExtractorTests.swift
@@ -87,12 +87,12 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
     // MARK: - Thinking / qwen-style fixture
     //
     // Two thinking lines → thinkingToken × 2; the third line has no
-    // `thinking` field and a non-empty `content` → thinkingComplete (auto-
+    // `thinking` field and a non-empty `content` → thinkingCompleted (auto-
     // closed on transition) + token. The done line carries usage.
     func test_extractor_thinkingQwenStyle_yieldsThinkingHandoff() throws {
         let events = try driveExtractor(scenario: "thinking/qwen-style", config: GenerationConfig())
 
-        XCTAssertEqual(events.count, 5, "expected thinkingToken × 2, thinkingComplete, token, usage (saw \(events))")
+        XCTAssertEqual(events.count, 5, "expected thinkingToken × 2, thinkingCompleted, token, usage (saw \(events))")
         guard events.count == 5 else { return }
 
         if case .thinkingToken(let t1) = events[0] { XCTAssertEqual(t1, "Let me consider") }
@@ -101,8 +101,8 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
         if case .thinkingToken(let t2) = events[1] { XCTAssertEqual(t2, " the question.") }
         else { XCTFail("event[1] expected .thinkingToken, got \(events[1])") }
 
-        if case .thinkingComplete = events[2] { /* ok */ }
-        else { XCTFail("event[2] expected .thinkingComplete, got \(events[2])") }
+        if case .thinkingCompleted = events[2] { /* ok */ }
+        else { XCTFail("event[2] expected .thinkingCompleted, got \(events[2])") }
 
         if case .token(let visible) = events[3] { XCTAssertEqual(visible, "Answer.") }
         else { XCTFail("event[3] expected .token, got \(events[3])") }
@@ -243,20 +243,20 @@ final class OllamaStreamEventExtractorParityTests: XCTestCase {
         switch event {
         case .token(let s): return "token(\(s))"
         case .thinkingToken(let s): return "thinkingToken(\(s))"
-        case .thinkingComplete: return "thinkingComplete"
+        case .thinkingCompleted: return "thinkingCompleted"
         case .thinkingSignature(let s): return "thinkingSignature(\(s))"
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
         case .usage(let p, let c): return "usage(\(p),\(c))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
-        case .toolLoopLimitReached(let n): return "toolLoopLimitReached(\(n))"
+        case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"
         case .toolProgress: return "toolProgress"
         case .toolDispatchStarted: return "toolDispatchStarted"
         case .toolDispatchCompleted: return "toolDispatchCompleted"
         case .kvCacheReuse: return "kvCacheReuse"
-        case .diagnosticThrottle: return "diagnosticThrottle"
+        case .throttleDiagnostic: return "throttleDiagnostic"
         case .handoffRequested(let h): return "handoffRequested(\(h.targetAgentID))"
         }
     }

--- a/Tests/ManifoldBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -184,19 +184,19 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
                     projected.append(ExpectedEvent(event: "toolCall", text: nil, tool_name: call.toolName, arguments_contains: nil, prompt: nil, completion: nil))
                 case .usage(let p, let c):
                     projected.append(ExpectedEvent(event: "usage", text: nil, tool_name: nil, arguments_contains: nil, prompt: p, completion: c))
-                case .thinkingToken, .thinkingComplete, .thinkingSignature:
+                case .thinkingToken, .thinkingCompleted, .thinkingSignature:
                     // Not exercised by tool-call fixtures; ignore for
                     // forward-compat with future thinking-in-tool-call
                     // captures.
                     break
-                case .toolResult, .toolLoopLimitReached:
+                case .toolResult, .toolIterationLimitExceeded:
                     // Raw backend replay never emits orchestrator-level
                     // events. Exhaustive stub so the switch stays honest as
                     // GenerationEvent grows.
                     break
                 case .kvCacheReuse:
                     break
-                case .diagnosticThrottle:
+                case .throttleDiagnostic:
                     // Cooperative thermal pause — informational only;
                     // raw backend replay neither emits nor projects it.
                     break

--- a/Tests/ManifoldBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAICompatEndpointTests.swift
@@ -210,24 +210,24 @@ struct OpenAICompatEndpointTests {
         }
 
         #expect(events.count == 4)
-        #expect(events[0] == .prefillProgress(nPast: 1024, nTotal: 4096, tokensPerSecond: 280.0))
-        #expect(events[1] == .prefillProgress(nPast: 3072, nTotal: 4096, tokensPerSecond: 300.5))
-        #expect(events[2] == .prefillProgress(nPast: 4096, nTotal: 4096, tokensPerSecond: 295.0))
+        #expect(events[0] == .prefillProgress(tokensProcessed: 1024, tokensTotal: 4096, tokensPerSecond: 280.0))
+        #expect(events[1] == .prefillProgress(tokensProcessed: 3072, tokensTotal: 4096, tokensPerSecond: 300.5))
+        #expect(events[2] == .prefillProgress(tokensProcessed: 4096, tokensTotal: 4096, tokensPerSecond: 295.0))
         #expect(events[3] == .token("Hello"))
 
         // Contract (issue #746): the prefill_progress event immediately preceding
-        // the first content token must satisfy nPast == nTotal. UI observers
+        // the first content token must satisfy tokensProcessed == tokensTotal. UI observers
         // rely on this equality to flip from "evaluating prompt" to "generating".
         let firstTokenIndex = events.firstIndex(where: { if case .token = $0 { true } else { false } })
         let lastPrefillBeforeToken = events
             .prefix(firstTokenIndex ?? events.count)
             .last(where: { if case .prefillProgress = $0 { true } else { false } })
-        guard case let .prefillProgress(nPast: boundaryNPast, nTotal: boundaryNTotal, tokensPerSecond: _) = lastPrefillBeforeToken else {
+        guard case let .prefillProgress(tokensProcessed: boundaryProcessed, tokensTotal: boundaryTotal, tokensPerSecond: _) = lastPrefillBeforeToken else {
             Issue.record("Expected at least one prefill_progress event before the first content token")
             return
         }
-        #expect(boundaryNPast == boundaryNTotal,
-                "Final prefill_progress before generation must report nPast == nTotal")
+        #expect(boundaryProcessed == boundaryTotal,
+                "Final prefill_progress before generation must report tokensProcessed == tokensTotal")
     }
 
     /// Ollama versions before 0.4.0 do not support `stream_options` and silently

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesBackendTests.swift
@@ -58,7 +58,7 @@ final class OpenAIResponsesBackendTests: XCTestCase {
 
     private enum EventCategory: Equatable {
         case thinkingToken(String)
-        case thinkingComplete
+        case thinkingCompleted
         case token(String)
         case usage
     }
@@ -66,11 +66,11 @@ final class OpenAIResponsesBackendTests: XCTestCase {
     private func categorise(_ event: GenerationEvent) -> EventCategory? {
         switch event {
         case .thinkingToken(let t): return .thinkingToken(t)
-        case .thinkingComplete: return .thinkingComplete
+        case .thinkingCompleted: return .thinkingCompleted
         case .token(let t): return .token(t)
         case .usage: return .usage
-        case .toolCall, .toolResult, .toolLoopLimitReached, .kvCacheReuse,
-             .diagnosticThrottle, .thinkingSignature,
+        case .toolCall, .toolResult, .toolIterationLimitExceeded, .kvCacheReuse,
+             .throttleDiagnostic, .thinkingSignature,
              .toolCallStart, .toolCallArgumentsDelta,
              .toolDispatchStarted, .toolDispatchCompleted,
              .prefillProgress, .toolProgress,
@@ -82,7 +82,7 @@ final class OpenAIResponsesBackendTests: XCTestCase {
     // MARK: - Tests
 
     /// Reasoning summary deltas surface as `.thinkingToken`, and a single
-    /// `.thinkingComplete` is emitted on the transition to visible content.
+    /// `.thinkingCompleted` is emitted on the transition to visible content.
     func test_reasoningSummaryDeltas_emitThinkingTokensThenCompleteThenContent() async throws {
         let (backend, url) = makeBackend()
 
@@ -118,17 +118,17 @@ final class OpenAIResponsesBackendTests: XCTestCase {
         XCTAssertEqual(contentEvents, [
             .thinkingToken("Analysing"),
             .thinkingToken(" the prompt..."),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("The answer"),
             .token(" is 42."),
         ], "Got: \(contentEvents)")
 
-        let completeCount = categories.filter { $0 == .thinkingComplete }.count
-        XCTAssertEqual(completeCount, 1, ".thinkingComplete must fire exactly once")
+        let completeCount = categories.filter { $0 == .thinkingCompleted }.count
+        XCTAssertEqual(completeCount, 1, ".thinkingCompleted must fire exactly once")
     }
 
     /// An explicit `response.reasoning_summary_text.done` event also flushes
-    /// `.thinkingComplete`, even before any visible content delta arrives.
+    /// `.thinkingCompleted`, even before any visible content delta arrives.
     func test_reasoningSummaryDoneEvent_emitsThinkingCompleteOnce() async throws {
         let (backend, url) = makeBackend()
 
@@ -155,12 +155,12 @@ final class OpenAIResponsesBackendTests: XCTestCase {
 
         XCTAssertEqual(categories, [
             .thinkingToken("Pondering"),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("hi"),
         ])
     }
 
-    /// Plain (non-reasoning) responses must never emit `.thinkingComplete`,
+    /// Plain (non-reasoning) responses must never emit `.thinkingCompleted`,
     /// matching the behaviour of `OpenAIBackend` for non-reasoning models.
     func test_emptyReasoning_noThinkingCompleteEmitted() async throws {
         let (backend, url) = makeBackend()
@@ -188,7 +188,7 @@ final class OpenAIResponsesBackendTests: XCTestCase {
             switch event {
             case .token(let t): tokens.append(t)
             case .thinkingToken: sawThinking = true
-            case .thinkingComplete: sawThinkingComplete = true
+            case .thinkingCompleted: sawThinkingComplete = true
             default: break
             }
         }
@@ -196,7 +196,7 @@ final class OpenAIResponsesBackendTests: XCTestCase {
         XCTAssertEqual(tokens, ["Hello", " world"])
         XCTAssertFalse(sawThinking)
         XCTAssertFalse(sawThinkingComplete,
-                       ".thinkingComplete must not fire when no reasoning was streamed")
+                       ".thinkingCompleted must not fire when no reasoning was streamed")
     }
 
     /// `response.error` events are surfaced as a thrown error so callers see
@@ -266,7 +266,7 @@ final class OpenAIResponsesBackendTests: XCTestCase {
 
         XCTAssertEqual(categories, [
             .thinkingToken("Thinking..."),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("done"),
         ])
     }
@@ -323,7 +323,7 @@ final class OpenAIResponsesBackendTests: XCTestCase {
     }
 
     /// Stream errors that fire while the parser is still inside a thinking
-    /// block must emit `.thinkingComplete` before rethrowing — otherwise UI
+    /// block must emit `.thinkingCompleted` before rethrowing — otherwise UI
     /// consumers hang in a thinking-only state. Pins the parser-error path
     /// through `ThinkingBlockManager.flushIfOpen`.
     func test_errorMidThinkingBlock_emitsThinkingCompleteBeforeThrow() async throws {
@@ -355,8 +355,8 @@ final class OpenAIResponsesBackendTests: XCTestCase {
         }
 
         XCTAssertTrue(threw, "expected response.error to throw out of the stream")
-        XCTAssertEqual(observed, [.thinkingToken("Pondering"), .thinkingComplete],
-                       ".thinkingComplete must fire before the throw — got \(observed)")
+        XCTAssertEqual(observed, [.thinkingToken("Pondering"), .thinkingCompleted],
+                       ".thinkingCompleted must fire before the throw — got \(observed)")
     }
 }
 #endif

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesStreamEventExtractorTests.swift
@@ -79,15 +79,15 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
         let events = try driveExtractor(scenario: "reasoning/summarized")
 
         // Expected: thinkingToken("Let me"), thinkingToken(" think..."),
-        // thinkingComplete (from reasoning_summary_text.done), then
+        // thinkingCompleted (from reasoning_summary_text.done), then
         // token("Answer."), then usage. The output_text.delta sees
         // thinking already closed by `.done` so it does NOT re-emit
-        // thinkingComplete.
+        // thinkingCompleted.
         let kinds = events.map { eventKind($0) }
         XCTAssertEqual(kinds, [
             "thinkingToken(Let me)",
             "thinkingToken( think...)",
-            "thinkingComplete",
+            "thinkingCompleted",
             "token(Answer.)",
             "usage(5,3)"
         ])
@@ -190,20 +190,20 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
         switch event {
         case .token(let s): return "token(\(s))"
         case .thinkingToken(let s): return "thinkingToken(\(s))"
-        case .thinkingComplete: return "thinkingComplete"
+        case .thinkingCompleted: return "thinkingCompleted"
         case .thinkingSignature(let s): return "thinkingSignature(\(s))"
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName))"
         case .usage(let p, let c): return "usage(\(p),\(c))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
-        case .toolLoopLimitReached(let n): return "toolLoopLimitReached(\(n))"
+        case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"
         case .toolProgress: return "toolProgress"
         case .toolDispatchStarted: return "toolDispatchStarted"
         case .toolDispatchCompleted: return "toolDispatchCompleted"
         case .kvCacheReuse: return "kvCacheReuse"
-        case .diagnosticThrottle: return "diagnosticThrottle"
+        case .throttleDiagnostic: return "throttleDiagnostic"
         case .handoffRequested(let h): return "handoffRequested(\(h.targetAgentID))"
         }
     }
@@ -313,20 +313,20 @@ final class OpenAIResponsesStreamEventExtractorParityTests: XCTestCase {
         switch event {
         case .token(let s): return "token(\(s))"
         case .thinkingToken(let s): return "thinkingToken(\(s))"
-        case .thinkingComplete: return "thinkingComplete"
+        case .thinkingCompleted: return "thinkingCompleted"
         case .thinkingSignature(let s): return "thinkingSignature(\(s))"
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
         case .usage(let p, let c): return "usage(\(p),\(c))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
-        case .toolLoopLimitReached(let n): return "toolLoopLimitReached(\(n))"
+        case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"
         case .toolProgress: return "toolProgress"
         case .toolDispatchStarted: return "toolDispatchStarted"
         case .toolDispatchCompleted: return "toolDispatchCompleted"
         case .kvCacheReuse: return "kvCacheReuse"
-        case .diagnosticThrottle: return "diagnosticThrottle"
+        case .throttleDiagnostic: return "throttleDiagnostic"
         case .handoffRequested(let h): return "handoffRequested(\(h.targetAgentID))"
         }
     }

--- a/Tests/ManifoldBackendsTests/OpenAIStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIStreamEventExtractorTests.swift
@@ -90,11 +90,11 @@ final class OpenAIStreamEventExtractorTests: XCTestCase {
     //
     // Two reasoning deltas (DeepSeek-shape `reasoning_content`), then a
     // visible content delta. Expected sequence: thinkingToken × 2,
-    // thinkingComplete (auto-closed on transition), token.
+    // thinkingCompleted (auto-closed on transition), token.
     func test_extractor_reasoningWithSummary_yieldsThinkingHandoff() throws {
         let events = try driveExtractor(scenario: "reasoning/with-summary")
 
-        XCTAssertEqual(events.count, 4, "expected thinkingToken × 2, thinkingComplete, token (saw \(events))")
+        XCTAssertEqual(events.count, 4, "expected thinkingToken × 2, thinkingCompleted, token (saw \(events))")
         guard events.count == 4 else { return }
 
         if case .thinkingToken(let t1) = events[0] { XCTAssertEqual(t1, "Let me") }
@@ -103,8 +103,8 @@ final class OpenAIStreamEventExtractorTests: XCTestCase {
         if case .thinkingToken(let t2) = events[1] { XCTAssertEqual(t2, " think...") }
         else { XCTFail("event[1] expected .thinkingToken, got \(events[1])") }
 
-        if case .thinkingComplete = events[2] { /* ok */ }
-        else { XCTFail("event[2] expected .thinkingComplete, got \(events[2])") }
+        if case .thinkingCompleted = events[2] { /* ok */ }
+        else { XCTFail("event[2] expected .thinkingCompleted, got \(events[2])") }
 
         if case .token(let visible) = events[3] { XCTAssertEqual(visible, "Answer.") }
         else { XCTFail("event[3] expected .token, got \(events[3])") }
@@ -295,20 +295,20 @@ final class OpenAIStreamEventExtractorParityTests: XCTestCase {
         switch event {
         case .token(let s): return "token(\(s))"
         case .thinkingToken(let s): return "thinkingToken(\(s))"
-        case .thinkingComplete: return "thinkingComplete"
+        case .thinkingCompleted: return "thinkingCompleted"
         case .thinkingSignature(let s): return "thinkingSignature(\(s))"
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
         case .usage(let p, let c): return "usage(\(p),\(c))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
-        case .toolLoopLimitReached(let n): return "toolLoopLimitReached(\(n))"
+        case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"
         case .toolProgress: return "toolProgress"
         case .toolDispatchStarted: return "toolDispatchStarted"
         case .toolDispatchCompleted: return "toolDispatchCompleted"
         case .kvCacheReuse: return "kvCacheReuse"
-        case .diagnosticThrottle: return "diagnosticThrottle"
+        case .throttleDiagnostic: return "throttleDiagnostic"
         case .handoffRequested(let h): return "handoffRequested(\(h.targetAgentID))"
         }
     }

--- a/Tests/ManifoldBackendsTests/SSECloudBackendAdapterRoutingTests.swift
+++ b/Tests/ManifoldBackendsTests/SSECloudBackendAdapterRoutingTests.swift
@@ -278,14 +278,14 @@ struct SSECloudBackendAdapterRoutingTests {
         for try await event in stream {
             switch event {
             case .thinkingToken(let text): events.append("thinking:\(text)")
-            case .thinkingComplete: events.append("thinkingComplete")
+            case .thinkingCompleted: events.append("thinkingCompleted")
             case .token(let text): events.append("token:\(text)")
             case .usage(let prompt, let completion): events.append("usage:\(prompt)/\(completion)")
             default: break
             }
         }
 
-        #expect(events == ["thinking:rationale", "thinkingComplete", "token:answer", "usage:7/11"])
+        #expect(events == ["thinking:rationale", "thinkingCompleted", "token:answer", "usage:7/11"])
         #expect(usageRecorder.lastPrompt == 7)
         #expect(usageRecorder.lastCompletion == 11)
         #expect(framedTransport.callCount == 1)

--- a/Tests/ManifoldBackendsTests/SSEExtractEventsTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEExtractEventsTests.swift
@@ -144,12 +144,12 @@ struct SSEExtractEventsTests {
                 "Default extractEvents must wrap the legacy extractToken result into [.token(...)]")
     }
 
-    // MARK: - (b) Thinking → token transition injects .thinkingComplete exactly once
+    // MARK: - (b) Thinking → token transition injects .thinkingCompleted exactly once
 
     /// When a handler emits one or more ``GenerationEvent/thinkingToken(_:)``
     /// events followed by a plain ``GenerationEvent/token(_:)``, the base
     /// ``SSECloudBackend/parseResponseStream(bytes:continuation:)`` loop must
-    /// inject a single ``GenerationEvent/thinkingComplete`` at the boundary.
+    /// inject a single ``GenerationEvent/thinkingCompleted`` at the boundary.
     /// The injected event must sit between the final thinking token and the
     /// first plain token, and must not repeat if further plain tokens follow.
     @Test func thinkingToTokenTransition_injectsThinkingCompleteOnce() async throws {
@@ -185,27 +185,27 @@ struct SSEExtractEventsTests {
             events.append(event)
         }
 
-        // Expected exact sequence: two thinking tokens, one thinkingComplete
+        // Expected exact sequence: two thinking tokens, one thinkingCompleted
         // injected by the base loop, then two plain tokens.
         let expected: [GenerationEvent] = [
             .thinkingToken("pondering"),
             .thinkingToken("more"),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("answer"),
             .token("continued"),
         ]
         #expect(events == expected,
-                "Base loop must inject exactly one .thinkingComplete at the thinking→token boundary; got \(events)")
+                "Base loop must inject exactly one .thinkingCompleted at the thinking→token boundary; got \(events)")
 
         // Extra pin: no duplicates.
-        let completes = events.filter { if case .thinkingComplete = $0 { return true } else { return false } }
+        let completes = events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }
         #expect(completes.count == 1,
-                ".thinkingComplete must appear exactly once across the whole stream")
+                ".thinkingCompleted must appear exactly once across the whole stream")
     }
 
-    // MARK: - (c) Handler-emitted .thinkingComplete is not double-injected
+    // MARK: - (c) Handler-emitted .thinkingCompleted is not double-injected
 
-    /// A handler that already emits ``GenerationEvent/thinkingComplete``
+    /// A handler that already emits ``GenerationEvent/thinkingCompleted``
     /// itself (e.g. an inline-tag backend using `ThinkingTransform`) must not
     /// get a second duplicate injected by the base loop. The internal
     /// `wasThinking` flag must clear when the handler's explicit event
@@ -218,7 +218,7 @@ struct SSEExtractEventsTests {
             case "THINK:DONE":
                 // Handler emits its own explicit close — e.g. ThinkingTransform
                 // saw the `</think>` closing tag.
-                return [.thinkingComplete]
+                return [.thinkingCompleted]
             case "TOKEN:answer":
                 return [.token("answer")]
             default:
@@ -244,15 +244,15 @@ struct SSEExtractEventsTests {
 
         let expected: [GenerationEvent] = [
             .thinkingToken("pondering"),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("answer"),
         ]
         #expect(events == expected,
-                "Handler-emitted .thinkingComplete must not be duplicated by the base loop; got \(events)")
+                "Handler-emitted .thinkingCompleted must not be duplicated by the base loop; got \(events)")
 
-        let completes = events.filter { if case .thinkingComplete = $0 { return true } else { return false } }
+        let completes = events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }
         #expect(completes.count == 1,
-                ".thinkingComplete must appear exactly once when the handler emits it explicitly")
+                ".thinkingCompleted must appear exactly once when the handler emits it explicitly")
     }
 
     // MARK: - (d) Multiple events per payload — one chunk, several events
@@ -283,11 +283,11 @@ struct SSEExtractEventsTests {
         }
 
         // Within the single payload: thinkingToken first, then the base loop
-        // injects .thinkingComplete because the next event is .token, then
+        // injects .thinkingCompleted because the next event is .token, then
         // the .token itself.
         let expected: [GenerationEvent] = [
             .thinkingToken("thought"),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("visible"),
         ]
         #expect(events == expected,

--- a/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
@@ -297,7 +297,7 @@ final class SSEPayloadReplayTests: XCTestCase {
     /// silently dropped by `parseToken` because it only matches `text_delta`.
     ///
     /// FIXME(#527): when thinking support lands, flip these assertions to expect
-    /// `.thinkingToken("Let me reason...")` + `.thinkingComplete` before the
+    /// `.thinkingToken("Let me reason...")` + `.thinkingCompleted` before the
     /// final `.token("Answer.")`.
     func test_claude_thinkingBlocks_todayDropsThinkingContent() async throws {
         let sseText = """

--- a/Tests/ManifoldBackendsTests/ThinkingBlockManagerTests.swift
+++ b/Tests/ManifoldBackendsTests/ThinkingBlockManagerTests.swift
@@ -4,7 +4,7 @@ import ManifoldInference
 @testable import ManifoldCloudCore
 
 /// Unit tests for `ThinkingBlockManager` — the open/flush primitive that the
-/// SSE backends share to guarantee `.thinkingComplete` is emitted exactly
+/// SSE backends share to guarantee `.thinkingCompleted` is emitted exactly
 /// once on the transition out of a thinking block.
 final class ThinkingBlockManagerTests: XCTestCase {
 
@@ -33,8 +33,8 @@ final class ThinkingBlockManagerTests: XCTestCase {
         }
 
         XCTAssertEqual(events.count, 1, "expected one event, got \(events)")
-        guard case .thinkingComplete = events.first else {
-            return XCTFail("expected .thinkingComplete, got \(String(describing: events.first))")
+        guard case .thinkingCompleted = events.first else {
+            return XCTFail("expected .thinkingCompleted, got \(String(describing: events.first))")
         }
     }
 
@@ -53,7 +53,7 @@ final class ThinkingBlockManagerTests: XCTestCase {
             manager.open()
             manager.open()
             manager.open()
-            // Still expect exactly one .thinkingComplete on flush.
+            // Still expect exactly one .thinkingCompleted on flush.
             manager.flushIfOpen(into: continuation)
         }
 
@@ -69,7 +69,7 @@ final class ThinkingBlockManagerTests: XCTestCase {
             manager.flushIfOpen(into: continuation)
         }
 
-        XCTAssertEqual(events.count, 1, "second flush must not re-emit .thinkingComplete")
+        XCTAssertEqual(events.count, 1, "second flush must not re-emit .thinkingCompleted")
     }
 
     func test_isOpen_reflectsState() {

--- a/Tests/ManifoldE2ETests/LlamaThinkingE2ETests.swift
+++ b/Tests/ManifoldE2ETests/LlamaThinkingE2ETests.swift
@@ -9,7 +9,7 @@ import ManifoldInference
 /// Hardware-gated end-to-end test for `LlamaBackend` driving a real thinking-capable
 /// GGUF (Qwen3-0.6B-Instruct-Q4_K_M or similar). Verifies the full
 /// `LlamaGenerationDriver` thinking-parser pipeline: per-token decode -> ThinkingTransform
-/// -> `.thinkingToken` / `.thinkingComplete` events -> visible `.token` events.
+/// -> `.thinkingToken` / `.thinkingCompleted` events -> visible `.token` events.
 ///
 /// All thinking-token tests in CI use `MockInferenceBackend`, which bypasses the real
 /// `LlamaGenerationDriver` integration with `ThinkingTransform`. A regression in the C-API
@@ -114,7 +114,7 @@ final class LlamaThinkingE2ETests: XCTestCase {
 
     /// Asserts the full thinking pipeline:
     /// - at least one `.thinkingToken` event
-    /// - exactly one `.thinkingComplete` event before the first visible `.token`
+    /// - exactly one `.thinkingCompleted` event before the first visible `.token`
     /// - non-empty visible output
     /// - visible output does NOT contain raw `<think>` / `</think>` tags
     ///   (the parser must strip them — leaking tags is a hard regression signal).
@@ -160,7 +160,7 @@ final class LlamaThinkingE2ETests: XCTestCase {
                 if sawFirstVisibleToken {
                     XCTFail("Received .thinkingToken after visible .token — reasoning must precede visible output (model: \(modelURL.lastPathComponent))")
                 }
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 thinkingCompleteCount += 1
                 if !sawFirstVisibleToken {
                     firstTokenAfterThinkingComplete = true
@@ -194,12 +194,12 @@ final class LlamaThinkingE2ETests: XCTestCase {
         XCTAssertEqual(
             thinkingCompleteCount,
             1,
-            "Exactly one .thinkingComplete event must fire (got \(thinkingCompleteCount), model: \(modelURL.lastPathComponent))"
+            "Exactly one .thinkingCompleted event must fire (got \(thinkingCompleteCount), model: \(modelURL.lastPathComponent))"
         )
         XCTAssertEqual(
             firstTokenAfterThinkingComplete,
             true,
-            ".thinkingComplete must fire before the first visible .token (model: \(modelURL.lastPathComponent))"
+            ".thinkingCompleted must fire before the first visible .token (model: \(modelURL.lastPathComponent))"
         )
         XCTAssertFalse(
             visibleText.isEmpty,

--- a/Tests/ManifoldE2ETests/OllamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/OllamaE2ETests.swift
@@ -123,7 +123,7 @@ final class OllamaE2ETests: XCTestCase {
                 evidence.visibleText += text
             case .thinkingToken:
                 evidence.thinkingTokenCount += 1
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 evidence.sawThinkingComplete = true
             default:
                 continue
@@ -137,7 +137,7 @@ final class OllamaE2ETests: XCTestCase {
     /// A non-empty response must arrive as either visible `.token` content or,
     /// on reasoning models whose visible portion may be trivially short for
     /// this prompt, as thinking-event evidence (`.thinkingToken` +
-    /// `.thinkingComplete`). An empty visible stream *with* no thinking events
+    /// `.thinkingCompleted`). An empty visible stream *with* no thinking events
     /// still fails — this is not a silent-pass.
     func test_realInference_generatesNonEmptyResponse() async throws {
         let evidence = try await collectEvidence(prompt: "Reply with exactly one word.")
@@ -149,7 +149,7 @@ final class OllamaE2ETests: XCTestCase {
             )
             XCTAssertTrue(
                 !evidence.visibleText.isEmpty || (evidence.thinkingTokenCount > 0 && evidence.sawThinkingComplete),
-                "Thinking model '\(modelName!)' must emit either visible text or a complete thinking trace (visible=\(evidence.visibleText.count) chars, thinkingTokens=\(evidence.thinkingTokenCount), thinkingComplete=\(evidence.sawThinkingComplete))"
+                "Thinking model '\(modelName!)' must emit either visible text or a complete thinking trace (visible=\(evidence.visibleText.count) chars, thinkingTokens=\(evidence.thinkingTokenCount), thinkingCompleted=\(evidence.sawThinkingComplete))"
             )
         } else {
             XCTAssertFalse(

--- a/Tests/ManifoldE2ETests/OllamaThinkingE2ETests.swift
+++ b/Tests/ManifoldE2ETests/OllamaThinkingE2ETests.swift
@@ -105,7 +105,7 @@ final class OllamaThinkingE2ETests: XCTestCase {
     // MARK: - Thinking Tests
 
     /// Test A — Thinking models must emit `.thinkingToken` events and fire
-    /// exactly one `.thinkingComplete` before the first visible `.token`.
+    /// exactly one `.thinkingCompleted` before the first visible `.token`.
     func testThinkingModel_emitsThinkingEventsBeforeVisibleOutput() async throws {
         // qwen3.5:4b can spend well over 1k tokens reasoning through the
         // train-meeting prompt before emitting any visible content. When
@@ -134,7 +134,7 @@ final class OllamaThinkingE2ETests: XCTestCase {
                 if sawFirstVisibleToken {
                     XCTFail("Received .thinkingToken after visible .token — reasoning must precede visible output on this backend")
                 }
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 thinkingCompleteCount += 1
                 if !sawFirstVisibleToken {
                     firstTokenAfterThinkingComplete = true
@@ -158,12 +158,12 @@ final class OllamaThinkingE2ETests: XCTestCase {
         XCTAssertEqual(
             thinkingCompleteCount,
             1,
-            "Exactly one .thinkingComplete event must fire (got \(thinkingCompleteCount), model: \(modelName!))"
+            "Exactly one .thinkingCompleted event must fire (got \(thinkingCompleteCount), model: \(modelName!))"
         )
         XCTAssertEqual(
             firstTokenAfterThinkingComplete,
             true,
-            ".thinkingComplete must fire before the first visible .token (model: \(modelName!))"
+            ".thinkingCompleted must fire before the first visible .token (model: \(modelName!))"
         )
         XCTAssertFalse(
             visibleText.isEmpty,
@@ -201,7 +201,7 @@ final class OllamaThinkingE2ETests: XCTestCase {
             switch event {
             case .thinkingToken:
                 thinkingTokenCount += 1
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 thinkingCompleteCount += 1
             case .token(let text):
                 visibleText += text
@@ -218,7 +218,7 @@ final class OllamaThinkingE2ETests: XCTestCase {
         XCTAssertEqual(
             thinkingCompleteCount,
             0,
-            "maxThinkingTokens=0 must fire zero .thinkingComplete events (got \(thinkingCompleteCount), model: \(modelName!))"
+            "maxThinkingTokens=0 must fire zero .thinkingCompleted events (got \(thinkingCompleteCount), model: \(modelName!))"
         )
         XCTAssertFalse(
             visibleText.isEmpty,
@@ -264,7 +264,7 @@ final class OllamaThinkingE2ETests: XCTestCase {
             switch event {
             case .thinkingToken:
                 thinkingTokenCount += 1
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 thinkingCompleteCount += 1
             case .token(let text):
                 visibleText += text
@@ -285,7 +285,7 @@ final class OllamaThinkingE2ETests: XCTestCase {
         XCTAssertEqual(
             thinkingCompleteCount,
             1,
-            "Exactly one .thinkingComplete event must fire even when capped (got \(thinkingCompleteCount), model: \(modelName!))"
+            "Exactly one .thinkingCompleted event must fire even when capped (got \(thinkingCompleteCount), model: \(modelName!))"
         )
         XCTAssertFalse(
             visibleText.isEmpty,

--- a/Tests/ManifoldFuzzTests/DetectorTests.swift
+++ b/Tests/ManifoldFuzzTests/DetectorTests.swift
@@ -291,7 +291,7 @@ final class DetectorTests: XCTestCase {
 
     func test_thinkingClassification_unbalancedEvents_skipsWhenMaxTokensTruncation() {
         // 64-token cap routinely truncates mid-`<think>` on reasoning models;
-        // the lack of a `thinkingComplete` event is the cap's fault, not a parser bug.
+        // the lack of a `thinkingCompleted` event is the cap's fault, not a parser bug.
         let r = makeRecord(
             thinkingRaw: "still reasoning…",
             thinkingCompleteCount: 0,

--- a/Tests/ManifoldFuzzTests/EventRecorderTests.swift
+++ b/Tests/ManifoldFuzzTests/EventRecorderTests.swift
@@ -7,7 +7,7 @@ import ManifoldInference
 final class EventRecorderTests: XCTestCase {
 
     /// A stream that throws mid-thinking-block must still surface the partial
-    /// reasoning it accumulated since the last `.thinkingComplete`. Without
+    /// reasoning it accumulated since the last `.thinkingCompleted`. Without
     /// this, detectors that rely on `thinkingRaw`/`thinkingParts` go blind on
     /// mid-stream failures (network drop, KV decode error, OOM) — they see a
     /// clean capture even though the model emitted and the harness saw real
@@ -36,17 +36,17 @@ final class EventRecorderTests: XCTestCase {
             "partial-apartial-b",
             "thinkingRaw must retain every thinking token seen before the throw"
         )
-        XCTAssertEqual(capture.thinkingCompleteCount, 0, "no thinkingComplete event was emitted")
+        XCTAssertEqual(capture.thinkingCompleteCount, 0, "no thinkingCompleted event was emitted")
     }
 
-    /// Sanity check the success path: when `.thinkingComplete` drains the
+    /// Sanity check the success path: when `.thinkingCompleted` drains the
     /// buffer, the post-loop flush is a no-op — no duplicate entries, no
     /// empty strings.
     func test_consume_successPath_doesNotDuplicateCompletedThinkingBlock() async {
         let stream = GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
             continuation.yield(.thinkingToken("hello "))
             continuation.yield(.thinkingToken("world"))
-            continuation.yield(.thinkingComplete)
+            continuation.yield(.thinkingCompleted)
             continuation.yield(.token("response"))
             continuation.finish()
         })

--- a/Tests/ManifoldFuzzTests/ThinkingScenarioTests.swift
+++ b/Tests/ManifoldFuzzTests/ThinkingScenarioTests.swift
@@ -83,8 +83,8 @@ final class ThinkingScenarioTests: XCTestCase {
             "maxThinkingTokens=0 must suppress every .thinkingToken event"
         )
         XCTAssertFalse(
-            outcome.events.contains { if case .thinkingComplete = $0 { return true } else { return false } },
-            "maxThinkingTokens=0 must suppress every .thinkingComplete event"
+            outcome.events.contains { if case .thinkingCompleted = $0 { return true } else { return false } },
+            "maxThinkingTokens=0 must suppress every .thinkingCompleted event"
         )
         XCTAssertTrue(
             outcome.events.contains { if case .token = $0 { return true } else { return false } },
@@ -100,24 +100,24 @@ final class ThinkingScenarioTests: XCTestCase {
         )
 
         let completeCount = outcome.events.reduce(0) { acc, e in
-            if case .thinkingComplete = e { return acc + 1 }
+            if case .thinkingCompleted = e { return acc + 1 }
             return acc
         }
         XCTAssertLessThanOrEqual(
             completeCount,
             1,
-            "cancelled stream must not fire .thinkingComplete more than once"
+            "cancelled stream must not fire .thinkingCompleted more than once"
         )
 
-        // If any thinkingComplete appeared at all, at least one thinkingToken
+        // If any thinkingCompleted appeared at all, at least one thinkingToken
         // must have preceded it — the canonical "no dangling complete" rule.
         if let completeIdx = outcome.events.firstIndex(where: {
-            if case .thinkingComplete = $0 { return true } else { return false }
+            if case .thinkingCompleted = $0 { return true } else { return false }
         }) {
             let precedingTokens = outcome.events.prefix(completeIdx).contains {
                 if case .thinkingToken = $0 { return true } else { return false }
             }
-            XCTAssertTrue(precedingTokens, "dangling .thinkingComplete with no prior .thinkingToken")
+            XCTAssertTrue(precedingTokens, "dangling .thinkingCompleted with no prior .thinkingToken")
         }
     }
 
@@ -129,13 +129,13 @@ final class ThinkingScenarioTests: XCTestCase {
         )
 
         let completeCount = outcome.events.reduce(0) { acc, e in
-            if case .thinkingComplete = e { return acc + 1 }
+            if case .thinkingCompleted = e { return acc + 1 }
             return acc
         }
         XCTAssertLessThanOrEqual(
             completeCount,
             1,
-            "retry must not surface more than one .thinkingComplete to the consumer"
+            "retry must not surface more than one .thinkingCompleted to the consumer"
         )
     }
 

--- a/Tests/ManifoldInferenceTests/BackendCapabilityMatrixTests.swift
+++ b/Tests/ManifoldInferenceTests/BackendCapabilityMatrixTests.swift
@@ -182,7 +182,7 @@ final class BackendCapabilityMatrixTests: XCTestCase {
             switch event {
             case .thinkingToken:
                 sawThinkingToken = true
-            case .thinkingComplete:
+            case .thinkingCompleted:
                 sawThinkingComplete = true
             default:
                 break
@@ -191,7 +191,7 @@ final class BackendCapabilityMatrixTests: XCTestCase {
 
         XCTAssertTrue(warnings.snapshot().isEmpty)
         XCTAssertTrue(sawThinkingToken, "a backend advertising thinking must surface reasoning tokens when produced")
-        XCTAssertTrue(sawThinkingComplete, "thinking tokens must be closed by thinkingComplete")
+        XCTAssertTrue(sawThinkingComplete, "thinking tokens must be closed by thinkingCompleted")
     }
 
     private func capabilities(

--- a/Tests/ManifoldInferenceTests/GenerationQueueTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueueTests.swift
@@ -492,14 +492,14 @@ final class GenerationQueueTests: XCTestCase {
 
         // Active request belongs to keepSession.
         let (_, activeStream) = try coord.enqueue(
-            messages: [("user", "active")], priority: .normal, sessionID: keepSession
+            messages: [("user", "active")], priority: .normal, requestGroupID: keepSession
         )
         // Queued: one matching keep, one not.
         let (_, keepStream) = try coord.enqueue(
-            messages: [("user", "keep")], priority: .normal, sessionID: keepSession
+            messages: [("user", "keep")], priority: .normal, requestGroupID: keepSession
         )
         let (_, dropStream) = try coord.enqueue(
-            messages: [("user", "drop")], priority: .normal, sessionID: dropSession
+            messages: [("user", "drop")], priority: .normal, requestGroupID: dropSession
         )
 
         await coord.discardRequests(notMatching: keepSession)
@@ -708,7 +708,7 @@ final class GenerationQueueTests: XCTestCase {
     /// When the per-token loop sees `.critical` thermal state mid-stream, the
     /// coordinator must pause via the injected sleep hook, re-check the
     /// provider after each sleep, and resume cleanly when the state drops
-    /// below `.critical`. Exactly one `.diagnosticThrottle` event must be
+    /// below `.critical`. Exactly one `.throttleDiagnostic` event must be
     /// emitted per pause cycle (not one per re-check tick).
     ///
     /// The test injects a deterministic provider that returns `.critical` for
@@ -755,7 +755,7 @@ final class GenerationQueueTests: XCTestCase {
             switch event {
             case .token(let t):
                 tokens.append(t)
-            case .diagnosticThrottle(let reason):
+            case .throttleDiagnostic(let reason):
                 throttleEvents.append(reason)
             default:
                 break
@@ -765,7 +765,7 @@ final class GenerationQueueTests: XCTestCase {
         XCTAssertEqual(tokens, ["a", "b"], "generation must complete after pause")
         XCTAssertEqual(
             throttleEvents.count, 1,
-            "exactly one .diagnosticThrottle event must be emitted per pause cycle, not per re-check"
+            "exactly one .throttleDiagnostic event must be emitted per pause cycle, not per re-check"
         )
         XCTAssertTrue(
             throttleEvents.first?.contains("critical") ?? false,
@@ -834,7 +834,7 @@ final class GenerationQueueTests: XCTestCase {
         // below is the real assertion that the activeTask unwinds.
         var sawThrottle = false
         for try await event in stream.events {
-            if case .diagnosticThrottle = event {
+            if case .throttleDiagnostic = event {
                 sawThrottle = true
                 break
             }

--- a/Tests/ManifoldInferenceTests/GenerationQueueToolLoopTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueueToolLoopTests.swift
@@ -9,7 +9,7 @@ import ManifoldTestSupport
 ///   `.toolResult` surfaces on the stream, next turn is invoked with the
 ///   result threaded through tool-aware history
 /// - iteration cap: after `maxToolIterations` tool calls the loop stops and
-///   emits `.toolLoopLimitReached(iterations:)`
+///   emits `.toolIterationLimitExceeded(iterations:)`
 /// - repeat-call short-circuit: identical `(name, args)` twice in a row
 ///   bypasses the executor
 /// - byte-budget guard: a tool that returns huge content terminates the loop
@@ -314,7 +314,7 @@ final class GenerationQueueToolLoopTests: XCTestCase {
 
     func test_loopCap_emitsToolLoopLimitReached() async throws {
         // Model emits a distinct tool call on every turn — coordinator must
-        // stop at `maxToolIterations` and surface `.toolLoopLimitReached`.
+        // stop at `maxToolIterations` and surface `.toolIterationLimitExceeded`.
         // Arguments vary per turn so the repeat-call short-circuit does not
         // bypass executor invocations.
         let executor = RecordingExecutor(name: "spam") { _ in
@@ -337,7 +337,7 @@ final class GenerationQueueToolLoopTests: XCTestCase {
         let events = try await collectEvents(stream)
 
         let limits = events.compactMap { event -> Int? in
-            if case .toolLoopLimitReached(let n) = event { return n } else { return nil }
+            if case .toolIterationLimitExceeded(let n) = event { return n } else { return nil }
         }
         // Sabotage check: deleting the `iterations > limit` guard in
         // runToolDispatchLoop lets the loop run forever (test times out) or,
@@ -441,7 +441,7 @@ extension GenerationQueue {
         messages: [(role: String, content: String)],
         config: GenerationConfig,
         priority: GenerationPriority = .normal,
-        sessionID: UUID? = nil
+        requestGroupID: UUID? = nil
     ) throws -> (token: GenerationRequestToken, stream: GenerationStream) {
         try enqueue(
             messages: messages,
@@ -456,7 +456,7 @@ extension GenerationQueue {
             toolChoice: config.toolChoice,
             maxToolIterations: config.maxToolIterations,
             priority: priority,
-            sessionID: sessionID
+            requestGroupID: requestGroupID
         )
     }
 }

--- a/Tests/ManifoldInferenceTests/GenerationStreamConsumerThinkingTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationStreamConsumerThinkingTests.swift
@@ -26,14 +26,14 @@ final class GenerationStreamConsumerThinkingTests: XCTestCase {
         XCTAssertEqual(action, .appendThinkingText(""))
     }
 
-    // MARK: - 2. thinkingComplete → finalizeThinking
+    // MARK: - 2. thinkingCompleted → finalizeThinking
 
     func test_thinkingComplete_mapsToFinalizeThinking() {
         var consumer = GenerationStreamConsumer()
-        let action = consumer.handle(.thinkingComplete)
+        let action = consumer.handle(.thinkingCompleted)
 
         XCTAssertEqual(action, .finalizeThinking,
-            ".thinkingComplete must map to .finalizeThinking so the UI commits the accumulator")
+            ".thinkingCompleted must map to .finalizeThinking so the UI commits the accumulator")
 
         // Sabotage check: returning .appendText("") instead of .finalizeThinking would
         // leave the thinking accumulator open indefinitely — this equality check would fail.
@@ -79,7 +79,7 @@ final class GenerationStreamConsumerThinkingTests: XCTestCase {
         let events: [GenerationEvent] = [
             .thinkingToken("reason"),
             .thinkingToken(" more"),
-            .thinkingComplete,
+            .thinkingCompleted,
             .token("answer"),
         ]
         let actions = events.map { consumer.handle($0) }

--- a/Tests/ManifoldInferenceTests/GrammarPhaseGateTests.swift
+++ b/Tests/ManifoldInferenceTests/GrammarPhaseGateTests.swift
@@ -73,7 +73,7 @@ final class GrammarPhaseGateTests: XCTestCase {
     }
 
     /// The flip must land on the FIRST post-`</think>` token, not one token late.
-    /// `.thinkingComplete` fires in the same ingest that consumes the close marker,
+    /// `.thinkingCompleted` fires in the same ingest that consumes the close marker,
     /// so the very next sample is strict.
     func test_grammarEngagesOnFirstTokenAfterThinkingComplete() {
         let chunks = ["<think>", "x", "</think>", "first", "second"]
@@ -112,16 +112,16 @@ final class GrammarPhaseGateTests: XCTestCase {
     func test_observe_isIdempotentOnceActive() {
         var gate = GrammarPhaseGate(gateOnThinking: true)
         XCTAssertFalse(gate.isGrammarActive)
-        gate.observe([.thinkingComplete])
+        gate.observe([.thinkingCompleted])
         XCTAssertTrue(gate.isGrammarActive)
         // A nested/duplicate close or stray thinking token must not reopen the gate.
         gate.observe([.thinkingToken("x")])
-        gate.observe([.thinkingComplete])
+        gate.observe([.thinkingCompleted])
         XCTAssertTrue(gate.isGrammarActive, "Grammar must stay engaged once the block has closed")
     }
 
     /// `.thinkingToken` events alone (reasoning still in progress) must NOT engage
-    /// the grammar — only the `.thinkingComplete` boundary does.
+    /// the grammar — only the `.thinkingCompleted` boundary does.
     func test_thinkingTokensAloneDoNotEngageGrammar() {
         var gate = GrammarPhaseGate(gateOnThinking: true)
         gate.observe([.thinkingToken("still"), .thinkingToken(" reasoning")])

--- a/Tests/ManifoldInferenceTests/InferenceServiceFacadeTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceFacadeTests.swift
@@ -89,7 +89,7 @@ final class InferenceServiceFacadeTests: XCTestCase {
 
         // Registration
         service.registerBackendFactory { _ in nil }
-        service.registerCloudBackendFactory { _ in nil }
+        service.registerEndpointBackendFactory { _ in nil }
         service.declareSupport(for: .gguf)
         service.declareSupport(for: .ollama)
 

--- a/Tests/ManifoldInferenceTests/InferenceServiceProgressTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceProgressTests.swift
@@ -213,12 +213,12 @@ final class InferenceServiceProgressTests: XCTestCase {
     func test_modelLoadProgress_cloudLoadAlsoPublishesProgress() async throws {
         let service = InferenceService()
         let backend = ProgressReportingCloudBackend()
-        service.registerCloudBackendFactory { provider in
+        service.registerEndpointBackendFactory { provider in
             provider == .ollama ? backend : nil
         }
 
         let endpoint = APIEndpointRecord(name: "Test", provider: .ollama, modelName: "demo")
-        let task = Task { try await service.loadCloudBackend(from: endpoint) }
+        let task = Task { try await service.loadEndpointBackend(from: endpoint) }
         await backend.waitUntilLoadStarted()
 
         XCTAssertEqual(service.modelLoadProgress, 0.0)
@@ -374,7 +374,7 @@ private final class ProgressReportingBackend: InferenceBackend,
 }
 
 /// Cloud variant of `ProgressReportingBackend` that conforms to the
-/// URL+model configurable protocol so `loadCloudBackend(from:)` accepts it.
+/// URL+model configurable protocol so `loadEndpointBackend(from:)` accepts it.
 private final class ProgressReportingCloudBackend: InferenceBackend,
                                                    LoadProgressReporting,
                                                    EndpointBackendURLModelConfigurable,

--- a/Tests/ManifoldInferenceTests/InferenceServiceProgressTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceProgressTests.swift
@@ -377,7 +377,7 @@ private final class ProgressReportingBackend: InferenceBackend,
 /// URL+model configurable protocol so `loadCloudBackend(from:)` accepts it.
 private final class ProgressReportingCloudBackend: InferenceBackend,
                                                    LoadProgressReporting,
-                                                   CloudBackendURLModelConfigurable,
+                                                   EndpointBackendURLModelConfigurable,
                                                    @unchecked Sendable {
     var isModelLoaded = false
     var isGenerating = false

--- a/Tests/ManifoldInferenceTests/InferenceServiceQueueTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceQueueTests.swift
@@ -382,17 +382,17 @@ final class InferenceServiceQueueTests: XCTestCase {
         let _ = try service.enqueue(
             messages: [("user", "active")],
             priority: .normal,
-            sessionID: sessionA
+            requestGroupID: sessionA
         )
         let (_, streamA) = try service.enqueue(
             messages: [("user", "queued-A")],
             priority: .normal,
-            sessionID: sessionA
+            requestGroupID: sessionA
         )
         let (_, streamB) = try service.enqueue(
             messages: [("user", "queued-B")],
             priority: .normal,
-            sessionID: sessionB
+            requestGroupID: sessionB
         )
 
         await service.discardRequests(notMatching: sessionB)
@@ -410,24 +410,24 @@ final class InferenceServiceQueueTests: XCTestCase {
                        "Session B request should be promoted to active after A is discarded")
     }
 
-    // MARK: - 10. nil sessionID never discarded
+    // MARK: - 10. nil requestGroupID never discarded
 
     func test_discardRequests_nilSessionID_neverDiscarded() async throws {
         let (service, _) = makeService()
         let sessionB = UUID()
 
         let _ = try service.enqueue(messages: [("user", "active")], priority: .normal)
-        // nil sessionID — session-agnostic.
+        // nil requestGroupID — group-agnostic.
         let (_, streamNil) = try service.enqueue(
             messages: [("user", "agnostic")],
             priority: .normal,
-            sessionID: nil
+            requestGroupID: nil
         )
 
         await service.discardRequests(notMatching: sessionB)
 
         XCTAssertEqual(streamNil.phase, .queued,
-                       "nil sessionID should survive discardRequests")
+                       "nil requestGroupID should survive discardRequests")
     }
 
     // MARK: - 11. isGenerating false when queue empty

--- a/Tests/ManifoldInferenceTests/InferenceServiceRegressionLockTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceRegressionLockTests.swift
@@ -40,7 +40,7 @@ final class InferenceServiceRegressionLockTests: XCTestCase {
         let service = InferenceService()
         service.registerBackendFactory { _ in nil }
         service.declareSupport(for: .gguf)
-        service.registerCloudBackendFactory { _ in nil }
+        service.registerEndpointBackendFactory { _ in nil }
         service.declareSupport(for: .ollama)
 
         let snapshot = service.registeredBackendSnapshot()

--- a/Tests/ManifoldInferenceTests/InferenceServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceTests.swift
@@ -934,7 +934,7 @@ private final class MockTokenUsageBackend: InferenceBackend,
 }
 
 private final class MockCloudURLModelBackend: InferenceBackend,
-                                              CloudBackendURLModelConfigurable,
+                                              EndpointBackendURLModelConfigurable,
                                               @unchecked Sendable {
     var isModelLoaded: Bool = false
     var isGenerating: Bool = false
@@ -973,7 +973,7 @@ private final class MockCloudURLModelBackend: InferenceBackend,
 }
 
 private final class MockCloudKeychainBackend: InferenceBackend,
-                                               CloudBackendKeychainConfigurable,
+                                               EndpointBackendKeychainConfigurable,
                                                @unchecked Sendable {
     var isModelLoaded: Bool = false
     var isGenerating: Bool = false
@@ -1077,7 +1077,7 @@ private actor ControlledLoadGate {
 }
 
 private final class ControlledLoadBackend: InferenceBackend,
-                                           CloudBackendURLModelConfigurable,
+                                           EndpointBackendURLModelConfigurable,
                                            @unchecked Sendable {
     var isModelLoaded = false
     var isGenerating = false

--- a/Tests/ManifoldInferenceTests/InferenceServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceTests.swift
@@ -135,16 +135,16 @@ final class InferenceServiceTests: XCTestCase {
                      "debug init without modelName leaves activeModelName unknown, not a copy of the backend label")
     }
 
-    // MARK: - loadCloudBackend
+    // MARK: - loadEndpointBackend
 
-    func test_loadCloudBackend_invalidURL_throwsError() async {
+    func test_loadEndpointBackend_invalidURL_throwsError() async {
         let service = InferenceService()
         // A null byte makes URL(string:) return nil on all Apple platforms.
         let badURL = "http://foo\0bar"
         let endpoint = APIEndpointRecord(name: "Bad", provider: .custom, baseURL: badURL)
 
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
             XCTFail("Expected CloudBackendError.invalidURL to be thrown")
         } catch CloudBackendError.invalidURL(let raw) {
             XCTAssertEqual(raw, badURL)
@@ -153,9 +153,9 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    // MARK: - loadCloudBackend endpoint validation (SSRF guard)
+    // MARK: - loadEndpointBackend endpoint validation (SSRF guard)
 
-    func test_loadCloudBackend_privateIPv4_throwsInvalidURL() async {
+    func test_loadEndpointBackend_privateIPv4_throwsInvalidURL() async {
         let service = InferenceService()
         let cases = [
             "https://192.168.1.100/api",
@@ -165,7 +165,7 @@ final class InferenceServiceTests: XCTestCase {
         for baseURL in cases {
             let endpoint = APIEndpointRecord(name: "Private", provider: .custom, baseURL: baseURL)
             do {
-                try await service.loadCloudBackend(from: endpoint)
+                try await service.loadEndpointBackend(from: endpoint)
                 XCTFail("Expected CloudBackendError.invalidURL for \(baseURL)")
             } catch CloudBackendError.invalidURL {
                 // expected
@@ -175,7 +175,7 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_loadCloudBackend_linkLocalIPv4_throwsInvalidURL() async {
+    func test_loadEndpointBackend_linkLocalIPv4_throwsInvalidURL() async {
         let service = InferenceService()
         let endpoint = APIEndpointRecord(
             name: "IMDS",
@@ -183,7 +183,7 @@ final class InferenceServiceTests: XCTestCase {
             baseURL: "https://169.254.169.254/latest/meta-data"
         )
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
             XCTFail("Expected CloudBackendError.invalidURL for link-local address")
         } catch CloudBackendError.invalidURL {
             // expected
@@ -198,7 +198,7 @@ final class InferenceServiceTests: XCTestCase {
             baseURL: "https://api.example.com"
         )
         do {
-            try await service.loadCloudBackend(from: publicEndpoint)
+            try await service.loadEndpointBackend(from: publicEndpoint)
         } catch CloudBackendError.invalidURL(let url) {
             XCTFail("Public endpoint should not be rejected as invalid URL, got \(url)")
         } catch {
@@ -207,7 +207,7 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_loadCloudBackend_insecureRemoteScheme_throwsInvalidURL() async {
+    func test_loadEndpointBackend_insecureRemoteScheme_throwsInvalidURL() async {
         let service = InferenceService()
         let endpoint = APIEndpointRecord(
             name: "Insecure Remote",
@@ -215,7 +215,7 @@ final class InferenceServiceTests: XCTestCase {
             baseURL: "http://api.example.com"
         )
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
             XCTFail("Expected CloudBackendError.invalidURL for http:// remote endpoint")
         } catch CloudBackendError.invalidURL {
             // expected
@@ -224,7 +224,7 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_loadCloudBackend_localhostHTTP_isNotRejectedByURLValidation() async {
+    func test_loadEndpointBackend_localhostHTTP_isNotRejectedByURLValidation() async {
         let service = InferenceService()
         let endpoint = APIEndpointRecord(
             name: "Local Ollama",
@@ -232,7 +232,7 @@ final class InferenceServiceTests: XCTestCase {
             baseURL: "http://localhost:11434"
         )
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
         } catch CloudBackendError.invalidURL(let url) {
             XCTFail("Localhost http:// should not fail URL validation, got invalidURL(\(url))")
         } catch {
@@ -240,7 +240,7 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_loadCloudBackend_ipv6LinkLocal_throwsInvalidURL() async {
+    func test_loadEndpointBackend_ipv6LinkLocal_throwsInvalidURL() async {
         let service = InferenceService()
         let endpoint = APIEndpointRecord(
             name: "IPv6 Link-Local",
@@ -248,7 +248,7 @@ final class InferenceServiceTests: XCTestCase {
             baseURL: "https://[fe80::1]/api"
         )
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
             XCTFail("Expected CloudBackendError.invalidURL for IPv6 link-local address")
         } catch CloudBackendError.invalidURL {
             // expected
@@ -257,12 +257,12 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_loadCloudBackend_noFactoryRegistered_throwsError() async {
+    func test_loadEndpointBackend_noFactoryRegistered_throwsError() async {
         let service = InferenceService()
         let endpoint = APIEndpointRecord(name: "Ollama", provider: .ollama)
 
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
             XCTFail("Expected InferenceError.inferenceFailure to be thrown")
         } catch InferenceError.inferenceFailure {
             // expected
@@ -271,14 +271,14 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_loadCloudBackend_setsIsModelLoaded() async throws {
+    func test_loadEndpointBackend_setsIsModelLoaded() async throws {
         let service = InferenceService()
         let mock = MockCloudURLModelBackend()
 
-        service.registerCloudBackendFactory { _ in mock }
+        service.registerEndpointBackendFactory { _ in mock }
 
         let endpoint = APIEndpointRecord(name: "Ollama", provider: .ollama)
-        try await service.loadCloudBackend(from: endpoint)
+        try await service.loadEndpointBackend(from: endpoint)
 
         XCTAssertTrue(service.isModelLoaded)
         XCTAssertEqual(service.activeBackendName, BackendName.ollama.rawValue)
@@ -289,15 +289,15 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertTrue(mock.didConfigureBeforeLoad)
     }
 
-    func test_loadCloudBackend_unloadsExistingModel() async throws {
+    func test_loadEndpointBackend_unloadsExistingModel() async throws {
         let firstMock = MockInferenceBackend()
         let service = InferenceService(backend: firstMock, name: "First")
 
         let cloudMock = MockCloudURLModelBackend()
-        service.registerCloudBackendFactory { _ in cloudMock }
+        service.registerEndpointBackendFactory { _ in cloudMock }
 
         let endpoint = APIEndpointRecord(name: "Ollama", provider: .ollama)
-        try await service.loadCloudBackend(from: endpoint)
+        try await service.loadEndpointBackend(from: endpoint)
 
         // The old backend should have been unloaded.
         XCTAssertEqual(firstMock.unloadCallCount, 1, "Old backend should be unloaded")
@@ -306,10 +306,10 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertEqual(service.activeBackendName, BackendName.ollama.rawValue)
     }
 
-    func test_loadCloudBackend_configuresKeychainBackend_beforeLoad() async throws {
+    func test_loadEndpointBackend_configuresKeychainBackend_beforeLoad() async throws {
         let service = InferenceService()
         let mock = MockCloudKeychainBackend()
-        service.registerCloudBackendFactory { _ in mock }
+        service.registerEndpointBackendFactory { _ in mock }
 
         let endpoint = APIEndpointRecord(
             name: "Claude",
@@ -317,7 +317,7 @@ final class InferenceServiceTests: XCTestCase {
             baseURL: "https://api.anthropic.com",
             modelName: "claude-sonnet-4-6"
         )
-        try await service.loadCloudBackend(from: endpoint)
+        try await service.loadEndpointBackend(from: endpoint)
 
         XCTAssertEqual(mock.configuredBaseURL?.absoluteString, endpoint.baseURL)
         XCTAssertEqual(mock.configuredModelName, endpoint.modelName)
@@ -325,15 +325,15 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertTrue(mock.didConfigureBeforeLoad)
     }
 
-    func test_loadCloudBackend_nonConfigurableBackend_throwsError() async {
+    func test_loadEndpointBackend_nonConfigurableBackend_throwsError() async {
         let service = InferenceService()
         let mock = MockInferenceBackend()
-        service.registerCloudBackendFactory { _ in mock }
+        service.registerEndpointBackendFactory { _ in mock }
 
         let endpoint = APIEndpointRecord(name: "Ollama", provider: .ollama)
 
         do {
-            try await service.loadCloudBackend(from: endpoint)
+            try await service.loadEndpointBackend(from: endpoint)
             XCTFail("Expected InferenceError.inferenceFailure when backend does not conform to config protocol")
         } catch InferenceError.inferenceFailure {
             // expected
@@ -384,12 +384,12 @@ final class InferenceServiceTests: XCTestCase {
         XCTAssertEqual(service.activeBackendName, BackendName.foundation.rawValue)
     }
 
-    func test_loadCloudBackend_rapidEndpointSwitch_latestRequestWins_staleCompletionSuppressed() async throws {
+    func test_loadEndpointBackend_rapidEndpointSwitch_latestRequestWins_staleCompletionSuppressed() async throws {
         let service = InferenceService()
         let firstBackend = ControlledLoadBackend()
         let secondBackend = ControlledLoadBackend()
 
-        service.registerCloudBackendFactory { provider in
+        service.registerEndpointBackendFactory { provider in
             switch provider {
             case .ollama:
                 firstBackend
@@ -404,12 +404,12 @@ final class InferenceServiceTests: XCTestCase {
         let secondEndpoint = makeEndpoint(name: "Second", provider: .lmStudio, modelName: "second-model")
 
         let firstTask = Task {
-            try await service.loadCloudBackend(from: firstEndpoint)
+            try await service.loadEndpointBackend(from: firstEndpoint)
         }
         await firstBackend.waitUntilLoadStarted()
 
         let secondTask = Task {
-            try await service.loadCloudBackend(from: secondEndpoint)
+            try await service.loadEndpointBackend(from: secondEndpoint)
         }
         await secondBackend.waitUntilLoadStarted()
 
@@ -681,25 +681,25 @@ final class InferenceServiceTests: XCTestCase {
         }
     }
 
-    func test_registerCloudBackendFactory_fallsBackToSecond() async throws {
+    func test_registerEndpointBackendFactory_fallsBackToSecond() async throws {
         let service = InferenceService()
 
         var firstCallCount = 0
-        service.registerCloudBackendFactory { provider in
+        service.registerEndpointBackendFactory { provider in
             firstCallCount += 1
             return nil  // always rejects
         }
 
         var secondCallCount = 0
         let secondMock = MockCloudURLModelBackend()
-        service.registerCloudBackendFactory { provider in
+        service.registerEndpointBackendFactory { provider in
             guard provider == .ollama else { return nil }
             secondCallCount += 1
             return secondMock
         }
 
         let endpoint = APIEndpointRecord(name: "Ollama", provider: .ollama)
-        try await service.loadCloudBackend(from: endpoint)
+        try await service.loadEndpointBackend(from: endpoint)
 
         XCTAssertEqual(firstCallCount, 1, "First cloud factory should be called once")
         XCTAssertEqual(secondCallCount, 1, "Second cloud factory should be called after first rejects")
@@ -784,13 +784,13 @@ final class InferenceServiceTests: XCTestCase {
                        "loadModel must NOT run on the main thread — blocking there triggers watchdog timeouts")
     }
 
-    func test_loadCloudBackend_doesNotCallBackendLoadOnMainThread() async throws {
+    func test_loadEndpointBackend_doesNotCallBackendLoadOnMainThread() async throws {
         let service = InferenceService()
         let mock = ControlledLoadBackend()
-        service.registerCloudBackendFactory { _ in mock }
+        service.registerEndpointBackendFactory { _ in mock }
 
         let endpointTask = Task {
-            try await service.loadCloudBackend(from: makeEndpoint(name: "Cloud", provider: .ollama, modelName: "m"))
+            try await service.loadEndpointBackend(from: makeEndpoint(name: "Cloud", provider: .ollama, modelName: "m"))
         }
         await mock.waitUntilLoadStarted()
 

--- a/Tests/ManifoldInferenceTests/MessageEnqueueTests.swift
+++ b/Tests/ManifoldInferenceTests/MessageEnqueueTests.swift
@@ -119,7 +119,7 @@ final class MessageEnqueueTests: XCTestCase {
     // MARK: - Value-typed config entry point
 
     /// Canonical exercise of the value-typed
-    /// ``InferenceService/enqueue(messages:config:priority:sessionID:)`` entry
+    /// ``InferenceService/enqueue(messages:config:priority:requestGroupID:)`` entry
     /// point introduced when the ~18-parameter sampling list was collapsed onto
     /// ``GenerationConfig``. Pins that a caller-built config reaches the backend
     /// verbatim, with every field preserved.
@@ -141,7 +141,7 @@ final class MessageEnqueueTests: XCTestCase {
             messages: [.user("hello")],
             config: config,
             priority: .normal,
-            sessionID: nil
+            requestGroupID: nil
         )
         for try await _ in stream.events {}
 

--- a/Tests/ManifoldInferenceTests/ModelLifecycleCoordinatorTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelLifecycleCoordinatorTests.swift
@@ -7,7 +7,7 @@ import os
 /// The coordinator's `beginLoadRequest`, `canCommitLoad`, `invalidateOutstandingLoads`,
 /// `finishLoadAttemptWithSuccess`, and `finishLoadAttemptWithFailure` methods are all
 /// private. These tests exercise them indirectly through the public/internal API:
-/// `loadModel(from:)`, `loadCloudBackend(from:)`, and `unloadModel()`, then assert
+/// `loadModel(from:)`, `loadEndpointBackend(from:)`, and `unloadModel()`, then assert
 /// on the observable state properties (`isModelLoaded`, `activeBackendName`,
 /// `modelLoadProgress`).
 ///

--- a/Tests/ManifoldInferenceTests/OutputParserSessionTests.swift
+++ b/Tests/ManifoldInferenceTests/OutputParserSessionTests.swift
@@ -18,7 +18,7 @@ final class OutputParserSessionTests: XCTestCase {
     }
 
     private func completions(_ events: [GenerationEvent]) -> Int {
-        events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+        events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }.count
     }
 
     private func toolCalls(_ events: [GenerationEvent]) -> [ToolCall] {
@@ -123,7 +123,7 @@ final class OutputParserSessionTests: XCTestCase {
     // MARK: - Adversarial byte-boundary splitting
 
     /// Coalesces adjacent same-kind `.token` / `.thinkingToken` events into one,
-    /// leaving every other event (`.thinkingComplete`, `.toolCall`, …) as a
+    /// leaving every other event (`.thinkingCompleted`, `.toolCall`, …) as a
     /// boundary. Two `.token` fragments produced only because a chunk split mid
     /// visible text are semantically identical to one merged `.token` — the
     /// chunk-invariance property is about *content and routing*, not how many

--- a/Tests/ManifoldInferenceTests/ParallelToolCallOrderingTests.swift
+++ b/Tests/ManifoldInferenceTests/ParallelToolCallOrderingTests.swift
@@ -55,9 +55,9 @@ final class ParallelToolCallOrderingTests: XCTestCase {
             case .toolCall(let c):
                 calls.append(c)
             case .prefillProgress, .token, .usage,
-                 .thinkingToken, .thinkingComplete, .thinkingSignature,
-                 .toolResult, .toolProgress, .toolLoopLimitReached,
-                 .kvCacheReuse, .diagnosticThrottle,
+                 .thinkingToken, .thinkingCompleted, .thinkingSignature,
+                 .toolResult, .toolProgress, .toolIterationLimitExceeded,
+                 .kvCacheReuse, .throttleDiagnostic,
                  .toolCallStart, .toolCallArgumentsDelta,
                  .toolDispatchStarted, .toolDispatchCompleted,
                  .handoffRequested:

--- a/Tests/ManifoldInferenceTests/ThinkingMarkerLeakRegressionTests.swift
+++ b/Tests/ManifoldInferenceTests/ThinkingMarkerLeakRegressionTests.swift
@@ -21,7 +21,7 @@ final class ThinkingMarkerLeakRegressionTests: XCTestCase {
     }
 
     private func countCompletions(_ events: [GenerationEvent]) -> Int {
-        events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+        events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }.count
     }
 
     // MARK: - Sniff-Replay Contract
@@ -30,7 +30,7 @@ final class ThinkingMarkerLeakRegressionTests: XCTestCase {
     /// "<think>reasoning</think>visible answer". When the driver buffers that
     /// prefix in sniff mode and replays it through `ThinkingParser(.qwen3)`,
     /// the parser must separate `reasoning` into `.thinkingToken` events,
-    /// emit one `.thinkingComplete`, and yield `visible answer` as `.token`.
+    /// emit one `.thinkingCompleted`, and yield `visible answer` as `.token`.
     ///
     /// Before the fix, the Llama3 template disabled `ThinkingParser` entirely
     /// (`PromptTemplate.llama3.thinkingMarkers == nil`) and the raw `<think>`
@@ -56,7 +56,7 @@ final class ThinkingMarkerLeakRegressionTests: XCTestCase {
         XCTAssertEqual(collectVisible(all), "visible answer",
                        "Content after </think> must be routed to .token — not leaked as raw tags")
         XCTAssertEqual(countCompletions(all), 1,
-                       "Exactly one .thinkingComplete must fire on the 1→0 depth transition")
+                       "Exactly one .thinkingCompleted must fire on the 1→0 depth transition")
         XCTAssertFalse(collectVisible(all).contains("<think>"),
                        "Raw <think> must NEVER appear in visible tokens — that is the leak we are preventing")
         XCTAssertFalse(collectVisible(all).contains("</think>"),
@@ -90,7 +90,7 @@ final class ThinkingMarkerLeakRegressionTests: XCTestCase {
     /// and correctly close when `</think>` arrives in a later chunk.
     ///
     /// Sabotage check: reset the parser between chunks (delete the `var` and
-    /// make it `let` per chunk). `<think>` never closes, `.thinkingComplete`
+    /// make it `let` per chunk). `<think>` never closes, `.thinkingCompleted`
     /// never fires, and the assertion `completions == 1` fails.
     func test_sniffBufferReplay_thenStreamedTail_closesAcrossChunks() {
         var parser = ThinkingParser(markers: .qwen3)
@@ -107,7 +107,7 @@ final class ThinkingMarkerLeakRegressionTests: XCTestCase {
                       "Pre-<think> text must still be visible after streamed tail")
         XCTAssertTrue(collectVisible(events).contains("visible"))
         XCTAssertEqual(countCompletions(events), 1,
-                       "Close tag arriving in a later chunk must still fire .thinkingComplete exactly once")
+                       "Close tag arriving in a later chunk must still fire .thinkingCompleted exactly once")
         XCTAssertFalse(collectVisible(events).contains("<think>"))
         XCTAssertFalse(collectVisible(events).contains("</think>"))
     }
@@ -131,6 +131,6 @@ final class ThinkingMarkerLeakRegressionTests: XCTestCase {
         XCTAssertEqual(collectThinking(all), "",
                        "Non-reasoning text must never produce .thinkingToken events")
         XCTAssertEqual(countCompletions(all), 0,
-                       "No .thinkingComplete without a <think> open tag")
+                       "No .thinkingCompleted without a <think> open tag")
     }
 }

--- a/Tests/ManifoldInferenceTests/ThinkingMarkersPresetsTests.swift
+++ b/Tests/ManifoldInferenceTests/ThinkingMarkersPresetsTests.swift
@@ -12,7 +12,7 @@ private func collectThinking(_ events: [GenerationEvent]) -> String {
 }
 
 private func countCompletions(_ events: [GenerationEvent]) -> Int {
-    events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+    events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }.count
 }
 
 /// Runs a single-block reasoning payload through a `ThinkingParser` parameterized
@@ -56,7 +56,7 @@ final class ThinkingMarkersPresetsTests: XCTestCase {
         XCTAssertEqual(r.visible, "answer",
             "Content after </thinking> must be emitted as .token")
         XCTAssertEqual(r.completions, 1,
-            "Exactly one .thinkingComplete event should fire on the 1→0 depth transition")
+            "Exactly one .thinkingCompleted event should fire on the 1→0 depth transition")
 
         // Sabotage check: swapping `.mistralReasoning` for `.qwen3` makes the parser
         // search for the `<think>` / `</think>` pair. Both are substrings of the
@@ -202,7 +202,7 @@ final class ThinkingMarkersPresetsTests: XCTestCase {
         XCTAssertEqual(r.visible, "answer",
             "Content after <|end_of_turn> must be emitted as .token")
         XCTAssertEqual(r.completions, 1,
-            "Exactly one .thinkingComplete must fire on the 1→0 depth transition")
+            "Exactly one .thinkingCompleted must fire on the 1→0 depth transition")
 
         // Sabotage check: using .qwen3 markers instead would search for "<think>" /
         // "</think>", miss the Gemma 4 open tag, and emit everything as visible text
@@ -250,7 +250,7 @@ final class ThinkingMarkersPresetsTests: XCTestCase {
         XCTAssertTrue(collectThinking(all).contains("partial thought"),
             "Unclosed Gemma 4 thinking block must be flushed as .thinkingToken by finalize()")
         XCTAssertEqual(countCompletions(all), 0,
-            "An unclosed block must NOT emit .thinkingComplete")
+            "An unclosed block must NOT emit .thinkingCompleted")
 
         // Sabotage check: if finalize() returned [] for a non-empty thinking buffer,
         // the partial chain-of-thought would be silently dropped.

--- a/Tests/ManifoldInferenceTests/ThinkingParserEdgeCaseTests.swift
+++ b/Tests/ManifoldInferenceTests/ThinkingParserEdgeCaseTests.swift
@@ -10,7 +10,7 @@ private func collectThinking(_ events: [GenerationEvent]) -> String {
 }
 
 private func countCompletions(_ events: [GenerationEvent]) -> Int {
-    events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+    events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }.count
 }
 
 /// Edge-case tests for `ThinkingParser` covering boundary conditions,
@@ -30,7 +30,7 @@ final class ThinkingParserEdgeCaseTests: XCTestCase {
         XCTAssertTrue(collectThinking(allEvents).contains("partial"),
             "Unclosed block content must be emitted as .thinkingToken by finalize()")
         XCTAssertEqual(countCompletions(allEvents), 0,
-            "An unclosed block must NOT emit .thinkingComplete")
+            "An unclosed block must NOT emit .thinkingCompleted")
 
         // Sabotage check: if finalize() returned [] for non-empty buffers, the
         // partial content would be silently discarded and this test would fail.
@@ -47,15 +47,15 @@ final class ThinkingParserEdgeCaseTests: XCTestCase {
         XCTAssertEqual(collectThinking(allEvents), "",
             "An empty <think></think> block should emit no .thinkingToken events")
         XCTAssertEqual(countCompletions(allEvents), 1,
-            "An empty think block must still fire .thinkingComplete")
+            "An empty think block must still fire .thinkingCompleted")
         XCTAssertEqual(collectVisible(allEvents), "text",
             "Text after the empty block should be visible")
 
-        // Sabotage check: if the parser skipped .thinkingComplete for empty blocks,
+        // Sabotage check: if the parser skipped .thinkingCompleted for empty blocks,
         // the UI would never finalize an in-progress thinking accumulator.
     }
 
-    // MARK: - 3. Multiple blocks — thinkingComplete count
+    // MARK: - 3. Multiple blocks — thinkingCompleted count
 
     func test_multipleThinkBlocks_thinkingCompleteCountEquals2() {
         var parser = ThinkingParser()
@@ -64,11 +64,11 @@ final class ThinkingParserEdgeCaseTests: XCTestCase {
         let allEvents = events + finalEvents
 
         XCTAssertEqual(countCompletions(allEvents), 2,
-            "Two sequential think blocks must each fire .thinkingComplete (total = 2)")
+            "Two sequential think blocks must each fire .thinkingCompleted (total = 2)")
         XCTAssertEqual(collectThinking(allEvents), "ab",
             "Thinking content from both blocks must be collected")
 
-        // Sabotage check: a parser that only fired .thinkingComplete once would
+        // Sabotage check: a parser that only fired .thinkingCompleted once would
         // cause the UI to finalize after the first block, leaving the second orphaned.
     }
 
@@ -110,7 +110,7 @@ final class ThinkingParserEdgeCaseTests: XCTestCase {
         // Input: <think><think>inner</think>outer</think>text
         //   - depth 0: finds <think>, enters thinking mode (depth=1)
         //   - depth 1: finds first </think>; before it: "<think>inner" → .thinkingToken
-        //     depth returns to 0, .thinkingComplete fires
+        //     depth returns to 0, .thinkingCompleted fires
         //   - depth 0: "outer</think>text" — no open tag found, emitted via finalize as visible
         let events = parser.process("<think><think>inner</think>outer</think>text")
         let finalEvents = parser.finalize()
@@ -129,7 +129,7 @@ final class ThinkingParserEdgeCaseTests: XCTestCase {
             "Text at end of stream must be visible")
 
         XCTAssertEqual(countCompletions(allEvents), 1,
-            "Exactly one .thinkingComplete fires on the single 1→0 depth transition")
+            "Exactly one .thinkingCompleted fires on the single 1→0 depth transition")
 
         // Sabotage check: a recursive-depth implementation would require TWO </think> to reach
         // depth 0, yielding no visible text and keeping 2 completions — this test would fail.

--- a/Tests/ManifoldInferenceTests/ThinkingParserTests.swift
+++ b/Tests/ManifoldInferenceTests/ThinkingParserTests.swift
@@ -12,7 +12,7 @@ private func collectThinking(_ events: [GenerationEvent]) -> String {
 }
 
 private func countCompletions(_ events: [GenerationEvent]) -> Int {
-    events.filter { if case .thinkingComplete = $0 { return true } else { return false } }.count
+    events.filter { if case .thinkingCompleted = $0 { return true } else { return false } }.count
 }
 
 /// Tests for `ThinkingParser` — the chunk-safe reasoning block separator.
@@ -54,10 +54,10 @@ final class ThinkingParserTests: XCTestCase {
         XCTAssertEqual(collectVisible(allEvents), "answer",
             "Content after </think> should be emitted as .token")
         XCTAssertEqual(countCompletions(allEvents), 1,
-            "Exactly one .thinkingComplete event should fire on block close")
+            "Exactly one .thinkingCompleted event should fire on block close")
 
         // Sabotage check: removing the depth transition in ThinkingParser causes
-        // "reason" to also appear in visible output and .thinkingComplete to not fire.
+        // "reason" to also appear in visible output and .thinkingCompleted to not fire.
     }
 
     // MARK: - Split tags
@@ -99,7 +99,7 @@ final class ThinkingParserTests: XCTestCase {
         // A nested <think> tag is treated as literal thinking text, not a depth increment.
         // Input: <think>outer<think>inner</think>still outer</think>text
         //   → depth 0: find <think>, enter thinking
-        //   → depth 1: find </think>, close block at "outer<think>inner", fire .thinkingComplete
+        //   → depth 1: find </think>, close block at "outer<think>inner", fire .thinkingCompleted
         //   → depth 0: "still outer</think>text" — no <think> found → stays in buffer/finalize
         let events = parser.process("<think>outer<think>inner</think>still outer</think>text")
         let finalEvents = parser.finalize()
@@ -118,7 +118,7 @@ final class ThinkingParserTests: XCTestCase {
             "Text after the second </think> is also visible")
 
         XCTAssertEqual(countCompletions(allEvents), 1,
-            "Only one .thinkingComplete fires when depth transitions from 1 to 0")
+            "Only one .thinkingCompleted fires when depth transitions from 1 to 0")
 
         // Sabotage check: if the parser switched to nested-depth mode, "still outer" would
         // become thinking text and this test would fail.
@@ -137,7 +137,7 @@ final class ThinkingParserTests: XCTestCase {
         XCTAssertEqual(collectVisible(allEvents), "betweenend",
             "Text between and after blocks should be visible")
         XCTAssertEqual(countCompletions(allEvents), 2,
-            "Two distinct thinking blocks should each fire .thinkingComplete")
+            "Two distinct thinking blocks should each fire .thinkingCompleted")
 
         // Sabotage check: if the parser reset depth incorrectly between blocks,
         // the second block's content might be emitted as .token instead of .thinkingToken.
@@ -267,7 +267,7 @@ final class ThinkingParserTests: XCTestCase {
         XCTAssertEqual(collectThinking(allEvents), "",
             "No thinking content should be emitted when there is no opening <think> tag")
         XCTAssertEqual(countCompletions(allEvents), 0,
-            "No .thinkingComplete events should fire without a matching open tag")
+            "No .thinkingCompleted events should fire without a matching open tag")
 
         // Sabotage check: if ThinkingParser searched for markers.close when depth == 0,
         // </think> would be consumed and "Visible  text" would be the (wrong) visible output.

--- a/Tests/ManifoldInferenceTests/ToolCallContractTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolCallContractTests.swift
@@ -208,10 +208,10 @@ final class ToolCallContractTests: XCTestCase {
             case .token(let text): tokens.append(text)
             case .toolCall(let call): toolCalls.append(call)
             case .usage: break
-            case .thinkingToken, .thinkingComplete, .thinkingSignature: break
-            case .toolResult, .toolProgress, .toolLoopLimitReached: break
+            case .thinkingToken, .thinkingCompleted, .thinkingSignature: break
+            case .toolResult, .toolProgress, .toolIterationLimitExceeded: break
             case .kvCacheReuse: break
-            case .diagnosticThrottle: break
+            case .throttleDiagnostic: break
             case .toolCallStart, .toolCallArgumentsDelta: break
             case .toolDispatchStarted, .toolDispatchCompleted: break
             case .handoffRequested: break
@@ -282,10 +282,10 @@ final class ToolCallContractTests: XCTestCase {
             case .token(let t): tokens.append(t)
             case .toolCall(let c): toolCalls.append(c)
             case .usage: break
-            case .thinkingToken, .thinkingComplete, .thinkingSignature: break
-            case .toolResult, .toolProgress, .toolLoopLimitReached: break
+            case .thinkingToken, .thinkingCompleted, .thinkingSignature: break
+            case .toolResult, .toolProgress, .toolIterationLimitExceeded: break
             case .kvCacheReuse: break
-            case .diagnosticThrottle: break
+            case .throttleDiagnostic: break
             case .toolCallStart, .toolCallArgumentsDelta: break
             case .toolDispatchStarted, .toolDispatchCompleted: break
             case .handoffRequested: break

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -168,7 +168,7 @@ final class QuickStartTests: XCTestCase {
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
         )
         let cloudBackend = QuickStartCloudBackend()
-        result.bootstrap.inferenceService.registerCloudBackendFactory { provider in
+        result.bootstrap.inferenceService.registerEndpointBackendFactory { provider in
             guard provider == .ollama else { return nil }
             return cloudBackend
         }

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -333,7 +333,7 @@ final class QuickStartTests: XCTestCase {
     }
 }
 
-private final class QuickStartCloudBackend: InferenceBackend, CloudBackendURLModelConfigurable, @unchecked Sendable {
+private final class QuickStartCloudBackend: InferenceBackend, EndpointBackendURLModelConfigurable, @unchecked Sendable {
     var isModelLoaded = false
     var isGenerating = false
     let capabilities = BackendCapabilities(

--- a/Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ScriptedBackendRuntimeTests.swift
@@ -142,7 +142,7 @@ final class ScriptedBackendRuntimeTests: XCTestCase {
         XCTAssertFalse(hasError, "kvCacheReuse must not cause errorRaised")
     }
 
-    /// `.diagnosticThrottle` is advisory and must not abort generation.
+    /// `.throttleDiagnostic` is advisory and must not abort generation.
     /// The turn must complete with `streamFinished`, not `errorRaised`.
     func test_diagnosticThrottle_doesNotAbortGeneration() async throws {
         let backend = ScriptedGenerationBackend(turns: [
@@ -176,7 +176,7 @@ final class ScriptedBackendRuntimeTests: XCTestCase {
         ], "throttle is advisory — generation must complete normally")
 
         let hasError = trace.contains { $0.kind == .errorRaised }
-        XCTAssertFalse(hasError, "diagnosticThrottle must not cause errorRaised")
+        XCTAssertFalse(hasError, "throttleDiagnostic must not cause errorRaised")
     }
 
     /// A mid-stream error surfaces as `errorRaised` in the trace. The

--- a/Tests/ManifoldTestSupportTests/RuntimeScenarioRunnerTests.swift
+++ b/Tests/ManifoldTestSupportTests/RuntimeScenarioRunnerTests.swift
@@ -49,7 +49,7 @@ final class RuntimeScenarioRunnerTests: XCTestCase {
         XCTAssertTrue(errorKinds.isEmpty, "Expected no errorRaised events, got \(errorKinds.count)")
     }
 
-    /// A backend that emits a `diagnosticThrottle` advisory before tokens must
+    /// A backend that emits a `throttleDiagnostic` advisory before tokens must
     /// not abort generation — the runtime treats the advisory as informational.
     func test_throttleAdvisory_completesWithoutError() async throws {
         let result = try await RuntimeScenarioRunner.run(.diagnosticThrottleAdvisory)

--- a/Tests/ManifoldTestSupportTests/ScriptedGenerationBackendTests.swift
+++ b/Tests/ManifoldTestSupportTests/ScriptedGenerationBackendTests.swift
@@ -58,7 +58,7 @@ final class ScriptedGenerationBackendTests: XCTestCase {
         XCTAssertEqual(events[1], .token("hi"))
     }
 
-    /// A `.diagnosticThrottle` event arrives before the token events when using
+    /// A `.throttleDiagnostic` event arrives before the token events when using
     /// the `.throttle(reason:then:)` factory.
     func test_throttle_emittedBeforeTokens() async throws {
         let backend = ScriptedGenerationBackend(turns: [
@@ -70,8 +70,8 @@ final class ScriptedGenerationBackendTests: XCTestCase {
         )
         let events = try await drain(stream)
 
-        XCTAssertEqual(events.count, 2, "expected diagnosticThrottle + token")
-        XCTAssertEqual(events[0], .diagnosticThrottle(reason: "burst-limit"))
+        XCTAssertEqual(events.count, 2, "expected throttleDiagnostic + token")
+        XCTAssertEqual(events[0], .throttleDiagnostic(reason: "burst-limit"))
         XCTAssertEqual(events[1], .token("x"))
     }
 

--- a/Tests/ManifoldUITests/LoadDispatchCoordinationTests.swift
+++ b/Tests/ManifoldUITests/LoadDispatchCoordinationTests.swift
@@ -291,7 +291,7 @@ private actor ControlledLoadGate {
 }
 
 private final class ControlledLoadBackend: InferenceBackend,
-                                           CloudBackendURLModelConfigurable,
+                                           EndpointBackendURLModelConfigurable,
                                            @unchecked Sendable {
     private let stateLock = NSLock()
     private let gate = ControlledLoadGate()

--- a/Tests/ManifoldUITests/LoadDispatchCoordinationTests.swift
+++ b/Tests/ManifoldUITests/LoadDispatchCoordinationTests.swift
@@ -112,7 +112,7 @@ final class LoadDispatchCoordinationTests: XCTestCase {
         let firstBackend = ControlledLoadBackend()
         let secondBackend = ControlledLoadBackend()
         let vm = makeViewModel { service in
-            service.registerCloudBackendFactory { provider in
+            service.registerEndpointBackendFactory { provider in
                 switch provider {
                 case .ollama:
                     firstBackend

--- a/Tests/ManifoldUITests/MultiThinkingBlockTests.swift
+++ b/Tests/ManifoldUITests/MultiThinkingBlockTests.swift
@@ -5,7 +5,7 @@ import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
 
-/// Tests for #482 / #604: two ``GenerationEvent/thinkingComplete`` events
+/// Tests for #482 / #604: two ``GenerationEvent/thinkingCompleted`` events
 /// on a single assistant turn must produce two distinct ``MessagePart/thinking``
 /// parts (not one concatenated). Per-block signatures must round-trip onto
 /// each part independently so the next replay against Anthropic carries the

--- a/Tests/ManifoldUITests/SessionAutoRenameTests.swift
+++ b/Tests/ManifoldUITests/SessionAutoRenameTests.swift
@@ -189,7 +189,7 @@ final class SessionAutoRenameTests: XCTestCase {
         let (activeToken, _) = try! service.enqueue(
             messages: [(role: "user", content: "Tell me a long story")],
             priority: .userInitiated,
-            sessionID: nil
+            requestGroupID: nil
         )
         _ = activeToken // silence unused-variable warning
 

--- a/Tests/ManifoldUITests/SessionQueueIsolationTests.swift
+++ b/Tests/ManifoldUITests/SessionQueueIsolationTests.swift
@@ -71,7 +71,7 @@ final class SessionQueueIsolationTests: XCTestCase {
         // Enqueue a request scoped to session A.
         let (_, stream) = try vm.inferenceService.enqueue(
             messages: [.user("hello")],
-            sessionID: sessionA.id
+            requestGroupID: sessionA.id
         )
 
         // Create session B and switch to it.

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -340,14 +340,14 @@ The `switch` above only matches two cases — `.token` and `.thinkingToken` — 
 | `.toolCallStart(callId: String, name: String)`                        | Streaming providers only — beginning of a tool call whose arguments stream as deltas.    |
 | `.toolCallArgumentsDelta(callId: String, textDelta: String)`          | JSON-arguments fragment for an in-flight streamed tool call.                             |
 | `.thinkingToken(String)`                                              | A fragment of model reasoning (inside a thinking block).                                 |
-| `.thinkingComplete`                                                   | Reasoning block closed; finalize any accumulated thinking content.                       |
+| `.thinkingCompleted`                                                   | Reasoning block closed; finalize any accumulated thinking content.                       |
 | `.thinkingSignature(String)`                                          | Anthropic-only opaque signature attached to the most recent thinking block.              |
-| `.toolLoopLimitReached(iterations: Int)`                              | Orchestrator stopped the tool-dispatch loop at `maxToolIterations`.                      |
+| `.toolIterationLimitExceeded(iterations: Int)`                              | Orchestrator stopped the tool-dispatch loop at `maxToolIterations`.                      |
 | `.toolResult(ToolResult)`                                             | Result of a tool the orchestrator dispatched on your behalf.                             |
 | `.kvCacheReuse(promptTokensReused: Int)`                              | Backend reused KV-cache prefix from the previous turn — that many tokens skipped decode. |
-| `.diagnosticThrottle(reason: String)`                                 | Runtime paused generation (e.g. thermal pressure); surface this in your UI.              |
+| `.throttleDiagnostic(reason: String)`                                 | Runtime paused generation (e.g. thermal pressure); surface this in your UI.              |
 | `.toolDispatchStarted(callId: String, name: String, attempt: Int)`    | Orchestrator began handling a tool call — pin spinners / start timers here.              |
-| `.toolDispatchCompleted(callId: String, durationMs: Int, errorKind: ToolResult.ErrorKind?)` | Orchestrator finished handling a tool call (success or failure).         |
+| `.toolDispatchCompleted(callId: String, durationMilliseconds: Int, errorKind: ToolResult.ErrorKind?)` | Orchestrator finished handling a tool call (success or failure).         |
 
 Adding a case to `GenerationEvent` is source-breaking for exhaustive `switch` statements — that's why the snippets in this guide always include `default: break`. If you'd rather opt into the compiler warning when a new case lands, switch on `@unknown default:` instead.
 

--- a/docs/images/launch/generationstream-backends-fan.svg
+++ b/docs/images/launch/generationstream-backends-fan.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1600 900">
+  <title id="title">GenerationStream backend fan diagram</title>
+  <desc id="desc">A single GenerationStream protocol fans out to local, Apple, cloud, LAN, and AnyLanguageModel bridge backends.</desc>
+  <defs>
+    <style>
+      :root {
+        --ink: #16212f;
+        --muted: #66717f;
+        --paper: #f7f9f7;
+        --panel: #ffffff;
+        --line: #b8c3bb;
+        --blue: #2267a8;
+        --teal: #127a73;
+        --green: #2f7d59;
+        --amber: #c87328;
+      }
+      .bg { fill: var(--paper); }
+      .headline { fill: var(--ink); font: 800 52px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .subhead { fill: var(--muted); font: 500 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .group { fill: var(--panel); stroke: #dbe2dc; stroke-width: 2; }
+      .group-label { fill: var(--muted); font: 800 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; text-transform: uppercase; }
+      .core { fill: #16212f; }
+      .core-title { fill: white; font: 800 34px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .core-sub { fill: #cdd6d0; font: 600 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .edge { fill: none; stroke: var(--line); stroke-width: 4; stroke-linecap: round; }
+      .node { fill: white; stroke-width: 3; }
+      .node-text { fill: var(--ink); font: 800 22px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .relay { fill: #fff7ed; stroke: var(--amber); stroke-width: 3; }
+      .relay-text { fill: #8a4519; font: 800 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .chip { fill: #e8f0ec; stroke: #d4ded7; stroke-width: 1; }
+      .chip-text { fill: #314035; font: 800 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .caption { fill: var(--muted); font: 600 21px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+    </style>
+    <filter id="shadow" x="-12%" y="-12%" width="124%" height="124%">
+      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#172033" flood-opacity=".13"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b8c3bb"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1600" height="900"/>
+  <text class="headline" x="96" y="100">One Protocol, Every Backend.</text>
+  <text class="subhead" x="100" y="142">Same stream surface for local models, Apple frameworks, cloud APIs, and provider bridges.</text>
+
+  <g opacity=".82">
+    <rect class="group" x="720" y="190" width="450" height="130" rx="24"/>
+    <text class="group-label" x="752" y="232">On-device</text>
+    <rect class="group" x="720" y="352" width="450" height="130" rx="24"/>
+    <text class="group-label" x="752" y="394">Apple</text>
+    <rect class="group" x="720" y="514" width="450" height="172" rx="24"/>
+    <text class="group-label" x="752" y="556">Cloud and LAN</text>
+    <rect class="group" x="1220" y="352" width="300" height="286" rx="24"/>
+    <text class="group-label" x="1252" y="394">Via bridge</text>
+  </g>
+
+  <path class="edge" marker-end="url(#arrow)" d="M 482 420 C 560 285 628 250 725 255"/>
+  <path class="edge" marker-end="url(#arrow)" d="M 482 420 C 582 407 625 415 725 415"/>
+  <path class="edge" marker-end="url(#arrow)" d="M 482 420 C 560 580 625 602 725 602"/>
+  <path class="edge" marker-end="url(#arrow)" d="M 482 420 C 720 430 930 430 1225 470"/>
+
+  <g filter="url(#shadow)">
+    <rect class="core" x="120" y="330" width="360" height="170" rx="36"/>
+    <text class="core-title" x="170" y="407">GenerationStream</text>
+    <text class="core-sub" x="171" y="446">one protocol surface</text>
+  </g>
+
+  <g>
+    <rect class="node" x="770" y="244" width="130" height="50" rx="25" stroke="#2267a8"/>
+    <text class="node-text" x="812" y="278">MLX</text>
+    <rect class="node" x="920" y="244" width="190" height="50" rx="25" stroke="#2267a8"/>
+    <text class="node-text" x="950" y="278">llama.cpp</text>
+
+    <rect class="node" x="790" y="404" width="320" height="54" rx="27" stroke="#127a73"/>
+    <text class="node-text" x="832" y="440">Foundation Models</text>
+
+    <rect class="node" x="762" y="584" width="110" height="50" rx="25" stroke="#2f7d59"/>
+    <text class="node-text" x="789" y="618">OpenAI</text>
+    <rect class="node" x="890" y="584" width="126" height="50" rx="25" stroke="#2f7d59"/>
+    <text class="node-text" x="918" y="618">Claude</text>
+    <rect class="node" x="1034" y="584" width="112" height="50" rx="25" stroke="#2f7d59"/>
+    <text class="node-text" x="1060" y="618">Ollama</text>
+    <rect class="node" x="812" y="636" width="94" height="42" rx="21" stroke="#2f7d59"/>
+    <text class="node-text" x="834" y="664" style="font-size:18px">LAN</text>
+    <rect class="node" x="924" y="636" width="184" height="42" rx="21" stroke="#2f7d59"/>
+    <text class="node-text" x="948" y="664" style="font-size:18px">Responses API</text>
+
+    <rect class="relay" x="1248" y="440" width="244" height="62" rx="31"/>
+    <text class="relay-text" x="1278" y="479">AnyLanguageModel</text>
+    <path class="edge" marker-end="url(#arrow)" d="M 1370 502 L 1370 540"/>
+    <rect class="node" x="1250" y="550" width="106" height="42" rx="21" stroke="#c87328"/>
+    <text class="node-text" x="1276" y="578" style="font-size:18px">Gemini</text>
+    <rect class="node" x="1374" y="550" width="78" height="42" rx="21" stroke="#c87328"/>
+    <text class="node-text" x="1400" y="578" style="font-size:18px">xAI</text>
+    <rect class="node" x="1250" y="600" width="88" height="42" rx="21" stroke="#c87328"/>
+    <text class="node-text" x="1274" y="628" style="font-size:18px">Groq</text>
+    <rect class="node" x="1356" y="600" width="110" height="42" rx="21" stroke="#c87328"/>
+    <text class="node-text" x="1377" y="628" style="font-size:18px">Mistral</text>
+  </g>
+
+  <g>
+    <rect class="chip" x="210" y="750" width="134" height="42" rx="21"/>
+    <text class="chip-text" x="239" y="778">streaming</text>
+    <rect class="chip" x="360" y="750" width="156" height="42" rx="21"/>
+    <text class="chip-text" x="386" y="778">tool calling</text>
+    <rect class="chip" x="532" y="750" width="190" height="42" rx="21"/>
+    <text class="chip-text" x="558" y="778">structured output</text>
+    <rect class="chip" x="738" y="750" width="174" height="42" rx="21"/>
+    <text class="chip-text" x="764" y="778">thinking tokens</text>
+    <rect class="chip" x="928" y="750" width="82" height="42" rx="21"/>
+    <text class="chip-text" x="958" y="778">MCP</text>
+  </g>
+
+  <text class="caption" x="100" y="846">Swap engines by changing descriptors. The stream, tools, structured output, and thinking-token surface stay the same.</text>
+</svg>

--- a/docs/images/launch/layer-cake-hero.svg
+++ b/docs/images/launch/layer-cake-hero.svg
@@ -1,0 +1,186 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1600 900">
+  <title id="title">ManifoldKit assembled full-stack hero diagram</title>
+  <desc id="desc">An isometric four-layer ManifoldKit stack showing UI, runtime, persistence, and backends as one assembled product, while other categories own only one layer.</desc>
+  <defs>
+    <style>
+      :root {
+        --ink: #111b2d;
+        --muted: #607083;
+        --paper: #f6f8f3;
+        --blue: #1868b7;
+        --blue-side: #0d477f;
+        --teal: #087b78;
+        --teal-side: #075753;
+        --green: #29845d;
+        --green-side: #1f5f44;
+        --amber: #cb7326;
+        --amber-side: #935018;
+        --line: #d8dfd4;
+      }
+      .bg { fill: url(#background); }
+      .halo { fill: url(#halo); opacity: .9; }
+      .brand { fill: var(--ink); font: 900 72px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .headline { fill: var(--ink); font: 850 38px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .subhead { fill: var(--muted); font: 600 23px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .micro { fill: var(--muted); font: 700 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .code-pill { fill: #111b2d; }
+      .code-text { fill: #dff4ea; font: 800 22px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0; }
+      .spark { fill: #f3a43b; }
+      .layer-title { fill: white; font: 900 32px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .layer-sub { fill: rgba(255,255,255,.88); font: 700 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .chip { fill: rgba(255,255,255,.2); stroke: rgba(255,255,255,.38); stroke-width: 1.2; }
+      .chip-text { fill: white; font: 800 15px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .brace { fill: none; stroke: #111b2d; stroke-width: 7; stroke-linecap: round; opacity: .92; }
+      .brace-text { fill: #111b2d; font: 900 22px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .ghost-top { fill: #eef2eb; stroke: #d5ddd2; stroke-width: 2; }
+      .ghost-side { fill: #dfe7dd; }
+      .ghost-label { fill: #6d796e; font: 900 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .ghost-note { fill: #7b8679; font: 700 15px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .callout { fill: white; stroke: #d8dfd4; stroke-width: 2; }
+      .callout-title { fill: var(--ink); font: 900 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .callout-sub { fill: var(--muted); font: 700 16px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .caption { fill: var(--ink); font: 850 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .caption-sub { fill: var(--muted); font: 650 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+    </style>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbfbf7"/>
+      <stop offset=".52" stop-color="#edf4f0"/>
+      <stop offset="1" stop-color="#f6f0e4"/>
+    </linearGradient>
+    <radialGradient id="halo" cx=".56" cy=".42" r=".55">
+      <stop offset="0" stop-color="#cbe9df"/>
+      <stop offset=".5" stop-color="#e7f0e9"/>
+      <stop offset="1" stop-color="#f6f8f3" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="stackShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="34" stdDeviation="30" flood-color="#172033" flood-opacity=".22"/>
+    </filter>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#172033" flood-opacity=".13"/>
+    </filter>
+    <linearGradient id="uiTop" x1="0" x2="1">
+      <stop offset="0" stop-color="#1f7fcb"/>
+      <stop offset="1" stop-color="#39a1df"/>
+    </linearGradient>
+    <linearGradient id="runtimeTop" x1="0" x2="1">
+      <stop offset="0" stop-color="#0b8f89"/>
+      <stop offset="1" stop-color="#23b3a7"/>
+    </linearGradient>
+    <linearGradient id="dataTop" x1="0" x2="1">
+      <stop offset="0" stop-color="#319164"/>
+      <stop offset="1" stop-color="#62b979"/>
+    </linearGradient>
+    <linearGradient id="backendTop" x1="0" x2="1">
+      <stop offset="0" stop-color="#d17825"/>
+      <stop offset="1" stop-color="#ee9b3d"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b6c1b8"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1600" height="900"/>
+  <ellipse class="halo" cx="930" cy="430" rx="620" ry="420"/>
+  <circle cx="1465" cy="105" r="210" fill="#e5ece6" opacity=".75"/>
+  <circle cx="95" cy="812" r="260" fill="#ece3d5" opacity=".72"/>
+
+  <g>
+    <text class="brand" x="92" y="116">ManifoldKit</text>
+    <text class="headline" x="98" y="168">One import that ships the stack.</text>
+    <text class="subhead" x="100" y="208">UI, runtime, data, and backends.</text>
+    <text class="subhead" x="100" y="238">Already wired. Ready to ship.</text>
+    <rect class="code-pill" x="100" y="282" width="314" height="58" rx="29"/>
+    <text class="code-text" x="130" y="319">import ManifoldKit</text>
+    <circle class="spark" cx="446" cy="311" r="6"/>
+    <circle class="spark" cx="470" cy="292" r="4"/>
+    <circle class="spark" cx="476" cy="332" r="3"/>
+  </g>
+
+  <g filter="url(#stackShadow)">
+    <!-- UI slab -->
+    <path d="M 500 230 L 1030 164 L 1244 238 L 713 316 Z" fill="url(#uiTop)"/>
+    <path d="M 713 316 L 1244 238 L 1244 302 L 713 382 Z" fill="var(--blue-side)"/>
+    <path d="M 500 230 L 713 316 L 713 382 L 500 294 Z" fill="#135a9b"/>
+
+    <!-- Runtime slab -->
+    <path d="M 500 342 L 1030 276 L 1244 350 L 713 428 Z" fill="url(#runtimeTop)"/>
+    <path d="M 713 428 L 1244 350 L 1244 414 L 713 494 Z" fill="var(--teal-side)"/>
+    <path d="M 500 342 L 713 428 L 713 494 L 500 406 Z" fill="#086b66"/>
+
+    <!-- Persistence slab -->
+    <path d="M 500 454 L 1030 388 L 1244 462 L 713 540 Z" fill="url(#dataTop)"/>
+    <path d="M 713 540 L 1244 462 L 1244 526 L 713 606 Z" fill="var(--green-side)"/>
+    <path d="M 500 454 L 713 540 L 713 606 L 500 518 Z" fill="#28764f"/>
+
+    <!-- Backends slab -->
+    <path d="M 500 566 L 1030 500 L 1244 574 L 713 652 Z" fill="url(#backendTop)"/>
+    <path d="M 713 652 L 1244 574 L 1244 638 L 713 718 Z" fill="var(--amber-side)"/>
+    <path d="M 500 566 L 713 652 L 713 718 L 500 630 Z" fill="#af641f"/>
+  </g>
+
+  <g>
+    <text class="layer-title" x="645" y="246">UI</text>
+    <text class="layer-sub" x="645" y="274">ChatView + sessions + model UI</text>
+    <rect class="chip" x="904" y="210" width="96" height="30" rx="15"/>
+    <text class="chip-text" x="925" y="230">ChatView</text>
+    <rect class="chip" x="1014" y="238" width="146" height="30" rx="15"/>
+    <text class="chip-text" x="1034" y="258">Model UI</text>
+
+    <text class="layer-title" x="632" y="360">Runtime</text>
+    <text class="layer-sub" x="632" y="388">send / regenerate / edit / cancel / branch</text>
+    <rect class="chip" x="936" y="324" width="130" height="30" rx="15"/>
+    <text class="chip-text" x="956" y="344">tool approval</text>
+    <rect class="chip" x="1078" y="344" width="138" height="30" rx="15"/>
+    <text class="chip-text" x="1098" y="364">metrics + cost</text>
+
+    <text class="layer-title" x="620" y="472">Persistence</text>
+    <text class="layer-sub" x="620" y="500">SwiftData stores + migrations</text>
+    <rect class="chip" x="956" y="434" width="132" height="30" rx="15"/>
+    <text class="chip-text" x="976" y="454">MessageStore</text>
+
+    <text class="layer-title" x="617" y="585">Backends</text>
+    <text class="layer-sub" x="617" y="613">MLX, GGUF, Apple, cloud, bridge</text>
+    <rect class="chip" x="918" y="544" width="66" height="30" rx="15"/>
+    <text class="chip-text" x="940" y="564">MLX</text>
+    <rect class="chip" x="998" y="526" width="120" height="30" rx="15"/>
+    <text class="chip-text" x="1020" y="546">OpenAI</text>
+    <rect class="chip" x="1034" y="588" width="100" height="30" rx="15"/>
+    <text class="chip-text" x="1055" y="608">Ollama</text>
+  </g>
+
+  <g>
+    <path class="brace" d="M 430 232 C 388 245 388 292 424 307 L 424 641 C 388 655 388 704 430 716"/>
+    <text class="brace-text" transform="translate(374 650) rotate(-90)">owned end to end</text>
+  </g>
+
+  <g filter="url(#softShadow)" opacity=".92">
+    <path class="ghost-top" d="M 1288 220 L 1436 202 L 1490 222 L 1342 244 Z"/>
+    <path class="ghost-side" d="M 1342 244 L 1490 222 L 1490 258 L 1342 282 Z"/>
+    <text class="ghost-label" x="1322" y="226">UI kits</text>
+    <text class="ghost-note" x="1322" y="249">one layer</text>
+
+    <path class="ghost-top" d="M 1290 555 L 1438 537 L 1492 557 L 1344 579 Z"/>
+    <path class="ghost-side" d="M 1344 579 L 1492 557 L 1492 593 L 1344 617 Z"/>
+    <text class="ghost-label" x="1315" y="562">engines</text>
+    <text class="ghost-note" x="1315" y="585">tokens only</text>
+
+    <path class="ghost-top" d="M 1286 645 L 1434 627 L 1488 647 L 1340 669 Z"/>
+    <path class="ghost-side" d="M 1340 669 L 1488 647 L 1488 683 L 1340 707 Z"/>
+    <text class="ghost-label" x="1309" y="652">cloud SDKs</text>
+    <text class="ghost-note" x="1309" y="675">one API</text>
+  </g>
+
+  <g>
+    <path d="M 1248 282 C 1290 276 1298 262 1322 244" fill="none" stroke="#b6c1b8" stroke-width="3" marker-end="url(#arrow)" opacity=".55"/>
+    <path d="M 1248 608 C 1290 598 1300 590 1324 579" fill="none" stroke="#b6c1b8" stroke-width="3" marker-end="url(#arrow)" opacity=".55"/>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect class="callout" x="112" y="682" width="360" height="98" rx="26"/>
+    <text class="callout-title" x="142" y="724">Competitors sell a layer.</text>
+    <text class="callout-sub" x="142" y="754">ManifoldKit sells the assembled product.</text>
+  </g>
+
+  <text class="caption" x="100" y="830">ChatView + ConversationRuntime + SwiftData + model-management UI + every backend.</text>
+  <text class="caption-sub" x="100" y="864">Competitors hand you one layer and a wiring diagram. ManifoldKit hands you the product.</text>
+</svg>

--- a/docs/images/launch/vs-field-matrix.svg
+++ b/docs/images/launch/vs-field-matrix.svg
@@ -1,0 +1,160 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1600 1000">
+  <title id="title">ManifoldKit versus the Swift AI field matrix</title>
+  <desc id="desc">A capability grid showing ManifoldKit filling every column while other categories cover only partial layers.</desc>
+  <defs>
+    <style>
+      :root {
+        --ink: #172033;
+        --muted: #657284;
+        --paper: #f7f8f5;
+        --panel: #ffffff;
+        --line: #dbe1d9;
+        --accent: #197267;
+        --partial: #c6782c;
+        --empty: #c6cec4;
+      }
+      .bg { fill: var(--paper); }
+      .headline { fill: var(--ink); font: 800 52px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .subhead { fill: var(--muted); font: 500 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .table { fill: var(--panel); stroke: var(--line); stroke-width: 2; }
+      .stripe { fill: #e5f1ed; }
+      .rowline { stroke: var(--line); stroke-width: 1; }
+      .capability { fill: var(--ink); font: 700 21px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .header { fill: var(--ink); font: 800 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .header-small { fill: var(--muted); font: 700 15px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .dot-full { fill: var(--accent); }
+      .dot-empty { fill: none; stroke: var(--empty); stroke-width: 5; }
+      .dot-half-base { fill: var(--empty); }
+      .dot-half { fill: var(--partial); }
+      .legend { fill: var(--muted); font: 700 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .footer { fill: var(--muted); font: 600 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+    </style>
+    <clipPath id="halfDot">
+      <rect x="0" y="0" width="16" height="32"/>
+    </clipPath>
+    <filter id="shadow" x="-6%" y="-6%" width="112%" height="112%">
+      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#172033" flood-opacity=".12"/>
+    </filter>
+  </defs>
+
+  <rect class="bg" width="1600" height="1000"/>
+  <text class="headline" x="90" y="88">Only One Column Fills In.</text>
+  <text class="subhead" x="94" y="128">UI kits draw bubbles. Engines stream tokens. Cloud clients wrap one API. ManifoldKit ships the stack.</text>
+
+  <g filter="url(#shadow)">
+    <rect class="table" x="80" y="178" width="1440" height="708" rx="28"/>
+    <rect class="stripe" x="438" y="178" width="172" height="708" rx="0"/>
+  </g>
+
+  <g>
+    <text class="header" x="120" y="232">Capability</text>
+    <text class="header" x="468" y="224">ManifoldKit</text>
+    <text class="header-small" x="492" y="250">package</text>
+    <text class="header" x="680" y="224">UI-only</text>
+    <text class="header-small" x="680" y="250">kits</text>
+    <text class="header" x="858" y="224">Engine-only</text>
+    <text class="header-small" x="880" y="250">wrappers</text>
+    <text class="header" x="1078" y="224">Thin cloud</text>
+    <text class="header-small" x="1096" y="250">clients</text>
+    <text class="header" x="1280" y="224">Apple FM</text>
+    <text class="header-small" x="1270" y="250">OS 26 only</text>
+  </g>
+
+  <g>
+    <line class="rowline" x1="80" x2="1520" y1="274" y2="274"/>
+    <line class="rowline" x1="80" x2="1520" y1="336" y2="336"/>
+    <line class="rowline" x1="80" x2="1520" y1="398" y2="398"/>
+    <line class="rowline" x1="80" x2="1520" y1="460" y2="460"/>
+    <line class="rowline" x1="80" x2="1520" y1="522" y2="522"/>
+    <line class="rowline" x1="80" x2="1520" y1="584" y2="584"/>
+    <line class="rowline" x1="80" x2="1520" y1="646" y2="646"/>
+    <line class="rowline" x1="80" x2="1520" y1="708" y2="708"/>
+    <line class="rowline" x1="80" x2="1520" y1="770" y2="770"/>
+    <line class="rowline" x1="80" x2="1520" y1="832" y2="832"/>
+  </g>
+
+  <g>
+    <text class="capability" x="120" y="314">Drop-in chat UI</text>
+    <text class="capability" x="120" y="376">Turn-loop runtime</text>
+    <text class="capability" x="120" y="438">SwiftData persistence</text>
+    <text class="capability" x="120" y="500">Multi-backend local + cloud</text>
+    <text class="capability" x="120" y="562">On-device + cloud in one API</text>
+    <text class="capability" x="120" y="624">Tool calling / structured output</text>
+    <text class="capability" x="120" y="686">MCP client + server</text>
+    <text class="capability" x="120" y="748">RAG + citations</text>
+    <text class="capability" x="120" y="810">Security as product</text>
+    <text class="capability" x="120" y="872">Serves iOS 18 / macOS 15</text>
+  </g>
+
+  <g>
+    <!-- ManifoldKit: full column -->
+    <circle class="dot-full" cx="524" cy="304" r="16"/>
+    <circle class="dot-full" cx="524" cy="366" r="16"/>
+    <circle class="dot-full" cx="524" cy="428" r="16"/>
+    <circle class="dot-full" cx="524" cy="490" r="16"/>
+    <circle class="dot-full" cx="524" cy="552" r="16"/>
+    <circle class="dot-full" cx="524" cy="614" r="16"/>
+    <circle class="dot-full" cx="524" cy="676" r="16"/>
+    <circle class="dot-full" cx="524" cy="738" r="16"/>
+    <circle class="dot-full" cx="524" cy="800" r="16"/>
+    <circle class="dot-full" cx="524" cy="862" r="16"/>
+
+    <!-- UI-only kits -->
+    <circle class="dot-full" cx="720" cy="304" r="16"/>
+    <circle class="dot-empty" cx="720" cy="366" r="16"/>
+    <circle class="dot-empty" cx="720" cy="428" r="16"/>
+    <circle class="dot-empty" cx="720" cy="490" r="16"/>
+    <circle class="dot-empty" cx="720" cy="552" r="16"/>
+    <circle class="dot-empty" cx="720" cy="614" r="16"/>
+    <circle class="dot-empty" cx="720" cy="676" r="16"/>
+    <circle class="dot-empty" cx="720" cy="738" r="16"/>
+    <circle class="dot-empty" cx="720" cy="800" r="16"/>
+    <circle class="dot-full" cx="720" cy="862" r="16"/>
+
+    <!-- Engine-only wrappers -->
+    <circle class="dot-empty" cx="934" cy="304" r="16"/>
+    <circle class="dot-empty" cx="934" cy="366" r="16"/>
+    <circle class="dot-empty" cx="934" cy="428" r="16"/>
+    <g transform="translate(934 490)"><circle class="dot-half-base" r="16"/><path class="dot-half" d="M 0 -16 A 16 16 0 0 1 0 16 L 0 0 Z"/></g>
+    <g transform="translate(934 552)"><circle class="dot-half-base" r="16"/><path class="dot-half" d="M 0 -16 A 16 16 0 0 1 0 16 L 0 0 Z"/></g>
+    <g transform="translate(934 614)"><circle class="dot-half-base" r="16"/><path class="dot-half" d="M 0 -16 A 16 16 0 0 1 0 16 L 0 0 Z"/></g>
+    <circle class="dot-empty" cx="934" cy="676" r="16"/>
+    <circle class="dot-empty" cx="934" cy="738" r="16"/>
+    <circle class="dot-empty" cx="934" cy="800" r="16"/>
+    <circle class="dot-full" cx="934" cy="862" r="16"/>
+
+    <!-- Thin cloud clients -->
+    <circle class="dot-empty" cx="1132" cy="304" r="16"/>
+    <circle class="dot-empty" cx="1132" cy="366" r="16"/>
+    <circle class="dot-empty" cx="1132" cy="428" r="16"/>
+    <circle class="dot-empty" cx="1132" cy="490" r="16"/>
+    <circle class="dot-empty" cx="1132" cy="552" r="16"/>
+    <g transform="translate(1132 614)"><circle class="dot-half-base" r="16"/><path class="dot-half" d="M 0 -16 A 16 16 0 0 1 0 16 L 0 0 Z"/></g>
+    <circle class="dot-empty" cx="1132" cy="676" r="16"/>
+    <circle class="dot-empty" cx="1132" cy="738" r="16"/>
+    <g transform="translate(1132 800)"><circle class="dot-half-base" r="16"/><path class="dot-half" d="M 0 -16 A 16 16 0 0 1 0 16 L 0 0 Z"/></g>
+    <circle class="dot-full" cx="1132" cy="862" r="16"/>
+
+    <!-- Apple Foundation Models -->
+    <circle class="dot-empty" cx="1326" cy="304" r="16"/>
+    <circle class="dot-empty" cx="1326" cy="366" r="16"/>
+    <circle class="dot-empty" cx="1326" cy="428" r="16"/>
+    <circle class="dot-empty" cx="1326" cy="490" r="16"/>
+    <circle class="dot-empty" cx="1326" cy="552" r="16"/>
+    <g transform="translate(1326 614)"><circle class="dot-half-base" r="16"/><path class="dot-half" d="M 0 -16 A 16 16 0 0 1 0 16 L 0 0 Z"/></g>
+    <circle class="dot-empty" cx="1326" cy="676" r="16"/>
+    <circle class="dot-empty" cx="1326" cy="738" r="16"/>
+    <text x="1312" y="807" fill="#8a948c" font="800 22px ui-rounded, 'SF Pro Rounded', 'Avenir Next', sans-serif">n/a</text>
+    <circle class="dot-empty" cx="1326" cy="862" r="16"/>
+  </g>
+
+  <g>
+    <circle class="dot-full" cx="112" cy="938" r="12"/>
+    <text class="legend" x="132" y="944">yes</text>
+    <g transform="translate(216 938)"><circle class="dot-half-base" r="12"/><path class="dot-half" d="M 0 -12 A 12 12 0 0 1 0 12 L 0 0 Z"/></g>
+    <text class="legend" x="236" y="944">partial</text>
+    <circle class="dot-empty" cx="348" cy="938" r="12"/>
+    <text class="legend" x="368" y="944">no</text>
+    <text class="footer" x="690" y="944">Full-stack apps are forkable apps, not packages you import.</text>
+  </g>
+</svg>

--- a/docs/images/launch/wwdc-backend-timing.svg
+++ b/docs/images/launch/wwdc-backend-timing.svg
@@ -1,0 +1,100 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1600 900">
+  <title id="title">WWDC timing visual for ManifoldKit</title>
+  <desc id="desc">Whatever Apple ships next flows into ManifoldKit as one more backend behind the same GenerationStream protocol, not a rewrite.</desc>
+  <defs>
+    <style>
+      :root {
+        --ink: #172033;
+        --muted: #647184;
+        --paper: #f7f8f5;
+        --panel: #ffffff;
+        --line: #d9e0d7;
+        --blue: #206da8;
+        --teal: #147a73;
+        --amber: #c47125;
+        --red: #b6433d;
+      }
+      .bg { fill: var(--paper); }
+      .headline { fill: var(--ink); font: 800 52px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .subhead { fill: var(--muted); font: 500 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .card { fill: var(--panel); stroke: var(--line); stroke-width: 2; }
+      .card-title { fill: var(--ink); font: 800 30px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .card-sub { fill: var(--muted); font: 600 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .arrow { fill: none; stroke: #aeb9b1; stroke-width: 8; stroke-linecap: round; }
+      .backend-band { fill: #e5f1ed; stroke: #c7dbd3; stroke-width: 2; }
+      .backend-title { fill: #0f4d47; font: 800 28px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .node { fill: white; stroke: var(--teal); stroke-width: 3; }
+      .node-text { fill: var(--ink); font: 800 19px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .new-node { fill: #fff7ed; stroke: var(--amber); stroke-width: 4; }
+      .new-node-text { fill: #884714; font: 800 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .ghost { fill: none; stroke: var(--red); stroke-width: 8; stroke-linecap: round; opacity: .28; }
+      .ghost-text { fill: var(--red); opacity: .18; font: 900 86px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .chip { fill: white; stroke: #d8ded7; stroke-width: 2; }
+      .chip-title { fill: var(--ink); font: 800 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .chip-sub { fill: var(--muted); font: 600 17px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .caption { fill: var(--muted); font: 600 21px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+    </style>
+    <filter id="shadow" x="-8%" y="-8%" width="116%" height="116%">
+      <feDropShadow dx="0" dy="16" stdDeviation="17" flood-color="#172033" flood-opacity=".13"/>
+    </filter>
+    <marker id="arrowhead" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#aeb9b1"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1600" height="900"/>
+  <text class="headline" x="96" y="100">WWDC Becomes a Backend Event.</text>
+  <text class="subhead" x="100" y="142">Whatever Apple ships next is one more node behind the same stream protocol.</text>
+
+  <g filter="url(#shadow)">
+    <rect class="card" x="120" y="260" width="320" height="190" rx="30"/>
+    <text class="card-title" x="166" y="335">WWDC 2026</text>
+    <text class="card-sub" x="166" y="373">whatever Apple</text>
+    <text class="card-sub" x="166" y="401">ships next</text>
+  </g>
+
+  <path class="arrow" marker-end="url(#arrowhead)" d="M 465 355 C 560 355 640 355 720 355"/>
+
+  <g filter="url(#shadow)">
+    <rect class="backend-band" x="720" y="232" width="760" height="300" rx="34"/>
+    <text class="backend-title" x="770" y="292">ManifoldKit backend band</text>
+    <text class="card-sub" x="770" y="325">GenerationStream stays the product surface.</text>
+
+    <rect class="node" x="770" y="370" width="112" height="50" rx="25"/>
+    <text class="node-text" x="804" y="403">MLX</text>
+    <rect class="node" x="900" y="370" width="132" height="50" rx="25"/>
+    <text class="node-text" x="924" y="403">GGUF</text>
+    <rect class="node" x="1050" y="370" width="188" height="50" rx="25"/>
+    <text class="node-text" x="1076" y="403">Foundation</text>
+    <rect class="node" x="770" y="442" width="138" height="50" rx="25"/>
+    <text class="node-text" x="796" y="475">OpenAI</text>
+    <rect class="node" x="926" y="442" width="152" height="50" rx="25"/>
+    <text class="node-text" x="952" y="475">Claude</text>
+    <rect class="node" x="1096" y="442" width="134" height="50" rx="25"/>
+    <text class="node-text" x="1122" y="475">Ollama</text>
+
+    <text class="ghost-text" x="1120" y="418" style="font-size:72px">REWRITE</text>
+    <line class="ghost" x1="1138" y1="350" x2="1450" y2="468"/>
+    <line class="ghost" x1="1450" y1="350" x2="1138" y2="468"/>
+
+    <rect class="new-node" x="1260" y="364" width="210" height="84" rx="42"/>
+    <text class="new-node-text" x="1300" y="398">+1 backend</text>
+    <text class="chip-sub" x="1310" y="426">not a rewrite</text>
+  </g>
+
+  <g>
+    <rect class="chip" x="164" y="625" width="380" height="102" rx="24"/>
+    <text class="chip-title" x="196" y="667">n-1 reach</text>
+    <text class="chip-sub" x="196" y="696">serves iOS 18 / macOS 15</text>
+
+    <rect class="chip" x="604" y="625" width="380" height="102" rx="24"/>
+    <text class="chip-title" x="636" y="667">FoundationOnly build</text>
+    <text class="chip-sub" x="636" y="696">lean App Store binary</text>
+
+    <rect class="chip" x="1044" y="625" width="392" height="102" rx="24"/>
+    <text class="chip-title" x="1076" y="667">Pre-wired stub traits</text>
+    <text class="chip-sub" x="1076" y="696">SystemAIProviderExtension + CoreAI</text>
+  </g>
+
+  <text class="caption" x="100" y="828">When Apple announces a new on-device model, ManifoldKit treats it as one backend behind GenerationStream.</text>
+</svg>

--- a/docs/plans/744-manifoldserver.md
+++ b/docs/plans/744-manifoldserver.md
@@ -153,10 +153,10 @@ Tests/
 | `.toolCallArgumentsDelta(id, frag)` *(expansion path)* | `choices[0].delta.tool_calls[idx].function.arguments = frag` |
 | `.usage(p, c)` | `usage = {prompt_tokens: p, completion_tokens: c, total_tokens: p+c}` on final chunk if `stream_options.include_usage = true` |
 | `.prefillProgress(nPast, nTotal, tokensPerSecond)` | `event: prefill_progress\ndata: {n_past, n_total, tokens_per_second}\n\n` — emitted only when request has `X-Manifold-Prefill-Progress: true` header (per #804 contract) |
-| `.thinkingToken(_)` / `.thinkingComplete` / `.thinkingSignature(_)` | dropped (v1) |
+| `.thinkingToken(_)` / `.thinkingCompleted` / `.thinkingSignature(_)` | dropped (v1) |
 | `.toolResult(_)` | dropped (server is pass-through; client owns dispatch) |
-| `.kvCacheReuse(_)` / `.diagnosticThrottle(_)` | dropped (internal signals) |
-| `.toolLoopLimitReached(_)` | derive `finish_reason: "length"` |
+| `.kvCacheReuse(_)` / `.throttleDiagnostic(_)` | dropped (internal signals) |
+| `.toolIterationLimitExceeded(_)` | derive `finish_reason: "length"` |
 | stream end clean | derive `finish_reason: "stop"` (or `"tool_calls"` if any tool-call event seen) |
 | stream error | emit `data: {"choices":[{"finish_reason":"stop"}], "error": {…}}\n\n` then close — spec-conformant `finish_reason` plus diagnostic |
 


### PR DESCRIPTION
## Summary

Pre-v1 naming and API surface cleanup across five areas. All changes are either additive (new conformances) or source-compatible renames with a deprecation bridge. Closes #1651, closes #1652.

- **`EndpointBackend*` protocols** — `CloudBackendURLModelConfigurable` and `CloudBackendKeychainConfigurable` renamed to `EndpointBackendURLModelConfigurable` / `EndpointBackendKeychainConfigurable`. "Cloud" was wrong for opt-in protocols that apply equally to local backends (Ollama, LM Studio). All conformers updated.

- **`prefillProgress` parameter labels** — `nPast:` / `nTotal:` (llama.cpp internals leaking through the public enum) renamed to `tokensProcessed:` / `tokensTotal:`. All pattern-match and construction sites updated.

- **`GenerationEvent` case normalization** — `thinkingComplete` → `thinkingCompleted`, `toolLoopLimitReached` → `toolIterationLimitExceeded`, `diagnosticThrottle` → `throttleDiagnostic`, `durationMs:` → `durationMilliseconds:` in `toolDispatchCompleted`. Normalizes the full enum to consistent past-tense / noun-phrase style.

- **`sessionID` → `requestGroupID`** in `GenerationQueue` — the `UUID?` request-grouping token was named identically to the persistent `sessionID: UUID` in `ConversationRuntime`. Renamed throughout the queue surface; persistent session references untouched. Closes #1651.

- **`AsyncSequence` conformances** (closes #1652) — `ImageGenerationRuntime`, `VideoGenerationRuntime`, `ConversationRuntime`, `MCPNotificationLifecycleEventObserver`, and `MCPHostStdioTransport` now conform to `AsyncSequence` via `nonisolated makeAsyncIterator()`. Consumers can write `for await event in x` instead of `for await event in x.events` across all event-bearing types.

## Test plan

- [ ] `swift build --build-tests --disable-default-traits` — clean
- [ ] Exhaustive `switch` on `GenerationEvent` compiles without warnings in any consumer
- [ ] `for try await event in stream` and `for await event in imageRuntime` both compile
- [ ] Deprecated `CloudBackend*` names still compile with a warning (bridge preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)