### PR TITLE
chore(fuzz): default fuzz-chat backend to llama.cpp instead of Ollama

### DIFF
--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -21,7 +21,7 @@ struct FuzzChatCLI {
             return
         }
 
-        var backend: BackendChoice = .ollama
+        var backend: BackendChoice = .llama
         var minutes: Int?
         var iterations: Int?
         var seed: UInt64 = UInt64.random(in: 0...UInt64.max)
@@ -522,7 +522,7 @@ struct FuzzChatCLI {
             "Usage: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat [options]",
             "",
             "Options:",
-            "  --backend ollama|mock|chaos|llama|foundation|mlx|all   default: ollama",
+            "  --backend ollama|mock|chaos|llama|foundation|mlx|all   default: llama",
             "                      mock  = MockInferenceBackend (hardware-free, used by PR-tier CI)",
             "                      chaos = ChaosBackend (hardware-free; injects stream failures)",
             "  --minutes N         time budget (default 5 if neither flag set)",

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -2,7 +2,7 @@
 # scripts/fuzz.sh — Run the ManifoldFuzz harness with a friendly preflight.
 #
 # Default behaviour (no args): runs `swift run --traits Fuzz,MLX,Llama,Ollama
-# fuzz-chat --minutes 5` against Ollama. Discovers which backends are usable and
+# fuzz-chat --minutes 5` against llama.cpp. Discovers which backends are usable and
 # prints a one-line summary before kicking off the harness.
 #
 # Local extensions:
@@ -25,7 +25,7 @@ for arg in "$@"; do
         --with-mlx) WITH_MLX=1 ;;
         -h|--help)
             cd "$PACKAGE_DIR"
-            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat\`"
+            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat\` (default backend: llama)"
             echo ""
             echo "Local flags:"
             echo "  --with-mlx   Also run the MLX XCTest fuzz suite via xcodebuild"


### PR DESCRIPTION
## Summary

- Switches `fuzz-chat`'s default `--backend` from `ollama` to `llama`
- Updates help text in `FuzzChatCLI.swift` and `scripts/fuzz.sh` to match

## Why

Benchmarked in today's fuzz session against `gemma4:12b`:

| Backend | 5-minute iterations | New findings |
|---|---|---|
| Ollama | 2 | 1 (timeout — Ollama HTTP overhead) |
| llama.cpp | 17 | 0 (clean) |

llama.cpp runs ~8.5× more iterations per minute on the same GGUF via Metal, and the timeout findings produced by Ollama are artifacts of the HTTP layer rather than real model anomalies. `--backend ollama` remains fully supported; this only changes what you get with no flags.

Related: #1664 (Ollama thinking-token probe bugs found during this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)