### PR TITLE
feat: rerank stage in RAG retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ Table-stakes capabilities that ship today (verified in source):
 - **Structured / typed output**, capability-routed by `StructuredOutputRouter` across GBNF, Foundation guided-generation, JSON-Schema, and JSON-prompting.
 - **Reasoning / thinking tokens** surfaced as first-class events.
 - **MCP client *and* server** ([ManifoldMCP](Sources/ManifoldMCP) + the `Server` trait).
-- **RAG with citations.**
+- **RAG with citations**, including an optional cross-encoder rerank stage (`Reranker` port; on-device `LlamaReranker` for `bge-reranker`-class GGUFs).
 - **Human-in-the-loop tool approval** via `ToolApprovalGate`.
 - **Metrics + cost estimation** for observability.
 - **On-device image generation** — `FluxDiffusionBackend` (FLUX.1 Schnell) and `MLXDiffusionBackend` (SDXL Turbo). See [docs/QUICKSTART-IMAGE-GEN.md](docs/QUICKSTART-IMAGE-GEN.md).
 
-**Status:** ManifoldKit is pre-1.0; breaking changes can land between minor versions. RAG reranking is not yet shipped ([#1637](https://github.com/roryford/ManifoldKit/issues/1637)). Deferred reliability features (e.g. mid-stream resume) are tracked in [docs/RELIABILITY.md](docs/RELIABILITY.md).
+**Status:** ManifoldKit is pre-1.0; breaking changes can land between minor versions. Deferred reliability features (e.g. mid-stream resume) are tracked in [docs/RELIABILITY.md](docs/RELIABILITY.md).
 
 ## Beyond chat
 

--- a/Sources/ManifoldInference/Protocols/Reranker.swift
+++ b/Sources/ManifoldInference/Protocols/Reranker.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Re-scores and re-orders retrieval candidates by query relevance.
+///
+/// A reranker is the post-retrieve, pre-inject stage of RAG: the retriever
+/// widens its initial candidate pool (e.g. cosine top-k*3), then the reranker
+/// scores every candidate against the query with a cross-encoder and returns
+/// the best `limit` in descending relevance order. Cross-encoders read the
+/// query and document *together*, so they recover relevance signal that the
+/// bi-encoder cosine stage — which embeds each side independently — misses.
+///
+/// ## Placement
+///
+/// This port lives in `ManifoldInference` rather than `ManifoldRuntime` for the
+/// same reason ``EmbeddingBackend`` does: the concrete on-device implementation
+/// (`LlamaReranker`) lives in a backend family target that depends on
+/// `ManifoldInference`, *not* `ManifoldRuntime`. `RAGService` (in
+/// `ManifoldRuntime`) consumes the port through its existing `ManifoldInference`
+/// import. A cloud reranker would conform to this same protocol — the seam is
+/// backend-agnostic.
+///
+/// ## Fallback contract
+///
+/// When no reranker is configured, `RAGService` retrieval behaves byte-for-byte
+/// as it did before this stage existed. ``PassthroughReranker`` makes that the
+/// default: it reports ``isReady`` as `false`, so the retriever neither widens
+/// the candidate set nor invokes ``rerank(query:candidates:limit:)``.
+public protocol Reranker: Sendable {
+    /// Whether a reranker model is loaded and ready to score.
+    ///
+    /// When `false`, `RAGService` skips candidate widening and the rerank call
+    /// entirely — retrieval (including the keyword fallback) is identical to the
+    /// pre-rerank pipeline. Implementations that load a model asynchronously
+    /// should report `false` until the model is resident.
+    var isReady: Bool { get }
+
+    /// Returns up to `limit` of `candidates`, re-scored against `query` and
+    /// sorted by descending relevance.
+    ///
+    /// - Parameters:
+    ///   - query: The user query the candidates were retrieved for.
+    ///   - candidates: The widened candidate set from the cosine/keyword stage,
+    ///     already ordered by their first-stage score.
+    ///   - limit: The maximum number of hits to return after reranking.
+    /// - Returns: At most `limit` hits in descending rerank-score order. Each
+    ///   returned hit carries the cross-encoder score in ``VectorSearchHit/score``
+    ///   so downstream citations surface the reranked relevance.
+    /// - Throws: When scoring fails. `RAGService` catches and falls back to the
+    ///   first-stage ordering, so a throwing reranker degrades gracefully rather
+    ///   than failing the turn.
+    func rerank(query: String, candidates: [VectorSearchHit], limit: Int) async throws -> [VectorSearchHit]
+}
+
+/// The no-op default reranker: reports itself as not ready so retrieval runs
+/// exactly as it did before the rerank stage was added.
+///
+/// Wiring `PassthroughReranker()` is equivalent to wiring no reranker at all —
+/// it exists so call sites can hold a non-optional ``Reranker`` without
+/// branching on `nil`.
+public struct PassthroughReranker: Reranker {
+    public init() {}
+
+    /// Always `false`: the passthrough reranker never widens or reorders.
+    public var isReady: Bool { false }
+
+    /// Returns the first `limit` candidates unchanged, preserving the
+    /// first-stage ordering and scores.
+    public func rerank(query: String, candidates: [VectorSearchHit], limit: Int) async throws -> [VectorSearchHit] {
+        Array(candidates.prefix(limit))
+    }
+}

--- a/Sources/ManifoldLlama/LlamaReranker.swift
+++ b/Sources/ManifoldLlama/LlamaReranker.swift
@@ -1,0 +1,416 @@
+#if Llama
+import Foundation
+import LlamaSwift
+import os
+import ManifoldInference
+
+/// llama.cpp cross-encoder reranker for RANK-pooling GGUF models
+/// (e.g. `bge-reranker-v2-m3`, `jina-reranker`).
+///
+/// A reranker model is a BERT-family classifier with a single-output rank head.
+/// Unlike ``LlamaEmbeddingBackend`` — a *bi-encoder* that embeds the query and
+/// each document independently and compares them with cosine similarity — this
+/// is a *cross-encoder*: it feeds the `[query, document]` pair through the model
+/// in one pass so the attention layers see both sides together, then reads the
+/// rank logit from `llama_get_embeddings_seq` (which, under
+/// `LLAMA_POOLING_TYPE_RANK`, returns the classification score rather than an
+/// embedding vector). Cross-encoders are slower but materially more accurate at
+/// relevance ordering, which is why they run as a second stage over a small
+/// widened candidate set rather than over the whole index.
+///
+/// ## Design notes
+///
+/// Mirrors ``LlamaEmbeddingBackend``'s ownership model: all C-level state
+/// (`llama_model *`, `llama_context *`, vocab) is confined to a private actor so
+/// the public surface can be `Sendable` while the underlying pointers are never
+/// touched concurrently. Pooling is forced to `LLAMA_POOLING_TYPE_RANK` at
+/// context creation — llama.cpp's own rerank path sets it explicitly rather than
+/// trusting GGUF metadata, and without it the model emits an embedding instead
+/// of a rank score.
+///
+/// ## Scores
+///
+/// The raw rank head emits an unbounded logit. ``rerank(query:candidates:limit:)``
+/// applies a logistic squash so the ``VectorSearchHit/score`` it writes back is
+/// a monotonic relevance probability in `(0, 1)` — comparable across calls and
+/// safe to surface in citations — while preserving the ordering the logits
+/// imply.
+public final class LlamaReranker: Reranker, @unchecked Sendable {
+
+    // MARK: - Logging
+
+    private static let logger = Logger(
+        subsystem: ManifoldConfiguration.shared.logSubsystem,
+        category: "reranker"
+    )
+
+    // MARK: - Storage
+
+    /// Owns all C-level resources. Confined to an actor so the C pointers are
+    /// never read from more than one task concurrently.
+    fileprivate actor Storage {
+        var model: OpaquePointer?
+        var context: OpaquePointer?
+        var vocab: OpaquePointer?
+        var contextSize: Int32 = 0
+        /// Sentence-separator token inserted between the query and the document
+        /// halves of the pair. `LLAMA_TOKEN_NULL` when the vocab has none.
+        var sepToken: llama_token = -1
+        var eosToken: llama_token = -1
+
+        var isLoaded: Bool { model != nil && context != nil }
+
+        func install(
+            model: OpaquePointer,
+            context: OpaquePointer,
+            vocab: OpaquePointer,
+            contextSize: Int32,
+            sepToken: llama_token,
+            eosToken: llama_token
+        ) {
+            self.model = model
+            self.context = context
+            self.vocab = vocab
+            self.contextSize = contextSize
+            self.sepToken = sepToken
+            self.eosToken = eosToken
+        }
+
+        /// Drops references and frees the C resources in the order
+        /// `llama_free` (context) → `llama_model_free` (model). Safe to call
+        /// when nothing is loaded.
+        func unload() {
+            let ctx = context
+            let mdl = model
+            context = nil
+            model = nil
+            vocab = nil
+            contextSize = 0
+            sepToken = -1
+            eosToken = -1
+            if let ctx { llama_free(ctx) }
+            if let mdl { llama_model_free(mdl) }
+        }
+
+        /// Scores a single `[query, document]` pair, returning the raw rank
+        /// logit emitted by the classification head.
+        ///
+        /// Builds the sequence `[BOS] query [EOS] [SEP] document [EOS]`,
+        /// encodes it, and reads `llama_get_embeddings_seq(ctx, 0)[0]`. Pointers
+        /// are read under the actor's serial executor so `unload()` cannot
+        /// interleave.
+        func score(query: String, document: String) throws -> Float {
+            guard let context, let vocab else {
+                throw RerankerError.modelNotLoaded
+            }
+            let maxTokens = Int(contextSize)
+
+            // Query half carries the BOS; document half does not. Separator and
+            // closing EOS tokens frame the pair the way BERT rerankers were
+            // trained on (`[CLS] q [SEP] d [SEP]`); we use EOS as the trailing
+            // marker since not every reranker vocab defines a distinct SEP.
+            var tokens = LlamaTokenization.tokenize(query, vocab: vocab, addBos: true)
+            if eosToken >= 0 { tokens.append(eosToken) }
+            if sepToken >= 0 { tokens.append(sepToken) }
+            tokens.append(contentsOf: LlamaTokenization.tokenize(document, vocab: vocab, addBos: false))
+            if eosToken >= 0 { tokens.append(eosToken) }
+
+            guard !tokens.isEmpty else {
+                // An all-empty pair has no relevance signal; the lowest possible
+                // score keeps it at the bottom of the ranking without throwing.
+                return -.greatestFiniteMagnitude
+            }
+
+            // Truncate from the tail so the query (sequence head) always
+            // survives — a query-less pair scores nothing meaningful.
+            if tokens.count > maxTokens {
+                tokens = Array(tokens.prefix(maxTokens))
+            }
+
+            // Clear KV / output state so back-to-back pair scores never share
+            // buffers across sequences.
+            if let mem = llama_get_memory(context) {
+                llama_memory_clear(mem, true)
+            }
+
+            var batch = llama_batch_init(Int32(tokens.count), 0, 1)
+            defer { llama_batch_free(batch) }
+            for i in 0..<tokens.count {
+                batch.token[i] = tokens[i]
+                batch.pos[i] = Int32(i)
+                batch.n_seq_id[i] = 1
+                batch.seq_id[i]?[0] = 0
+                batch.logits[i] = 1
+            }
+            batch.n_tokens = Int32(tokens.count)
+
+            let rc = llama_encode(context, batch)
+            if rc != 0 {
+                // Some reranker GGUFs expose only decode, mirroring the
+                // embedding backend's resilience to upstream packaging.
+                let drc = llama_decode(context, batch)
+                if drc != 0 {
+                    throw RerankerError.scoringFailed(underlying: NSError(
+                        domain: "LlamaReranker",
+                        code: Int(rc),
+                        userInfo: [NSLocalizedDescriptionKey: "llama_encode/decode failed (encode rc=\(rc), decode rc=\(drc))"]
+                    ))
+                }
+            }
+
+            llama_synchronize(context)
+
+            // Under RANK pooling this row is `float[n_cls_out]` — the rank
+            // score(s). Rerankers have a single-output head, so element 0 is the
+            // relevance logit.
+            guard let row = llama_get_embeddings_seq(context, 0) else {
+                throw RerankerError.scoringFailed(underlying: NSError(
+                    domain: "LlamaReranker",
+                    code: -20,
+                    userInfo: [NSLocalizedDescriptionKey: "llama_get_embeddings_seq returned NULL — model is not a RANK-pooling reranker"]
+                ))
+            }
+            return row[0]
+        }
+    }
+
+    private let storage = Storage()
+
+    private let stateLock = NSLock()
+    private var _isReady = false
+
+    /// `true` once a RANK-pooling GGUF is resident. Reads are lock-guarded so a
+    /// concurrent `loadModel` / `unloadModel` cannot expose a half-installed
+    /// context to a scoring call.
+    public var isReady: Bool {
+        stateLock.withLock { _isReady }
+    }
+
+    // MARK: - Init / Deinit
+
+    public init() {
+        LlamaBackendProcessLifecycle.retain()
+    }
+
+    deinit {
+        // Fire-and-forget the actor unload; never block deinit. Same rationale
+        // as ``LlamaEmbeddingBackend``: blocking here freezes the owning actor
+        // (often @MainActor) or deadlocks on a main-actor hop inside unload.
+        // Keep the process refcount alive until the detached unload finishes.
+        LlamaBackendProcessLifecycle.retain()
+        let storage = storage
+        Task.detached(priority: .utility) {
+            await storage.unload()
+            LlamaBackendProcessLifecycle.release()
+        }
+        LlamaBackendProcessLifecycle.release()
+    }
+
+    // MARK: - Loading
+
+    /// Loads a cross-encoder reranker GGUF and makes the instance ``isReady``.
+    ///
+    /// - Throws: ``RerankerError/modelLoadFailed`` when the GGUF cannot be
+    ///   opened or a RANK context cannot be created.
+    public func loadModel(from url: URL) async throws {
+        await storage.unload()
+        stateLock.withLock { _isReady = false }
+
+        let loaded: LoadedReranker
+        do {
+            loaded = try await Task.detached(priority: .userInitiated) {
+                try Self.serializedLoad(from: url)
+            }.value
+        } catch let error as RerankerError {
+            throw error
+        } catch {
+            throw RerankerError.modelLoadFailed(underlying: error)
+        }
+
+        await storage.install(
+            model: loaded.model,
+            context: loaded.context,
+            vocab: loaded.vocab,
+            contextSize: loaded.contextSize,
+            sepToken: loaded.sepToken,
+            eosToken: loaded.eosToken
+        )
+        stateLock.withLock { _isReady = true }
+
+        Self.logger.info("LlamaReranker loaded \(url.lastPathComponent) (n_ctx=\(loaded.contextSize))")
+    }
+
+    /// Unloads the model, flipping ``isReady`` to `false` immediately. Any
+    /// in-flight scoring finishes first via the actor's serial executor.
+    public func unloadModel() {
+        stateLock.withLock { _isReady = false }
+        let storage = storage
+        Task.detached(priority: .utility) {
+            await storage.unload()
+        }
+    }
+
+    // MARK: - Reranker
+
+    public func rerank(
+        query: String,
+        candidates: [VectorSearchHit],
+        limit: Int
+    ) async throws -> [VectorSearchHit] {
+        guard isReady else {
+            // Defensive: `RAGService` only calls us when `isReady`, but honour
+            // the contract directly rather than scoring against a freed context
+            // if the model was unloaded between the gate and this call.
+            return Array(candidates.prefix(limit))
+        }
+        guard !candidates.isEmpty, limit > 0 else { return [] }
+
+        // Score each candidate against the query, then sort by descending
+        // relevance. Scoring is sequential because the actor owns one context;
+        // the candidate set is small (top-k*3) so this stays well-bounded.
+        var scored: [(hit: VectorSearchHit, score: Float)] = []
+        scored.reserveCapacity(candidates.count)
+        for hit in candidates {
+            let logit = try await storage.score(query: query, document: hit.chunk.text)
+            scored.append((hit, logit))
+        }
+
+        scored.sort { $0.score > $1.score }
+
+        return scored.prefix(limit).map { entry in
+            VectorSearchHit(
+                chunk: entry.hit.chunk,
+                documentTitle: entry.hit.documentTitle,
+                // Squash the unbounded logit into (0, 1) so the surfaced score
+                // is a comparable relevance probability, not a raw activation.
+                score: Self.sigmoid(entry.score)
+            )
+        }
+    }
+
+    /// Numerically stable logistic squash. Branches on the sign so neither
+    /// `exp(+large)` nor `exp(-large)` overflows.
+    static func sigmoid(_ x: Float) -> Float {
+        if x >= 0 {
+            return 1 / (1 + expf(-x))
+        } else {
+            let e = expf(x)
+            return e / (1 + e)
+        }
+    }
+
+    // MARK: - Loader
+
+    private struct LoadedReranker: @unchecked Sendable {
+        let model: OpaquePointer
+        let context: OpaquePointer
+        let vocab: OpaquePointer
+        let contextSize: Int32
+        let sepToken: llama_token
+        let eosToken: llama_token
+    }
+
+    /// BERT-family architectures a reranker GGUF can legitimately declare. Same
+    /// set the embedding loader allows — rerankers are BERT classifiers — minus
+    /// the encoder-only families that have no classification head.
+    private static let rerankerArchitectureAllowlist: Set<String> = [
+        "bert",
+        "nomic-bert",
+        "jina-bert-v2",
+    ]
+
+    private static func serializedLoad(from url: URL) throws -> LoadedReranker {
+        loadLock.lock()
+        defer { loadLock.unlock() }
+
+        var modelParams = llama_model_default_params()
+        modelParams.n_gpu_layers = LlamaSamplingPolicy.gpuLayerCount()
+
+        guard let rawModel = llama_model_load_from_file(url.path, modelParams) else {
+            throw RerankerError.modelLoadFailed(underlying: NSError(
+                domain: "LlamaReranker",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to load reranker GGUF from \(url.lastPathComponent)"]
+            ))
+        }
+
+        if let architecture = LlamaModelLoader.readArchitectureMetadata(model: rawModel) {
+            let normalized = architecture.lowercased()
+            let isRerankerAllowlisted = rerankerArchitectureAllowlist.contains(normalized)
+            let isGenerationDenied = LlamaModelLoader.isUnsupportedArchitecture(architecture)
+            if !isRerankerAllowlisted && isGenerationDenied {
+                llama_model_free(rawModel)
+                throw RerankerError.modelLoadFailed(underlying: InferenceError.unsupportedModelArchitecture(architecture))
+            }
+        }
+
+        var ctxParams = llama_context_default_params()
+        ctxParams.embeddings = true
+        // Force the rank head on rather than trusting GGUF pooling metadata —
+        // this is what makes `llama_get_embeddings_seq` return a score instead
+        // of a hidden-state vector. Matches llama.cpp's rerank example.
+        ctxParams.pooling_type = LLAMA_POOLING_TYPE_RANK
+        let trainCtx = llama_model_n_ctx_train(rawModel)
+        let requestedCtx = max(Int32(512), min(trainCtx, Int32(8192)))
+        ctxParams.n_ctx = UInt32(requestedCtx)
+        ctxParams.n_batch = UInt32(requestedCtx)
+        ctxParams.n_ubatch = UInt32(requestedCtx)
+        ctxParams.n_threads = LlamaSamplingPolicy.threadCount()
+        ctxParams.n_threads_batch = ctxParams.n_threads
+
+        guard let ctx = llama_init_from_model(rawModel, ctxParams) else {
+            llama_model_free(rawModel)
+            throw RerankerError.modelLoadFailed(underlying: NSError(
+                domain: "LlamaReranker",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create RANK context for \(url.lastPathComponent)"]
+            ))
+        }
+
+        llama_set_embeddings(ctx, true)
+
+        guard let vocab = llama_model_get_vocab(rawModel) else {
+            llama_free(ctx)
+            llama_model_free(rawModel)
+            throw RerankerError.modelLoadFailed(underlying: NSError(
+                domain: "LlamaReranker",
+                code: -3,
+                userInfo: [NSLocalizedDescriptionKey: "Reranker model has no vocabulary"]
+            ))
+        }
+
+        return LoadedReranker(
+            model: rawModel,
+            context: ctx,
+            vocab: vocab,
+            contextSize: requestedCtx,
+            sepToken: llama_vocab_sep(vocab),
+            eosToken: llama_vocab_eos(vocab)
+        )
+    }
+
+    /// Serializes reranker-load `llama_model_load_from_file` calls against each
+    /// other. Eventually funnels through GGML's process-global init lock, so
+    /// cross-pool serialisation with generation / embedding loads is implicit.
+    private static let loadLock = NSLock()
+}
+
+// MARK: - RerankerError
+
+public enum RerankerError: LocalizedError {
+    case modelNotLoaded
+    case modelLoadFailed(underlying: Error)
+    case scoringFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotLoaded:
+            return "Reranker model is not loaded."
+        case .modelLoadFailed(let underlying):
+            return "Reranker model load failed: \(underlying.localizedDescription)"
+        case .scoringFailed(let underlying):
+            return "Reranker scoring failed: \(underlying.localizedDescription)"
+        }
+    }
+}
+#endif

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -15,10 +15,36 @@ import ManifoldInference
 /// let bootstrap = try ManifoldBootstrap(configuration: config, ragConfiguration: rag)
 /// bootstrap.ragService?.ingest(url: myDocumentURL)
 /// ```
+///
+/// ## Reranking (optional)
+///
+/// Supply a ``Reranker`` to add a cross-encoder rerank stage after cosine
+/// retrieval. The retriever widens its candidate pool, the reranker re-scores
+/// each passage against the query, and the top results are injected. On-device,
+/// `LlamaReranker` (from `ManifoldLlama`) wraps a RANK-pooling cross-encoder
+/// GGUF such as `bge-reranker`:
+///
+/// ```swift
+/// let reranker = LlamaReranker()
+/// try await reranker.loadModel(from: bgeRerankerGGUFURL)
+/// let rag = RAGConfiguration(
+///     embeddingBackend: myLlamaEmbeddingBackend,
+///     reranker: reranker
+/// )
+/// ```
+///
+/// When `reranker` is `nil` (the default) or its model is not loaded, retrieval
+/// behaves exactly as it does without reranking — including the keyword
+/// fallback.
 public struct RAGConfiguration: Sendable {
     /// Optional embedding backend for semantic search. When `nil`, retrieval
     /// falls back to case-insensitive keyword search.
     public var embeddingBackend: (any EmbeddingBackend)?
+    /// Optional reranker for the post-retrieve, pre-inject stage. When `nil`
+    /// (or not ready), retrieval behaves exactly as it did before reranking
+    /// existed. Supply `LlamaReranker` (from `ManifoldLlama`) loaded with a
+    /// cross-encoder GGUF (e.g. `bge-reranker`) to enable it.
+    public var reranker: (any Reranker)?
     /// Character count per chunk. Default: 1800.
     public var chunkSize: Int
     /// Character overlap between consecutive chunks. Default: 200.
@@ -31,12 +57,14 @@ public struct RAGConfiguration: Sendable {
 
     public init(
         embeddingBackend: (any EmbeddingBackend)? = nil,
+        reranker: (any Reranker)? = nil,
         chunkSize: Int = 1800,
         chunkOverlap: Int = 200,
         topK: Int = 5,
         vectorStoreURL: URL? = nil
     ) {
         self.embeddingBackend = embeddingBackend
+        self.reranker = reranker
         self.chunkSize = chunkSize
         self.chunkOverlap = chunkOverlap
         self.topK = topK
@@ -360,6 +388,7 @@ public final class ManifoldBootstrap {
             documentStore: documentStore,
             vectorStore: vectorStore,
             embeddingBackend: ragConfig.embeddingBackend,
+            reranker: ragConfig.reranker,
             chunker: chunker
         )
     }

--- a/Sources/ManifoldRuntime/Services/RAGService.swift
+++ b/Sources/ManifoldRuntime/Services/RAGService.swift
@@ -11,24 +11,44 @@ import ManifoldInference
 /// When no embedding model is loaded, retrieval falls back to case-insensitive
 /// keyword search so the knowledge base remains useful without configuring a
 /// separate embedding model.
+///
+/// ## Rerank stage
+///
+/// When a ``Reranker`` is supplied and reports ``Reranker/isReady`` as `true`,
+/// ``retrieve(query:limit:)`` widens the first-stage candidate pool
+/// (`limit * `` ``rerankCandidateMultiplier``) and hands it to the reranker,
+/// which scores each passage against the query with a cross-encoder and returns
+/// the top `limit`. With no reranker — the default — retrieval is byte-for-byte
+/// identical to the pre-rerank pipeline, including the keyword fallback.
 public actor RAGService {
 
     private let documentStore: any DocumentStore
     private let vectorStore: any VectorStore
     private let embeddingBackend: (any EmbeddingBackend)?
+    private let reranker: (any Reranker)?
     private let chunker: DocumentChunker
     private let parsers: [any DocumentParser]
+
+    /// How much wider than `limit` the first-stage candidate set is fetched
+    /// when a reranker is active. A 3× pool gives the cross-encoder enough
+    /// candidates to recover relevant passages the bi-encoder cosine stage
+    /// ranked just outside the top-`limit`, without paying to score the whole
+    /// index. Only applied when `reranker?.isReady == true`; otherwise the
+    /// fetch width is exactly `limit` so behaviour is unchanged.
+    static let rerankCandidateMultiplier = 3
 
     public init(
         documentStore: any DocumentStore,
         vectorStore: any VectorStore,
         embeddingBackend: (any EmbeddingBackend)? = nil,
+        reranker: (any Reranker)? = nil,
         chunker: DocumentChunker = DocumentChunker(),
         parsers: [any DocumentParser] = [TextDocumentParser(), PDFDocumentParser()]
     ) {
         self.documentStore = documentStore
         self.vectorStore = vectorStore
         self.embeddingBackend = embeddingBackend
+        self.reranker = reranker
         self.chunker = chunker
         self.parsers = parsers
     }
@@ -152,6 +172,15 @@ public actor RAGService {
             cappedQuery = query
         }
 
+        // When a reranker is loaded, widen the first-stage candidate pool so the
+        // cross-encoder has more passages to reorder; we trim back to `limit`
+        // after reranking. With no reranker active, `candidateLimit == limit`
+        // and the fetch is byte-for-byte the pre-rerank behaviour.
+        let rerankerActive = reranker?.isReady == true
+        let candidateLimit = rerankerActive
+            ? limit * Self.rerankCandidateMultiplier
+            : limit
+
         let hits: [VectorSearchHit]
         if let backend = embeddingBackend, backend.isModelLoaded {
             do {
@@ -163,18 +192,36 @@ public actor RAGService {
                 guard let queryEmbedding = try await backend.embed([cappedQuery]).first else {
                     throw RAGError.embeddingFailed(underlying: InferenceError.inferenceFailure("Embedding backend returned no vectors for query"))
                 }
-                hits = try await vectorStore.search(embedding: queryEmbedding, limit: limit)
+                hits = try await vectorStore.search(embedding: queryEmbedding, limit: candidateLimit)
             } catch {
                 Log.inference.warning("RAGService: embedding query failed, falling back to keyword search: \(error.localizedDescription)")
-                hits = try await vectorStore.keywordSearch(query: cappedQuery, limit: limit)
+                hits = try await vectorStore.keywordSearch(query: cappedQuery, limit: candidateLimit)
             }
         } else {
-            hits = try await vectorStore.keywordSearch(query: cappedQuery, limit: limit)
+            hits = try await vectorStore.keywordSearch(query: cappedQuery, limit: candidateLimit)
         }
 
         guard !hits.isEmpty else { return .empty }
 
-        let content = hits.map { hit in
+        // Rerank stage. Only runs when a reranker is loaded; otherwise `hits`
+        // (already capped at `limit`) flows through untouched. A throwing
+        // reranker degrades to the first-stage ordering — retrieval quality may
+        // drop but the turn never fails for a reranker error.
+        let rankedHits: [VectorSearchHit]
+        if let reranker, rerankerActive {
+            do {
+                rankedHits = try await reranker.rerank(query: cappedQuery, candidates: hits, limit: limit)
+            } catch {
+                Log.inference.warning("RAGService: rerank failed, using first-stage ordering: \(error.localizedDescription)")
+                rankedHits = Array(hits.prefix(limit))
+            }
+        } else {
+            rankedHits = hits
+        }
+
+        guard !rankedHits.isEmpty else { return .empty }
+
+        let content = rankedHits.map { hit in
             "[\(hit.documentTitle)]\n\(hit.chunk.text)"
         }.joined(separator: "\n\n---\n\n")
 
@@ -186,7 +233,7 @@ public actor RAGService {
             label: "Retrieved Documents"
         )
 
-        let citations = hits.map { hit in
+        let citations = rankedHits.map { hit in
             Citation(
                 documentID: hit.chunk.documentID,
                 documentTitle: hit.documentTitle,

--- a/Tests/ManifoldBackendsTests/LlamaRerankerTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaRerankerTests.swift
@@ -1,0 +1,107 @@
+#if Llama
+import XCTest
+@testable import ManifoldInference
+@testable import ManifoldTestSupport
+@testable import ManifoldLlama
+
+/// Tests for the #1637 local cross-encoder reranker (``LlamaReranker``).
+///
+/// The model-free tests (squash math, not-ready contract) run anywhere. The
+/// RANK-pooling end-to-end test needs a reranker GGUF and Metal, so it skips
+/// unless `LLAMA_RERANKER_MODEL` points at a cross-encoder model
+/// (e.g. `bge-reranker-v2-m3`).
+final class LlamaRerankerTests: XCTestCase {
+
+    // MARK: - Model-free contract
+
+    /// The logistic squash must be monotonic and map into (0, 1) so reranked
+    /// citation scores are comparable relevance probabilities. A larger logit
+    /// must always yield a strictly larger probability.
+    func test_sigmoid_isMonotonicAndBounded() {
+        // Inputs are kept inside the range where Float32 still represents the
+        // result distinctly from the asymptote — at |x| ≳ 16 the squash
+        // legitimately saturates to exactly 0 or 1 in single precision, which is
+        // correct behaviour, not a bound violation.
+        let inputs: [Float] = [-15, -5, -1, 0, 1, 5, 15]
+        let outputs = inputs.map { LlamaReranker.sigmoid($0) }
+
+        for value in outputs {
+            XCTAssertGreaterThan(value, 0)
+            XCTAssertLessThan(value, 1)
+        }
+        for i in 1..<outputs.count {
+            XCTAssertGreaterThan(outputs[i], outputs[i - 1],
+                                 "sigmoid must be strictly increasing")
+        }
+        XCTAssertEqual(LlamaReranker.sigmoid(0), 0.5, accuracy: 1e-6)
+    }
+
+    /// Before any model is loaded, `isReady` must be `false` so `RAGService`
+    /// never widens or invokes the reranker against a freed context.
+    func test_isReady_falseBeforeLoad() {
+        let reranker = LlamaReranker()
+        XCTAssertFalse(reranker.isReady)
+    }
+
+    /// When not ready, `rerank` must honour the ``Reranker`` contract by
+    /// returning the first `limit` candidates unchanged — never touching the C
+    /// context. This is the safety net behind the `RAGService` gate.
+    func test_rerank_whenNotReady_returnsFirstLimitUnchanged() async throws {
+        let reranker = LlamaReranker()  // never loaded → not ready
+        let docID = UUID()
+        let candidates = (0..<5).map {
+            VectorSearchHit(
+                chunk: DocumentChunk(documentID: docID, text: "p\($0)", chunkIndex: $0),
+                documentTitle: "Doc",
+                score: Float($0)
+            )
+        }
+
+        let result = try await reranker.rerank(query: "q", candidates: candidates, limit: 3)
+
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result.map(\.chunk.chunkIndex), [0, 1, 2],
+                       "not-ready reranker must passthrough the first `limit` candidates")
+    }
+
+    // MARK: - RANK-pooling end-to-end (model-gated)
+
+    /// Loads a real cross-encoder GGUF and verifies it surfaces the obviously
+    /// relevant passage above an unrelated one. Skips unless a reranker model is
+    /// configured via `LLAMA_RERANKER_MODEL`.
+    func test_rerank_withRealModel_ranksRelevantPassageFirst() async throws {
+        try XCTSkipUnless(HardwareRequirements.isPhysicalDevice,
+                          "LlamaReranker requires Metal (unavailable in simulator)")
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon,
+                          "LlamaReranker requires Apple Silicon")
+
+        let env = ProcessInfo.processInfo.environment
+        guard let rawPath = env["LLAMA_RERANKER_MODEL"], !rawPath.isEmpty else {
+            throw XCTSkip("Set LLAMA_RERANKER_MODEL=<path to a cross-encoder reranker GGUF> to run the RANK-pooling end-to-end test.")
+        }
+        let modelURL = URL(filePath: (rawPath as NSString).expandingTildeInPath)
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            throw XCTSkip("LLAMA_RERANKER_MODEL does not point at an existing file: \(modelURL.path)")
+        }
+
+        let reranker = LlamaReranker()
+        addTeardownBlock { reranker.unloadModel() }
+        try await reranker.loadModel(from: modelURL)
+        XCTAssertTrue(reranker.isReady)
+
+        let docID = UUID()
+        let candidates = [
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "The Eiffel Tower is located in Paris, France.", chunkIndex: 0), documentTitle: "Doc", score: 0.5),
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "Photosynthesis converts sunlight into chemical energy in plants.", chunkIndex: 1), documentTitle: "Doc", score: 0.5),
+        ]
+
+        let ranked = try await reranker.rerank(query: "Where is the Eiffel Tower?", candidates: candidates, limit: 2)
+
+        XCTAssertEqual(ranked.count, 2)
+        XCTAssertEqual(ranked.first?.chunk.chunkIndex, 0,
+                       "the cross-encoder must rank the Eiffel-Tower passage above the unrelated one")
+        XCTAssertGreaterThan(ranked[0].score, ranked[1].score,
+                             "reranked scores must be ordered descending")
+    }
+}
+#endif

--- a/Tests/ManifoldPersistenceSwiftDataTests/RAGServiceRerankIntegrationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/RAGServiceRerankIntegrationTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+import SwiftData
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+
+/// Integration coverage for the #1637 rerank stage exercising the *real*
+/// persistence stack: an in-memory SwiftData ``SwiftDataDocumentStore`` and an
+/// on-disk ``FlatFileVectorStore``, driven end-to-end through ``RAGService``.
+///
+/// These are integration tests (they touch SwiftData and the flat-file index),
+/// so they live in `ManifoldPersistenceSwiftDataTests` rather than the unit
+/// suite. The reranker is a fake here: the *real* RANK-pooling reranker
+/// (`LlamaReranker`) needs a cross-encoder GGUF and Metal, so its model path is
+/// covered (and skipped without a model) in `ManifoldBackendsTests`. What this
+/// suite pins is that the widen → rerank → trim wiring survives a trip through
+/// the shipped stores.
+@MainActor
+final class RAGServiceRerankIntegrationTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var vectorURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try ModelContainerFactory.makeInMemoryContainer()
+        vectorURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".bin")
+    }
+
+    override func tearDown() {
+        if let vectorURL { try? FileManager.default.removeItem(at: vectorURL) }
+        container = nil
+        vectorURL = nil
+        super.tearDown()
+    }
+
+    /// Ingest three chunks through the real stores, then retrieve with a
+    /// reranker that intentionally inverts the cosine order. The injected slot
+    /// and citations must reflect the reranked order, proving the stage is wired
+    /// through SwiftData + the flat-file index, not just the in-memory fakes.
+    func test_ingestThenRetrieve_rerankReordersThroughRealStores() async throws {
+        let documentStore = SwiftDataDocumentStore(modelContext: container.mainContext)
+        let vectorStore = FlatFileVectorStore(storageURL: vectorURL)
+
+        // Pre-seed the vector index directly so we control the embedding
+        // geometry (cosine order) independent of any embedding backend.
+        let docID = UUID()
+        let chunks = [
+            DocumentChunk(documentID: docID, text: "alpha chunk", chunkIndex: 0),
+            DocumentChunk(documentID: docID, text: "bravo chunk", chunkIndex: 1),
+            DocumentChunk(documentID: docID, text: "charlie chunk", chunkIndex: 2),
+        ]
+        // Query will be [1,0,0]. Cosine order: alpha > bravo > charlie.
+        let embeddings: [[Float]] = [[1, 0, 0], [0.7, 0.7, 0], [0.1, 0.99, 0]]
+        try await vectorStore.insert(chunks: chunks, documentTitle: "Doc", embeddings: embeddings)
+        try documentStore.insertDocument(DocumentRecord(
+            id: docID, title: "Doc",
+            sourceURL: URL(filePath: "/tmp/Doc.txt"),
+            fileType: "txt", chunkCount: chunks.count
+        ))
+
+        // Reranker that flips the cosine order: charlie becomes most relevant.
+        let reranker = ClosureReranker { hits in
+            hits.sorted { lhs, rhs in lhs.chunk.chunkIndex > rhs.chunk.chunkIndex }
+        }
+
+        let sut = RAGService(
+            documentStore: documentStore,
+            vectorStore: vectorStore,
+            embeddingBackend: AxisEmbeddingBackend(),
+            reranker: reranker
+        )
+
+        let result = try await sut.retrieve(query: "alpha", limit: 3)
+
+        XCTAssertEqual(result.citations.count, 3)
+        XCTAssertEqual(result.citations.map(\.chunkIndex), [2, 1, 0],
+                       "reranked order must flow through the real SwiftData + flat-file stores")
+
+        // Sabotage: cosine order would be [0, 1, 2]; the rerank must have changed it.
+        XCTAssertNotEqual(result.citations.map(\.chunkIndex), [0, 1, 2])
+    }
+
+    /// Without a reranker, the same real-store pipeline must return the cosine
+    /// order untouched — the passthrough-default guarantee, end to end.
+    func test_retrieve_noReranker_preservesCosineOrderThroughRealStores() async throws {
+        let documentStore = SwiftDataDocumentStore(modelContext: container.mainContext)
+        let vectorStore = FlatFileVectorStore(storageURL: vectorURL)
+
+        let docID = UUID()
+        let chunks = [
+            DocumentChunk(documentID: docID, text: "alpha chunk", chunkIndex: 0),
+            DocumentChunk(documentID: docID, text: "bravo chunk", chunkIndex: 1),
+        ]
+        try await vectorStore.insert(chunks: chunks, documentTitle: "Doc", embeddings: [[1, 0, 0], [0.5, 0.86, 0]])
+        try documentStore.insertDocument(DocumentRecord(
+            id: docID, title: "Doc",
+            sourceURL: URL(filePath: "/tmp/Doc.txt"),
+            fileType: "txt", chunkCount: chunks.count
+        ))
+
+        let sut = RAGService(
+            documentStore: documentStore,
+            vectorStore: vectorStore,
+            embeddingBackend: AxisEmbeddingBackend()
+        )
+
+        let result = try await sut.retrieve(query: "alpha", limit: 3)
+        XCTAssertEqual(result.citations.map(\.chunkIndex), [0, 1],
+                       "no reranker must preserve descending cosine order")
+    }
+}
+
+// MARK: - Fakes
+
+/// Reorders candidates with a closure; always ready.
+private struct ClosureReranker: Reranker {
+    let reorder: @Sendable ([VectorSearchHit]) -> [VectorSearchHit]
+    var isReady: Bool { true }
+    func rerank(query: String, candidates: [VectorSearchHit], limit: Int) async throws -> [VectorSearchHit] {
+        Array(reorder(candidates).prefix(limit))
+    }
+}
+
+/// Embeds every query as the unit vector along the first axis so the
+/// pre-seeded chunk geometry drives a deterministic cosine order.
+private final class AxisEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var dimensions: Int = 3
+    func loadModel(from url: URL) async throws {}
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        texts.map { _ in [1, 0, 0] }
+    }
+    func unloadModel() { isModelLoaded = false }
+}

--- a/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
+++ b/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
@@ -11,6 +11,10 @@ private actor FakeVectorStore: VectorStore {
     var deletedDocumentIDs: [UUID] = []
     var searchResults: [VectorSearchHit] = []
     var keywordResults: [VectorSearchHit] = []
+    /// Records the `limit` the service requested so tests can assert candidate
+    /// widening (or the absence of it).
+    var lastSearchLimit: Int?
+    var lastKeywordLimit: Int?
 
     func insert(chunks: [DocumentChunk], documentTitle: String, embeddings: [[Float]]) throws {
         insertedChunks.append(contentsOf: chunks)
@@ -18,10 +22,47 @@ private actor FakeVectorStore: VectorStore {
         insertedTitles.append(contentsOf: [String](repeating: documentTitle, count: chunks.count))
     }
 
-    func search(embedding: [Float], limit: Int) throws -> [VectorSearchHit] { searchResults }
-    func keywordSearch(query: String, limit: Int) throws -> [VectorSearchHit] { keywordResults }
+    func search(embedding: [Float], limit: Int) throws -> [VectorSearchHit] {
+        lastSearchLimit = limit
+        return searchResults
+    }
+    func keywordSearch(query: String, limit: Int) throws -> [VectorSearchHit] {
+        lastKeywordLimit = limit
+        return keywordResults
+    }
     func delete(documentID: UUID) throws { deletedDocumentIDs.append(documentID) }
     func deleteAll() throws { insertedChunks.removeAll() }
+}
+
+// MARK: - Reranker fakes
+
+/// Reorders candidates with a caller-supplied closure (or reports itself not
+/// ready). Lets a test inject a known re-ranking and assert the service honours
+/// it.
+private struct FakeReranker: Reranker {
+    let ready: Bool
+    let reorder: @Sendable ([VectorSearchHit]) -> [VectorSearchHit]
+
+    init(ready: Bool = true, reorder: @escaping @Sendable ([VectorSearchHit]) -> [VectorSearchHit]) {
+        self.ready = ready
+        self.reorder = reorder
+    }
+
+    var isReady: Bool { ready }
+
+    func rerank(query: String, candidates: [VectorSearchHit], limit: Int) async throws -> [VectorSearchHit] {
+        Array(reorder(candidates).prefix(limit))
+    }
+}
+
+/// A ready reranker whose `rerank` always throws — drives the graceful
+/// fall-back-to-first-stage path.
+private struct ThrowingReranker: Reranker {
+    struct Boom: Error {}
+    var isReady: Bool { true }
+    func rerank(query: String, candidates: [VectorSearchHit], limit: Int) async throws -> [VectorSearchHit] {
+        throw Boom()
+    }
 }
 
 @MainActor
@@ -414,6 +455,135 @@ final class RAGServiceTests: XCTestCase {
         let deleted = await vectorStore.deletedDocumentIDs
         XCTAssertTrue(deleted.contains(record.id))
         XCTAssertTrue(docStore.deletedIDs.contains(record.id))
+    }
+
+    // MARK: - #1637: rerank stage
+
+    /// Three semantic hits arrive in a deliberately *wrong* cosine order — the
+    /// most relevant passage ("C") is ranked last by the bi-encoder. A reranker
+    /// that knows C is best must pull it to the front of both the injected slot
+    /// content and the citation list.
+    func test_retrieve_rerankReordersKnownBadCosineOrdering() async throws {
+        let docID = UUID()
+        let hitA = VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "AAA passage", chunkIndex: 0), documentTitle: "Doc", score: 0.90)
+        let hitB = VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "BBB passage", chunkIndex: 1), documentTitle: "Doc", score: 0.80)
+        let hitC = VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "CCC passage", chunkIndex: 2), documentTitle: "Doc", score: 0.70)
+
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setSearchResults([hitA, hitB, hitC])  // bad order: C last
+
+        // Reranker knows the true relevance is C > A > B.
+        let reranker = FakeReranker { hits in
+            hits.sorted { lhs, rhs in
+                func rank(_ t: String) -> Int { t.hasPrefix("CCC") ? 0 : t.hasPrefix("AAA") ? 1 : 2 }
+                return rank(lhs.chunk.text) < rank(rhs.chunk.text)
+            }
+        }
+
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: FakeEmbeddingBackend(isModelLoaded: true),
+            reranker: reranker
+        )
+
+        let result = try await sut.retrieve(query: "which is most relevant?", limit: 3)
+
+        // Citations reflect the reranked order, not the cosine order.
+        XCTAssertEqual(result.citations.map(\.chunkIndex), [2, 0, 1],
+                       "reranker must reorder citations C, A, B")
+        // The injected slot content leads with the reranked-best passage.
+        let content = result.slots.first?.content ?? ""
+        guard let cPos = content.range(of: "CCC passage")?.lowerBound,
+              let aPos = content.range(of: "AAA passage")?.lowerBound else {
+            return XCTFail("slot content must contain reranked passages")
+        }
+        XCTAssertLessThan(cPos, aPos, "reranked-best passage must appear first in the slot")
+
+        // Sabotage: if the service ignored the reranker and used cosine order,
+        // citations would be [0, 1, 2] and this equality would fail.
+        XCTAssertNotEqual(result.citations.map(\.chunkIndex), [0, 1, 2])
+    }
+
+    /// With a reranker loaded, the first-stage fetch must be widened to
+    /// `limit * rerankCandidateMultiplier` so the cross-encoder has more
+    /// candidates to reorder.
+    func test_retrieve_withReranker_widensCandidatePool() async throws {
+        let vectorStore = FakeVectorStore()
+        let hit = VectorSearchHit(chunk: DocumentChunk(documentID: UUID(), text: "x", chunkIndex: 0), documentTitle: "Doc", score: 0.9)
+        await vectorStore.setSearchResults([hit])
+
+        let reranker = FakeReranker { $0 }  // ready, identity reorder
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: FakeEmbeddingBackend(isModelLoaded: true),
+            reranker: reranker
+        )
+
+        _ = try await sut.retrieve(query: "anything", limit: 5)
+
+        let requested = await vectorStore.lastSearchLimit
+        XCTAssertEqual(requested, 5 * RAGService.rerankCandidateMultiplier,
+                       "candidate pool must be widened to limit*\(RAGService.rerankCandidateMultiplier) when a reranker is active")
+    }
+
+    /// Passthrough default: a `PassthroughReranker` (or no reranker) must leave
+    /// retrieval byte-for-byte unchanged — same fetch width, same ordering,
+    /// same citations as the pre-rerank pipeline.
+    func test_retrieve_passthroughDefault_leavesRetrievalUnchanged() async throws {
+        let docID = UUID()
+        let hits = [
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "first", chunkIndex: 0), documentTitle: "Doc", score: 0.9),
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "second", chunkIndex: 1), documentTitle: "Doc", score: 0.8),
+        ]
+
+        func run(reranker: (any Reranker)?) async throws -> (limit: Int?, citations: [Int]) {
+            let vectorStore = FakeVectorStore()
+            await vectorStore.setSearchResults(hits)
+            let sut = RAGService(
+                documentStore: FakeDocumentStore(),
+                vectorStore: vectorStore,
+                embeddingBackend: FakeEmbeddingBackend(isModelLoaded: true),
+                reranker: reranker
+            )
+            let result = try await sut.retrieve(query: "q", limit: 5)
+            let limit = await vectorStore.lastSearchLimit
+            return (limit, result.citations.map(\.chunkIndex))
+        }
+
+        let baseline = try await run(reranker: nil)
+        let passthrough = try await run(reranker: PassthroughReranker())
+
+        XCTAssertEqual(baseline.limit, 5, "no reranker must fetch exactly `limit`, not a widened pool")
+        XCTAssertEqual(passthrough.limit, 5, "PassthroughReranker must not widen the candidate pool")
+        XCTAssertEqual(baseline.citations, passthrough.citations,
+                       "passthrough reranker must produce identical results to no reranker")
+        XCTAssertEqual(passthrough.citations, [0, 1], "ordering must be unchanged from the first stage")
+    }
+
+    /// A reranker that throws must degrade to the first-stage ordering rather
+    /// than failing the retrieval.
+    func test_retrieve_rerankFailure_fallsBackToFirstStage() async throws {
+        let docID = UUID()
+        let hits = (0..<3).map {
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "p\($0)", chunkIndex: $0), documentTitle: "Doc", score: Float(0.9) - Float($0) * 0.1)
+        }
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setSearchResults(hits)
+
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            embeddingBackend: FakeEmbeddingBackend(isModelLoaded: true),
+            reranker: ThrowingReranker()
+        )
+
+        let result = try await sut.retrieve(query: "q", limit: 2)
+
+        XCTAssertEqual(result.citations.count, 2, "must trim the widened pool back to `limit` even on rerank failure")
+        XCTAssertEqual(result.citations.map(\.chunkIndex), [0, 1],
+                       "rerank failure must preserve the first-stage cosine ordering")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

`RAGService.retrieve` did embed → cosine top-k → keyword fallback with no relevance re-ranking. This adds an optional cross-encoder **rerank stage** between retrieval and prompt injection — the single biggest RAG-quality lever still open.

The default is a **passthrough no-op**: when no reranker is configured (or its model isn't loaded), retrieval behaves **byte-for-byte** as it did before, keyword fallback included.

## How it works

- `Reranker` port lives in **ManifoldInference** (alongside `EmbeddingBackend` / `VectorSearchHit`), not `ManifoldRuntime`. The issue suggested Runtime, but the dependency rules forbid it: the Llama-backed implementation must conform, and `ManifoldLlama` depends on `ManifoldInference`, *not* `ManifoldRuntime`. Placing the port in Inference follows the exact `EmbeddingBackend` precedent and keeps Runtime free of backend families. `RAGService` consumes it through its existing `ManifoldInference` import.
- `RAGService.retrieve` widens the first-stage pool to `limit * rerankCandidateMultiplier` (3×) **only when** `reranker?.isReady`, reranks down to `limit`, and degrades to the first-stage ordering if the reranker throws. No reranker ⇒ fetch width and ordering unchanged.
- `LlamaReranker` (ManifoldLlama) loads a RANK-pooling cross-encoder GGUF (e.g. `bge-reranker`), scores `[query, document]` pairs via `llama_get_embeddings_seq` under `LLAMA_POOLING_TYPE_RANK`, and squashes the logit into a (0,1) relevance probability. Mirrors `LlamaEmbeddingBackend`'s actor-isolated C-pointer ownership.
- Cloud rerank: protocol seam only — no concrete backend (per scope).

## Scope checklist (from #1637)

- [x] Optional `Reranker` port, passthrough/no-op default (`PassthroughReranker`)
- [x] Wired as post-retrieve, pre-inject stage in `RAGService.retrieve` (widen `top-k*3` → rerank → `top-k`); injection call site is `ConversationTurnExecutor` via `RAGService.retrieve`
- [x] Local reranker via `LlamaEmbeddingBackend` RANK-pooling notes → `LlamaReranker`
- [x] Cloud rerank left as a protocol seam (no concrete backend)
- [x] Honest fallback: no reranker model ⇒ retrieval exactly as today, keyword path unchanged
- [x] Tests: unit (rerank reorders known-bad cosine order), integration (in-memory SwiftData + flat-file stores), passthrough-default sabotage check
- [x] DocC (`Reranker`, `RAGService`, `RAGConfiguration`) + RAG quickstart snippet + README

## Backend checklist

- [x] **Llama** — `LlamaReranker` RANK-pooling implementation + model-gated E2E (`LLAMA_RERANKER_MODEL`)
- [x] **Cloud** — protocol seam only (out of scope per issue)
- [x] **MLX / Foundation** — N/A (no cross-encoder rerank path); all reach the same passthrough default

## Tests / gate

`Reranker` is uniform across backends, so this ships as one PR. Validation run locally:
- CI-shape `swift build --build-tests --disable-default-traits`: **green**; affected suites (Runtime, Persistence, Inference audit, API-freeze, trait-gate audit, RAG integration): **648 tests, 8 skipped, 0 failures**.
- Full local combo minus Ollama (`MLX,Llama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Macros`) build-tests **green**; `RAGServiceTests` + `RAGServiceRerankIntegrationTests` + `LlamaRerankerTests`: **0 failures** (1 model-gated skip).
- The real RANK-pooling E2E skips unless `LLAMA_RERANKER_MODEL` points at a cross-encoder GGUF (none on this machine); the rest of `LlamaReranker` (squash math, not-ready contract) is covered model-free.

> Note: the full Ollama trait combo currently fails to compile on `main` (`OllamaBackend(_registrar:)` — an `internal` init called cross-module from `ManifoldBackendsUmbrella/CloudBackends.swift`, introduced by the recent pre-v1 naming pass). It is unrelated to this PR (reproduces on pristine `main`, touches no file here) and does not affect CI, which builds `--disable-default-traits`. Flagging separately.

Closes #1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)