### PR TITLE
feat: block-rotate fuzz models to amortize model-load cost

### DIFF
--- a/Sources/ManifoldFuzz/RotatingFuzzFactory.swift
+++ b/Sources/ManifoldFuzz/RotatingFuzzFactory.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// `FuzzBackendFactory` that round-robins through a fixed list of child factories,
-/// advancing one step each time `makeHandle()` is called. Used by the CLI to
-/// rotate the Ollama target model per iteration when the caller did not pin a
-/// specific model with `--model <substr>`.
+/// advancing through them in fixed-size *blocks* of consecutive `makeHandle()`
+/// calls. Used by the CLI to rotate the Ollama target model across a campaign
+/// when the caller did not pin a specific model with `--model <substr>`.
 ///
 /// ## Why option (b)?
 ///
@@ -12,13 +12,27 @@ import Foundation
 /// `init(config:factory:)` contract from #537 intact and isolates rotation
 /// behind the existing factory boundary — the runner is unchanged.
 ///
+/// ## Why block rotation?
+///
+/// `FuzzRunner` calls `makeHandle()` once per iteration, so a step-1
+/// round-robin switches the active model on *every* iteration. For a
+/// multi-model campaign (`--model all`) that means Ollama/Llama/MLX pay a
+/// multi-second model load on nearly every iteration — the resident model is
+/// evicted before it does any useful work. Block rotation amortises that cost:
+/// the factory stays on the same child for `blockSize` consecutive calls before
+/// advancing, so a model loads once and serves a whole block of iterations.
+/// With `blockSize == 1` the behaviour is byte-for-byte identical to the
+/// original step-1 round-robin, so existing callers are unaffected.
+///
 /// ## Determinism
 ///
-/// Rotation is a plain monotonic index increment, so replay against a pinned
-/// seed is stable as long as the caller provides the same ordered list of
-/// child factories. The CLI sorts discovered Ollama models by UTF-8 byte
-/// order before handing them here, so two invocations on the same machine
-/// yield the same sequence regardless of the order Ollama reports them.
+/// The index is `(callCount / blockSize) % children.count`, where `callCount`
+/// is a plain monotonic counter. It reads no wall-clock or random state, so a
+/// fixed seed + fixed child order + fixed `blockSize` always yields the same
+/// model sequence — the contract `--seed` replay (#490) depends on. The CLI
+/// sorts discovered Ollama models by UTF-8 byte order before handing them here,
+/// so two invocations on the same machine yield the same sequence regardless of
+/// the order Ollama reports them.
 ///
 /// ## Thread safety
 ///
@@ -45,19 +59,33 @@ public struct RotatingFuzzFactory: FuzzBackendFactory {
     }
 
     public let children: [any FuzzBackendFactory]
+
+    /// Number of consecutive `makeHandle()` calls served by one child before
+    /// the rotation advances. `1` restores the original step-1 round-robin.
+    public let blockSize: Int
+
     private let counter: Counter
 
-    /// - Parameter children: ordered list of child factories to rotate through.
-    ///   Must be non-empty. The CLI sorts Ollama model names by UTF-8 byte
-    ///   order before wrapping, so the order here is already deterministic.
-    public init(children: [any FuzzBackendFactory]) {
+    /// - Parameters:
+    ///   - children: ordered list of child factories to rotate through. Must be
+    ///     non-empty. The CLI sorts Ollama model names by UTF-8 byte order
+    ///     before wrapping, so the order here is already deterministic.
+    ///   - blockSize: how many consecutive `makeHandle()` calls stay on the same
+    ///     child before advancing. Must be `>= 1`. Larger blocks keep a model
+    ///     resident across more iterations, amortising load cost; the default of
+    ///     `1` preserves the historical per-call rotation.
+    public init(children: [any FuzzBackendFactory], blockSize: Int = 1) {
         precondition(!children.isEmpty, "RotatingFuzzFactory requires at least one child factory")
+        precondition(blockSize >= 1, "RotatingFuzzFactory blockSize must be >= 1")
         self.children = children
+        self.blockSize = blockSize
         self.counter = Counter()
     }
 
     public func makeHandle() async throws -> FuzzRunner.BackendHandle {
-        let idx = counter.nextAndAdvance() % children.count
+        // Integer-divide the monotonic call count by the block size so each
+        // child serves `blockSize` consecutive calls before the index advances.
+        let idx = (counter.nextAndAdvance() / blockSize) % children.count
         return try await children[idx].makeHandle()
     }
 }

--- a/Sources/ManifoldFuzzBackends/OllamaFuzzFactory.swift
+++ b/Sources/ManifoldFuzzBackends/OllamaFuzzFactory.swift
@@ -63,12 +63,15 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
     ///
     /// - When `modelHint` is `nil`, empty, or `"all"`: enumerates every installed
     ///   Ollama model, sorts by UTF-8 byte order, and wraps them in a
-    ///   `RotatingFuzzFactory` so the runner round-robins one model per
-    ///   iteration.
+    ///   `RotatingFuzzFactory` so the runner serves each model for `blockSize`
+    ///   consecutive iterations before advancing — keeping a model resident long
+    ///   enough to amortise its multi-second load.
     /// - When `modelHint` names a specific model: returns a single pinned factory
-    ///   so callers preserve the pre-rotation behaviour.
+    ///   so callers preserve the pre-rotation behaviour. `blockSize` is ignored
+    ///   because there is nothing to rotate through.
     public static func makeCampaignFactory(
         modelHint: String? = nil,
+        blockSize: Int = 1,
         baseURL: URL = URL(string: "http://localhost:11434")!,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> any FuzzBackendFactory {
@@ -86,7 +89,7 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
             let children: [any FuzzBackendFactory] = models.sorted().map {
                 OllamaFuzzFactory(modelHint: $0, baseURL: baseURL, environment: environment)
             }
-            return RotatingFuzzFactory(children: children)
+            return RotatingFuzzFactory(children: children, blockSize: blockSize)
         }
 
         return OllamaFuzzFactory(modelHint: normalizedHint, baseURL: baseURL, environment: environment)

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -35,6 +35,12 @@ struct FuzzChatCLI {
         var corpusSubset: Corpus.Subset = .full
         var tools = false
         var workers = 1
+        // How many consecutive iterations stay on the same model before the
+        // `--model all` rotation advances. Default 16 keeps a model resident
+        // across a block of iterations so a multi-model campaign doesn't pay a
+        // model load on nearly every iteration. Ignored when a single model is
+        // pinned. See RotatingFuzzFactory for the block-rotation rationale.
+        var rotateEvery = 16
         var outputDir = URL(fileURLWithPath: "tmp/fuzz", isDirectory: true)
 
         var i = argv.startIndex
@@ -63,6 +69,10 @@ struct FuzzChatCLI {
                 i = argv.index(after: i)
                 guard i < argv.endIndex, let n = Int(argv[i]), n > 0 else { fail("--workers requires a positive integer") }
                 workers = n
+            case "--rotate-every":
+                i = argv.index(after: i)
+                guard i < argv.endIndex, let n = Int(argv[i]), n >= 1 else { fail("--rotate-every requires an integer >= 1") }
+                rotateEvery = n
             case "--output-dir":
                 i = argv.index(after: i)
                 guard i < argv.endIndex else { fail("--output-dir requires a path") }
@@ -145,6 +155,7 @@ struct FuzzChatCLI {
                         sessionScripts: sessionScripts,
                         corpusSubset: corpusSubset,
                         tools: tools,
+                        rotateEvery: rotateEvery,
                         outputDir: outputDir
                     ),
                     slices: slices
@@ -164,7 +175,7 @@ struct FuzzChatCLI {
         case .ollama:
             #if Fuzz && Ollama
             do {
-                factory = try OllamaFuzzFactory.makeCampaignFactory(modelHint: modelHint)
+                factory = try OllamaFuzzFactory.makeCampaignFactory(modelHint: modelHint, blockSize: rotateEvery)
             } catch {
                 fail(String(describing: error))
             }
@@ -269,6 +280,7 @@ struct FuzzChatCLI {
         var sessionScripts: Bool
         var corpusSubset: Corpus.Subset
         var tools: Bool
+        var rotateEvery: Int
         var outputDir: URL
     }
 
@@ -386,6 +398,9 @@ struct FuzzChatCLI {
         if options.tools {
             args.append("--tools")
         }
+        // Forward the rotation block size so each worker's RotatingFuzzFactory
+        // keeps the same amortisation behaviour as the parent invocation.
+        args += ["--rotate-every", "\(options.rotateEvery)"]
         return args
     }
 
@@ -530,6 +545,9 @@ struct FuzzChatCLI {
             "  --seed N            RNG seed (default random)",
             "  --workers N         process-level workers for campaign mode (default 1).",
             "                      Iterations are split; time budgets apply per worker.",
+            "  --rotate-every N    iterations to stay on each model before rotating",
+            "                      (default 16). Only affects `--model all`; keeps a",
+            "                      model resident across a block to amortise load cost.",
             "  --output-dir PATH   findings directory (default tmp/fuzz)",
             "  --model <substr>    Ollama: pin to first installed model containing <substr>.",
             "                      Pass `all` (or omit) to rotate through every installed",

--- a/Tests/ManifoldFuzzTests/ModelRotationTests.swift
+++ b/Tests/ManifoldFuzzTests/ModelRotationTests.swift
@@ -91,6 +91,65 @@ final class ModelRotationTests: XCTestCase {
         }
     }
 
+    // MARK: - Block rotation
+
+    /// `blockSize: 1` (the default) must reproduce the historical step-1
+    /// round-robin: the model changes on every call. This is the backward-compat
+    /// floor — anything else would silently alter existing campaigns.
+    func test_blockSize1_matchesStep1RoundRobin() async throws {
+        let explicit = RotatingFuzzFactory(children: [
+            TagFactory(tag: "A"),
+            TagFactory(tag: "B"),
+        ], blockSize: 1)
+
+        var observed: [String] = []
+        for _ in 0..<6 {
+            observed.append(try await explicit.makeHandle().modelId)
+        }
+
+        XCTAssertEqual(observed, ["A", "B", "A", "B", "A", "B"],
+                       "blockSize 1 must behave identically to the original per-call rotation")
+    }
+
+    /// `blockSize: 3` with two children must serve each model for three
+    /// consecutive calls before advancing, then wrap: A,A,A,B,B,B,A,...
+    /// This is the amortisation contract — a model stays resident across a block
+    /// of iterations instead of reloading every iteration.
+    func test_blockSize3_holdsModelForThreeCalls() async throws {
+        let factory = RotatingFuzzFactory(children: [
+            TagFactory(tag: "model0"),
+            TagFactory(tag: "model1"),
+        ], blockSize: 3)
+
+        var observed: [String] = []
+        for _ in 0..<7 {
+            observed.append(try await factory.makeHandle().modelId)
+        }
+
+        XCTAssertEqual(observed,
+                       ["model0", "model0", "model0", "model1", "model1", "model1", "model0"],
+                       "blockSize 3 must keep each model for 3 consecutive calls before advancing")
+    }
+
+    /// A valid even `blockSize` constructs and rotates correctly across a wrap
+    /// boundary: blockSize 2 over three children yields a,a,b,b,c,c,a,a,...
+    func test_blockSize2_constructsAndRotatesAcrossWrap() async throws {
+        let factory = RotatingFuzzFactory(children: [
+            TagFactory(tag: "a"),
+            TagFactory(tag: "b"),
+            TagFactory(tag: "c"),
+        ], blockSize: 2)
+        XCTAssertEqual(factory.blockSize, 2)
+
+        var observed: [String] = []
+        for _ in 0..<8 {
+            observed.append(try await factory.makeHandle().modelId)
+        }
+
+        XCTAssertEqual(observed, ["a", "a", "b", "b", "c", "c", "a", "a"],
+                       "blockSize 2 must serve each child twice and wrap after the last child")
+    }
+
     /// Two fresh `RotatingFuzzFactory` instances with the same ordered child
     /// list must produce the same rotation sequence. This is the contract
     /// `--replay` (#490) relies on: the UTF-8-sorted model list in the CLI


### PR DESCRIPTION
## Problem

In `--model all` fuzz campaigns the rotator switched the active model on **every** iteration. `FuzzRunner` calls `makeHandle()` once per iteration, and the old step-1 round-robin advanced the index each call — so Ollama/Llama/MLX paid a multi-second model load on nearly every iteration, evicting the resident model before it did any useful work. This dominates wall-clock in multi-model runs (e.g. the weekly fuzz CI).

## Fix

`RotatingFuzzFactory` now stays on one child for `blockSize` consecutive `makeHandle()` calls before advancing, via `(callCount / blockSize) % children.count` over a plain monotonic counter. A model loads once and serves a whole block of iterations.

- New CLI flag `--rotate-every N` (default **16**), validated `N >= 1`, threaded through `CampaignOptions.rotateEvery` to the `RotatingFuzzFactory` construction site **and** forwarded to parallel worker subprocesses so workers don't silently diverge from the parent.
- `blockSize == 1` is byte-for-byte the original step-1 behavior; the default `init(children:)` call sites are unchanged.
- **Determinism preserved**: the index reads only the monotonic counter + `blockSize` — no wall-clock, no RNG — so `--seed` replay (#490) stays stable for a fixed child order and block size.
- **Pinned-model runs are unaffected**: when `--model <substr>` resolves to a single factory, the rotation wrapper is bypassed entirely and `blockSize` is ignored (no error, no behavior change).

## Tests

Added block-rotation cases to `ModelRotationTests` (reusing the existing `TagFactory` stub):
- `blockSize: 1` reproduces the historical A,B,A,B,… round-robin (backward-compat floor).
- `blockSize: 3` over two children asserts the exact sequence A,A,A,B,B,B,A.
- `blockSize: 2` over three children asserts a,a,b,b,c,c,a,a across the wrap boundary.

Verified with `swift test --traits Fuzz,Ollama --filter ManifoldFuzzTests`: 201 tests, 0 failures (rebased onto current `main`, including #1672 Glass Box wiring). Help/usage text updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)