### PR TITLE
fix(backends): make OllamaBackend registrar init package-visible for cross-module call

### DIFF
--- a/Sources/ManifoldCloud/OllamaBackend.swift
+++ b/Sources/ManifoldCloud/OllamaBackend.swift
@@ -132,15 +132,17 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
 
     // MARK: - Init
 
-    /// Internal initializer used by registrar and framework-internal infrastructure.
+    /// Package-internal initializer used by registrar and framework-internal infrastructure.
     ///
     /// This path is identical to the public `init(urlSession:)` with a `nil` session
     /// but is NOT marked deprecated, so framework-internal callers
     /// (``CloudBackends``, ``TraitAwareServerBackendProvider``, etc.) don't generate
     /// deprecation warnings when following the recommended migration path.
-    /// External consumers building `OllamaBackend` directly should use the public
-    /// init or register via `DefaultBackends.register(_:)`.
-    internal init(_registrar: Void) {
+    /// `package` (not `internal`) because ``CloudBackends`` lives in the
+    /// `ManifoldBackendsUmbrella` module and calls this across the module boundary
+    /// under `#if Ollama`. External consumers building `OllamaBackend` directly
+    /// should use the public init or register via `DefaultBackends.register(_:)`.
+    package init(_registrar: Void) {
         self.adapter = OllamaAdapter(
             capabilities: Self.defaultAdapterCapabilities,
             requestBuilder: { _, _, _, _ in


### PR DESCRIPTION
## Problem

`OllamaBackend.init(_registrar:)` was introduced as `internal` in #1649, but `ManifoldBackendsUmbrella/CloudBackends.swift` calls it **across the module boundary** under `#if Ollama`. `internal` access does not cross modules, so any build with the `Ollama` trait fails to compile:

```
CloudBackends.swift:27: extra argument '_registrar' in call
```

## Why CI didn't catch it

CI runs `--disable-default-traits`, which turns the `Ollama` trait off, so the `#if Ollama` block is never compiled. The breakage only surfaces where the `Ollama` trait is built — the **pre-push `scripts/test.sh --profile local` gate** and the **trait-combo sweep** (`swift build --build-tests --traits …,Ollama,…`). Surfaced while validating a sibling backend PR (#1659) against the full trait surface.

## Fix

Change the init from `internal` to `package`. The init's own doc-comment already names `CloudBackends` as an intended caller, so cross-module access was the design intent — only the access level was wrong. `package` is the correct level: framework-internal callers across the package may use it; external consumers cannot (they use the public `init(urlSession:)` or `DefaultBackends.register(_:)`). `package` is an established pattern here (71 existing uses).

## Verification

```
swift build --target ManifoldBackends --traits Ollama,CloudSaaS   # Build complete (was: compile error)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)