### PR TITLE
test: behavioral proof that backends release resource claims on drop (#1623)

### DIFF
--- a/Tests/ManifoldBackendsTests/LlamaBackendResourceReleaseConformanceTest.swift
+++ b/Tests/ManifoldBackendsTests/LlamaBackendResourceReleaseConformanceTest.swift
@@ -1,0 +1,43 @@
+#if Llama && DEBUG
+import XCTest
+@testable import ManifoldLlama
+
+/// Behavioral proof that dropping a `LlamaBackend` releases its process-lifecycle
+/// claim (#1623 class C — "asymmetric sibling").
+///
+/// This is the runtime counterpart to `BackendDeinitSymmetryAuditTest`, which only
+/// *source-scans* `LlamaBackend.deinit` for the release token. The audit proves the
+/// release call is present in the text; this proves it actually fires when the
+/// instance is dropped. The two together close the gap the footgun audit flagged:
+/// a deinit that *looks* symmetric but never runs would pass the scan and leak the
+/// claim — only an end-to-end retain/release delta catches that.
+///
+/// Fast-lane: `LlamaBackend.init()` calls `LlamaBackendProcessLifecycle.retain()`
+/// synchronously and `deinit` calls `.release()` — both are pure refcounting (no
+/// model load, no Metal), so this runs in the standard `swift test` lane without a
+/// GPU or weights. The refcount accessor is `DEBUG`-only, hence the `&& DEBUG` gate.
+///
+/// - Important: This asserts a **before/after delta** on a process-global refcount.
+///   It must not run under `--parallel` alongside other tests that construct and hold
+///   `LlamaBackend` instances, or a concurrently-live backend would perturb the count.
+///   The pre-push gate (`scripts/test.sh --profile local`) deliberately omits
+///   `--parallel` for exactly this class of process-global accounting test.
+final class LlamaBackendResourceReleaseConformanceTest: XCTestCase {
+
+    func test_llamaBackend_releasesProcessClaim_onDrop() {
+        let before = LlamaBackendProcessLifecycle._refCountForTesting
+
+        var backend: LlamaBackend? = LlamaBackend()
+        XCTAssertEqual(
+            LlamaBackendProcessLifecycle._refCountForTesting, before + 1,
+            "LlamaBackend.init() must retain the process lifecycle"
+        )
+
+        backend = nil // deinit -> release()
+        XCTAssertEqual(
+            LlamaBackendProcessLifecycle._refCountForTesting, before,
+            "Dropping LlamaBackend must release its process-lifecycle claim (#1623 class C)"
+        )
+    }
+}
+#endif

--- a/Tests/ManifoldMLXIntegrationTests/MLXBackendResourceReleaseIntegrationTest.swift
+++ b/Tests/ManifoldMLXIntegrationTests/MLXBackendResourceReleaseIntegrationTest.swift
@@ -1,0 +1,68 @@
+#if MLX
+import XCTest
+import ManifoldInference
+@testable import ManifoldTestSupport
+@testable import ManifoldBackends
+@testable import ManifoldMLX
+
+/// Behavioral proof that dropping an `MLXBackend` releases its `MLXResourceArbiter`
+/// claim (#1623 class C — "asymmetric sibling").
+///
+/// This is the Metal companion to `LlamaBackendResourceReleaseConformanceTest`
+/// (fast-lane, refcount-only) and the runtime counterpart to
+/// `BackendDeinitSymmetryAuditTest`'s source scan. The audit proves the release
+/// token is present in `MLXBackend.deinit`; the two behavioral tests prove the
+/// release actually fires. The MLX deinit leak the footgun audit flagged would
+/// have been caught here: a backend that claims an arbiter slot on `loadModel` but
+/// never releases it leaves `MLX.Memory.clearCache()`'s last-release guarantee
+/// permanently un-fired, and this test would see the active-claim count never drop.
+///
+/// Unlike the Llama claim — synchronous in `init` — the MLX claim is only
+/// established **after a real model load** (`MLXResourceArbiter.shared.claim(...)`
+/// runs once the container loads on Metal). So this proof cannot live in the
+/// fast-lane: it requires Apple Silicon + a Metal device + a discoverable on-disk
+/// MLX model, and is skipped otherwise. Release is also **asynchronous** —
+/// `deinit` schedules `MLXResourceArbiter.shared.release(backendID:)` in a
+/// `Task.detached` that first awaits the prior cleanup task — so the test polls the
+/// active-claim count against a deadline rather than asserting immediately.
+@MainActor
+final class MLXBackendResourceReleaseIntegrationTest: XCTestCase {
+
+    func test_mlxBackend_releasesArbiterClaim_onDrop() async throws {
+        try XCTSkipUnless(HardwareRequirements.isAppleSilicon, "Requires Apple Silicon")
+        try XCTSkipUnless(HardwareRequirements.hasMetalDevice, "Requires Metal GPU")
+
+        guard let mlxDir = HardwareRequirements.findMLXModelDirectory() else {
+            throw XCTSkip(
+                "No loadable MLX model found on disk. Install a local MLX snapshot with config.json, tokenizer, and safetensors weights."
+            )
+        }
+
+        let before = await MLXResourceArbiter.shared._activeClaimCountForTesting()
+
+        var backend: MLXBackend? = MLXBackend()
+        try await backend!.loadModel(from: mlxDir, plan: .testStub(effectiveContextSize: 2048))
+
+        let claimed = await MLXResourceArbiter.shared._activeClaimCountForTesting()
+        XCTAssertEqual(claimed, before + 1, "loadModel must claim an arbiter slot")
+
+        backend = nil // deinit -> Task.detached -> release (async)
+
+        // Poll until the claim drops back to baseline or a ~5s deadline elapses.
+        // Release is async (chained behind the prior cleanup task), so an immediate
+        // read after `= nil` would race the detached release.
+        var released = false
+        for _ in 0..<50 {
+            if await MLXResourceArbiter.shared._activeClaimCountForTesting() == before {
+                released = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        XCTAssertTrue(
+            released,
+            "Dropping MLXBackend must release its arbiter claim (#1623 class C)"
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## What

Closes the last open item of #1623 (the footgun-audit conformance matrix): the flagship **arbiter-release** assertion — a runtime proof that dropping an inference backend actually releases its resource claim. Two new test files, one per local backend family:

- **Llama (fast-lane)** — `Tests/ManifoldBackendsTests/LlamaBackendResourceReleaseConformanceTest.swift`, gated `#if Llama && DEBUG`. `LlamaBackend.init()` calls `LlamaBackendProcessLifecycle.retain()` synchronously and `deinit` calls `.release()` — pure refcounting, no model, no Metal. The test asserts a before/after delta on the DEBUG-only `_refCountForTesting` accessor: `+1` after construction, back to baseline after `= nil`. Documented as non-`--parallel`-safe (process-global refcount), matching the existing pre-push gate shape.
- **MLX (Metal-gated integration)** — `Tests/ManifoldMLXIntegrationTests/MLXBackendResourceReleaseIntegrationTest.swift`, gated `#if MLX`. The MLX claim is only established **after a real model load** (`MLXResourceArbiter.shared.claim` runs once the container loads on Metal), so the proof can't live in the fast-lane. Skips without Apple Silicon + Metal + a discoverable on-disk MLX model. Release is **async** (`deinit` schedules `release(backendID:)` in a `Task.detached` chained behind the prior cleanup task), so the test polls `_activeClaimCountForTesting()` against a ~5s deadline rather than asserting immediately.

## Why

This is the behavioral counterpart to `BackendDeinitSymmetryAuditTest`, which only **source-scans** each backend's `deinit` for the release token. The scan proves the call is present in the text; these tests prove it actually fires at runtime. The MLX deinit leak the footgun audit flagged (#1627) would have been caught here — a deinit that looks symmetric but never runs passes the scan and still leaks the claim. Complements the source-scan audit and the #1679 cross-backend conformance scenarios.

## Validation in this environment

- **Llama**: ran green (`swift test --traits Llama --filter LlamaBackendResourceReleaseConformanceTest` → executed 1, 0 failures). Sabotage-verified: keeping the backend alive so `release()` never fires turned the second assertion RED (`"1" is not equal to "0"`), then reverted to green.
- **MLX**: **compiled only, not run.** `xcodebuild build-for-testing -scheme ManifoldKit-Package -only-testing:ManifoldMLXIntegrationTests` → `TEST BUILD SUCCEEDED`. It was not executed headlessly (the integration suite needs Metal + an on-disk MLX model and would `XCTSkip`); the test was hand-verified against the `MLXModelE2ETests` load/skip patterns it copies.
- `BackendDeinitSymmetryAuditTest` re-run green to confirm the source scan is undisturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)