### PR TITLE
docs: add BYO-UI, tool-calling, and AppIntents developer-journey quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ struct MyChatApp: App {
 See [docs/QUICKSTART.md](docs/QUICKSTART.md) for backend selection, traits, and configuration.
 Building a multi-session SwiftUI app with a sidebar, persisted chats, and relaunch restore? See [docs/SWIFTUI-MULTI-SESSION.md](docs/SWIFTUI-MULTI-SESSION.md) — the canonical end-to-end guide.
 Building a CLI, server, or non-SwiftUI consumer? See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) — compile-tested Foundation Models, local GGUF, and Ollama / OpenAI examples.
+Want the inference layer with a fully custom SwiftUI UI (no `ChatView`)? See [docs/QUICKSTART-BRING-YOUR-OWN-UI.md](docs/QUICKSTART-BRING-YOUR-OWN-UI.md).
+Registering tools the model can call? See [docs/QUICKSTART-TOOLS.md](docs/QUICKSTART-TOOLS.md) — `ToolRegistry`, the local-model tool ceiling, approval gates, and streaming results.
+Exposing an `AppIntent` to the model? See [docs/QUICKSTART-APPINTENTS.md](docs/QUICKSTART-APPINTENTS.md).
 Full runnable: [`Example/Examples/MinimalExample`](Example/Examples/MinimalExample).
 
 ## Why ManifoldKit
@@ -254,6 +257,8 @@ let (_, stream) = try inferenceService.enqueue(
 ```
 
 **Local backend tool ceiling:** Local instruct models (3B–8B) degrade sharply when given more than ~5 tool definitions per request. For cloud backends (OpenAI, Anthropic, large Ollama models) 20+ tools is fine. When targeting a local backend, curate tools per request and keep definitions at or below 5 per call.
+
+For the complete guide — tool definition shape, `TypedToolExecutor`, streaming tool results, approval gates, and the `preToolUseHook` — see [docs/QUICKSTART-TOOLS.md](docs/QUICKSTART-TOOLS.md).
 
 ## MCP
 

--- a/docs/QUICKSTART-APPINTENTS.md
+++ b/docs/QUICKSTART-APPINTENTS.md
@@ -1,0 +1,57 @@
+# AppIntents Integration
+
+Bridge an `AppIntent` into ManifoldKit's tool-calling pipeline so an inference backend can invoke it like any other registered tool. This is the entry point for surfacing existing Siri / App Shortcuts actions to the model.
+
+The full reference — parameter-type coverage, the `Decodable` boilerplate AppIntents requires, enum handling, and approval policy — lives in the source-of-truth DocC article:
+
+**[`Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md`](../Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md)**
+
+This page is a thin pointer to it plus the package wiring.
+
+## Module and trait
+
+`ManifoldAppIntents` is a non-default, opt-in module. It depends only on `ManifoldInference` (and AppIntents, which ships with the OS), so apps that don't need SwiftData persistence or the chat UI can adopt it with no transitive weight.
+
+Add it explicitly to your target, and enable the `AppIntents` trait on the package dependency:
+
+```swift
+.package(
+    url: "https://github.com/roryford/ManifoldKit.git",
+    from: "0.43.0", // x-release-please-version
+    traits: [.trait(name: "AppIntents")]
+)
+```
+
+```swift
+.target(name: "MyApp", dependencies: [
+    .product(name: "ManifoldAppIntents", package: "ManifoldKit"),
+    .product(name: "ManifoldInference", package: "ManifoldKit"),
+])
+```
+
+## Wiring
+
+`AppIntentToolExecutor` wraps any `AppIntent` and exposes it through the `ToolExecutor` protocol. Register it into a `ToolRegistry`, then pass that registry to your `InferenceService`:
+
+```swift,no-build
+import ManifoldAppIntents
+import ManifoldInference
+
+let registry = ToolRegistry()
+registry.register(AppIntentToolExecutor(AskManifoldDemoIntent.self))
+
+let inference = InferenceService(toolRegistry: registry)
+```
+
+The model now sees the intent in its tool list (named from the intent type) and can invoke it whenever the conversation calls for it. The executor synthesises the JSON-Schema document from the intent's `@Parameter` properties, decodes the model's argument payload back into a fresh intent instance, calls `perform()`, and surfaces the `IntentResult` as a `ToolResult`.
+
+## Availability and approval
+
+`AppIntentToolExecutor` is annotated `@available(iOS 26, macOS 26, *)` — it ships alongside the on-device LLM-actuation features in the current AppIntents revision. Gate registration behind `if #available(iOS 26, macOS 26, *)` on apps with a lower deployment floor.
+
+The executor requires per-call approval by default. For explicitly read-only intents, opt out with `approvalPolicy: .readOnlyAutoApprove`. See the DocC article for the `Decodable` conformance every bridged intent needs and the full parameter-type table.
+
+## Where to go next
+
+- [`docs/QUICKSTART-TOOLS.md`](QUICKSTART-TOOLS.md) — the general tool-calling guide: `ToolRegistry`, the local-model tool ceiling, approval gates, and streaming results.
+- [`Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md`](../Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md) — the complete AppIntents bridge reference.

--- a/docs/QUICKSTART-BRING-YOUR-OWN-UI.md
+++ b/docs/QUICKSTART-BRING-YOUR-OWN-UI.md
@@ -1,0 +1,145 @@
+# Bring Your Own UI
+
+Use ManifoldKit's inference layer with a fully custom SwiftUI interface — no `ChatView`, no `ManifoldBootstrap`, no SwiftData. This path suits evaluation, embedding inference into an existing app, or building a bespoke chat surface where the framework's transcript, scroll-anchoring, and composer are not wanted.
+
+> Only restyling bubbles or overriding how *some* messages render? You do not need this. Keep `ChatView` and use the in-framework theming seams — `.chatTheme(_:)`, `.messageBubbleStyle(_:)`, and `.chatMessageRenderer(_:)`. See the [Theming the Chat UI](../Sources/ManifoldUI/ManifoldUI.docc/Articles/Theming.md) DocC article. Drop to full BYO-UI only when you need to replace the transcript, scroll-anchoring, and composer wholesale.
+
+## What you depend on
+
+Skip the `ManifoldKit` umbrella and depend on `ManifoldInference` plus the backends you want:
+
+```swift
+.target(name: "MyApp", dependencies: [
+    .product(name: "ManifoldInference", package: "ManifoldKit"),
+    .product(name: "ManifoldBackends", package: "ManifoldKit"),
+])
+```
+
+This keeps SwiftData, `ManifoldRuntime`, and `ManifoldUI` out of your app graph entirely. The backends you get are gated by SwiftPM traits — see [QUICKSTART.md → Customizing backends](QUICKSTART.md#customizing-backends).
+
+## Minimal headless example
+
+Construct an `InferenceService`, register the compiled-in backends, load a model, and stream `GenerationEvent.token` values:
+
+```swift
+import ManifoldInference
+import ManifoldBackends
+
+@main
+struct BYOExample {
+    static func main() async throws {
+        let inference = InferenceService()
+        DefaultBackends.register(with: inference)
+
+        try await inference.loadModel(from: .builtInFoundation, plan: .cloud())
+
+        let stream = try inference.generate(messages: [("user", "Hello")])
+        for try await event in stream.events {
+            if case .token(let text) = event { print(text, terminator: "") }
+        }
+    }
+}
+```
+
+`InferenceService` is `@MainActor @Observable`. `DefaultBackends.register(with:)` registers every backend compiled into your build and returns the count, so you can fail fast on an empty service. `loadModel(from:plan:)` takes a precomputed `ModelLoadPlan`; `.cloud()` is the factory for endpoint-backed and OS-provided models. `generate(messages:)` returns a `GenerationStream` whose `events` property is an `AsyncThrowingStream<GenerationEvent, Error>`.
+
+## Wiring it into SwiftUI
+
+Hold the `InferenceService` in an `@Observable @MainActor` model and append streamed tokens to a published transcript. The view binds to that state like any other SwiftUI state.
+
+```swift,no-build
+import SwiftUI
+import ManifoldInference
+import ManifoldBackends
+
+@Observable
+@MainActor
+final class CustomChatModel {
+    var transcript: [(role: String, content: String)] = []
+    var streamingReply = ""
+    var isGenerating = false
+
+    private let inference = InferenceService()
+
+    func bootstrap() async throws {
+        DefaultBackends.register(with: inference)
+        try await inference.loadModel(from: .builtInFoundation, plan: .cloud())
+    }
+
+    func send(_ prompt: String) async {
+        transcript.append((role: "user", content: prompt))
+        streamingReply = ""
+        isGenerating = true
+        defer { isGenerating = false }
+
+        do {
+            let stream = try inference.generate(messages: transcript)
+            for try await event in stream.events {
+                if case .token(let text) = event { streamingReply += text }
+            }
+            transcript.append((role: "assistant", content: streamingReply))
+            streamingReply = ""
+        } catch {
+            transcript.append((role: "assistant", content: "Error: \(error.localizedDescription)"))
+        }
+    }
+}
+
+struct CustomChatView: View {
+    @State private var model = CustomChatModel()
+    @State private var draft = ""
+
+    var body: some View {
+        VStack {
+            ScrollView {
+                ForEach(Array(model.transcript.enumerated()), id: \.offset) { _, message in
+                    Text("\(message.role): \(message.content)")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                if !model.streamingReply.isEmpty {
+                    Text("assistant: \(model.streamingReply)")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            HStack {
+                TextField("Message", text: $draft)
+                Button("Send") {
+                    let prompt = draft
+                    draft = ""
+                    Task { await model.send(prompt) }
+                }
+                .disabled(model.isGenerating)
+            }
+            .padding()
+        }
+        .task {
+            do { try await model.bootstrap() }
+            catch { /* surface a load failure in your UI */ }
+        }
+    }
+}
+```
+
+## Beyond tokens
+
+`GenerationEvent` carries more than `.token`. The cases you will most likely switch on:
+
+| Case | Meaning |
+|------|---------|
+| `.token(String)` | A content chunk. Append to the visible reply. |
+| `.thinkingToken(String)` | A reasoning/thinking chunk (models that emit a separate thinking channel). Render separately or drop. |
+| `.toolCall(ToolCall)` | The model asked to invoke a tool. See [QUICKSTART-TOOLS.md](QUICKSTART-TOOLS.md). |
+| `.usage(prompt:completion:)` | Token accounting for the turn. |
+
+The full case list lives in [`Sources/ManifoldInference/Models/GenerationEvent.swift`](../Sources/ManifoldInference/Models/GenerationEvent.swift). The enum is non-frozen, so an exhaustive `switch` should keep a `default` branch.
+
+## Cloud and local endpoints
+
+For an Ollama, OpenAI-compatible, or Anthropic endpoint, build an `APIEndpointRecord` and call `loadEndpointBackend(from:)` instead of `loadModel(from:plan:)`. Cloud SaaS providers additionally require an API key in the keychain. The endpoint construction is the same shape shown in [QUICKSTART.md → Seeding an Ollama endpoint](QUICKSTART.md#seeding-an-ollama-endpoint); only the load call differs in the BYO path (you call it on your own `InferenceService`, not through `quickStart()`).
+
+## Where to go next
+
+- [`docs/QUICKSTART-TOOLS.md`](QUICKSTART-TOOLS.md) — register tools and handle `.toolCall` events.
+- [`docs/QUICKSTART-CLI.md`](QUICKSTART-CLI.md) — compile-tested `Package.swift` + `main.swift` for Foundation Models, local GGUF, and Ollama / OpenAI endpoints.
+- [`docs/FeatureMatrix.md`](FeatureMatrix.md) — full trait → backend → capability table.
+- [`docs/QUICKSTART.md`](QUICKSTART.md) — the full-stack `quickStart()` path if you decide you want `ChatView` after all.

--- a/docs/QUICKSTART-TOOLS.md
+++ b/docs/QUICKSTART-TOOLS.md
@@ -1,0 +1,182 @@
+# Tool Calling
+
+Register tools the model can invoke, dispatch the calls it emits, and feed results back into the conversation. Tool calling behaves identically across backends that report `BackendCapabilities.supportsToolCalling` — MLX, llama.cpp, Foundation Models, OpenAI, Anthropic, and tool-capable Ollama models.
+
+The types in this guide live in `ManifoldInference`. The umbrella `import ManifoldKit` re-exports them; BYO-UI consumers import `ManifoldInference` directly.
+
+## The shape of a tool
+
+A tool is a `ToolDefinition` (the JSON-Schema contract the model sees) paired with an executor that runs it. The protocol is `ToolExecutor`, but most callers use `TypedToolExecutor`, which decodes JSON arguments into a Swift type, runs a handler, and encodes the result back to JSON.
+
+```swift,no-build
+import ManifoldInference
+
+struct WeatherArgs: Decodable, Sendable { let city: String }
+struct WeatherResult: Encodable, Sendable { let summary: String; let celsius: Double }
+
+let weatherSchema: JSONSchemaValue = .object([
+    "type": .string("object"),
+    "properties": .object([
+        "city": .object([
+            "type": .string("string"),
+            "description": .string("City name")
+        ])
+    ]),
+    "required": .array([.string("city")])
+])
+
+let weather = TypedToolExecutor<WeatherArgs, WeatherResult>(
+    definition: ToolDefinition(
+        name: "get_weather",
+        description: "Returns current weather for a city.",
+        parameters: weatherSchema
+    )
+) { args in
+    WeatherResult(summary: "Sunny", celsius: 22.0)
+}
+```
+
+`ToolDefinition.parameters` is a `JSONSchemaValue` — a typed enum (`.object`, `.array`, `.string`, `.number`, `.bool`, `.null`), not a `[String: Any]` dictionary. Build the schema with the enum cases as shown above.
+
+> Prefer to declare the schema once on the argument type? The `@ToolSchema` macro synthesises a `static var jsonSchema` from your `Decodable` struct, so you can pass `WeatherArgs.jsonSchema` to `parameters:`. The macro is gated behind the `Macros` SwiftPM trait (default-off, because it pulls in swift-syntax). Without that trait, hand-write the `JSONSchemaValue` as above.
+
+## Registering tools
+
+A `ToolRegistry` holds executors keyed by name (case-insensitive). Register on construction or with `register(_:)`:
+
+```swift,no-build
+let registry = ToolRegistry()
+registry.register(weather)
+```
+
+Wire the registry into an `InferenceService` at init time:
+
+```swift,no-build
+let inference = InferenceService(toolRegistry: registry)
+DefaultBackends.register(with: inference)
+```
+
+The coordinator re-reads the registry on every turn, so you can `register(_:)` more tools later through `inference.toolRegistry` (a get-only accessor returning the same instance). The registry property cannot be reassigned after init — pass the populated registry to the initializer.
+
+## Passing tools to a request
+
+For the queued chat path, put `registry.definitions` on a `GenerationConfig`:
+
+```swift,no-build
+var config = GenerationConfig(...)
+config.tools = registry.definitions
+config.toolChoice = .auto          // .auto | .none | .required | .tool(name:)
+config.maxToolIterations = 10      // per-request cap on the tool loop
+
+let (_, stream) = try inference.enqueue(messages: history, config: config)
+```
+
+When a registry is installed on the `InferenceService`, the generation coordinator dispatches `toolCall` events through it automatically and feeds each `ToolResult` back into the conversation before the next turn — you observe the loop through the event stream rather than dispatching by hand.
+
+## The local-model tool ceiling
+
+Local instruct models in the 3B–8B range degrade sharply when given more than about **5 tool definitions** per request: they confuse tools, hallucinate arguments, or stop calling tools entirely. Cloud backends (OpenAI, Anthropic, large Ollama models) handle 20+ without issue.
+
+`ToolRegistry.definitions` logs a warning when it returns more than 5 entries. When you target a local backend, curate tools per request rather than advertising the full catalog — pass a filtered subset to `config.tools`, or use `advertisedToolNames` / `advertisedDefinitions` to hide tools from the model while keeping them dispatchable for in-flight calls.
+
+## Observing the tool loop
+
+If you drive generation directly (BYO-UI), the events you switch on are:
+
+| Event | Meaning |
+|-------|---------|
+| `.toolCall(ToolCall)` | The model emitted a complete tool call. |
+| `.toolCallStart(callId:name:)` / `.toolCallArgumentsDelta(callId:textDelta:)` | Streaming assembly of a call (deltas merge into one `.toolCall`). |
+| `.toolResult(ToolResult)` | A dispatched tool's outcome was recorded into the transcript. |
+| `.toolProgress(ToolProgressEvent)` | Interim progress from a streaming executor. |
+| `.toolIterationLimitExceeded(iterations:)` | The `maxToolIterations` cap was hit. |
+
+The complete list is in [`Sources/ManifoldInference/Models/GenerationEvent.swift`](../Sources/ManifoldInference/Models/GenerationEvent.swift).
+
+## Streaming tool results
+
+Long-running tools (downloads, paginated fetches, multi-step queries) can report liveness without breaking the atomic-result contract. Override `executeStreaming(arguments:)` to yield `ToolExecutionEvent.progress(message:fraction:)` chunks, then exactly one `.completed(ToolResult)`:
+
+```swift,no-build
+struct BulkFetchTool: ToolExecutor {
+    let definition: ToolDefinition
+
+    func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
+        // Non-streaming fallback: buffer everything, return one result.
+        ToolResult(callId: "", content: try await fetchAll())
+    }
+
+    func executeStreaming(arguments: JSONSchemaValue) -> AsyncThrowingStream<ToolExecutionEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var buffer = ""
+                    for page in 0..<pageCount {
+                        try Task.checkCancellation()
+                        buffer += try await fetchPage(page)
+                        continuation.yield(.progress(
+                            message: "Fetched page \(page + 1) of \(pageCount)",
+                            fraction: Double(page + 1) / Double(pageCount)
+                        ))
+                    }
+                    continuation.yield(.completed(ToolResult(callId: "", content: buffer)))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}
+```
+
+The terminal `ToolResult` is **atomic**: progress events are observational, and only the `.completed` value flows into the transcript. Partial work accumulated before a throw is discarded. The default `executeStreaming` implementation just wraps `execute(arguments:)` and yields one terminal event, so non-streaming executors get this for free. Executors must also cooperate with cancellation — check `Task.checkCancellation()` at yield points so a user stop tears the work down promptly.
+
+## Error classification
+
+Return a `ToolResult` with an explicit `errorKind` when a failure is meaningful to the model. The vocabulary (`ToolResult.ErrorKind`) is locked for 1.0: `invalidArguments`, `permissionDenied`, `notFound`, `timeout`, `rateLimited`, `cancelled`, `transient`, `permanent`, `unknownTool`. Throwing from an executor is the catch-all — the registry records it as `.permanent` (not retry-safe by design). Signal a retriable failure by returning `.transient` explicitly rather than throwing.
+
+## Approving side-effecting tools
+
+Pure-read tools auto-approve. A tool that writes a file, sends a message, or calls a paid API should set `requiresApproval` to `true`:
+
+```swift,no-build
+let sendTool = TypedToolExecutor<SendArgs, SendResult>(
+    definition: ToolDefinition(name: "send_email", description: "Sends an email.", parameters: schema),
+    requiresApproval: true
+) { args in try await send(args) }
+```
+
+The orchestrator then consults a `ToolApprovalGate` before dispatching. The default is `AutoApproveGate` (dispatches everything). Supply your own conformer — e.g. one that presents a SwiftUI sheet and awaits the user's tap — via `InferenceService(toolRegistry:toolApprovalGate:)`. Returning `.denied(reason:)` synthesises a `ToolResult` with `.permissionDenied` and continues the stream so the model can acknowledge the refusal; it does not cancel generation.
+
+## Sanitizing or blocking with a pre-tool-use hook
+
+Distinct from approval, a `PreToolUseHook` runs synchronously before dispatch and can rewrite arguments or block the call. The closure shape is:
+
+```swift,no-build
+let hook: PreToolUseHook = { toolName, arguments, requestGroupID in
+    if isDangerous(arguments) {
+        return .block(reason: "blocked by policy")
+    }
+    return .proceed(arguments: sanitized(arguments))
+}
+
+let (_, stream) = try inference.enqueue(
+    structuredMessages: history,
+    config: config,
+    preToolUseHook: hook
+)
+```
+
+`.proceed(arguments:)` must preserve the same set of top-level JSON keys as the original (sanitize-only). `.block(reason:)` synthesises a `permissionDenied` result and lets the turn loop continue. Full-stack hosts wire this through the Runtime `HookRegistry` rather than passing the closure directly — see the [Hook System](../Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/HookSystem.md) DocC article.
+
+## Bridging external tools
+
+- **MCP** — connect to a Model Context Protocol server and register its tools into the same `ToolRegistry`. See [`Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md`](../Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md).
+- **AppIntents** — expose an `AppIntent` as a tool with `AppIntentToolExecutor`. See [`docs/QUICKSTART-APPINTENTS.md`](QUICKSTART-APPINTENTS.md).
+
+## Where to go next
+
+- [`docs/QUICKSTART-BRING-YOUR-OWN-UI.md`](QUICKSTART-BRING-YOUR-OWN-UI.md) — drive generation and the tool loop yourself.
+- [`Sources/ManifoldTools/README.md`](../Sources/ManifoldTools/README.md) — the `manifold-tools` CLI harness that exercises tool calling end-to-end on a real backend.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -276,6 +276,8 @@ See [`docs/FeatureMatrix.md`](FeatureMatrix.md) for the full trait → capabilit
 
 ### Bring your own UI
 
+> For the standalone walkthrough — package wiring, a SwiftUI view model that streams tokens, and the full `GenerationEvent` surface — see [`QUICKSTART-BRING-YOUR-OWN-UI.md`](QUICKSTART-BRING-YOUR-OWN-UI.md). The summary below is the seed.
+
 If you don't want `ChatView` and prefer your own SwiftUI surface, skip `quickStart()` and depend on just `ManifoldInference` plus the backends you want. Construct an `InferenceService` directly, register the compiled backends, and stream `GenerationEvent.token` into your transcript:
 
 ```swift


### PR DESCRIPTION
## Summary

Three developer journeys lacked a clear entry point from the README or `docs/`. This promotes existing buried content into standalone pages and links them from the README "Hello World" block. Discoverability fix only — no net-new APIs; every snippet was verified against the current public surface in `Sources/`.

New files:

- **`docs/QUICKSTART-BRING-YOUR-OWN-UI.md`** — using ManifoldKit's inference layer with a fully custom SwiftUI UI (no `ChatView`, no `ManifoldBootstrap`, no SwiftData). Promoted from the buried subsection at `QUICKSTART.md` and expanded with an `@Observable @MainActor` view model that streams `GenerationEvent.token` into a transcript, plus the broader event surface.
- **`docs/QUICKSTART-TOOLS.md`** — complete tool-calling guide: `ToolRegistry`, `ToolDefinition` / `JSONSchemaValue` shape, `TypedToolExecutor`, the local-model ~5-tool ceiling, the streaming `executeStreaming` / `ToolExecutionEvent` contract, `ToolApprovalGate`, and the `PreToolUseHook`.
- **`docs/QUICKSTART-APPINTENTS.md`** — thin wrapper promoting the source-of-truth DocC article at `Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md`, with package/trait wiring.

Edits:

- README "Hello World" block links all three new quickstarts; the "Tool Calling" section links the full tools guide.
- `QUICKSTART.md` "Bring your own UI" subsection now points at the standalone page.

## Verification

- Every internal doc link resolves to a real file.
- Every type/API in a code snippet exists in `Sources/` (`InferenceService`, `DefaultBackends`, `ModelLoadPlan.cloud()`, `ModelInfo.builtInFoundation`, `GenerationStream.events`, `ToolRegistry`, `TypedToolExecutor`, `ToolExecutionEvent`, `PreToolUseHook`, `ToolApprovalGate`, `AppIntentToolExecutor`).

Docs-only (markdown); no build required.

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)