### PR TITLE
feat(docs): unified ManifoldKit DocC site — umbrella root, cross-catalog curation, hosted Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,134 @@
+name: Docs (DocC → GitHub Pages)
+
+# Builds the unified ManifoldKit DocC site (umbrella `ManifoldKit.docc` root plus
+# every module catalog reachable from the `ManifoldKit` scheme) and publishes it
+# to GitHub Pages.
+#
+# Why `xcodebuild docbuild` and not `swift package generate-documentation`:
+# ManifoldKit's umbrella target `@_exported import`s the backends, which pull in
+# the binary `llama` xcframework (a `.framework`-style slice on macOS). The
+# SwiftPM Swift-DocC plugin invokes `swift-symbolgraph-extract` with `-I`
+# (header search) instead of `-F` (framework search) for that binary slice, so
+# symbol-graph extraction fails with `missing required module 'llama'`.
+# `xcodebuild docbuild` passes framework search paths correctly, builds the whole
+# scheme's catalog set in one pass (so cross-target `<doc:>` links resolve), and
+# emits a single `.doccarchive` we transform for static hosting.
+#
+# SELF-VALIDATION: the `paths:` filter below MUST list this workflow's own path
+# plus every DocC catalog and `Package.swift`, otherwise edits to a catalog or to
+# the gate itself would not re-trigger the publish (see CLAUDE.md memory:
+# "Script-driven CI gates need their script path in paths: filter").
+
+on:
+  # Publish on every merge to main that can change the rendered docs.
+  push:
+    branches: [main]
+    paths:
+      - "Sources/**/*.docc/**"
+      - "Sources/**/*.swift"
+      - "Package.swift"
+      - "Package.resolved"
+      - "README.md"
+      - ".github/workflows/docs.yml"
+  # Manual re-publish without a code change.
+  workflow_dispatch:
+
+# Allow one concurrent deployment; let an in-flight run finish (don't cancel a
+# publish midway and leave Pages half-written).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: macos-15  # Apple Silicon arm64 — matches ci.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # Same pin as ci.yml / readme-snippets.yml — single toolchain truth.
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-docs-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-spm-
+
+      - name: Build DocC archive
+        # docbuild emits a .doccarchive into DerivedData. The ManifoldKit scheme
+        # builds the umbrella catalog plus every dependency catalog, so the
+        # re-exported public surface renders under one root.
+        #
+        # Note: this is a best-effort *publish*, not a link-correctness gate — it
+        # deliberately does NOT pass `--warnings-as-errors`. The scheme also
+        # compiles dependency catalogs that carry pre-existing DocC warnings
+        # (e.g. stale symbol references in ManifoldInference.docc) which are out
+        # of scope here; failing the publish on them would block the site for
+        # unrelated debt. Snippet drift is already gated by readme-snippets.yml.
+        run: |
+          set -euo pipefail
+          xcodebuild docbuild \
+            -scheme ManifoldKit \
+            -destination 'generic/platform=macOS' \
+            -derivedDataPath "$RUNNER_TEMP/docc-dd" \
+            -skipPackagePluginValidation
+
+      - name: Transform for static hosting
+        # Pick the umbrella archive (named ManifoldKit.doccarchive) as the site
+        # root, then rewrite asset/reference paths for a project Pages site served
+        # from https://<user>.github.io/ManifoldKit/.
+        run: |
+          set -euo pipefail
+          ARCHIVE=$(find "$RUNNER_TEMP/docc-dd" -type d -name 'ManifoldKit.doccarchive' | head -n 1)
+          if [ -z "$ARCHIVE" ]; then
+            echo "::error::ManifoldKit.doccarchive not found under DerivedData"
+            find "$RUNNER_TEMP/docc-dd" -type d -name '*.doccarchive' || true
+            exit 1
+          fi
+          echo "Using archive: $ARCHIVE"
+          rm -rf ./docs-site
+          $(xcrun --find docc) process-archive transform-for-static-hosting \
+            "$ARCHIVE" \
+            --output-path ./docs-site \
+            --hosting-base-path ManifoldKit
+          # Redirect the site root to the umbrella landing page so visiting
+          # https://<user>.github.io/ManifoldKit/ lands on ManifoldKit, not a 404.
+          cat > ./docs-site/index.html <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>ManifoldKit Documentation</title>
+          <meta http-equiv="refresh" content="0; url=documentation/manifoldkit/">
+          <link rel="canonical" href="documentation/manifoldkit/">
+          <p>Redirecting to <a href="documentation/manifoldkit/">the ManifoldKit documentation</a>…</p>
+          HTML
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs-site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0e252045623baf3a289ee7c6df9b0fc770bf5f91d1456e900ff2ae7ae76da6d8",
+  "originHash" : "cd63de45ffdec6a4f20996a58f7212cce4af57fffeac00c6644aa4a2985f7a50",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -89,6 +89,24 @@
       "state" : {
         "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin.git",
+      "state" : {
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -164,6 +164,13 @@ let package = Package(
         // logging façade; no runtime overhead beyond the backend you install.
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
+        // DocC build/host plugin: drives `swift package generate-documentation` for the
+        // unified ManifoldKit.docc front door and the GitHub Pages publish workflow.
+        // Build-time only (a command plugin); never linked into any product, so it adds
+        // no runtime weight and is safe under any trait combination. `from: "1.4.0"`
+        // resolves to the latest 1.x (currently 1.5.0); the plugin's own
+        // swift-tools-version sits below this package's 6.1 ceiling.
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.4.0"),
     ],
     targets: [
         // Macro compiler plugin: implements @ToolSchema. Runs at build time in

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 [![Swift 6.1+](https://img.shields.io/badge/Swift-6.1%2B-F05138?logo=swift&logoColor=white)](https://swift.org)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%2018%2B%20%7C%20macOS%2015%2B-blue)](#requirements)
 [![SwiftPM](https://img.shields.io/badge/SwiftPM-compatible-brightgreen?logo=swift&logoColor=white)](#install)
+[![Documentation](https://img.shields.io/badge/Docs-DocC-blue?logo=swift&logoColor=white)](https://roryford.github.io/ManifoldKit/documentation/manifoldkit/)
 
 The only open-source Swift package that bundles UI, turn-loop runtime, persistence, and multi-backend inference into one drop-in chat product for Apple platforms.
 
 ![ManifoldKit assembled full-stack hero — one import gives you the SwiftUI ChatView, the ConversationRuntime turn loop, SwiftData persistence, model-management UI, and every backend; competitors own a single band](docs/images/product/layer-cake-hero.svg)
 
-**New here?** Start with **[Why ManifoldKit — and how it's built to last](docs/WHY-MANIFOLDKIT.md)** for the honest "what it solves and why trust it" narrative, or jump to the [docs index](docs/README.md) for the full guided path from install to first token.
+**New here?** Start with **[Why ManifoldKit — and how it's built to last](docs/WHY-MANIFOLDKIT.md)** for the honest "what it solves and why trust it" narrative, or jump to the [docs index](docs/README.md) for the full guided path from install to first token. Prefer rendered API reference? The full **[DocC documentation site](https://roryford.github.io/ManifoldKit/documentation/manifoldkit/)** ties every module's reference together under one navigable root.
 
 ManifoldKit is a full-stack, multi-backend AI chat framework for iOS 18+ / macOS 15+. Import one umbrella package and you get a SwiftUI `ChatView`, the `ConversationRuntime` turn loop (send / regenerate / edit / cancel / branch), SwiftData persistence, model download and management UI, and inference backends spanning on-device (MLX, llama.cpp, Apple Foundation Models) and cloud (OpenAI, Anthropic, Ollama, LAN) — all behind one `InferenceBackend` protocol. Competitors ship a single layer; ManifoldKit ships the assembled product and the wiring between layers. It survives real failures — streaming retries, latest-wins model handoff, memory admission, certificate pinning, and a mock backend for app-level testing. See [docs/RELIABILITY.md](docs/RELIABILITY.md) for the source-backed contract, or [docs/POSITIONING.md](docs/POSITIONING.md) for the full "why ManifoldKit vs. the field" rationale.
 

--- a/Sources/ManifoldFuzz/ManifoldFuzz.docc/ManifoldFuzz.md
+++ b/Sources/ManifoldFuzz/ManifoldFuzz.docc/ManifoldFuzz.md
@@ -1,0 +1,31 @@
+# ``ManifoldFuzz``
+
+The chat-fuzzing harness that stress-tests every ManifoldKit backend against
+malformed prompts, mutated corpora, and adversarial streaming conditions.
+
+## Overview
+
+`ManifoldFuzz` drives a backend with seeded, mutated prompts and records every
+generation as a structured ``RunRecord`` so findings are replayable, shrinkable,
+and triageable long after the run. The harness is the engine behind
+`scripts/fuzz.sh`; its on-disk `record.json` is the de-facto API every external
+tool (`--replay`, `--shrink`, triage UIs, CI dashboards) decodes.
+
+Because that on-disk shape is a public contract even though it crosses no Swift
+API boundary, ``RunRecord`` carries an explicit ``RunRecord/schemaVersion`` and a
+``RunRecord/validate(schemaVersion:)`` gate. See <doc:RunRecordSchema> for the
+field-by-field reference and the three-step migration procedure.
+
+## Topics
+
+### Articles
+
+- <doc:RunRecordSchema>
+
+### Run records
+
+- ``RunRecord``
+- ``RunRecord/currentSchema``
+- ``RunRecord/schemaVersion``
+- ``RunRecord/validate(schemaVersion:)``
+- ``RunRecord/SchemaError``

--- a/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
+++ b/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
@@ -1,0 +1,118 @@
+# ``ManifoldKit``
+
+The only open-source Swift package that bundles UI, turn-loop runtime,
+persistence, and multi-backend inference into one drop-in chat product for Apple
+platforms.
+
+## Overview
+
+Most AI-chat libraries hand you a single layer — a UI kit, an engine wrapper, or
+a thin cloud client — and leave the rest as an exercise. `ManifoldKit` ships the
+assembled product: import one umbrella module and you get a SwiftUI ``ChatView``,
+the ``ConversationRuntime`` turn loop (send / regenerate / edit / cancel /
+branch), SwiftData persistence, model download & management UI, and inference
+backends spanning on-device (MLX, llama.cpp, Apple Foundation Models) and cloud
+(OpenAI, Anthropic, Ollama, LAN) — all behind one ``InferenceBackend`` protocol.
+Swapping engines is a config change, not a rewrite.
+
+`import ManifoldKit` re-exports the 80%-case modules — the inference surface,
+``ConversationRuntime``, persistence, the backends, and the chat UI. Specialised
+modules stay explicit imports: `ManifoldMCP` (Model Context Protocol),
+`ManifoldVoice` (speech I/O), `ManifoldUIModelManagement` (the model browser),
+and `ManifoldAppIntents`.
+
+### Hello World
+
+Add the package, then drop this into your app entry point.
+``ManifoldKit/quickStart(configuration:)`` builds the SwiftData container,
+registers the compiled-in backends, and wires up a ``ChatViewModel`` in one call.
+Errors surface as ``ManifoldKitError``.
+
+```swift
+import SwiftUI
+import SwiftData
+import ManifoldKit
+
+@main
+struct MyChatApp: App {
+    @State private var result: QuickStartResult?
+    @State private var error: ManifoldKitError?
+    @State private var showModelManagement = false
+
+    var body: some Scene {
+        WindowGroup {
+            if let result {
+                ChatView(showModelManagement: $showModelManagement)
+                    .environment(result.viewModel)
+                    .modelContainer(result.bootstrap.modelContainer)
+            } else if let error {
+                ContentUnavailableView("Failed to start", systemImage: "exclamationmark.triangle", description: Text(error.errorDescription ?? ""))
+            } else {
+                ProgressView().task {
+                    do { result = try await ManifoldKit.quickStart() }
+                    catch let e as ManifoldKitError { error = e }
+                    catch { self.error = .from(error) }
+                }
+            }
+        }
+    }
+}
+```
+
+> Important: The chat is inert until you select a model. `quickStart()` registers
+> the compiled-in backends but loads none, so on first run the composer reads
+> "No model loaded." Present `ModelManagementSheet` (from the opt-in
+> `ManifoldUIModelManagement` module) bound to `showModelManagement`, or seed a
+> model at launch.
+
+> Warning: **The trait cliff.** With no backend trait enabled (`MLX`, `Llama`,
+> `CloudSaaS`, `Ollama`, …), `quickStart()` compiles but throws
+> ``ManifoldKitError`` `.noBackendsRegistered` at runtime — there is nothing to
+> generate with. Enable at least one backend trait for your target.
+
+### The guided path
+
+This reference ties the module catalogs together. For the prose walkthrough from
+install to first token, follow the loose-markdown front door:
+
+- **Start here:** [Why ManifoldKit](https://github.com/roryford/ManifoldKit/blob/main/docs/WHY-MANIFOLDKIT.md) · [docs index](https://github.com/roryford/ManifoldKit/blob/main/docs/README.md)
+- **Getting started:** [QUICKSTART](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART.md) → [Multi-session SwiftUI](https://github.com/roryford/ManifoldKit/blob/main/docs/SWIFTUI-MULTI-SESSION.md)
+- **Branch points:** [CLI / server](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-CLI.md) · [Bring your own UI](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-BRING-YOUR-OWN-UI.md)
+- **Add a capability:** [Tools](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-TOOLS.md) · [App Intents](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-APPINTENTS.md) · [RAG](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-RAG.md) · [Voice](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-VOICE.md) · [Image gen](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-IMAGE-GEN.md) · [Video gen](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-VIDEO-GEN.md)
+
+## Topics
+
+### Get Started
+
+- ``ManifoldKit/quickStart(configuration:)``
+- ``QuickStartResult``
+- ``ManifoldConfiguration``
+- ``ManifoldKitError``
+
+### Build a Chat UI
+
+- ``ChatView``
+- ``ChatViewModel``
+
+### Bring Your Own UI
+
+- ``InferenceService``
+- ``ConversationRuntime``
+- ``ModelRegistry``
+
+### Backends
+
+Every engine sits behind one ``InferenceBackend`` protocol; ``DefaultBackends``
+registers the ones compiled in for the active traits. The on-device families are
+re-exported here. Cloud backends (OpenAI, Anthropic, Ollama, LAN) live in
+`ManifoldCloud` and appear once the `CloudSaaS` / `Ollama` traits are enabled.
+
+- ``InferenceBackend``
+- ``DefaultBackends``
+- ``MLXBackend``
+- ``LlamaBackend``
+- ``FoundationBackend``
+
+### Persistence & Bootstrap
+
+- ``ManifoldBootstrap``

--- a/Sources/ManifoldMCPHost/ManifoldMCPHost.docc/ManifoldMCPHost.md
+++ b/Sources/ManifoldMCPHost/ManifoldMCPHost.docc/ManifoldMCPHost.md
@@ -1,0 +1,29 @@
+# ``ManifoldMCPHost``
+
+Expose your app as a Model Context Protocol **server** — let Claude Desktop, CI
+agents, or other MCP clients query your live conversation history, RAG documents,
+and session tools.
+
+## Overview
+
+ManifoldKit ships a full client-side MCP stack (`MCPClient`, `MCPToolSource`)
+that connects your app *to* external servers. `ManifoldMCPHost` is the
+server-side counterpart: an `actor` that listens for incoming JSON-RPC
+connections and surfaces your app's runtime state — sessions, messages, and
+optional RAG search — to any compliant MCP client.
+
+The host is opt-in by design. It never starts unless you instantiate
+``ManifoldMCPHost`` and call ``ManifoldMCPHost/run(transport:)``. See
+<doc:MCPHostServer> for the end-to-end setup, the exposed resources and tools,
+and Claude Desktop wiring.
+
+## Topics
+
+### Articles
+
+- <doc:MCPHostServer>
+
+### Server
+
+- ``ManifoldMCPHost``
+- ``ManifoldMCPHost/run(transport:)``


### PR DESCRIPTION
## Summary

PR 2 of the 0.45 "Front Door" release (`docs/plans/0.45-front-door.md`, WS8/WS10/WS11). PR 1 (#1675) built the loose-markdown front door; this adds the unified **DocC** layer + a hosted documentation site **alongside** it (no loose docs deleted).

## Delivered

### P0 — Umbrella DocC root
- New `Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md` — the single front-door root for the re-exporting umbrella target (previously absent; the 12 module catalogs rendered as disconnected archives).
- Overview leads with **why**, then the **canonical Hello World verbatim from README** (same compile-gated snippet — no divergent copy), plus the model-gating and trait-cliff callouts and links into the loose-markdown guided path.
- Curated `## Topics` spine: **Get Started · Build a Chat UI · Bring Your Own UI · Backends · Persistence & Bootstrap**, all symbol links to the umbrella's re-exported surface (incl. `MLXBackend` / `LlamaBackend` / `FoundationBackend`).

### P0 — Hosted site
- `swift-docc-plugin` added to `Package.swift` (build-time command plugin, never linked).
- `.github/workflows/docs.yml` builds the DocC archive and deploys to GitHub Pages; README links the site (badge + lead paragraph).
- **`xcodebuild docbuild` instead of the SwiftPM plugin** — see "Key finding" below.
- `paths:` filter includes the workflow's own path + every `.docc/**` + `Package.swift` (self-validation footgun avoided).

### P1 — Orphaned catalogs fixed
- `# ``ManifoldFuzz``` root curating `RunRecordSchema`.
- `# ``ManifoldMCPHost``` root curating `MCPHostServer`.
- Both previously had articles but no module root → DocC orphaned them.

### P2 — Partial (rest deferred + logged)
- **Done:** on-device backend symbols (`MLXBackend`, `LlamaBackend`, `FoundationBackend`) curated in the umbrella Backends group.
- **Deferred — DocC Tutorials:** done right, a `@Tutorial` needs `@Intro` imagery + `@Code` resource files; a half-wired tutorial emits resource warnings and would undermine the clean-build claim. Deferred to a follow-up rather than ship something that warns.
- **Deferred — full catalogs for the 4 catalog-less backend targets** (`ManifoldLlama`, `ManifoldCloud`, `ManifoldFoundation`, `ManifoldHuggingFace`): the on-device families are curated from the umbrella root; per-target catalogs (and Cloud backends, which are trait-gated out of the default docs build) are a follow-up.
- **Deferred — multi-archive site:** `xcodebuild docbuild` emits one archive per target; the published site is the umbrella archive (self-contained via re-exported symbols). Cross-archive navigation across all 12 modules needs combined-documentation (experimental) — follow-up.

## Key finding (why `xcodebuild docbuild`)
The plan assumed `swift package generate-documentation --target ManifoldKit` would work. It does **not**: the umbrella `@_exported import`s the backends → the binary `llama` xcframework (a `.framework`-style macOS slice). The SwiftPM plugin's `swift-symbolgraph-extract` call passes `-I` (header search) instead of `-F` (framework search) for that slice and aborts with `missing required module 'llama'`. `xcodebuild docbuild` passes framework search paths correctly. The orphan catalogs (no binary deps) still validate fine via the SwiftPM plugin.

## Package.resolved delta
Exactly two additions, **no existing pin changed**:
- `swift-docc-plugin` 1.5.0
- `swift-docc-symbolkit` 1.0.0

(Restored from `origin/main` after a `swift build --traits` run rewrote it with trait-gated server deps, then re-resolved with default traits.)

## Gate results (all observed locally)
- [x] `swift package resolve` — clean; only the two docc pins added.
- [x] `xcodebuild docbuild -scheme ManifoldKit` — **BUILD DOCUMENTATION SUCCEEDED**; `ManifoldKit.doccarchive` produced; **zero** warnings on `ManifoldKit.md` (all symbol links + 5 Backends-group symbols resolved into the archive).
- [x] Orphan catalogs — `swift package generate-documentation --target ManifoldFuzz` / `--target ManifoldMCPHost` build clean; **zero** warnings on the two new root pages.
- [x] `docc process-archive transform-for-static-hosting … --hosting-base-path ManifoldKit` — produces `documentation/manifoldkit/`.
- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace` — **Build complete!**
- [x] `actionlint .github/workflows/docs.yml` — clean.

Pre-existing DocC warnings in dependency catalogs (e.g. stale symbol refs in `ManifoldInference.docc`, cross-module refs in `ManifoldFuzz` source doc comments) are **out of scope** and untouched; the publish is best-effort (no `--warnings-as-errors`) so it doesn't block on that debt.

## Maintainer action
GitHub Pages must be set to **Source: GitHub Actions** once for `deploy-pages` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
