### PR TITLE
feat: graduate the AnyLanguageModel bridge to a documented provider-breadth path

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ open Advanced.xcodeproj
 
 AnyLanguageModel is HuggingFace's Swift package — it mirrors Apple's `FoundationModels` API and exposes many providers behind a single protocol. ManifoldKit and AnyLanguageModel occupy adjacent niches: AnyLanguageModel optimises for provider coverage and API familiarity; ManifoldKit optimises for production reliability and drop-in chat UI (`ChatView` + `SessionListView` + `ModelManagementSheet` on day one). Pick the one whose axis matches the problem you're solving.
 
+ManifoldKit also **consumes** AnyLanguageModel as a backend: the `AnyLanguageModel` trait is the supported path for providers without a native backend — Gemini, xAI, Groq, Mistral, OpenRouter, and any OpenAI/Anthropic-compatible endpoint — so they plug into the same `ChatViewModel` and runtime as a native backend. See [docs/PROVIDER-BRIDGE.md](docs/PROVIDER-BRIDGE.md) for the provider list, URL/trait setup, and capability limits.
+
 ## Migrating from BaseChatKit
 
 This package was renamed from `BaseChatKit` to `ManifoldKit` in v0.20. The old GitHub URL redirects, but:

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -37,6 +37,7 @@ public enum ManifoldCapability: String, CaseIterable, Sendable {
     case imageGeneration
     case modelDownload           // HuggingFace background download
     case embeddings
+    case providerBridge          // additional providers via the AnyLanguageModel bridge
 }
 
 /// A SwiftPM trait declared in `Package.swift` and the capabilities it unlocks.
@@ -83,8 +84,8 @@ public enum FeatureMatrix {
         ),
         ManifoldTrait(
             name: "AnyLanguageModel",
-            description: "Enable the AnyLanguageModel bridge backend target.",
-            unlocks: [.localInference]
+            description: "Reach providers without a native backend (Gemini, xAI, Groq, Mistral, OpenRouter, and others) through the AnyLanguageModel bridge.",
+            unlocks: [.providerBridge]
         ),
         ManifoldTrait(
             name: "Ollama",

--- a/Tests/ManifoldBackendsTests/AnyLanguageModel/AnyLanguageModelConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/AnyLanguageModel/AnyLanguageModelConformanceTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+@testable import ManifoldInference
+
+#if AnyLanguageModel
+import AnyLanguageModel
+@testable import ManifoldBackends
+
+/// Holds the AnyLanguageModel bridge to the same universal backend contract as
+/// the native backends.
+///
+/// Two tiers:
+///
+/// 1. **Offline contract + capability mapping** — runs whenever the
+///    `AnyLanguageModel` trait is enabled, with no network access. Exercises
+///    the universal `InferenceBackend` invariants, the capability
+///    meta-contract, and the fail-closed mapping between the advertised
+///    `BackendCapabilities` and `generate()`'s actual behaviour.
+///
+/// 2. **Live provider conformance** — gated behind `RUN_ANYLM_E2E=1` plus an
+///    `ANYLM_E2E_URL` bridge URL (for example
+///    `gemini://gemini-2.0-flash?apiKey=…`). Skipped cleanly when either is
+///    absent so the default suite never requires a key to compile or pass.
+final class AnyLanguageModelConformanceTests: XCTestCase {
+
+    private let backendName = "AnyLanguageModelBackend"
+
+    // MARK: - Tier 1: offline universal contract
+
+    func test_contract_allInvariants() {
+        BackendContractChecks.assertAllInvariants(makingBackend: { AnyLanguageModelBackend() })
+    }
+
+    /// The bridge streams plain text only: it advertises the conservative
+    /// capability floor (no tools / structured output / thinking) so the
+    /// capability router never routes those requests to it. The meta-contract
+    /// passes trivially because no tracked flag is declared `true`.
+    func test_contract_capabilityMetaContract() {
+        BackendContractChecks.resetCapabilityClaims(forBackend: backendName)
+        BackendContractChecks.assertCapabilityMetaContract(
+            backendName: backendName,
+            capabilities: AnyLanguageModelBackend().capabilities
+        )
+    }
+
+    // MARK: - Tier 1: capability mapping ↔ behaviour
+
+    /// Confirms the advertised floor matches what `generate()` actually accepts.
+    /// If a future change flips one of these flags `true` without wiring the
+    /// behaviour, the capability router would misroute a request the bridge
+    /// then rejects at runtime — this test pins the two in sync.
+    func test_capabilityMapping_matchesFailClosedBehaviour() async throws {
+        let caps = AnyLanguageModelBridgeCapabilities.remote()
+        XCTAssertFalse(caps.supportsToolCalling, "bridge does not translate tool definitions")
+        XCTAssertFalse(caps.supportsStructuredOutput, "bridge streams plain text only")
+        XCTAssertFalse(caps.supportsNativeJSONMode, "bridge has no JSON mode")
+        XCTAssertFalse(caps.supportsThinking, "bridge does not surface reasoning tokens")
+        XCTAssertFalse(caps.supportsGrammarConstrainedSampling, "bridge exposes no grammar sampling")
+        XCTAssertTrue(caps.isRemote, "bridge providers are reached over the network")
+        XCTAssertTrue(caps.supportsStreaming)
+
+        let backend = AnyLanguageModelBackend { _ in
+            AnyLanguageModelDescriptor(
+                model: ConformanceMockLanguageModel(chunks: ["ok"]),
+                capabilities: AnyLanguageModelBridgeCapabilities.remote()
+            )
+        }
+        try await backend.loadModel(from: URL(string: "openai://gpt-4o?apiKey=test")!, plan: makePlan(context: 1_024))
+
+        // tools advertised false ⇒ generate must reject a tools config
+        let tools = GenerationConfig(tools: [ToolDefinition(name: "t", description: "d", parameters: .object([:]))])
+        XCTAssertThrowsError(try backend.generate(prompt: "hi", systemPrompt: nil, config: tools))
+
+        // structured output advertised false ⇒ generate must reject jsonMode
+        let json = GenerationConfig(jsonMode: true)
+        XCTAssertThrowsError(try backend.generate(prompt: "hi", systemPrompt: nil, config: json))
+    }
+
+    // MARK: - Tier 2: live provider (env-gated)
+
+    func test_live_streamsRealCompletion() async throws {
+        let env = ProcessInfo.processInfo.environment
+        try XCTSkipUnless(env["RUN_ANYLM_E2E"] == "1", "Set RUN_ANYLM_E2E=1 to run AnyLanguageModel live conformance.")
+        guard let urlString = env["ANYLM_E2E_URL"], let url = URL(string: urlString) else {
+            throw XCTSkip("Set ANYLM_E2E_URL to a bridge URL (e.g. gemini://gemini-2.0-flash?apiKey=…).")
+        }
+
+        // Universal invariants hold against the live-configured backend too.
+        BackendContractChecks.assertAllInvariants(makingBackend: { AnyLanguageModelBackend() })
+
+        let backend = AnyLanguageModelBackend()
+        try await backend.loadModel(from: url, plan: makePlan(context: 8_192))
+        XCTAssertTrue(backend.isModelLoaded)
+
+        let config = GenerationConfig(maxOutputTokens: 64)
+        let stream = try backend.generate(
+            prompt: "Reply with the single word: pong.",
+            systemPrompt: "You are a terse test fixture.",
+            config: config
+        )
+
+        var text = ""
+        for try await event in stream.events {
+            if case .token(let delta) = event { text += delta }
+        }
+
+        XCTAssertFalse(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "live provider produced no text")
+        XCTAssertFalse(backend.isGenerating, "isGenerating must reset after the stream finishes")
+
+        // The advertised capability floor must survive a real load — the router
+        // reads these after the model is in memory.
+        XCTAssertFalse(backend.capabilities.supportsToolCalling)
+        XCTAssertFalse(backend.capabilities.supportsThinking)
+    }
+
+    // MARK: - Helpers
+
+    private func makePlan(context: Int) -> ModelLoadPlan {
+        ModelLoadPlan(
+            inputs: .init(
+                modelFileSize: 0,
+                memoryStrategy: .external,
+                requestedContextSize: context,
+                trainedContextLength: nil,
+                kvBytesPerToken: 0,
+                availableMemoryBytes: 0,
+                physicalMemoryBytes: 0,
+                absoluteContextCeiling: context,
+                headroomFraction: 0
+            ),
+            outcome: .init(
+                effectiveContextSize: context,
+                estimatedResidentBytes: 0,
+                estimatedKVBytes: 0,
+                totalEstimatedBytes: 0,
+                verdict: .allow,
+                reasons: []
+            )
+        )
+    }
+}
+
+/// Minimal `LanguageModel` stub for the offline capability-mapping test. Named
+/// distinctly from `AnyLanguageModelBackendTests`' private mock to avoid a
+/// duplicate-symbol clash within the test target.
+private struct ConformanceMockLanguageModel: LanguageModel {
+    typealias UnavailableReason = Never
+
+    let chunks: [String]
+
+    func respond<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) async throws -> LanguageModelSession.Response<Content> where Content: Generable {
+        let final = chunks.last ?? ""
+        return LanguageModelSession.Response(
+            content: final as! Content,
+            rawContent: GeneratedContent(final),
+            transcriptEntries: []
+        )
+    }
+
+    func streamResponse<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) -> sending LanguageModelSession.ResponseStream<Content> where Content: Generable {
+        let stream = AsyncThrowingStream<LanguageModelSession.ResponseStream<Content>.Snapshot, any Error> { continuation in
+            for chunk in chunks {
+                continuation.yield(
+                    LanguageModelSession.ResponseStream<Content>.Snapshot(
+                        content: (chunk as! Content).asPartiallyGenerated(),
+                        rawContent: GeneratedContent(chunk)
+                    )
+                )
+            }
+            continuation.finish()
+        }
+        return LanguageModelSession.ResponseStream(stream: stream)
+    }
+}
+#endif

--- a/docs/FeatureMatrix.md
+++ b/docs/FeatureMatrix.md
@@ -5,9 +5,10 @@ Do not edit by hand — re-run the script.
 
 | Trait | Description | Capabilities Unlocked |
 |-------|-------------|-----------------------|
-| `AnyLanguageModel` | Enable the AnyLanguageModel bridge backend target. | `localInference` |
+| `AnyLanguageModel` | Reach providers without a native backend (Gemini, xAI, Groq, Mistral, OpenRouter, and others) through the AnyLanguageModel bridge. | `providerBridge` |
 | `AppIntents` | Enable the ManifoldAppIntents AppIntent ↔ ToolDefinition bridge. | `toolCalling` |
 | `CloudSaaS` | Third-party SaaS providers (Claude, OpenAI). Off by default. | `cloudOpenAI`, `cloudClaude`, `toolCalling`, `visionInput` |
+| `CoreAI` | Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface. | _(none — harness/build lever)_ |
 | `FoundationOnly` | App Store-lean: Apple Foundation Models only. Pass `traits: ["FoundationOnly"]` from the consumer manifest — overrides the MLX/Llama/HuggingFace default trait set. | `foundationBackend` |
 | `Fuzz` | Enable real inference backends in fuzz-chat (Ollama, Llama, Foundation). Required by scripts/fuzz.sh; not needed for swift test or xcodebuild test. | _(none — harness/build lever)_ |
 | `HuggingFace` | Enable HuggingFace Hub search, browse, and download | `modelDownload` |
@@ -19,5 +20,6 @@ Do not edit by hand — re-run the script.
 | `Ollama` | Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major. | `ollama`, `toolCalling`, `embeddings` |
 | `Server` | Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency. | `embeddings` |
 | `Skills` | Enable the ManifoldSkills target: Claude-Code-compatible filesystem skill discovery (~/.claude/skills/<name>/SKILL.md) plus a single `invoke_skill` dispatch tool. macOS-only in v1 — compiles on iOS as a no-op registry. | `toolCalling` |
+| `SystemAIProviderExtension` | Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API. | _(none — harness/build lever)_ |
 | `Tools` | Enable the ManifoldTools end-to-end tool-calling validation harness and its `manifold-tools` CLI. | `toolCalling` |
 | `Voice` | Enable the ManifoldVoice speech I/O spike and voice composer UI. | `voiceIO` |

--- a/docs/PROVIDER-BRIDGE.md
+++ b/docs/PROVIDER-BRIDGE.md
@@ -1,0 +1,75 @@
+# Provider bridge (AnyLanguageModel)
+
+ManifoldKit ships native backends for MLX, llama.cpp/GGUF, Apple Foundation Models, OpenAI (Chat + Responses), Anthropic, and Ollama. Providers without a native backend are reached through the **AnyLanguageModel bridge** — a single `InferenceBackend` adapter over HuggingFace's [AnyLanguageModel](https://github.com/huggingface/AnyLanguageModel) package.
+
+AnyLanguageModel operates at the model-access altitude (one protocol, many providers). ManifoldKit operates at the application-framework altitude and consumes it as one more backend, so a bridged provider plugs into the same `ChatViewModel`, conversation runtime, and persistence path as a native backend.
+
+## Providers unlocked
+
+The bridge is the supported path for providers ManifoldKit does not implement natively, including:
+
+- Google **Gemini**
+- **xAI** (Grok)
+- **Groq**
+- **Mistral**
+- **OpenRouter** (and any OpenAI-compatible `/responses` endpoint)
+- Any OpenAI- or Anthropic-API-compatible endpoint
+
+OpenAI, Anthropic, and Ollama also resolve through the bridge, but the native `CloudSaaS` / `Ollama` backends are preferred for those — they add certificate pinning, retry, circuit-breaking, and latest-wins cancellation that the bridge does not.
+
+## Enabling the trait
+
+The bridge lives behind the opt-in `AnyLanguageModel` trait. Enable it from the consumer manifest:
+
+```swift
+.package(
+    url: "https://github.com/roryford/ManifoldKit.git",
+    from: "0.43.0",
+    traits: ["AnyLanguageModel"]
+)
+```
+
+## Configuring a provider
+
+Models are resolved from a URL whose scheme selects the provider. The model identifier is the host/path; credentials and overrides are query items.
+
+| Scheme | Example | Required query items |
+|--------|---------|----------------------|
+| `gemini` | `gemini://gemini-2.0-flash?apiKey=KEY` | `apiKey` |
+| `openai` | `openai://gpt-4o?apiKey=KEY` | `apiKey` |
+| `openai-responses` | `openai-responses://gpt-4.1?apiKey=KEY` | `apiKey` |
+| `anthropic` | `anthropic://claude-3-5-sonnet?apiKey=KEY` | `apiKey` |
+| `ollama` | `ollama://llama3.2?baseURL=http://localhost:11434` | — |
+| `openresponses` | `openresponses://x-ai/grok-2?apiKey=KEY` | `apiKey` |
+
+Common optional query items: `baseURL` (override the provider endpoint — point `openai`/`openai-responses` at xAI, Groq, or Mistral's OpenAI-compatible URL), `apiVersion`, and provider-specific overrides documented inline in `AnyLanguageModelURLResolver`.
+
+```swift
+import ManifoldBackends
+
+let backend = AnyLanguageModelBackend()
+let url = URL(string: "gemini://gemini-2.0-flash?apiKey=\(key)")!
+try await backend.loadModel(from: url, plan: plan)
+let stream = try backend.generate(prompt: prompt, systemPrompt: system, config: config)
+```
+
+## Capabilities and limits
+
+The bridge advertises a conservative capability floor — `isRemote = true`, streaming on, and tool calling / structured output / native JSON mode / thinking tokens / grammar-constrained sampling all **off**. `generate()` fail-closes (throws) on a tool, JSON-mode, or grammar request rather than silently dropping it, so the capability router never routes those requests here. This floor is uniform across wrapped providers because the bridge streams plain text only.
+
+Requests routed through the bridge do **not** inherit ManifoldKit's certificate pinning, retry strategy, circuit breaker, or latest-wins cancellation — AnyLanguageModel owns those concerns internally. `stopGeneration()` maps to `Task.cancel()`, so stop promptness depends on AnyLanguageModel's implementation.
+
+When a bridged provider grows enough demand to justify reasoning-token fidelity or operational parity, the path is to promote it to a native backend. See [`SCOPE_DECISION.md`](SCOPE_DECISION.md) for the recorded Gemini native-vs-bridge decision.
+
+## Testing
+
+`AnyLanguageModelConformanceTests` runs the universal backend contract and the capability meta-contract against the bridge offline (no network) whenever the trait is enabled. A live tier exercises a real provider end-to-end, gated behind an env var like the other live E2E suites:
+
+```bash
+RUN_ANYLM_E2E=1 \
+ANYLM_E2E_URL='gemini://gemini-2.0-flash?apiKey=YOUR_KEY' \
+swift test --traits AnyLanguageModel \
+  --filter AnyLanguageModelConformanceTests/test_live_streamsRealCompletion
+```
+
+Without `RUN_ANYLM_E2E=1` and `ANYLM_E2E_URL`, the live test skips cleanly.

--- a/docs/SCOPE_DECISION.md
+++ b/docs/SCOPE_DECISION.md
@@ -56,3 +56,24 @@ AnyLanguageModel optimizes for provider abstraction — one protocol, many provi
 The internal consumer keeps building on its own vendored expander, so the ManifoldKit-side deletion does not affect it.
 
 ChatbotUI-iOS migrates its single-field usage from the old context property to the `systemPromptContext` dictionary: the dict was added in 0.6.0 as the forward-compatible replacement for that specific use case. Drop-in UI, `ChatViewModel`, `ModelManagementSheet`, `APIConfigurationView`, and the HuggingFace downloader all remain unchanged.
+
+---
+
+# Scope Decision — Gemini: bridge, not native backend (2026-06)
+
+**Decision: reach Gemini through the AnyLanguageModel bridge. Do not write a native Gemini backend at this time.**
+
+Context: graduating the AnyLanguageModel bridge to the documented provider-breadth path (issue #1638) raised the question of whether Gemini specifically warrants a native backend. Gemini is high-demand, and its API surfaces thinking/reasoning tokens that the generic bridge flattens (the bridge advertises `supportsThinking = false` and streams plain text only).
+
+Why bridge:
+
+- **Provider breadth is the goal, not per-provider depth.** The bridge unlocks Gemini, xAI, Groq, Mistral, OpenRouter, and others through one adapter. A native Gemini backend buys depth for one provider at the cost of an Nth cloud backend to maintain (auth, retry, pinning, streaming wire format, tool-call dialect, capability probe, conformance suite).
+- **The current gap is bounded and documented.** Bridged Gemini loses reasoning-token fidelity and ManifoldKit's operational guarantees (pinning, retry, circuit breaker, latest-wins cancellation). Both are stated in [PROVIDER-BRIDGE.md](PROVIDER-BRIDGE.md) so the limitation is visible, not silent.
+- **No measured consumer demand for native Gemini yet.** Consistent with the "delete what nobody used" discipline of 0.6.0, a native backend is speculative surface area until demand is observed.
+
+Revisit trigger — promote Gemini to a native backend when **either** holds:
+
+- A shipping consumer needs Gemini reasoning/thinking-token streaming (the bridge's flattening becomes a product gap, not a cosmetic one), or
+- A shipping consumer needs the operational guarantees (pinning / retry / circuit breaker / latest-wins) on Gemini traffic specifically.
+
+Until then, Gemini is a first-class **bridged** provider: documented, surfaced in the Feature Matrix, and held to the universal backend contract by `AnyLanguageModelConformanceTests`.


### PR DESCRIPTION
Closes #1638.

Graduates the AnyLanguageModel bridge from a hidden, thinly-covered trait into a documented, contract-tested path for providers without a native backend (Gemini, xAI, Groq, Mistral, OpenRouter, and any OpenAI/Anthropic-compatible endpoint). The bridge is treated as a complementary inference provider at the model-access altitude that ManifoldKit consumes — not a competitor.

## Scope checklist

- [x] **Conformance suite vs. a live provider, env-gated.** New `AnyLanguageModelConformanceTests` adds (1) an offline tier — universal `InferenceBackend` invariants + capability meta-contract + capability-mapping/fail-closed behaviour — that runs whenever the `AnyLanguageModel` trait is on, and (2) a live tier gated behind `RUN_ANYLM_E2E=1` + `ANYLM_E2E_URL` (e.g. `gemini://gemini-2.0-flash?apiKey=…`) that skips cleanly with no key. The default suite needs no key to compile or pass.
- [x] **Documentation.** New `docs/PROVIDER-BRIDGE.md` (provider list, trait/URL setup, capability limits, test command) + a README mention under the AnyLanguageModel comparison section.
- [x] **Gemini native-vs-bridge decision, recorded.** Appended to `docs/SCOPE_DECISION.md`. No native Gemini backend implemented in this PR.
- [x] **Capability mapping confirmed.** The bridge advertises a conservative floor (tools / structured output / native JSON / thinking / grammar all off, `isRemote` on, streaming on); `generate()` fail-closes on tool/JSON/grammar requests, so the capability router never misroutes. A test pins caps in sync with that behaviour. No mismatch to fix.
- [x] **Feature Matrix.** Fixed the mapping: `AnyLanguageModel` now unlocks a new `providerBridge` capability (it is a remote provider bridge, not `localInference`). `docs/FeatureMatrix.md` regenerated via `scripts/render-feature-matrix.sh`.

## Gemini decision (one line)

Reach Gemini through the bridge for now; do not write a native backend yet — revisit only when a shipping consumer needs Gemini reasoning-token streaming or ManifoldKit's operational guarantees (pinning/retry/circuit-breaker/latest-wins) on Gemini traffic specifically.

## Validation

- `swift build --build-tests --disable-default-traits` (CI-accurate compile path) — Build complete.
- `swift build --build-tests --traits AnyLanguageModel,CloudSaaS,HuggingFace,MCP,MCPBuiltinCatalog` — Build complete.
- `AnyLanguageModelConformanceTests`: 3 offline tests pass, live tier skips (no env). `FeatureMatrixTests` (7) and existing `AnyLanguageModelBackendTests` (3) pass.

## Note: pre-existing `main` regression (out of scope)

The full trait-combo sweep with `Ollama` on (`MLX,Llama,Ollama,CloudSaaS,…`) fails to build at `Sources/ManifoldBackendsUmbrella/CloudBackends.swift:27` — `extra argument '_registrar' in call`. `OllamaBackend.init(_registrar:)` was changed from package-visible to `internal` in commit `dec9bf86` (on `main`, today), breaking cross-module umbrella calls under the `Ollama` trait. This PR touches none of those files, and CI's `--disable-default-traits` lane (Ollama off) does not trip it. Left unfixed here to keep this PR scoped to #1638; flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)