### PR TITLE
feat(fuzz): target OpenAI-compatible cloud endpoints (OpenRouter) in fuzz-chat

### DIFF
--- a/Sources/ManifoldFuzz/FuzzConfig.swift
+++ b/Sources/ManifoldFuzz/FuzzConfig.swift
@@ -6,6 +6,9 @@ public enum BackendChoice: String, Sendable, CaseIterable {
     case foundation
     case mlx
     case all
+    /// OpenAI-Chat-Completions-compatible cloud endpoint (OpenRouter, OpenAI,
+    /// Together, …) driven via `OpenAIBackend`. Gated on the `CloudSaaS` trait.
+    case openai
     /// Hardware-free `MockInferenceBackend` path. Used by PR-tier CI.
     case mock
     /// Hardware-free `ChaosBackend` path for exercising failure-mode plumbing.

--- a/Sources/ManifoldFuzz/ParallelFuzzWorkers.swift
+++ b/Sources/ManifoldFuzz/ParallelFuzzWorkers.swift
@@ -26,6 +26,10 @@ public enum ParallelFuzzWorkerPlanner {
             return 4
         case .llama, .foundation, .mlx, .all:
             return 1
+        // Cloud endpoints are rate-limited (HTTP 429); fanning out workers only
+        // amplifies throttling and burns quota. Pin to a single worker.
+        case .openai:
+            return 1
         }
     }
 

--- a/Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift
+++ b/Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift
@@ -1,0 +1,62 @@
+#if CloudSaaS && Fuzz
+import Foundation
+import ManifoldBackends
+import ManifoldFuzz
+import ManifoldInference
+
+/// `FuzzBackendFactory` conformance that instantiates a fresh `OpenAIBackend`
+/// configured against any OpenAI-Chat-Completions-compatible cloud endpoint —
+/// primarily OpenRouter (`https://openrouter.ai/api`), but equally OpenAI,
+/// Together, Groq, or a self-hosted gateway.
+///
+/// Mirrors ``OllamaFuzzFactory``: it constructs the backend, configures it,
+/// runs the no-op cloud `loadModel`, and snapshots the model's thinking
+/// markers so the runner records the correct marker family. Unlike Ollama
+/// there is no model-discovery round-trip — cloud endpoints don't enumerate a
+/// stable per-host model list, so the model slug is supplied explicitly via
+/// `--model`.
+///
+/// `baseURL` must NOT include the `/v1` suffix: `OpenAIBackend.buildRequest`
+/// appends `v1/chat/completions` itself. The OpenRouter base is therefore
+/// `https://openrouter.ai/api`, not `https://openrouter.ai/api/v1`.
+public struct OpenAIFuzzFactory: FuzzBackendFactory {
+    public let baseURL: URL
+    public let apiKey: String
+    public let modelName: String
+
+    /// Cloud generation is non-deterministic — providers do not honour a seed
+    /// reproducibly across requests, and `:free` slugs route to shifting
+    /// backends. `Replayer` short-circuits with `.nonDeterministicBackend`
+    /// when this is `false` rather than run a guaranteed-noisy replay.
+    public var supportsDeterministicReplay: Bool { false }
+
+    public init(baseURL: URL, apiKey: String, modelName: String) {
+        self.baseURL = baseURL
+        self.apiKey = apiKey
+        self.modelName = modelName
+    }
+
+    public func makeHandle() async throws -> FuzzRunner.BackendHandle {
+        let backend = OpenAIBackend()
+        backend.configure(baseURL: baseURL, apiKey: apiKey, modelName: modelName)
+        // Cloud `loadModel` is a no-op that only validates the base URL and
+        // flips `isModelLoaded` — no network round-trip happens here, so the
+        // factory stays cheap and the first request fires only on `generate`.
+        try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
+        // Reuse whatever marker family the manifest table mapped the slug to
+        // (many OpenRouter-hosted reasoning models — Qwen3, DeepSeek-R1 — use
+        // `<think>`/`</think>`). Fall back to the Qwen3-style tags when the
+        // manifest carries no markers, matching `OllamaFuzzFactory`.
+        let autoMarkers = backend.manifest?.thinkingMarkers
+        let markers = autoMarkers.map { RunRecord.MarkerSnapshot(open: $0.open, close: $0.close) }
+            ?? RunRecord.MarkerSnapshot(open: "<think>", close: "</think>")
+        return FuzzRunner.BackendHandle(
+            backend: backend,
+            modelId: modelName,
+            modelURL: URL(string: "openai:" + modelName)!,
+            backendName: "openai",
+            templateMarkers: markers
+        )
+    }
+}
+#endif

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -42,6 +42,12 @@ struct FuzzChatCLI {
         // pinned. See RotatingFuzzFactory for the block-rotation rationale.
         var rotateEvery = 16
         var outputDir = URL(fileURLWithPath: "tmp/fuzz", isDirectory: true)
+        // Cloud (OpenAI-compatible) backend wiring. `--base-url` is required for
+        // `--backend openai`; the key is read from the environment by default
+        // (keys on argv leak into `ps`/shell history), with `--api-key` as an
+        // explicit opt-out.
+        var baseURLString: String?
+        var apiKeyArg: String?
 
         var i = argv.startIndex
         while i < argv.endIndex {
@@ -81,6 +87,14 @@ struct FuzzChatCLI {
                 i = argv.index(after: i)
                 guard i < argv.endIndex else { fail("--model requires a value") }
                 modelHint = argv[i]
+            case "--base-url":
+                i = argv.index(after: i)
+                guard i < argv.endIndex else { fail("--base-url requires a URL") }
+                baseURLString = argv[i]
+            case "--api-key":
+                i = argv.index(after: i)
+                guard i < argv.endIndex else { fail("--api-key requires a value") }
+                apiKeyArg = argv[i]
             case "--detector":
                 i = argv.index(after: i)
                 guard i < argv.endIndex else { fail("--detector requires a value") }
@@ -201,6 +215,16 @@ struct FuzzChatCLI {
             }
             #else
             fail("Foundation backend requires macOS 26+ with FoundationModels and the Fuzz build trait. Run via: scripts/fuzz.sh")
+            #endif
+        case .openai:
+            #if CloudSaaS && Fuzz
+            factory = makeOpenAIFactory(
+                baseURLString: baseURLString,
+                apiKeyArg: apiKeyArg,
+                modelHint: modelHint
+            )
+            #else
+            fail("openai backend requires the Fuzz and CloudSaaS build traits. Run via: swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat --backend openai ... (or scripts/fuzz.sh --backend openai)")
             #endif
         case .mlx:
             fail("MLX cannot run via `swift run` (needs Xcode-compiled metallib). Use scripts/fuzz.sh --with-mlx or --backend mlx.")
@@ -521,6 +545,38 @@ struct FuzzChatCLI {
         }
     }
 
+    #if CloudSaaS && Fuzz
+    /// Builds the OpenAI-compatible cloud factory, validating the base URL and
+    /// resolving the API key. The key is read from `--api-key` when present,
+    /// otherwise from the environment (`OPENROUTER_API_KEY` preferred, then
+    /// `OPENAI_API_KEY`) — keys on argv leak into `ps`/shell history. Fails
+    /// with an actionable message naming the exact remedy for any missing input.
+    static func makeOpenAIFactory(
+        baseURLString: String?,
+        apiKeyArg: String?,
+        modelHint: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> OpenAIFuzzFactory {
+        guard let baseURLString, !baseURLString.isEmpty else {
+            fail("--backend openai requires --base-url <url> (e.g. https://openrouter.ai/api — note: NO /v1 suffix; OpenAIBackend appends v1/chat/completions itself).")
+        }
+        guard let url = URL(string: baseURLString),
+              let scheme = url.scheme, scheme == "http" || scheme == "https",
+              url.host != nil else {
+            fail("--base-url must be an absolute http(s) URL with a host (got: \(baseURLString))")
+        }
+        let resolvedKey = apiKeyArg ?? environment["OPENROUTER_API_KEY"] ?? environment["OPENAI_API_KEY"]
+        guard let apiKey = resolvedKey, !apiKey.isEmpty else {
+            fail("--backend openai requires an API key. Set OPENROUTER_API_KEY (preferred) or OPENAI_API_KEY in the environment, or pass --api-key (keys on argv leak into ps/shell history).")
+        }
+        guard let model = modelHint,
+              !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            fail("--backend openai requires --model <slug> (e.g. --model deepseek/deepseek-r1:free).")
+        }
+        return OpenAIFuzzFactory(baseURL: url, apiKey: apiKey, modelName: model)
+    }
+    #endif
+
     /// Validates `--replay` argument shape: 12–40 lowercase hex chars. Finding
     /// hashes produced by `Finding.computeHash` are exactly 12 chars today;
     /// allowing up to 40 lets us roundtrip full SHA-256 prefixes if the finding
@@ -537,9 +593,14 @@ struct FuzzChatCLI {
             "Usage: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat [options]",
             "",
             "Options:",
-            "  --backend ollama|mock|chaos|llama|foundation|mlx|all   default: llama",
-            "                      mock  = MockInferenceBackend (hardware-free, used by PR-tier CI)",
-            "                      chaos = ChaosBackend (hardware-free; injects stream failures)",
+            "  --backend ollama|mock|chaos|llama|foundation|mlx|openai|all   default: llama",
+            "                      mock   = MockInferenceBackend (hardware-free, used by PR-tier CI)",
+            "                      chaos  = ChaosBackend (hardware-free; injects stream failures)",
+            "                      openai = OpenAI-compatible cloud endpoint (OpenRouter, OpenAI, …)",
+            "                               via OpenAIBackend. Needs the CloudSaaS trait:",
+            "                               swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat",
+            "                               --backend openai --base-url <url> --model <slug>",
+            "                               Replay/shrink are unavailable (cloud is non-deterministic).",
             "  --minutes N         time budget (default 5 if neither flag set)",
             "  --iterations N      iteration budget",
             "  --seed N            RNG seed (default random)",
@@ -553,7 +614,13 @@ struct FuzzChatCLI {
             "                      Pass `all` (or omit) to rotate through every installed",
             "                      Ollama model, one per iteration. Llama: pin to the",
             "                      first GGUF whose filename contains <substr>; `all` is",
-            "                      ignored because llama.cpp stays single-model.",
+            "                      ignored because llama.cpp stays single-model. openai:",
+            "                      the exact model slug to request (e.g. deepseek/deepseek-r1:free).",
+            "  --base-url <url>    openai backend: base URL of the OpenAI-compatible endpoint.",
+            "                      MUST omit the /v1 suffix (OpenAIBackend appends it). OpenRouter",
+            "                      base = https://openrouter.ai/api",
+            "  --api-key <key>     openai backend: API key (discouraged — leaks into ps/history).",
+            "                      Prefer the OPENROUTER_API_KEY (or OPENAI_API_KEY) env var.",
             "  --detector ids      comma-separated detector ids to run",
             "  --single            shorthand for --iterations 1",
             "  --quiet             suppress live output (still prints findings)",

--- a/Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift
+++ b/Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift
@@ -1,0 +1,57 @@
+#if Fuzz
+#if CloudSaaS
+import XCTest
+import ManifoldFuzz
+import ManifoldInference
+@testable import ManifoldFuzzBackends
+
+/// Unit tests for ``OpenAIFuzzFactory`` — the OpenAI-Chat-Completions-compatible
+/// cloud fuzz factory (OpenRouter, OpenAI, …).
+///
+/// Network-free: `makeHandle()` constructs an `OpenAIBackend`, configures it,
+/// and runs the no-op cloud `loadModel` (which only validates the base URL and
+/// flips `isModelLoaded`). No HTTP request is issued until `generate`, so these
+/// assertions never touch the wire and need no API key, no live endpoint, and
+/// no `MockURLProtocol` stubs.
+final class OpenAIFuzzFactoryTests: XCTestCase {
+
+    private func makeFactory(model: String = "gpt-4o-mini") -> OpenAIFuzzFactory {
+        OpenAIFuzzFactory(
+            // No /v1 suffix — OpenAIBackend.buildRequest appends it. (No request
+            // is built here regardless; this documents the contract.)
+            baseURL: URL(string: "https://openrouter.ai/api")!,
+            apiKey: "sk-test-never-sent-no-network",
+            modelName: model
+        )
+    }
+
+    /// Cloud generation cannot be bit-reproduced — providers don't honour a seed
+    /// reproducibly and `:free` slugs route to shifting backends. The factory
+    /// must opt out of deterministic replay so `Replayer` short-circuits with
+    /// `.nonDeterministicBackend` instead of running a guaranteed-noisy replay.
+    func test_supportsDeterministicReplay_isFalse() {
+        XCTAssertFalse(
+            makeFactory().supportsDeterministicReplay,
+            "Cloud backends are non-deterministic; replay/shrink must refuse."
+        )
+    }
+
+    /// `makeHandle()` wires a `BackendHandle` whose identity fields match the
+    /// configured slug, with `backendName == \"openai\"` and a non-nil marker
+    /// snapshot. Exercises the full construct→configure→loadModel path offline.
+    func test_makeHandle_producesExpectedBackendHandle() async throws {
+        let slug = "deepseek/deepseek-r1:free"
+        let handle = try await makeFactory(model: slug).makeHandle()
+
+        XCTAssertEqual(handle.backendName, "openai",
+                       "Factory must label the backend so findings attribute to the cloud path.")
+        XCTAssertEqual(handle.modelId, slug,
+                       "modelId must echo the requested slug verbatim.")
+        XCTAssertEqual(handle.modelURL, URL(string: "openai:\(slug)"),
+                       "modelURL must namespace the slug under the openai: scheme.")
+        XCTAssertNotNil(handle.templateMarkers,
+                        "Factory always sets a marker snapshot (manifest markers or the Qwen3 fallback).")
+    }
+}
+#endif
+#endif

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -32,6 +32,14 @@ for arg in "$@"; do
             echo "  --workers N  Run N process-level fuzz-chat workers (SwiftPM path only)"
             echo "  -h, --help   Show this help and forward to fuzz-chat -h"
             echo ""
+            echo "Cloud (OpenAI-compatible, e.g. OpenRouter):"
+            echo "  export OPENROUTER_API_KEY=sk-or-...   # preferred; or OPENAI_API_KEY"
+            echo "  scripts/fuzz.sh --backend openai --base-url https://openrouter.ai/api \\"
+            echo "                  --model deepseek/deepseek-r1:free --minutes 5"
+            echo "  Adds the CloudSaaS trait automatically. Caveats: replay/shrink unavailable"
+            echo "  (non-deterministic); free models are rate-limited (429) and ':free' slugs may"
+            echo "  404 on data-policy gating; --base-url must omit /v1 (backend appends it)."
+            echo ""
             echo "Forwarding to: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h"
             echo "─────────────────────────────────────────────────────────────"
             swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h || true
@@ -49,14 +57,17 @@ for ((i = 0; i < ${#FORWARDED_ARGS[@]}; i++)); do
         --backend)
             if (( i + 1 < ${#FORWARDED_ARGS[@]} )); then
                 REQUESTED_BACKEND="${FORWARDED_ARGS[$((i + 1))]}"
-                ((i++))
+                # `i=$((i+1))` not `((i++))`: post-increment returns the old
+                # value, so when i=0 the `((i++))` exit status is 1 and `set -e`
+                # would abort the script (bites `--backend` as the first arg).
+                i=$((i + 1))
             fi
             ;;
         --backend=*) REQUESTED_BACKEND="${arg#*=}" ;;
         --workers)
             if (( i + 1 < ${#FORWARDED_ARGS[@]} )); then
                 REQUESTED_WORKERS="${FORWARDED_ARGS[$((i + 1))]}"
-                ((i++))
+                i=$((i + 1))
             fi
             ;;
         --workers=*) REQUESTED_WORKERS="${arg#*=}" ;;
@@ -66,6 +77,16 @@ done
 if ! [[ "$REQUESTED_WORKERS" =~ ^[0-9]+$ ]] || (( REQUESTED_WORKERS < 1 )); then
     echo "scripts/fuzz.sh: --workers requires a positive integer" >&2
     exit 2
+fi
+
+# Trait set forwarded to `swift run`. The openai (OpenAI-compatible cloud)
+# backend additionally needs the CloudSaaS trait so ManifoldCloud's
+# OpenAIBackend links into fuzz-chat.
+TRAITS="Fuzz,MLX,Llama,Ollama"
+CLOUD_BACKEND=0
+if [[ "$REQUESTED_BACKEND" == "openai" ]]; then
+    TRAITS="Fuzz,CloudSaaS,MLX,Llama,Ollama"
+    CLOUD_BACKEND=1
 fi
 
 RUN_SWIFT=1
@@ -86,50 +107,76 @@ if [[ "$REQUESTED_BACKEND" == "mlx" ]]; then
     done
 fi
 
-LLAMA_HIT="miss"
-MLX_HIT="miss"
-OLLAMA_HIT="miss"
-FOUNDATION_HIT="miss"
-
-MODELS_DIR="$HOME/Documents/Models"
-if [[ -d "$MODELS_DIR" ]]; then
-    if find "$MODELS_DIR" -maxdepth 2 -type f -name "*.gguf" -print -quit 2>/dev/null | grep -q .; then
-        LLAMA_HIT="hit"
+if [[ $CLOUD_BACKEND -eq 1 ]]; then
+    # Cloud (OpenAI-compatible) backend: no local model discovery. Require an
+    # API key in the environment (keys on argv leak into ps/shell history) and
+    # surface the free-tier caveats up front.
+    CLOUD_KEY="${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  ManifoldFuzz preflight (cloud / OpenAI-compatible)"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    if [[ -z "$CLOUD_KEY" ]]; then
+        echo "scripts/fuzz.sh: --backend openai needs an API key in the environment." >&2
+        echo "  export OPENROUTER_API_KEY=sk-or-...   (preferred; or OPENAI_API_KEY)" >&2
+        echo "  Do NOT pass keys on the command line — they leak into ps/shell history." >&2
+        exit 2
     fi
-    if find "$MODELS_DIR" -maxdepth 3 -type f -name "*.safetensors" -print -quit 2>/dev/null | grep -q .; then
-        MLX_HIT="hit"
+    echo "  API key: present (env)"
+    echo "  Caveats:"
+    echo "    • Replay/shrink are unavailable — cloud generation is non-deterministic."
+    echo "    • Free OpenRouter models are rate-limited (HTTP 429) and ':free' slugs"
+    echo "      can 404 on data-policy gating. Transient HTTP errors are recorded as"
+    echo "      failed runs, NOT fuzz findings, so a throttled campaign stays honest."
+    echo "    • --base-url must omit the /v1 suffix (OpenRouter base = https://openrouter.ai/api)."
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+else
+    LLAMA_HIT="miss"
+    MLX_HIT="miss"
+    OLLAMA_HIT="miss"
+    FOUNDATION_HIT="miss"
+
+    MODELS_DIR="$HOME/Documents/Models"
+    if [[ -d "$MODELS_DIR" ]]; then
+        if find "$MODELS_DIR" -maxdepth 2 -type f -name "*.gguf" -print -quit 2>/dev/null | grep -q .; then
+            LLAMA_HIT="hit"
+        fi
+        if find "$MODELS_DIR" -maxdepth 3 -type f -name "*.safetensors" -print -quit 2>/dev/null | grep -q .; then
+            MLX_HIT="hit"
+        fi
     fi
-fi
 
-if [[ $WITH_MLX -eq 1 && "$REQUESTED_BACKEND" != "mlx" && $REQUESTED_WORKERS -gt 1 ]]; then
-    echo "scripts/fuzz.sh: --workers > 1 cannot be combined with --with-mlx; run the SwiftPM and MLX campaigns separately." >&2
-    exit 2
-fi
+    if [[ $WITH_MLX -eq 1 && "$REQUESTED_BACKEND" != "mlx" && $REQUESTED_WORKERS -gt 1 ]]; then
+        echo "scripts/fuzz.sh: --workers > 1 cannot be combined with --with-mlx; run the SwiftPM and MLX campaigns separately." >&2
+        exit 2
+    fi
 
-if curl -s -m 2 http://localhost:11434/api/tags >/dev/null 2>&1; then
-    OLLAMA_HIT="hit"
-fi
+    if curl -s -m 2 http://localhost:11434/api/tags >/dev/null 2>&1; then
+        OLLAMA_HIT="hit"
+    fi
 
-PRODUCT_VERSION="$(sw_vers -productVersion 2>/dev/null || echo 0)"
-PRODUCT_MAJOR="${PRODUCT_VERSION%%.*}"
-if [[ "$PRODUCT_MAJOR" =~ ^[0-9]+$ ]] && (( PRODUCT_MAJOR >= 26 )); then
-    FOUNDATION_HIT="hit"
-fi
+    PRODUCT_VERSION="$(sw_vers -productVersion 2>/dev/null || echo 0)"
+    PRODUCT_MAJOR="${PRODUCT_VERSION%%.*}"
+    if [[ "$PRODUCT_MAJOR" =~ ^[0-9]+$ ]] && (( PRODUCT_MAJOR >= 26 )); then
+        FOUNDATION_HIT="hit"
+    fi
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  ManifoldFuzz preflight"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-printf "  Discovered: Llama=%s, MLX=%s, Ollama=%s, Foundation=%s\n" \
-    "$LLAMA_HIT" "$MLX_HIT" "$OLLAMA_HIT" "$FOUNDATION_HIT"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  ManifoldFuzz preflight"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    printf "  Discovered: Llama=%s, MLX=%s, Ollama=%s, Foundation=%s\n" \
+        "$LLAMA_HIT" "$MLX_HIT" "$OLLAMA_HIT" "$FOUNDATION_HIT"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-if [[ "$LLAMA_HIT" == "miss" && "$MLX_HIT" == "miss" && "$OLLAMA_HIT" == "miss" && "$FOUNDATION_HIT" == "miss" ]]; then
-    echo "No usable backends detected. Install hints:" >&2
-    echo "  Ollama:     brew install ollama && ollama serve   (then: ollama pull qwen3.5:4b)" >&2
-    echo "  Llama:      drop a *.gguf into ~/Documents/Models/ or ~/Documents/Models/<name>/" >&2
-    echo "  MLX:        drop an MLX snapshot into ~/Documents/Models/<name>/ (config.json + *.safetensors + tokenizer)" >&2
-    echo "  Foundation: requires macOS 26+" >&2
-    exit 2
+    if [[ "$LLAMA_HIT" == "miss" && "$MLX_HIT" == "miss" && "$OLLAMA_HIT" == "miss" && "$FOUNDATION_HIT" == "miss" ]]; then
+        echo "No usable backends detected. Install hints:" >&2
+        echo "  Ollama:     brew install ollama && ollama serve   (then: ollama pull qwen3.5:4b)" >&2
+        echo "  Llama:      drop a *.gguf into ~/Documents/Models/ or ~/Documents/Models/<name>/" >&2
+        echo "  MLX:        drop an MLX snapshot into ~/Documents/Models/<name>/ (config.json + *.safetensors + tokenizer)" >&2
+        echo "  Foundation: requires macOS 26+" >&2
+        echo "  OpenAI:     --backend openai --base-url https://openrouter.ai/api --model <slug>" >&2
+        echo "              (set OPENROUTER_API_KEY; no local model needed)" >&2
+        exit 2
+    fi
 fi
 
 HAS_BUDGET=0
@@ -196,11 +243,11 @@ cd "$PACKAGE_DIR"
 SWIFT_EXIT=0
 if [[ $RUN_SWIFT -eq 1 ]]; then
     echo ""
-    echo "Running: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat ${FORWARDED_ARGS[*]+"${FORWARDED_ARGS[*]}"}"
+    echo "Running: swift run --traits $TRAITS fuzz-chat ${FORWARDED_ARGS[*]+"${FORWARDED_ARGS[*]}"}"
     echo ""
 
     set +e
-    swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}"
+    swift run --traits "$TRAITS" fuzz-chat "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}"
     SWIFT_EXIT=$?
     set -e
 else


### PR DESCRIPTION
## What

Lets the fuzz harness (`fuzz-chat`) target any OpenAI-Chat-Completions-compatible cloud endpoint — primarily **OpenRouter** — via the native `OpenAIBackend`. Previously the only backends were Ollama/Llama/MLX/Foundation/Mock/Chaos.

## Changes

- **`OpenAIFuzzFactory`** (`Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift`, gated `#if CloudSaaS && Fuzz`) mirrors `OllamaFuzzFactory`: construct `OpenAIBackend` → `configure(baseURL:apiKey:modelName:)` → no-op cloud `loadModel(plan: .cloud())` → marker snapshot. `supportsDeterministicReplay == false` so replay/shrink refuse with `.nonDeterministicBackend`.
- **`BackendChoice.openai`** wired in `FuzzChatCLI`. New flags `--base-url <url>` and `--api-key <key>`; the key is read from `OPENROUTER_API_KEY` (preferred) then `OPENAI_API_KEY`, with `--api-key` as a discouraged opt-out (keys on argv leak into `ps`/shell history). Missing trait/url/key/model each fail with an actionable message naming the exact `swift run --traits ...` line. `workerLimit(.openai) == 1` (cloud rate-limits make fan-out harmful).
- **`scripts/fuzz.sh --backend openai`** adds the `CloudSaaS` trait, skips local model discovery, requires the key env var, and prints the free-tier caveats. Also fixes a latent `set -e` bug — `((i++))` returns exit status 1 when `i==0`, which aborted the script whenever `--backend` was the first arg.
- **Network-free unit test** (`Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift`) asserts the `BackendHandle` identity fields (`backendName == "openai"`, `modelId`, `modelURL`) and `supportsDeterministicReplay == false`. Sabotage-verified, then removed.

## Run it

```bash
export OPENROUTER_API_KEY=sk-or-...   # preferred; or OPENAI_API_KEY
swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat \
  --backend openai \
  --base-url https://openrouter.ai/api \
  --model deepseek/deepseek-r1:free \
  --minutes 5
# or: scripts/fuzz.sh --backend openai --base-url https://openrouter.ai/api --model <slug> --minutes 5
```

## Caveats

- **Replay/shrink unavailable** — cloud generation is non-deterministic (`supportsDeterministicReplay == false`).
- **Free models are rate-limited (HTTP 429)** and `:free` slugs can **404 on data-policy gating**. The runner already separates backend errors from detector findings: a thrown transport error (429/5xx/401/404) is captured as a *failed* `RunRecord` (`phase="failed"`, `error` set, empty output) and every empty/missing-output detector gates on `error == nil` / `phase == "done"`, so transient HTTP errors are **not** misclassified as findings. Verified end-to-end against a dead local port (1 iteration → 0 findings, exit 0). No runner change was needed.
- **`--base-url` must omit `/v1`** — `OpenAIBackend` appends `v1/chat/completions` itself. OpenRouter base = `https://openrouter.ai/api`.

## Backend scope

Cloud-only (OpenAI-compatible). This is not a per-family fan-out; it adds one cloud path through the existing `OpenAIBackend`.

## Gates (all green, local)

- `swift build --traits Fuzz,CloudSaaS,MLX,Llama,Ollama --product fuzz-chat` ✅; also builds **without** CloudSaaS and the `openai` path fails with the clear trait message ✅
- Trait-combo sweep `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` ✅
- New test `swift test --traits Fuzz,CloudSaaS --filter ManifoldFuzzTests.OpenAIFuzzFactoryTests` ✅ (2/2)
- `scripts/test.sh --profile local` ✅ (4844 + 83 tests, 0 failures)

## Deviation from brief

No `Package.swift` change was required. `OpenAIBackend` reaches `fuzz-chat` transitively (`ManifoldFuzzBackends → ManifoldBackends → ManifoldCloud` under `CloudSaaS`), and the `.define("CloudSaaS")` already exists on both `ManifoldFuzzBackends` and `fuzz-chat`. Adding a direct `.when(traits: ["CloudSaaS","Fuzz"])` edge would over-link `ManifoldCloud` into the default (Fuzz-only) build due to OR-semantics, so it was deliberately omitted. Consequently `Package.resolved` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
