### PR TITLE
fix: commit deleteSession message purge and session delete atomically

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -163,7 +163,20 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         guard let session = try fetchSwiftDataSession(id: sessionID) else {
             throw ChatPersistenceError.sessionNotFound(sessionID)
         }
-        try await deleteMessages(for: sessionID)
+        // Stage the message purge and the session delete against the context,
+        // then commit both with a single `save()` so they land atomically.
+        // The previous shape called the public `deleteMessages(for:)` (which
+        // saves on its own) and then saved the session delete separately — two
+        // commits, so a failure on the second left the messages already
+        // committed-gone while the session row survived. Staging both before
+        // one save closes that window: if the save throws, neither delete
+        // reaches the store.
+        let messages = try modelContext.fetch(
+            FetchDescriptor<ChatMessage>(predicate: #Predicate { $0.sessionID == sessionID })
+        )
+        for message in messages {
+            modelContext.delete(message)
+        }
         modelContext.delete(session)
         try modelContext.save()
     }
@@ -383,6 +396,17 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     public func performMessageMutations(_ mutations: [MessageStoreMutation]) async throws {
         guard !mutations.isEmpty else { return }
 
+        // Stage every mutation against the context, then commit with one
+        // `save()`. On any failure we MUST explicitly `rollback()` the staged
+        // changes.
+        //
+        // Do NOT "simplify" this into `modelContext.transaction { ... }`:
+        // `transaction(block:)` groups the changes into a single atomic save,
+        // but it does NOT discard staged in-memory changes when the block
+        // throws — a staged `.update` survives the throw and leaks on the next
+        // save (proven by SwiftDataTransactionalMutationTests'
+        // rollback cases, which fail under a transaction-based rewrite). The
+        // manual rollback is what gives the batch its all-or-nothing semantics.
         var writtenRecords: [ManifoldInference.ChatMessage] = []
         do {
             for mutation in mutations {

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
@@ -190,6 +190,27 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         XCTAssertEqual(messages.count, 0)
     }
 
+    func test_deleteSession_purgesOnlyTargetSessionMessages() async throws {
+        // deleteSession stages the message purge and the session delete and
+        // commits them with a single save. Verify the commit is scoped to the
+        // target session: a sibling session and its messages survive untouched.
+        let target = ManifoldInference.ChatSession(title: "Target")
+        let sibling = ManifoldInference.ChatSession(title: "Sibling")
+        try await provider.insertSession(target)
+        try await provider.insertSession(sibling)
+        try await provider.insertMessage(ManifoldInference.ChatMessage(role: .user, content: "t1", sessionID: target.id))
+        try await provider.insertMessage(ManifoldInference.ChatMessage(role: .user, content: "s1", sessionID: sibling.id))
+
+        try await provider.deleteSession(target.id)
+
+        let sessions = try await provider.fetchSessions()
+        XCTAssertEqual(sessions.map(\.id), [sibling.id])
+        let targetMessages = try await provider.fetchMessages(for: target.id)
+        XCTAssertEqual(targetMessages.count, 0)
+        let siblingMessages = try await provider.fetchMessages(for: sibling.id)
+        XCTAssertEqual(siblingMessages.map(\.content), ["s1"])
+    }
+
     func test_deleteSession_throwsWhenSessionMissing() async throws {
         let ghost = UUID()
         do {


### PR DESCRIPTION
## What

`SwiftDataPersistenceProvider.deleteSession` committed in two steps: it called the public `deleteMessages(for:)` (which saves on its own), then deleted the session row and saved **again**. A failure on that second save left the messages already committed-gone while the session survived — a small but real atomicity window.

This stages both deletes against the `ModelContext` and commits them with a single `save()`, so neither lands if the save throws.

Part of #1682 (SwiftData API coverage gaps).

## The `transaction { }` finding

The tracking issue proposed folding `performMessageMutations`' hand-rolled `do/catch { rollback() }` into `ModelContext.transaction { }`. **That doesn't work, and the test suite proves it:** `transaction(block:)` groups changes into a single atomic save but does **not** discard staged in-memory changes when the block throws — a staged `.update` survives the throw and leaks on the next save. Converting the batch path broke 4 rollback assertions.

So `performMessageMutations` keeps its manual `rollback()`, now with an inline comment documenting the pitfall so it isn't "simplified" away again. `deleteSession` likewise uses a plain single `save()` rather than `transaction` — the single save is already atomic, and `transaction` would only imply a rollback guarantee it doesn't provide.

## Tests

- New `test_deleteSession_purgesOnlyTargetSessionMessages` — verifies the delete is scoped to the target session (sibling session + its messages survive).
- Existing `deleteSession` and `performMessageMutations` rollback/commit tests stay green.
- Full `scripts/test.sh --profile local` gate: **4841 passed, 0 failed.**

> Note: an unrelated pre-existing ordering flake in `SwiftDataTransactionalMutationTests`, surfaced while validating this change, is split into its own PR (#1688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)