### PR TITLE
test: prune stale behavior-pinning tests and unskip foundation parity

### DIFF
--- a/Tests/ManifoldBackendsTests/LlamaKVPersistenceTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaKVPersistenceTests.swift
@@ -363,8 +363,8 @@ final class LlamaKVPersistenceTests: XCTestCase {
             "Turn 2 must emit .kvCacheReuse — without it this determinism check is vacuous"
         )
 
-        // FIXME: https://github.com/roryford/ManifoldKit/issues — file a tracking issue for
-        // "enforce same batch shape on KV-reuse re-decode to guarantee greedy determinism".
+        // FIXME: https://github.com/roryford/ManifoldKit/issues/1677 — enforce same batch shape
+        // on KV-reuse re-decode to guarantee greedy determinism.
         // Metal attention kernels use different parallel-reduction strategies for batches of
         // different sizes. When KV prefix reuse re-decodes only the last 2 prompt tokens (a
         // 2-token batch), the FP accumulation order differs from Turn 1's full-prompt batch,

--- a/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
@@ -291,101 +291,12 @@ final class SSEPayloadReplayTests: XCTestCase {
         XCTAssertEqual(tokens, ["A", "B", "C"])
     }
 
-    // MARK: - Claude thinking blocks (#527)
+    // MARK: - Claude citations_delta (currently unsupported)
 
-    /// Pins today's behaviour: Claude 3.7+ `thinking` / `thinking_delta` events are
-    /// silently dropped by `parseToken` because it only matches `text_delta`.
-    ///
-    /// FIXME(#527): when thinking support lands, flip these assertions to expect
-    /// `.thinkingToken("Let me reason...")` + `.thinkingCompleted` before the
-    /// final `.token("Answer.")`.
-    func test_claude_thinkingBlocks_todayDropsThinkingContent() async throws {
-        let sseText = """
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me reason..."}}
-
-        data: {"type":"content_block_stop","index":0}
-
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer."}}
-
-        data: {"type":"message_stop"}
-
-        """
-
-        let payloads = try await collectPayloads(from: sseText)
-        let handler: CloudPayloadHandler = .claude
-        let tokens = payloads.compactMap { handler.extractToken(from: $0) }
-
-        // Contract-pinning: today only the text_delta survives; the thinking_delta
-        // is dropped. Flipping this assertion is the signal that the fix landed.
-        XCTAssertEqual(tokens, ["Answer."],
-                       "ClaudeBackend currently drops thinking_delta payloads — pin behaviour until #527 ships")
-
-        // Sanity: the thinking_delta payload *is* present in the stream, we're
-        // just not surfacing it. This guards against the mistake of fixing
-        // the test by removing the upstream event.
-        let thinkingPayload = payloads.first { $0.contains("thinking_delta") }
-        XCTAssertNotNil(thinkingPayload, "thinking_delta event should be in the raw SSE stream")
-        XCTAssertNil(handler.extractToken(from: thinkingPayload!),
-                     "thinking_delta must not leak into the token stream today")
-    }
-
-    // MARK: - Claude tool_use streaming (#528)
-
-    /// Pins today's contract: `content_block_start` with `type:tool_use` and
-    /// `input_json_delta` payloads produce no tokens. A refactor that widens
-    /// `content_block_delta` matching would leak tool-use JSON into visible output.
-    ///
-    /// FIXME(#528): once tool calling is wired, flip to assert structured
-    /// tool-call events (`.toolCallStart` / `.toolCallEnd`).
-    func test_claude_toolUseStreaming_todayProducesNoTokens() async throws {
-        let sseText = """
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":"}}
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"Paris\\"}"}}
-
-        data: {"type":"content_block_stop","index":0}
-
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}
-
-        data: {"type":"message_stop"}
-
-        """
-
-        let payloads = try await collectPayloads(from: sseText)
-        let handler: CloudPayloadHandler = .claude
-
-        // Every payload should return nil from extractToken — no token leakage.
-        for payload in payloads {
-            XCTAssertNil(handler.extractToken(from: payload),
-                         "tool_use / input_json_delta payloads must not yield tokens: \(payload)")
-        }
-
-        // Completion token count on the tool_use message_delta should still parse.
-        let messageDeltaPayload = payloads.first { $0.contains("\"type\":\"message_delta\"") }
-        XCTAssertNotNil(messageDeltaPayload)
-        let usage = handler.extractUsage(from: messageDeltaPayload!)
-        XCTAssertEqual(usage?.completionTokens, 5)
-
-        // message_stop terminates the stream.
-        let messageStop = payloads.first { $0.contains("\"type\":\"message_stop\"") }
-        XCTAssertNotNil(messageStop)
-        XCTAssertTrue(handler.isStreamEnd(messageStop!))
-    }
-
-    // MARK: - Claude citations_delta (#529)
-
-    /// Pins today's contract: `citations_delta` inside `content_block_delta`
-    /// is ignored. Only surrounding `text_delta` events yield tokens.
-    ///
-    /// FIXME(#529): once citation metadata is surfaced, flip to assert the
-    /// structured citation event between the two text tokens.
-    func test_claude_citationsDelta_todayIgnored() async throws {
+    // Claude citations_delta is not currently surfaced as a GenerationEvent — no
+    // citation case exists in the cloud event model. This documents the gap;
+    // update if/when citation surfacing lands.
+    func test_claude_citationsDelta_currentlyUnsupported() async throws {
         let sseText = """
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Einstein said "}}
 
@@ -410,15 +321,12 @@ final class SSEPayloadReplayTests: XCTestCase {
                      "citations_delta must not leak into the token stream today")
     }
 
-    // MARK: - Claude stop_reason variants (#530)
+    // MARK: - Claude stop_reason variants (currently parse usage only)
 
-    /// Pins today's contract: non-`end_turn` stop reasons (`refusal`,
-    /// `max_tokens`, `stop_sequence`) are no-ops for the token path. Usage
-    /// still parses out the `output_tokens` value from every variant.
-    ///
-    /// FIXME(#530): once structured stream events carry the stop reason,
-    /// flip to assert `.stopped(.refusal)` / `.stopped(.maxTokens)` etc.
-    func test_claude_stopReasonVariants_todayParseUsageOnly() async throws {
+    // GenerationEvent has no stopReason case, so Claude stop_reason variants
+    // (refusal/max_tokens/stop_sequence) are not surfaced — only usage is parsed.
+    // This documents the current gap.
+    func test_claude_stopReasonVariants_currentlyParseUsageOnly() async throws {
         let sseText = """
         data: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":3}}
 
@@ -445,48 +353,6 @@ final class SSEPayloadReplayTests: XCTestCase {
             XCTAssertFalse(handler.isStreamEnd(payload),
                            "message_delta must not be treated as stream end: \(payload)")
         }
-    }
-
-    // MARK: - Claude interleaved content blocks (#532)
-
-    /// Pins the "flatten all text_deltas in order, regardless of `index`"
-    /// contract. Three interleaved blocks (text → tool_use → text) produce
-    /// exactly the two text tokens in order. The tool_use block's
-    /// `input_json_delta` is ignored.
-    ///
-    /// FIXME(#532): once structured block events are supported, flip to
-    /// `.token("First")`, `.toolCallStart/.toolCallEnd`, `.token("Second")`.
-    func test_claude_interleavedBlocks_todayFlattensTextInOrder() async throws {
-        let sseText = """
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"First"}}
-
-        data: {"type":"content_block_stop","index":0}
-
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"x","input":{}}}
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}
-
-        data: {"type":"content_block_stop","index":1}
-
-        data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}
-
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Second"}}
-
-        data: {"type":"content_block_stop","index":2}
-
-        data: {"type":"message_stop"}
-
-        """
-
-        let payloads = try await collectPayloads(from: sseText)
-        let handler: CloudPayloadHandler = .claude
-        let tokens = payloads.compactMap { handler.extractToken(from: $0) }
-
-        // Two text_deltas survive, the tool_use input_json_delta is dropped.
-        XCTAssertEqual(tokens, ["First", "Second"],
-                       "Interleaved blocks must flatten text_deltas in order and drop tool_use json")
     }
 
     // MARK: - Existing tests

--- a/Tests/ManifoldInferenceTests/ToolErrorClassificationParityTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolErrorClassificationParityTests.swift
@@ -35,7 +35,9 @@ import ManifoldTestSupport
 /// behavior under test is the registry's classification logic, not the
 /// backend's wire-format parsing.
 ///
-/// Foundation row is present but skipped (blocked on #713).
+/// Foundation row is included (tool calling shipped in #713). Because the
+/// matrix is mock-driven, the Foundation row needs no hardware or availability
+/// gate.
 @MainActor
 final class ToolErrorClassificationParityTests: XCTestCase {
 
@@ -128,9 +130,10 @@ final class ToolErrorClassificationParityTests: XCTestCase {
     /// permanent) break simultaneously.
     private static let matrix: [MatrixRow] = {
         // Build the rows for every kind × every applicable backend.
-        // Backends: openai-chat, openai-responses, ollama, anthropic, mlx
-        // (Foundation is skipped — blocked on #713).
-        let backends = ["openai-chat", "openai-responses", "ollama", "anthropic", "mlx"]
+        // Backends: openai-chat, openai-responses, ollama, anthropic, mlx,
+        // foundation (tool calling shipped in #713; matrix is mock-driven so no
+        // hardware/availability gate is needed).
+        let backends = ["openai-chat", "openai-responses", "ollama", "anthropic", "mlx", "foundation"]
 
         var rows: [MatrixRow] = []
 
@@ -217,8 +220,8 @@ final class ToolErrorClassificationParityTests: XCTestCase {
     /// hardware gating. The behavior under test is the registry's
     /// classification seam, not real backend code.
     ///
-    /// Foundation row: skipped — blocked on #713. When #713 lands, add
-    /// "foundation" to `backends` above and remove this skip comment.
+    /// The Foundation row is included here — tool calling shipped in #713 and
+    /// the mock-driven matrix needs no hardware/availability gate.
     func test_parityMatrix_allErrorKinds_allBackends() async {
         for row in Self.matrix {
             let registry = ToolRegistry()
@@ -250,17 +253,6 @@ final class ToolErrorClassificationParityTests: XCTestCase {
                 "[\(row.backend)/\(row.fault)] callId must be stamped from the incoming ToolCall"
             )
         }
-    }
-
-    // MARK: - Foundation row (blocked)
-
-    /// Foundation backend row — skipped pending fix for #713.
-    ///
-    /// When #713 is resolved, remove this test and add "foundation" to the
-    /// `backends` array in `matrix` above.
-    func test_foundationBackend_allErrorKinds_skipped() throws {
-        // FIXME: https://github.com/roryford/ManifoldKit/issues/713
-        try XCTSkipIf(true, "Foundation backend tool-calling is blocked on #713 — skipping all Foundation rows")
     }
 }
 


### PR DESCRIPTION
## Summary
Cleanup of stale "pin-the-broken-behavior" tests found in a test-suite audit. All four changes trace to one origin: the #515–#532 "add a fixture" epic plus the #713 skip, where tests pinned current/absent behavior with "flip when #N ships" but were never flipped after the feature shipped.

## Changes
1. **Remove** 3 `SSEPayloadReplayTests` that assert the legacy `extractToken` path drops thinking/tool_use/interleaved blocks (#527/#528/#532). Live behavior ships via `extractEvents` and is covered by `ClaudePayloadHandlerTests` / `ClaudeStreamEventExtractorTests` / `ClaudeBackendToolCallingTests`. Preserved the malformed-JSON crash-safety and legacy usage/error unit tests.
2. **Re-frame** the citations (#529) and stop_reason (#530) tests — assertions are accurate (behavior genuinely unimplemented), only the `_today`/closed-issue framing was misleading. Renamed and re-commented.
3. **Unskip** the Foundation row in `ToolErrorClassificationParityTests` — tool calling shipped (#713). The matrix is mock-driven (registry classification seam), so the row needs no hardware.
4. **Fix** the incomplete KV-reuse determinism FIXME in `LlamaKVPersistenceTests` with a real tracking issue (test behavior unchanged — the documented nondeterminism is live and user-reachable).

## Not in scope (deliberately left as-is)
- Gemma4 MoE #802 skip — flipping it would crash the integration lane (the broadcast abort fires during lazy stream consumption, outside the `withErrorHandler` scope).
- The KV-reuse `XCTExpectFailure` itself — load-bearing; documents a live gap.

Draft: full `scripts/test.sh --profile local` gate still to run before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)