### PR TITLE
fix(dx): harden first-run onboarding — robust BYO default, clearer model-gating error, gate BYO snippets

### DIFF
--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -29,9 +29,11 @@ on:
       #   - The scripts the gate runs (including check-readme.sh, which the
       #     workflow's pre-flight step invokes — leaving the script off the
       #     filter would mean an edit to the lint silently bypasses the gate).
+      # The QUICKSTART glob + WHY-MANIFOLDKIT.md match extract-snippets.sh's
+      # actual coverage (every docs/QUICKSTART*.md is swept).
       - "README.md"
-      - "docs/QUICKSTART.md"
-      - "docs/QUICKSTART-CLI.md"
+      - "docs/QUICKSTART*.md"
+      - "docs/WHY-MANIFOLDKIT.md"
       - "Sources/**/*.docc/**/*.md"
       - "Sources/ManifoldKit/**"
       - "Sources/ManifoldUI/**"
@@ -47,8 +49,8 @@ on:
     branches: [main]
     paths:
       - "README.md"
-      - "docs/QUICKSTART.md"
-      - "docs/QUICKSTART-CLI.md"
+      - "docs/QUICKSTART*.md"
+      - "docs/WHY-MANIFOLDKIT.md"
       - "Sources/**/*.docc/**/*.md"
       - "Sources/ManifoldKit/**"
       - "Sources/ManifoldUI/**"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ struct MyChatApp: App {
 }
 ```
 
+> **The chat is inert until you select a model.** `quickStart()` registers the compiled-in backends but loads none, so on first run the composer reads "No model loaded" and the empty-state **Select Model** button only flips `showModelManagement` — nothing is presented until you attach a sheet to that binding. Fastest route: present `ModelManagementSheet` (from the opt-in `ManifoldUIModelManagement` module) with `.sheet(isPresented: $showModelManagement)`, or seed a model at launch. Step-by-step: [First-launch backend selection](docs/QUICKSTART.md#first-launch-backend-selection).
+
 See [docs/QUICKSTART.md](docs/QUICKSTART.md) for backend selection, traits, and configuration.
 Building a multi-session SwiftUI app with a sidebar, persisted chats, and relaunch restore? See [docs/SWIFTUI-MULTI-SESSION.md](docs/SWIFTUI-MULTI-SESSION.md) — the canonical end-to-end guide.
 Building a CLI, server, or non-SwiftUI consumer? See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) — compile-tested Foundation Models, local GGUF, and Ollama / OpenAI examples.

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -139,7 +139,13 @@ final class ModelLifecycleCoordinator {
         guard let newBackend = createBackend(for: modelInfo.modelType) else {
             throw InferenceError.inferenceFailure(
                 "No registered backend can handle model type \(modelInfo.modelType). "
-                + "Register a BackendFactory before loading models."
+                + "This usually means the matching backend is unavailable on this OS or "
+                + "build rather than unregistered: environment-gated types only resolve "
+                + "when their prerequisites are met (e.g. .foundation requires macOS 26 / "
+                + "iOS 26 with Apple Intelligence enabled; MLX and GGUF require their "
+                + "SwiftPM traits to be on). If you genuinely have not registered a backend "
+                + "for this type, register a BackendFactory (or call DefaultBackends.register) "
+                + "before loading models."
             )
         }
 
@@ -172,7 +178,13 @@ final class ModelLifecycleCoordinator {
         guard let newBackend = createBackend(for: modelInfo.modelType) else {
             throw InferenceError.inferenceFailure(
                 "No registered backend can handle model type \(modelInfo.modelType). "
-                + "Register a BackendFactory before loading models."
+                + "This usually means the matching backend is unavailable on this OS or "
+                + "build rather than unregistered: environment-gated types only resolve "
+                + "when their prerequisites are met (e.g. .foundation requires macOS 26 / "
+                + "iOS 26 with Apple Intelligence enabled; MLX and GGUF require their "
+                + "SwiftPM traits to be on). If you genuinely have not registered a backend "
+                + "for this type, register a BackendFactory (or call DefaultBackends.register) "
+                + "before loading models."
             )
         }
 

--- a/docs/QUICKSTART-BRING-YOUR-OWN-UI.md
+++ b/docs/QUICKSTART-BRING-YOUR-OWN-UI.md
@@ -19,7 +19,9 @@ This keeps SwiftData, `ManifoldRuntime`, and `ManifoldUI` out of your app graph 
 
 ## Minimal headless example
 
-Construct an `InferenceService`, register the compiled-in backends, load a model, and stream `GenerationEvent.token` values:
+Construct an `InferenceService`, register the compiled-in backends, load a model, and stream `GenerationEvent.token` values.
+
+> **Prerequisite for this snippet:** `.builtInFoundation` is the only backend that needs no model file and no server, so it makes the shortest first-token demo — but it exists only on macOS 26 / iOS 26 **with Apple Intelligence enabled**. On older OSes (or a Mac without Apple Intelligence) it is not registered and the load throws. The snippet guards the OS at compile/runtime; if it logs the fallback message on your machine, load a local GGUF (`loadModel(from:plan:)` with a file URL) or a cloud endpoint (`loadEndpointBackend(from:)`, shown below) instead.
 
 ```swift
 import ManifoldInference
@@ -30,6 +32,19 @@ struct BYOExample {
     static func main() async throws {
         let inference = InferenceService()
         DefaultBackends.register(with: inference)
+
+        // `.builtInFoundation` is the zero-file, zero-server choice, but Apple
+        // Intelligence only exists on macOS 26 / iOS 26. Guard availability so
+        // the demo degrades with a clear message instead of an opaque throw.
+        guard #available(macOS 26, iOS 26, *) else {
+            print("""
+            Apple Intelligence (.builtInFoundation) needs macOS 26 / iOS 26 with \
+            Apple Intelligence enabled. Load a local GGUF via loadModel(from:plan:) \
+            with a file URL, or a cloud endpoint via loadEndpointBackend(from:) — \
+            see "Cloud and local endpoints" below.
+            """)
+            return
+        }
 
         try await inference.loadModel(from: .builtInFoundation, plan: .cloud())
 

--- a/docs/QUICKSTART-IMAGE-GEN.md
+++ b/docs/QUICKSTART-IMAGE-GEN.md
@@ -54,7 +54,7 @@ or the standard diffusers layout with `safetensors`). How you obtain that
 directory is your choice — `HuggingFaceService.downloadDiffusionModel` is one
 option (see [§4](#4-picking-a-model)).
 
-```swift
+```swift,no-build
 import Foundation
 import ManifoldInference
 import ManifoldMLX
@@ -123,7 +123,7 @@ flag, throws `CancellationError`, and finishes the stream.
 If you're managing multiple image models or want backend lifecycle parity
 with `InferenceService`, wire `ImageGenerationService`:
 
-```swift
+```swift,no-build
 import ManifoldInference
 import ManifoldMLX
 

--- a/docs/QUICKSTART-VOICE.md
+++ b/docs/QUICKSTART-VOICE.md
@@ -56,7 +56,7 @@ targets: [
 your app uses — an image-gen prompt, a search bar, a notes field. The
 controller does not know or care that ManifoldKit ships a chat UI.
 
-```swift
+```swift,no-build
 import SwiftUI
 import ManifoldVoice
 
@@ -114,7 +114,7 @@ That's the whole standalone STT integration. No `ChatViewModel`, no
 The same controller speaks arbitrary strings — useful for read-aloud features
 in any app:
 
-```swift
+```swift,no-build
 let voice = VoiceConversationController()
 voice.togglePlayback(for: "Generation complete. Tap to view the result.")
 
@@ -133,7 +133,7 @@ The Apple-backed transcriber is the default, but ``SpeechTranscribing`` is
 just a protocol — wire in a local Whisper, an HTTP STT endpoint, or a
 deterministic test fake:
 
-```swift
+```swift,no-build
 final class FakeTranscriber: SpeechTranscribing {
     @MainActor func requestAuthorization() async -> VoiceAuthorizationStatus { .authorized }
     @MainActor func startTranscribing(
@@ -157,7 +157,7 @@ Same shape for ``SpeechSynthesizing`` (TTS) and ``WakeWordDetector``.
 `ManifoldVoice` ships ``AppleWakeWordDetector`` for on-device phrase matching
 against the live transcript stream:
 
-```swift
+```swift,no-build
 let detector = AppleWakeWordDetector(wakeWords: ["hey assistant", "ok manifold"])
 let voice = VoiceConversationController(wakeWordDetector: detector)
 

--- a/scripts/extract-snippets.sh
+++ b/scripts/extract-snippets.sh
@@ -85,11 +85,22 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Every docs/QUICKSTART-*.md is swept (not just the high-level ones): a doc with
+# no compile gate drifts silently. Blocks needing a trait the gate does not enable
+# (MLX in IMAGE-GEN, ManifoldVoice in VOICE) are tagged ```swift,no-build``` in the
+# doc; package-manifest fragments (APPINTENTS) auto-skip via the .package/.target
+# heuristic. The workflow `paths:` filter globs docs/QUICKSTART*.md to match.
 INPUTS=(
     "README.md"
     "docs/QUICKSTART.md"
     "docs/QUICKSTART-CLI.md"
     "docs/QUICKSTART-RAG.md"
+    "docs/QUICKSTART-BRING-YOUR-OWN-UI.md"
+    "docs/QUICKSTART-TOOLS.md"
+    "docs/QUICKSTART-APPINTENTS.md"
+    "docs/QUICKSTART-IMAGE-GEN.md"
+    "docs/QUICKSTART-VIDEO-GEN.md"
+    "docs/QUICKSTART-VOICE.md"
     "docs/WHY-MANIFOLDKIT.md"
 )
 
@@ -258,6 +269,12 @@ extract_one "README.md" "readme"
 extract_one "docs/QUICKSTART.md" "quickstart"
 extract_one "docs/QUICKSTART-CLI.md" "quickstart-cli"
 extract_one "docs/QUICKSTART-RAG.md" "quickstart-rag"
+extract_one "docs/QUICKSTART-BRING-YOUR-OWN-UI.md" "quickstart-byo-ui"
+extract_one "docs/QUICKSTART-TOOLS.md" "quickstart-tools"
+extract_one "docs/QUICKSTART-APPINTENTS.md" "quickstart-appintents"
+extract_one "docs/QUICKSTART-IMAGE-GEN.md" "quickstart-image-gen"
+extract_one "docs/QUICKSTART-VIDEO-GEN.md" "quickstart-video-gen"
+extract_one "docs/QUICKSTART-VOICE.md" "quickstart-voice"
 extract_one "docs/WHY-MANIFOLDKIT.md" "why"
 
 # DocC catalogs. Walk every Markdown file inside any Sources/*/Documentation.docc/


### PR DESCRIPTION
A cold-start audit of the onboarding paths found three issues the docs-only front-door PR (#1675) did not fix. This PR fixes them (code + CI + docs).

## FIX 1 — Bring-your-own-UI runtime P0

**(a) Robust BYO first-token demo.** The minimal headless example in `docs/QUICKSTART-BRING-YOUR-OWN-UI.md` defaulted its zero-config first-token demo to `loadModel(from: .builtInFoundation, plan: .cloud())`. `.builtInFoundation` is the most environment-gated backend — on macOS 15 (the advertised n-1 floor) or macOS 26 without Apple Intelligence it is not registered and the load throws at runtime.

**Decision:** kept Foundation rather than switching backends. It is the only backend that needs no model file *and* no server, so it makes the shortest honest first-token demo; every alternative (local GGUF, cloud endpoint) needs out-of-band setup a newcomer doesn't have. Made it copy-paste-safe by adding a `guard #available(macOS 26, iOS 26, *) else { … return }` that prints a clear fallback message, plus a one-sentence prerequisite above the snippet pointing at the GGUF / cloud paths. The snippet compiles under the gate (the issue was runtime, not compile) — not papered over with no-build.

**(b) Clearer model-gating error.** Reworded both `loadModel` no-backend throw sites in `Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift`. The old text ("Register a BackendFactory before loading models.") misled newcomers who *had* registered backends via `DefaultBackends.register`. It now names OS / Apple Intelligence / SwiftPM-trait gating as the likely cause for environment-gated types while staying accurate for the genuinely-unregistered case.

## FIX 2 — CI gate gap

`docs/QUICKSTART-BRING-YOUR-OWN-UI.md` (and every other ungated `docs/QUICKSTART-*.md`) was in no snippet-compile gate. Swept all of them into `scripts/extract-snippets.sh` and globbed `docs/QUICKSTART*.md` (+ `docs/WHY-MANIFOLDKIT.md`) in the `readme-snippets.yml` `paths:` filter so it matches the script's actual coverage (#1675 added RAG + WHY to the script but couldn't touch the workflow).

Per-doc handling so every `swift` block compiles or is correctly `no-build`:
- **BYO-UI** — Foundation snippet compiles under the gate; Package fragment + SwiftUI block auto-skip / no-build.
- **APPINTENTS** — live blocks are `.package`/`.target` fragments (auto-skip).
- **TOOLS, VIDEO-GEN** — already all no-build.
- **IMAGE-GEN, VOICE** — live blocks import `ManifoldMLX` / `ManifoldVoice`, traits the FoundationOnly gate doesn't enable, so tagged `swift,no-build` (genuinely non-compilable under the gate, not papering).

## FIX 3 — High-level path P1 (inert first run)

**(a, must-have)** Added one line under the README Hello World: the chat is inert until a model is selected, with the fastest route (present `ModelManagementSheet` via `.sheet`, or seed a model) and a link to the QUICKSTART first-launch section. `docs/QUICKSTART.md` already documents this thoroughly (lines 69, 100–249), so no mirror was needed there.

**(b, nice-to-have) — intentionally deferred.** Did not wire `showModelManagement` to a real sheet in `MinimalExample`. The only model-management sheet lives in the opt-in, non-default `ManifoldUIModelManagement` module; adding it would enlarge the "minimal" example's dependency surface and undercut its framing as the canonical Hello World. The README note (3a) closes the dead-end with documentation instead.

## Gate results (all run locally on Apple Silicon)

- `bash scripts/extract-snippets-test.sh` — **11 passed, 0 failed** (incl. `quickstart-byo-ui-002`, the FIX 1a Foundation snippet).
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace` — **Build complete** (only pre-existing warnings).
- `swift test --traits MLX,Llama --filter ModelLifecycleCoordinatorTests` — **10 passed**.
- `swift test --traits MLX,Llama --filter "InferenceBackendContractTests|ErrorDescriptionTests|CapabilityFlagEnforcementTests"` — **29 passed**.

No test pinned the old error string (grepped all of `Tests/` for the message text, `noBackendSatisfiesRequirements`, and `ModelLifecycleCoordinator`), so no test updates were required for the reword.

## Checklist
- [x] FIX 1a — BYO Foundation demo guarded + prerequisite; compiles under gate
- [x] FIX 1b — error message reworded (both throw sites); no tests pinned it
- [x] FIX 2 — all QUICKSTART docs gated in script + workflow; blocks compile or correctly no-build
- [x] FIX 3a — README inert-first-run note
- [x] FIX 3b — deferred to keep MinimalExample minimal (rationale above)
- [x] Package.resolved untouched
- [x] Snippet gate + all-traits build + contract tests green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)