### PR TITLE
test: cross-backend conformance matrix for footgun-audit invariants (#1623)

### DIFF
--- a/Tests/Fixtures/backends/claude/error/in-stream/event.json
+++ b/Tests/Fixtures/backends/claude/error/in-stream/event.json
@@ -1,0 +1,1 @@
+{"type":"error","error":{"message":"upstream rejected: leaked token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.AAAAAAAA and callback url https://evil.example/cb?x=1 padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding"}}

--- a/Tests/Fixtures/backends/openai_responses/error/in-stream/event.json
+++ b/Tests/Fixtures/backends/openai_responses/error/in-stream/event.json
@@ -1,0 +1,1 @@
+{"__event":"response.error","__data":"{\"error\":{\"message\":\"upstream rejected: leaked token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.AAAAAAAA and callback url https://evil.example/cb?x=1 padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding padding\"}}"}

--- a/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
@@ -313,6 +313,67 @@ final class InferenceBackendContractTests: XCTestCase {
         }
     }
 
+    // MARK: - Error sanitization (footgun audit class A — #1623)
+
+    /// A poison probe used only to prove the *negative* path: backends that
+    /// declare no in-stream error fixture must return `nil` from
+    /// `extractStreamError` for any input, confirming the skip below can't
+    /// mask a newly-introduced (and unsanitized) handler error path.
+    private static let poisonProbe =
+        #"{"type":"error","error":{"message":"boom https://evil.example eyJabc"}}"#
+
+    /// Every cloud backend that surfaces an upstream error *inside* a 200-OK
+    /// stream must route that text through `CloudErrorSanitizer` before it can
+    /// reach the UI. The footgun audit (2026-06-05) found the sanitize
+    /// invariant wired into only the non-2xx HTTP branch (class A — "two paths,
+    /// one guard"); #1630 added the `sanitized*` construction chokepoint. This
+    /// scenario is the per-family conformance proof that the chokepoint is
+    /// actually on every backend's in-stream error path.
+    ///
+    /// Only Claude and the OpenAI Responses adapter expose an in-stream handler
+    /// error path (`extractStreamError`); OpenAI Chat Completions and Ollama
+    /// surface server errors at the HTTP-status boundary in `SSECloudBackend`
+    /// (covered by `CloudBackendErrorSanitizedFactoryTests`). Participants
+    /// without an `error/in-stream` fixture are asserted to genuinely lack the
+    /// path rather than silently skipped.
+    ///
+    /// The fixture payloads carry a JWT, a URL, and >256 chars of padding. The
+    /// redaction audit (`FixtureRedactionAuditTest`) has no JWT/URL pattern, so
+    /// the poison is safe to commit while still exercising the sanitizer's JWT
+    /// redaction, URL redaction, and length cap.
+    func test_inStreamServerError_isSanitizedAtHandler() throws {
+        for p in Self.participants {
+            let url = try fixtureURL(for: p, scenario: "error/in-stream", file: "event.json")
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                XCTAssertNil(
+                    p.handler.extractStreamError(from: Self.poisonProbe),
+                    "[\(p.label)] declares no in-stream error fixture, but extractStreamError returned a non-nil error — a new handler error path was added without a sanitization conformance fixture"
+                )
+                continue
+            }
+            let payload = try String(contentsOf: url, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let surfaced = p.handler.extractStreamError(from: payload) else {
+                XCTFail("[\(p.label)] in-stream error fixture did not surface an error through extractStreamError")
+                continue
+            }
+            let text = (surfaced as? CloudBackendError)?.errorDescription
+                ?? String(describing: surfaced)
+            XCTAssertFalse(text.contains("eyJ"), "[\(p.label)] surfaced error leaked a JWT")
+            XCTAssertFalse(text.contains("://"), "[\(p.label)] surfaced error leaked a URL scheme")
+            XCTAssertFalse(
+                text.lowercased().contains("evil.example"),
+                "[\(p.label)] surfaced error leaked a URL host"
+            )
+            // Sanitizer caps the upstream text at 256 chars + ellipsis; the
+            // error-description wrapper adds a short fixed prefix.
+            XCTAssertLessThan(
+                text.count, 400,
+                "[\(p.label)] surfaced error was not length-bounded — sanitizer cap not applied"
+            )
+        }
+    }
+
     // MARK: - Fixture loading
 
     /// Reads `response.sse` from the participant's scenario directory and

--- a/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
@@ -374,6 +374,23 @@ final class InferenceBackendContractTests: XCTestCase {
         }
     }
 
+    /// Bounded-fetch conformance (footgun audit class D — #1623).
+    ///
+    /// Every cloud backend resolves its SSE/NDJSON stream caps through
+    /// `SSECloudBackend.effectiveSSEStreamLimits`, which falls back to this
+    /// shared default. A cap of 0 or `Int.max` would disable the defense
+    /// against a hostile upstream that streams without end. Assert the
+    /// inherited default is finite and positive on every field.
+    func test_sseStreamLimits_areBounded() {
+        let limits = SSEStreamLimits.default
+        XCTAssertGreaterThan(limits.maxEventBytes, 0)
+        XCTAssertLessThan(limits.maxEventBytes, Int.max)
+        XCTAssertGreaterThan(limits.maxTotalBytes, 0)
+        XCTAssertLessThan(limits.maxTotalBytes, Int.max)
+        XCTAssertGreaterThan(limits.maxEventsPerSecond, 0)
+        XCTAssertLessThan(limits.maxEventsPerSecond, Int.max)
+    }
+
     // MARK: - Fixture loading
 
     /// Reads `response.sse` from the participant's scenario directory and

--- a/Tests/ManifoldBackendsTests/LocalBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/LocalBackendContractTests.swift
@@ -401,6 +401,33 @@ final class LocalBackendContractTests: XCTestCase {
         )
     }
 
+    /// Capability-gate conformance (footgun audit class A — #1623).
+    ///
+    /// `requiredCapabilities` enforcement previously lived only in
+    /// `RouterBackend`; #1630 moved it into `generateEnforcingCapabilities` so a
+    /// host running against a single concrete backend gets the same fail-fast.
+    /// This proves every local backend honors it. `.minContextTokens(Int.max)`
+    /// is a requirement no backend can satisfy, so the gate fires uniformly
+    /// without per-backend reasoning — and because enforcement throws *before*
+    /// `generate()`, it runs in the fast lane for the hardware-gated
+    /// participants too (no model, no Metal, no RUN_SLOW_TESTS).
+    func test_capabilityGate_disclaimedRequirementThrows() async throws {
+        var config = GenerationConfig()
+        config.requiredCapabilities = [.minContextTokens(Int.max)]
+        for p in Self.participants {
+            let backend = await p.makeBackend()
+            XCTAssertThrowsError(
+                try backend.generateEnforcingCapabilities(prompt: "hi", systemPrompt: nil, config: config),
+                "[\(p.label)] must reject a requirement it cannot satisfy"
+            ) { error in
+                guard case InferenceError.noBackendSatisfiesRequirements = error else {
+                    XCTFail("[\(p.label)] threw \(error); expected noBackendSatisfiesRequirements")
+                    return
+                }
+            }
+        }
+    }
+
     // MARK: - Hardware helpers
 
     /// Returns `true` when running inside the iOS/macOS Simulator, where Metal


### PR DESCRIPTION
Closes the one remaining open item of the #1623 umbrella: the cross-backend conformance matrix. It generalizes the per-backend contract suites so each backend family is asserted against three cross-cutting invariants drawn from the footgun audit, rather than relying on per-backend ad-hoc coverage:

- **(c) In-stream cloud error sanitization** — every cloud backend surfaces a length-bounded, redacted error when the upstream emits an in-stream error event (shipped in the first commit on this branch).
- **(b) `requiredCapabilities` enforcement** — every local backend rejects a requirement it cannot satisfy via `generateEnforcingCapabilities`, the enforcement #1630 lifted out of `RouterBackend` into the shared extension. Uses `.minContextTokens(Int.max)` so the gate fires uniformly across backends and throws *before* `generate()`, keeping it in the fast lane for the hardware-gated participants (no model, no Metal, no `RUN_SLOW_TESTS`).
- **(d) Bounded SSE stream limits** — the SSE/NDJSON stream-limit default every cloud backend inherits (`SSEStreamLimits.default`) is asserted finite and positive on every field, closing footgun class D against an unbounded hostile upstream.

### Deferred follow-ups
- The class-C resource-arbiter-release behavioral proof (needs the MLX test seam plus an integration-suite companion).
- A literal-or-allowlist source-scan tripwire for the sanitizer chokepoint.

### Notes
- **Test-only.** Three commits on this branch: error-sanitization proof (c), then capability-gate + bounded stream-limit (b + d).
- Validated locally under the `MLX,Llama,CloudSaaS,Ollama` trait combo (build sweep across all traits + the three affected suites green; both new assertions sabotage-verified red-then-reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)