### PR TITLE
docs: testing/CI principles, QA evaluation, and repeatable audit process

### DIFF
--- a/docs/QA-EVALUATION-2026-06.md
+++ b/docs/QA-EVALUATION-2026-06.md
@@ -1,0 +1,88 @@
+# ManifoldKit Evaluation — Architecture, QA, DX, Economics (June 2026)
+
+**Date:** 2026-06-07 · **Method:** principle-driven, evidence-first audit (see [`QA-EVALUATION-PROCESS.md`](QA-EVALUATION-PROCESS.md)) · **Rubric:** [`TESTING-CI-PRINCIPLES.md`](TESTING-CI-PRINCIPLES.md)
+
+Every finding is anchored to `file:line`. Findings are evidence-cited from a single-pass sweep; the cross-dimension reconciliations (e.g. the API-breakage gate) were adversarially confirmed — treat un-reconciled findings as high-but-not-certain confidence until verified.
+
+## Headline
+
+**The deductive and adversarial core is genuinely strong; the systemic gap is self-instrumentation.** ManifoldKit proves correctness well (owned seams, exhaustive switch funnel, audit-test discipline, a real fuzz harness, regression-encoding as habit) but does not *measure* its own quality or cost: no mutation score, no flake-rate / time-to-green / re-run-tax telemetry. The principles it espouses in `TESTING-CI-PRINCIPLES.md` §10/§16 are written but not mechanically emitted. Secondary theme: **doctrine lags implementation** — `CLAUDE.md`'s caching/batching narrative and several doc/CI paths have drifted from the shipped workflows and a past file move.
+
+## Scorecard
+
+| Dimension | Principle | Verdict | Anchor |
+|---|---|---|---|
+| **Architecture** | Switch exhaustiveness (P2/P3) | CONFORMS | `GenerationStreamConsumer.swift:17-77` (exhaustive funnel); 1 gap `GenerationToolDispatchLoop.swift:221` |
+| | Module boundaries: compiler vs lint (P3) | PARTIAL | UI edges already deductive `Package.swift:520-523`; lints `ci.yml:258-270` redundant; framework-isolation lints necessary |
+| | Illegal states unrepresentable (P3) | PARTIAL | non-negative-`Int` guards `PromptSlot.swift:316`, `RedirectGuardDelegate.swift:83` → `UInt`/value type |
+| | Force-unwrap posture (P3) | PARTIAL | lint real `ci.yml:325`; **whole-file** allowlist trusts future edits `lint-no-new-force-unwraps.sh:80` |
+| | Public API as contract (P5) | PARTIAL | live gate **3 of ~24 targets** `ci.yml:385-402`; richer test dormant `PublicAPIStabilityTest.swift:36` |
+| | `@testable` vs plain import (P5) | PARTIAL | 584/649 `@testable`; plain-import slice exists `APIFreezeTests/PublicSurfaceTests.swift:16` |
+| | Owned seams (P15) | CONFORMS | `ClaudeBackend.swift:49`, `MockURLProtocol.swift:23`, `MLXModelContainerProtocol.swift:62`; no foreign-type mocks |
+| | Cold-start consumability (P14) | CONFORMS | tiers 1-4 `ci.yml:792-877`; gap: only umbrella+UI products |
+| | Ownership topology (A1) | CONFORMS | `Exports.swift:16-29`; gates only at consumer→family edges `Package.swift:466-503` |
+| **QA** | Determinism / hermeticity (P6) | CONFORMS | `UserDefaultsStandardAuditTest.swift:63`, `TrafficBoundaryAuditTest`; minor: 170 `Task.sleep` in tests |
+| | Trust / signal integrity (P7) | CONFORMS | `withKnownIssue`=0; `TestSuiteSilentSkipAuditTest`; durable analog = `AuditSabotageSuiteTests.swift` |
+| | Discovered-space / regression (P13) | CONFORMS | 200 `#NNN` refs; `KVCacheReuseRaceRegressionTests.swift:9-15`; pinning labeled |
+| | Tiering by value-of-info (P8) | PARTIAL | excellent speed-tiering; turn loop per-PR golden `ci.yml:522`; placement **cost-justified, not severity-ranked** |
+| | Change-confidence measured (P10) | **GAP** | **no mutation testing**; coverage lagging nightly floor 10pp low, 4/~20 modules `check-coverage.sh:20-25` |
+| | Adversarial verification (P4) | CONFORMS | TLS/DNS/sanitizer/MCP suites + fuzz harness (7×16); caveats below |
+| | Self-instrumentation (P16) | **GAP** | metrics named `TESTING-CI-PRINCIPLES.md:71` but **no collector**; 2.1× tax is anecdotal |
+| **DX** | Feedback latency | PARTIAL | `--profile spike`/`--minimal` real `test.sh:260-425`; **no installed git hooks** |
+| | Change-confidence, felt | CONFORMS | honest-summary tripwires `test.sh:603-611`; 19 audits + sabotage + cold-start (strongest DX axis) |
+| | Cold-start / onboarding (P14) | PARTIAL | `quickStart()` `QuickStart.swift:78`; strong error `ManifoldKitError.swift:87`; **chat inert until model selected**; 3 broken doc links |
+| | Docs as DX surface | PARTIAL | snippet-compile real `readme-snippets.yml`; **its own `paths:` filter references 2 missing files** |
+| **Economics** | Batch sizing → interior optimum (P9) | PARTIAL | concurrency-cancel + path-filter shipped `ci.yml:53-126`; no upper-bound guard; doctrine stale |
+| | Selective / affected testing | CONFORMS | Tier-0 resolver + Tier-2 exec `ci.yml:143-481`; FULL-fallback backstops |
+| | Cost instrumentation (P16) | **GAP** (telemetry) | no billing/run-count tracking anywhere; dep-cache live `ci.yml:200-213` |
+| | Commitment gradient / platform (P12) | PARTIAL | floor declared `Package.swift:25-27`, **no availability-floor audit**; API gate core-only |
+
+**Adversarial caveats (P4 CONFORMS but):** GitHub Actions are tag-pinned not SHA-pinned (`maxim-lobanov/setup-xcode@v1`, `dorny/paths-filter@v4`); `dependency-review` is `continue-on-error: true` → fail-open (`lint.yml:281`); the fuzz harness has no automated cadence (`fuzz-weekly.yml:18-21`, schedule disabled).
+
+## Cross-cutting themes
+
+1. **Self-instrumentation is the one systemic GAP** — it surfaces in *both* QA (no flake / signal-to-noise / time-to-green) and Economics (no cost / re-run-tax telemetry). The metrics are named in the principles doc; nothing emits them. Highest-leverage cross-dimension fix.
+2. **Change-confidence is asserted, not measured** — strong golden/characterization assets (turn-loop snapshots) but no mutation score or escaped-defect rate; coverage is a lagging nightly proxy.
+3. **Doctrine/docs lag implementation** — `CLAUDE.md` still says "compiled-artifact caching ruled out" (dependency caching is in fact live and the real win) and frames "fewer/bigger PRs" as the dominant lever (concurrency-cancel + path-filter already shipped; the framing now steers toward over-batching). Plus a cluster of drift defects from the `ManifoldInference → ManifoldModelCatalog` file move: 3 broken doc links + a stale `readme-snippets.yml` path filter.
+4. **CI's own supply chain is softer than the product's** — adversarial rigor is applied to runtime (TLS/DNS/sanitizers/fuzz) but the pipeline uses mutable action tags and a fail-open dependency check.
+5. **The contract gate is real but narrow** — live for 3 core targets; the umbrella surface consumers actually `import` is unprotected, and a `fix:`/`feat:` can still drift a family target's surface.
+6. **Severity-ranking is implicit** — tiering decisions are justified by billing, not by a documented risk matrix; some defect-detection (coverage, the sabotage audit) was demoted to nightly for cost, accepting a ≤24h blind window on a per-PR gate.
+
+## Prioritized actions
+
+Ranked by severity-weighted leverage (P8: risk-reduction per unit cost), not finding count.
+
+### P0 — do first
+
+**A1. Stand up QA + cost telemetry (closes the P16 gap in both QA and Economics).**
+A scheduled 1×-billed ubuntu job querying `gh api` / the Actions API weekly for run-count, re-run ratio, time-to-green, and selective-vs-full outcomes, writing a committed trend file or step-summary. Converts the anecdotal 2.1× re-run tax into a standing signal and gives the §16 metrics a home. *Why #1:* the re-run tax is the largest premium-runner line item and is entirely un-instrumented; the fix is cheap and cross-cutting. *Evidence:* no collector found in `.github/` or `scripts/`; `TESTING-CI-PRINCIPLES.md:71`.
+
+**A2. Widen the API-breakage gate beyond the 3 core targets.**
+The live gate (`ci.yml:385-402`) digests only `ManifoldInference`/`Runtime`/`CloudCore`. Add the umbrella `ManifoldKit` surface (what consumers import) and family targets where the `llama` C-module issue can be sidestepped; optionally activate the dormant annotated `PublicAPIStabilityTest.swift` (its `SemVerBreak`/`feat!:` plumbing is already written) to mechanically link the version bump to the actual surface change. *Why:* a silent breaking change fans out irreversibly to every consumer (P5, P12).
+
+### P1 — high value, low cost
+
+**B1. Fix the docs/CI drift cluster + add a path-existence audit.**
+Three reader-facing broken links to `ManifoldKitError.swift` (README.md:21, QUICKSTART.md:36/305 → actual `Sources/ManifoldModelCatalog/ManifoldKitError.swift`); the snippet gate's own `paths:` filter references two non-existent files (`readme-snippets.yml:40-41,57-58`) so error-rim changes can skip the gate; `CLAUDE.md`'s caching/batching narrative is stale. Add a CI audit asserting every literal `Sources/...` path in markdown and workflow YAML exists on disk (same self-validation discipline already used for cold-start scripts). *Why:* cheap, all real defects, all from one untracked file move; the path-filter hole is a silent self-disarming gate.
+
+**B2. Pilot mutation testing on the turn loop + `ConversationRuntime` (closes P10).**
+Even a one-off manual mutation run on the two highest-value deterministic modules produces a baseline mutation score — converting "fearless change" from aspiration to a measured deliverable. Pair with moving the coverage *no-regression delta* check onto per-PR for the 4 critical modules. *Evidence:* no mutation tooling exists; `check-coverage.sh` is nightly-only and 10pp below baseline.
+
+**B3. Harden CI's own supply chain (P4).**
+SHA-pin third-party Actions (at minimum `maxim-lobanov/setup-xcode`, `dorny/paths-filter`, `amannn/action-semantic-pull-request`) with Dependabot `github-actions`; enable the repo dependency graph and remove `continue-on-error` from `dependency-review` (`lint.yml:281`) to make it fail-closed.
+
+### P2 — worth doing
+
+**C1. Add an availability-floor audit (P12).** A lint over `Sources/` flagging `#available`/`@available` predicated above the declared `Package.swift:25-27` floor (outside OS-gated Foundation/Skills) — makes the n-1 policy compiler-truth, not prose.
+
+**C2. Document a test-tier risk matrix (P8).** Map highest-risk paths (turn loop, streaming, persistence atomicity, supply chain) to required tiers and assert each has a *blocking per-PR* check; reconsider the nightly demotion of the sabotage-audit tripwire (a broken audit silently disarms a per-PR gate for ≤24h).
+
+**C3. Architecture deduction conversions.** Line-anchor the force-unwrap allowlist (so trusted *files* don't become unaudited); replace non-negative-`Int` `precondition`s with `UInt`/value types; expand the `StreamAction` `default:` at `GenerationToolDispatchLoop.swift:221` to explicit cases.
+
+**C4. Close the cold-start per-product/per-trait gap (P14).** A matrix cold-start job importing `ManifoldMCP`/`ManifoldVoice`/`ManifoldUIModelManagement`/`ManifoldServer` under their enabling traits.
+
+**C5. DX loop + batch bounds.** Ship an opt-in `scripts/install-hooks.sh` (pre-push runs `--profile spike`) so the keystone fast-feedback loop isn't discipline-only; add an upper-bound to `CLAUDE.md`'s PR-size guidance so the EOQ curve is defended on both sides; reframe the "one call to chat" onboarding claim (chat is inert until a model is selected).
+
+## What is already strong — do not "fix"
+
+Owned seams (P15), ownership topology (A1), the exhaustive switch funnel, the audit-test + audit-sabotage discipline, regression-encoding as habit (P13), determinism tripwires (P6), and the adversarial runtime suites (P4) are all CONFORMS with strong evidence. The two UI-boundary lints are *redundant* with the compiler (fine as fast-feedback aids) — don't mistake them for the enforcement of record.

--- a/docs/QA-EVALUATION-PROCESS.md
+++ b/docs/QA-EVALUATION-PROCESS.md
@@ -1,0 +1,58 @@
+# QA Evaluation Process
+
+A repeatable, principle-driven audit of ManifoldKit's architecture, QA, DX, and CI economics. Run it periodically (suggested: each minor-version train, or quarterly) to catch drift, regressions in discipline, and rules that have quietly expired. The most recent run is [`QA-EVALUATION-2026-06.md`](QA-EVALUATION-2026-06.md).
+
+This process turns the principles in [`TESTING-CI-PRINCIPLES.md`](TESTING-CI-PRINCIPLES.md) from a reference into an **audit instrument**. The principles are the rubric; this doc is the procedure.
+
+## Why it works this way
+
+Three rules make the output trustworthy rather than vibes:
+
+1. **Codebase is the only truth.** Every finding cites `file:line`. A claim without an anchor is a hypothesis, not a finding. This is what catches "the test exists ✓" when the test actually always skips.
+2. **Evidence first, judgment second.** Workers gather grep/read evidence *before* rating. No rating without the anchor that supports it.
+3. **Adversarially reconcile.** Where two workers' evidence conflicts (it will), the conflict is the signal — reconcile it explicitly. The June 2026 run flipped a "no API-breakage gate" GAP to a "narrow gate" PARTIAL exactly this way.
+
+## The instrument: principle → diagnostic
+
+Each principle becomes a diagnostic question, an evidence target, and a severity-weighted verdict (CONFORMS / PARTIAL / GAP). The dimensions and their principle clusters:
+
+| Dimension | Principles | Core diagnostic questions |
+|---|---|---|
+| **Architecture** | P2/P3 (mode selection, deduction-first), P5 (API contract), P14 (cold-start), P15 (owned seams), A1 (topology) | Where is induction used where deduction is free? Is the public API a mechanically-enforced contract? Are foreign deps faked at owned seams? Can a stranger build against each product? |
+| **QA** | P6 (determinism), P7 (trust), P8 (tiering), P10 (change-confidence), P13 (discovered space), P4 (adversarial), P16 (instrument) | Is every test reproducible & hermetic? Is flake debt zero and skips justified? Is tiering severity-ranked or only speed-ranked? Is change-confidence *measured* (mutation/coverage)? Is the suite itself instrumented? |
+| **DX** | P10 (felt confidence), P14 (onboarding), feedback latency | How fast is the inner loop, and is it the real gate? How many steps from zero to working? Are docs tested and links live? |
+| **Economics** | P9 (EOQ batching), P12 (commitment gradient), P16 (cost telemetry) | Is batch size at an interior optimum or "bigger is always better"? Is affected-only testing safe? Is the re-run tax instrumented? Is the platform floor enforced or just declared? |
+
+For each principle also ask the **contingency question**: *is this a good practice, or an expired one?* (over-batching after caching improved, mocking a contract you now own, inducting what you could deduce, doctrine that lags the shipped code).
+
+## The protocol
+
+1. **Scope.** Pick the dimensions (all four, or one as a proof-of-method). Re-read `TESTING-CI-PRINCIPLES.md` for the current rubric.
+2. **Fan out evidence workers** — one per dimension (split QA into two; it's the densest). Each worker:
+   - gets the diagnostic questions for its cluster (use the June run's worker prompts as templates),
+   - greps/reads the real repo, citing `file:line`,
+   - returns CONFORMS / PARTIAL / GAP per area with evidence and 1-3 candidate actions.
+3. **Reconcile + adversarially verify.** Cross-read the worker outputs for conflicts; re-check any material or surprising finding against the source before trusting it. Conflicts are findings.
+4. **Severity-weight (P8).** Rank gaps by *risk reduction per unit cost*, not by count. A dormant contract gate (consumer-fanning, irreversible) outranks ten cosmetic items. Note cross-cutting gaps (a gap that appears in two dimensions is higher leverage).
+5. **Write the report** — scorecard table, cross-cutting themes, prioritized P0/P1/P2 actions with anchors, and an explicit "already strong — do not fix" section so the audit isn't only negative.
+6. **Track the actions** — one tracking issue with a checklist, or a checklist in the report. Do **not** fan out one issue per finding (see `CLAUDE.md` issue hygiene).
+
+## Running it from Claude Code
+
+Ask Claude to "run the QA evaluation process" (point it at this file). The expected shape:
+
+- Dispatch 4-5 parallel evidence workers (`general-purpose` agents) with the per-dimension diagnostic prompts. Each must cite `file:line` and rate CONFORMS/PARTIAL/GAP.
+- Optionally add an adversarial-verify pass: a skeptic re-checks each GAP/PARTIAL against the source and tries to refute it; survivors stand.
+- Synthesize into a dated `docs/QA-EVALUATION-<YYYY-MM>.md` mirroring the latest run's structure.
+
+The June 2026 worker prompts are the canonical templates — reuse and update them. For a heavier, fully-orchestrated run (fan-out → adversarial verify → synthesis as one deterministic pipeline), this is a good candidate for a multi-agent workflow.
+
+## Cadence & scope guidance
+
+- **Full audit:** each minor-version train or quarterly. ~4-5 workers; a few hours of agent time.
+- **Single-dimension spot-check:** when touching a specific area (e.g. after CI changes, re-run Economics only).
+- **Drift watch:** the cheapest recurring value is re-checking the cross-cutting themes — self-instrumentation, doctrine-vs-implementation drift, and self-validating gates (path filters, audit-of-audits) — because those rot silently between full runs.
+
+## Reading the output
+
+A CONFORMS is not "done forever" — it's "true as of this run, at this anchor." A PARTIAL with a cheap deductive fix usually outranks a GAP with an expensive one. And every recommendation should name the driver it serves, so a future reader can tell whether the action still matters when the facts change (see the expiry-condition discipline in `TESTING-CI-PRINCIPLES.md`).

--- a/docs/TESTING-CI-PRINCIPLES.md
+++ b/docs/TESTING-CI-PRINCIPLES.md
@@ -1,0 +1,71 @@
+# Testing & CI Principles
+
+A first-principles framework for how we test and run CI for an SDK like ManifoldKit. These were derived from fresh research into testing/CI practice, reduced to their underlying drivers, then adversarially stress-tested by a panel of critics (epistemology, practice, economics, reduction). The corrections from that review are baked in.
+
+**How to read this.** Each principle states the rule, then names the *driver* it serves — and, where the rule is contingent on a fact that can change, its *expiry condition* (when to stop obeying it). Hold the drivers, not the rules: when a situation is new, re-derive the move from the driver instead of looking up a principle. The principles are peers — when two conflict, drop to their drivers and let the current facts arbitrate.
+
+---
+
+## 1. Verification has two irreducible roots: specification and confidence-under-cost
+
+Every testing decision serves one of two things that do not reduce to each other. **Specification** — what does "correct" even mean here? — is normative and supplied only by a human; no amount of sampling or compute produces it. **Confidence-under-cost** — given a spec, how much warrant do we have that the code meets it, and what did that warrant cost? — is a decision under uncertainty (expected loss = warrant × cost-of-being-wrong). Most "where do I put this test" arguments are really confusion about which root you're serving. The automation boundary falls exactly here: machines verify conformance (*is* the code correct against a spec), humans own specification (*what should* be correct). Automate verification; reserve human judgment for specification, breaking-change intent, and "is this a flake or a real regression."
+
+## 2. Choose the verification *mode* before you write the test
+
+A universal claim ("this works for all inputs") can be established three structurally different ways, and picking the wrong one is the most expensive mistake in the suite. **Deductive** — types, exhaustive `switch`, Swift 6 concurrency proofs — covers the entire input space, paid once, with zero samples. **Inductive** — tests — samples a finite set and generalizes. **Adversarial** — security, supply-chain — must hold against an optimizing attacker, not random variance. Architecture *is* mode selection. Before writing a test, ask which mode the claim wants; reaching for induction by reflex is how a state machine ends up with twelve table-driven tests that an exhaustive enum would have made unrepresentable.
+
+## 3. Prefer deduction — prove the universal in the type system and you never sample it
+
+When the compiler can make an illegal state unrepresentable, that is a universal proven for *all* inputs, for free, forever — categorically stronger and cheaper than any number of inductive tests. Push correctness into types, exhaustive enums, non-optionals, and strict-concurrency checks first; write tests only for what the type system cannot prove. This is why we "validate at system boundaries only — don't guard internal invariants the type system already enforces." The highest-leverage refactor is often *deleting* tests by making their failure mode uncompilable.
+
+## 4. Treat security and supply-chain as adversarial, not statistical
+
+An attacker is not entropy. Entropy is random and samplable; an adversary reads where you looked and targets the complement, so you cannot sample your way to "no exploit exists." Provenance, signing, dependency pinning, and reproducible builds are not economic optimizations or extra tests — they are the *adversarial* mode of verification, and they belong on every release because we are a supply-chain upstream: one tampered artifact fans out to every consumer.
+
+## 5. Test through the public API — it is both the contract and the population you are inferring about
+
+For an SDK, the public API is simultaneously the unit of test, the unit of versioning, and the contract with consumers — they coincide. Test *behavior* at that surface, not internal structure, and keep at least one test target that imports you exactly as a stranger would (plain `import`, public symbols only). Tests coupled to internals stay green while the public API breaks, and they make pure refactors expensive — which trains people to stop refactoring. Enforce semantic versioning mechanically by diffing the public surface against a baseline, with an explicit allowlist for intended breaks.
+
+## 6. Determinism is the lever that makes a finite suite mean anything
+
+A non-deterministic test tells you only about the run that just happened; to generalize you would need infinite runs. Determinism collapses that — one run stands in for all future runs of the same code — which is what makes a *finite* suite valid at all. So hermeticity (no real network, injected clock, injected RNG, isolated global state) is the single highest-leverage technique, but it is a *lever against uncontrolled entropy at your boundaries*, not a first principle in its own right. It earns its primacy by being the thing every other inductive guarantee rests on. *Driver:* boundary entropy. *Note:* determinism collapses the entropy dimension, not the coverage dimension — you still haven't run all inputs.
+
+## 7. Trust is the gate; nothing downstream has value without it
+
+The product of a test suite is not "green checks" — it is a calibrated trust that converts a red signal into action. Trust is a path-dependent capital stock with an *absorbing failure state*: flaky reds train people to ignore the suite, after which even true reds no longer convert to fixes and you pay to run tests that yield negative value (false confidence). The loop is bistable and recovery is slow — you must re-earn trust over many green runs. This is why flakiness is categorically worse than slowness: slowness is a linear cost, flakiness poisons the channel. Guard signal integrity above raw coverage. *Caveat:* a suite at 70% trust is degraded-but-positive; "worse than nothing" is only true once it falls into the lower attractor.
+
+## 8. Tier by severity-weighted value of information, not by cost-per-bug
+
+Place each check where it buys the most *risk reduction* per dollar, not where it catches the most *bugs* per dollar — a single data-loss bug outranks a hundred cosmetic ones, and a bug a later tier would have caught anyway has near-zero value here. Bias toward a wide base of fast, deterministic, mocked tests on every PR; gate expensive real-model / real-network / fuzz tests behind explicit flags on a nightly tier. The two tiers test different things: the hermetic tier carries *correctness of your code*, the gated real tier carries *currency against an upstream world you don't control*. Don't pay for currency on every PR.
+
+## 9. Batch work to an interior optimum, not "as large as possible"
+
+On premium runners (macOS bills ~10×) a fixed cold-build floor is paid per run, so amortizing it over a batch lowers cost — but only up to a point. This is a setup-cost lot-sizing problem (EOQ), and total cost is U-shaped: batch size also *raises* the rerun tax (a batch of n independent changes fails with probability `1−(1−p)ⁿ`), degrades review catch-rate past a few hundred lines of diff, and adds queueing delay. The optimum `B* ≈ √(2DS/H)` shrinks as caching cuts the setup cost S, but it never reaches "infinitely big." *Expiry / caveat:* batching is multi-causal — review economics, semantic-conflict risk, bisectability, and the absence of an org merge queue all push on PR size. Better caching relaxes only the build-floor term; do not fan back out to per-change PRs the moment a cache lands.
+
+## 10. The deliverable is change-confidence — so measure it, don't sloganize it
+
+The asset a suite produces is the confidence to change code without fear. Stated as a slogan ("green checks aren't the point") it licenses deleting "brittle" tests that were catching real regressions, so make it a number: mutation score (does the suite actually fail when behavior breaks?) and escaped-defect rate. A sabotage check — confirm the test fails when the code path breaks — is the per-test instance of this. Optimize the suite's *severity* (would it catch a real break?), not its coverage percentage.
+
+## 11. Add a layer; don't flip a rule
+
+Verification needs stratify, they don't switch. When you start owning a dependency you previously mocked, you *add* a thin real-integration layer and *keep* the fast deterministic mocks for unit speed — nothing "flipped." When you find a genuine three-way configuration bug, you add that one regression case and keep sampling the rest of the matrix. Framing changes as binary rule-flips ("the mock expired") flattens the test pyramid and tends to delete the fast layer that was carrying determinism.
+
+## 12. The cost of a defect tracks accumulated dependency commitment, not elapsed time
+
+A bug gets expensive in proportion to how much dependent, hard-to-reverse work has been built on top of it before detection — not simply how long it sat there. A dormant bug in a leaf module stays cheap; a bug that quickly acquires many dependents (or ships in a release consumers integrate against) is expensive almost immediately, because fixing it is now itself a breaking change. Optimize for catching defects *before the next irreversible commitment*, not merely "early." This is why SDKs have a steeper gradient than apps: each release accretes consumer commitment fast and irreversibly.
+
+## 13. Your test space is discovered, not known — so encode every escaped defect
+
+The configuration/input space has an enumerable part (traits × platforms × backends) you can sample deliberately, and an unknowable part you only learn about by being hurt. You cannot compute the ideal suite up front; the reactive loop — when a bug escapes, add the test that would have caught it — is principled active learning over an unknown space, not a sign of laziness. Treat every production or CI escape as a permanent addition to the known space. The enumerable part justifies a small boundary/pairwise config matrix (bugs cluster at low-order interactions, so pairwise coverage captures most defect mass cheaply); the discovered part justifies the ever-growing regression set.
+
+## 14. Prove a stranger can consume you
+
+A green internal suite does not prove a downstream app can import and build against your published artifact across the ownership boundary — the one place your CI is structurally blind. A separate cold-start consumer package that depends on you as an external client, using only public products, is the only sample that crosses that boundary; it catches accidentally-internal symbols, missing re-exports, broken umbrellas, and trait combinations that fail to link. Compile your README/quick-start examples against the *packaged* form too — a broken first example fails on the consumer's machine where you cannot see it.
+
+## 15. A test double is a frozen assertion about a contract — only fake contracts you own
+
+Every mock encodes a claim: "the real thing behaves like this." If you own the contract, the compiler keeps that claim honest when the contract changes. If a third party owns it (a cloud API, a GPU driver), your mock can silently drift into a lie that passes — green tests, moved reality. So wrap every foreign dependency behind an interface you own, fake *that* for orchestration tests, and verify the real adapter against reality on the gated tier. Prefer state verification (assert what you got back) over interaction verification (assert which calls were made); the former survives refactors.
+
+## 16. Instrument the pipeline itself
+
+You cannot drive down what you do not measure, and the pipeline that manages verification needs verification too. Track the waste directly: CI rerun rate (the retry tax — usually the largest line item on premium runners), flaky-test rate, time-to-green, and signal-to-noise (share of failures that are real bugs; below ~80% the suite is a noise generator and trust is sliding toward the lower attractor). These convert "CI feels expensive" and "the suite feels flaky" into numbers you can act on.

--- a/scripts/dx-walkthrough/briefs/04-iphone-design-to-app.md
+++ b/scripts/dx-walkthrough/briefs/04-iphone-design-to-app.md
@@ -72,7 +72,8 @@ Create this at the start of your run. **Do not commit it.** The agent reads it f
 
 DEVICE_NAME: <e.g. "Rory's iPhone">
 DEVICE_UDID: <from `xcrun devicectl list devices`>
-TEAM_ID: <10-char team ID from Xcode > Settings > Accounts, or "PERSONAL" for free-tier>
+TEAM_ID: <10-char provisioning team ID — NOT the cert team ID from `security find-identity`. Get it with:
+         defaults read com.apple.dt.Xcode IDEProvisioningTeamByIdentifier | grep -o '"[A-Z0-9]\{10\}"' | head -1>
 BUNDLE_ID: <e.g. com.example.localimage — must be unique to your team>
 HAS_LIBIMOBILEDEVICE: <true|false>
 ```
@@ -112,9 +113,10 @@ After install, launch via:
 ```bash
 xcrun devicectl device process launch \
   --device "$DEVICE_UDID" \
-  --start-stopped \
   <bundle-id>
 ```
+
+If the launch fails with "has an invalid code signature ... has not been explicitly trusted by the user", complete the cert trust dance on-device: **Settings > General > VPN & Device Management > [Apple Development: your@email.com] > Trust**. Then re-run the launch command. (`--start-stopped` is for debugger attachment only — it does not affect trust resolution.)
 
 If `xcodebuild install` fails on signing, fall back to opening the project in Xcode and hitting Run — log every signing-related friction step.
 
@@ -131,12 +133,9 @@ If `xcodebuild install` fails on signing, fall back to opening the project in Xc
 
 ## Screenshot capture
 
-If `HAS_LIBIMOBILEDEVICE` is true:
-```bash
-idevicescreenshot -u "$DEVICE_UDID" screenshots/<state>.png
-```
+`idevicescreenshot` (libimobiledevice) is **broken on Xcode 16+** — the `screenshotr` service was deprecated and `xcrun devicectl` has no screenshot subcommand.
 
-Otherwise the developer captures via the device (side button + volume up) and AirDrops to the run directory. Note in the friction log how awkward this was — that's the kind of papercut the periodic run is designed to surface.
+Capture screenshots manually: **side button + volume up** on the device, then AirDrop to the run directory. Set `HAS_LIBIMOBILEDEVICE: false` in RUN-CONFIG.md regardless of whether the tool is installed.
 
 ## Deliverables
 

--- a/scripts/dx-walkthrough/runs/2026-06-07_v0.44.0_iter1/04-iphone-design-to-app/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-06-07_v0.44.0_iter1/04-iphone-design-to-app/SUMMARY.md
@@ -1,0 +1,149 @@
+# LocalImage — Phase 4 (iPhone Deploy) — iteration 1
+
+**Date**: 2026-06-07
+**MK version**: 0.44.0
+**Agent model**: Sonnet 4.6 (single run — physical device constraint; 3-run parallelism not applicable)
+**App outcome**: **build + install + cert trust succeeded; model load BLOCKED — `MLXDiffusionBackend.loadModel()` OOM on FP32 unet (9.6 GB, 4–5 GB usable RAM). No viable iPhone model path in MK today (see #1691).**
+
+## Why a single run
+
+Brief 4 deploys to one physical iPhone. Running three parallel agents against the same device would produce signing conflicts and Metal/microphone races. Future runs of this brief should also be single-agent.
+
+## Run summary
+
+| Step | Status | Notes |
+|---|---|---|
+| Package resolution | PASS | Clean first attempt, no manual intervention |
+| Swift compilation | PASS | One `@Sendable` fix on a download progress closure |
+| Code signing | PASS (after fix) | Team ID mismatch in RUN-CONFIG (see F-01) cost ~10 min |
+| `xcodebuild install` | PASS | `** INSTALL SUCCEEDED **` |
+| First launch on device | PASS | Cert trust dance completed (Settings > General > VPN & Device Management > Trust) |
+| Model download | BLOCKED | FP32 unet 9.6 GB — OOM during URLSession temp write; foreground URLSession also stops on screen lock (#1692) |
+| Model load | BLOCKED | `MLXDiffusionBackend.loadModel()` OOM — 9.6 GB FP32 unet, 4–5 GB usable RAM (#1691) |
+| Background download | NOT TESTED | Foreground URLSession — would pause on backgrounding (#1692) |
+| Voice on real mic | NOT TESTED | |
+| Image generation on-device | NOT TESTED | |
+| Save to Photos | NOT TESTED | |
+| History persistence | NOT TESTED | |
+| Screenshots | NOT CAPTURED | `idevicescreenshot` broken on Xcode 26 |
+
+**Phase 3 comparison signal:** The Swift API surface (MLXDiffusionBackend, VoiceConversationController) translated identically from macOS to iOS. All friction was in the iOS deployment layer or in doc gaps that were already present in phase 3.
+
+---
+
+## Finding buckets
+
+### Both phases — MK doc gaps
+
+These surfaced in phase 4 but are present in any MK consumer trying image gen; phase 4 just amplified them.
+
+#### F-03 · P1 · DOC-MISSING — `MLXDiffusionBackend` has no standalone quickstart example
+
+`QUICKSTART-IMAGE-GEN.md` demonstrates only `FluxDiffusionBackend` end-to-end. `MLXDiffusionBackend` (SDXL-Turbo) is the right choice for iPhone and has no walkthrough. The doc header says "Apple Silicon Mac" which a developer reads as "iOS not supported." Both backends' `register*` methods are listed in §3 but their module location (`ManifoldMLX`) is not stated — importing `ManifoldInference` only gets the protocol.
+
+**Fix:** Add a `MLXDiffusionBackend` (SDXL-Turbo) end-to-end example to QUICKSTART-IMAGE-GEN.md marked as the recommended iPhone path.
+
+#### F-04 · P1 · DOC-MISSING — Platform note misleadingly implies image gen is Mac-only
+
+The QUICKSTART-IMAGE-GEN.md opening note reads "Apple Silicon Mac (FLUX.1 Schnell needs ~7 GB of unified memory headroom)." This is accurate for Flux but creates a false impression that image gen as a whole is macOS-only. `MLXDiffusionBackend` runs on iOS 18+.
+
+**Fix:** Split the platform note per backend: "FluxDiffusionBackend: macOS 15+ only (~7 GB RAM). MLXDiffusionBackend: iOS 18+ / macOS 15+."
+
+#### F-06 · P2 · DOC-MISSING — `@Sendable` requirement for progress callbacks not mentioned
+
+The Swift 6 `@Sendable` constraint on closures crossing actor boundaries (e.g. a download progress handler passed into `@MainActor` `AppState`) isn't called out in QUICKSTART-IMAGE-GEN.md or QUICKSTART-VOICE.md. Phase 4 surfaces it more often because of the download progress + actor-isolated state machine combination.
+
+**Fix:** Add a one-line note to both quickstarts: "When passing progress callbacks from non-isolated code into a `@MainActor` observable, annotate the closure `@Sendable`."
+
+---
+
+### Phase 4 only — iOS deployment friction
+
+These are iOS ecosystem friction, not MK API issues. Only some have MK-actionable fixes.
+
+#### F-01 · P1 · IOS-DEPLOYMENT — Team ID discovery: cert ID ≠ Xcode personal team ID
+
+`security find-identity -v -p codesigning` returns the development certificate's team ID (`RDR4DZMS9Y`); this is **not** the same as the Xcode Personal Team ID that has provisioning authority (`YHX2HHZ52Y`). Using the cert's ID produces "No Account for Team / No profiles found." The brief says "10-char team ID from Xcode > Settings > Accounts" but a developer reaching for `security find-identity` (the natural shell path) will get the wrong value.
+
+**Note:** This was a brief instrumentation bug in this run — the RUN-CONFIG.md was pre-filled with the cert team ID. The correct extraction command is:
+```bash
+defaults read com.apple.dt.Xcode IDEProvisioningTeamByIdentifier | grep -o '"[A-Z0-9]\{10\}"' | head -1
+```
+
+**Fix:** Update the brief to add this command and explicitly warn that the cert team ID ≠ the Xcode provisioning team ID.
+
+#### F-02 · P1 · IOS-DEPLOYMENT — Cert trust dance navigation path missing; error message is opaque
+
+After install, `xcrun devicectl device process launch` fails with "has an invalid code signature ... or its profile has not been explicitly trusted by the user." The brief mentions the trust dance but not the exact path (`Settings > General > VPN & Device Management > [Apple Development: you@email.com] > Trust`). Multi-minute confusion spiral for a first-timer.
+
+**Fix:** Add the exact navigation path and note that the Xcode alternative (Product > Run) shows a trust prompt inline.
+
+#### F-05 · P2 · IOS-DEPLOYMENT — `idevicescreenshot` broken on Xcode 26
+
+`idevicescreenshot` fails: "Could not start screenshotr service: Invalid service / Remember that you have to mount the Developer disk image." The `screenshotr` service was deprecated in Xcode 17+. `xcrun devicectl` has no screenshot subcommand. The only working path is: device side button + volume up, AirDrop to Mac.
+
+**Fix:** Update the brief's screenshot section — remove `idevicescreenshot` guidance for Xcode 16+; document the manual capture path.
+
+#### F-07 · P2 · IOS-DEPLOYMENT — `--start-stopped` in the brief's launch command is confusing post-cert-trust
+
+The brief gives `xcrun devicectl device process launch --start-stopped` as the launch command. The flag is for debugger attachment, not for cert issues. A developer hitting the trust error and retrying with `--start-stopped` doesn't see any improvement — the flag is orthogonal to trust.
+
+**Fix:** Remove `--start-stopped` from the default launch command in the brief; add a note that `--start-stopped` is for debugger attachment only.
+
+#### F-08 · P2 · DOC-MISSING — `HuggingFaceDownloadService` background download behavior undocumented
+
+`HuggingFaceDownloadService` uses foreground `URLSession` — a 1.4 GB model download will be paused by iOS when the app backgrounds. The brief's acceptance criteria include "survives at least one app backgrounding," but the current MK API doesn't provide a resumable background URLSession path. It's also unclear whether `BGTaskSchedulerPermittedIdentifiers` is needed in Info.plist.
+
+**MK gap (more than iOS friction):** For a download of this size on cellular, foreground-only is a meaningful gap. This is the one phase 4 finding with a potential MK API fix.
+
+**Fix (doc):** State in QUICKSTART-IMAGE-GEN.md that `HuggingFaceDownloadService` uses foreground URLSession and does not survive backgrounding; recommend keeping the app in foreground during download.
+
+**Fix (API, longer term):** Add a background URLSession transfer path to `HuggingFaceDownloadService`.
+
+---
+
+## Concordance map
+
+| Finding | Bucket | Severity | Actionable fix |
+|---|---|---|---|
+| F-03 MLXDiffusionBackend no quickstart | Both phases | P1 | QUICKSTART-IMAGE-GEN.md iPhone example |
+| F-04 "Mac only" platform note misleads | Both phases | P1 | Split platform note per backend |
+| F-06 `@Sendable` callbacks undocumented | Both phases | P2 | One-line note in quickstarts |
+| F-01 Team ID: cert ≠ provisioning team | Phase 4 only | P1 | Brief + extraction command fix |
+| F-02 Cert trust dance path missing | Phase 4 only | P1 | Add exact navigation path to brief |
+| F-05 `idevicescreenshot` broken | Phase 4 only | P2 | Update brief screenshot section |
+| F-07 `--start-stopped` misleading | Phase 4 only | P2 | Remove from default launch command |
+| F-08 Background download — foreground URLSession stops on screen lock | Phase 4 only | P1 | Background URLSession path (#1692) |
+| F-09 Progress fires per-file, not per-chunk | Both phases | P1 | `HuggingFaceDownloadService` byte-level progress (#1692) |
+| F-10 No viable iPhone model — FP32 OOM; diffusionkit layout unsupported | Phase 4 only | **P0** | Diffusionkit support + iPhone model catalog entry (#1691) |
+
+## Why brief 4 cannot pass today
+
+iPhone image gen has no working end-to-end path in MK:
+
+- Bundled downloader only supports diffusers layout → only model available is `stabilityai/sdxl-turbo` FP32 (9.6 GB unet)
+- iPhone 16 Pro Max has 4–5 GB usable RAM for inference — model load fails with OOM (confirmed by pushing model directly via USB)
+- iPhone-appropriate models (FLUX.1 Schnell 4-bit, ~1–2 GB) use diffusionkit layout → bundled downloader explicitly rejects them
+
+This is not a configuration problem. Brief 4 cannot produce a passing run until MK adds diffusionkit layout support + a curated iPhone model entry. Tracked in #1691.
+
+---
+
+## What this run validated
+
+1. **MK's public Swift API translates cleanly to iPhone.** One Swift 6 fix (`@Sendable` closure), zero API friction, zero compile errors from the MK surface. The same patterns from macOS phase 3 work on iOS.
+2. **The deployment barrier is iOS ecosystem friction, not MK.** Provisioning, cert trust, broken tooling — these are the dominant cost for a first-time iOS deployer. A developer with prior iOS experience would skip F-01/F-02 entirely.
+3. **Background download is a real gap for iPhone.** A multi-GB model download that pauses when the user locks their phone is a blocking UX problem. `HuggingFaceDownloadService` uses foreground URLSession and doesn't solve this. Tracked in #1692.
+4. **iPhone image gen has no working end-to-end path.** The "Apple Silicon Mac" framing in `QUICKSTART-IMAGE-GEN.md` turns away iOS developers, and the one supported model (FP32 SDXL-Turbo, 13 GB) can't load on iPhone at all. iPhone-appropriate models use an unsupported layout. Tracked in #1691, #1693.
+
+## Recommended next steps
+
+**Gating (brief 4 cannot re-run without these):**
+- #1691 — diffusionkit layout support + iPhone model catalog entry (WWDC-gated; wait for Core AI signal June 8)
+- Brief 04 instrumentation fixes (no issue): team ID extraction command, cert trust nav path, `idevicescreenshot` deprecation, `--start-stopped` clarification
+
+**Follow-on once #1691 lands:**
+- #1692 — `HuggingFaceDownloadService` background URLSession + per-chunk progress
+
+**Independent doc fix (can ship now):**
+- #1693 — `QUICKSTART-IMAGE-GEN.md` iPhone framing: split Mac/iPhone platform note, add `MLXDiffusionBackend` Mac example, storage/RAM callouts


### PR DESCRIPTION
## What

Three docs forming one coherent unit — a rubric, a first run against it, and the procedure to repeat it:

- **`docs/TESTING-CI-PRINCIPLES.md`** — a first-principles testing/CI framework (16 principles, each `rule + driver + expiry condition`), derived from research and adversarially stress-tested.
- **`docs/QA-EVALUATION-2026-06.md`** — an evidence-first evaluation of architecture, QA, DX, and CI economics. Scorecard across 24 principle-checks, six cross-cutting themes, severity-ranked P0/P1/P2 action list. Every finding anchored to `file:line`.
- **`docs/QA-EVALUATION-PROCESS.md`** — the repeatable audit procedure (the instrument, the worker protocol, how to re-run, cadence guidance).

## Headline findings

The deductive + adversarial core is strong (owned seams, exhaustive-switch funnel, audit/sabotage discipline, real fuzz harness, regression-encoding habit). The systemic gaps:

- **Self-instrumentation (P0):** no mutation score, no flake-rate / time-to-green / re-run-tax telemetry. The 2.1× re-run tax is anecdotal, not emitted.
- **API contract gate is narrow (P0):** live for 3 of ~24 targets; the umbrella surface consumers import is unprotected.
- **Doctrine lags implementation (P1):** `CLAUDE.md` caching/batching narrative is stale; a drift cluster of broken doc links + a self-disarming snippet-gate path filter.

Action tracking: see the companion tracking issue.

## Notes

- Docs-only change; no source or CI behavior touched.
- Findings are single-pass evidence-cited; cross-dimension reconciliations (e.g. the API-breakage gate) were adversarially confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)