### PR TITLE
feat(fuzz): add --request-timeout to bound cloud fuzz request hangs

### DIFF
--- a/Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift
+++ b/Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift
@@ -24,21 +24,37 @@ public struct OpenAIFuzzFactory: FuzzBackendFactory {
     public let apiKey: String
     public let modelName: String
 
+    /// Per-request HTTP idle timeout (seconds) applied to every generation
+    /// request via ``SSECloudBackend/requestIdleTimeout``. Bounds how long a
+    /// hung iteration waits before abandoning, overriding the 300s session
+    /// default from `URLSessionProvider` for the fuzz path only. Slow/throttled
+    /// free OpenRouter models otherwise hang the full 300s per request even
+    /// though the detectors already flag anything over 60s, so a tighter bound
+    /// loses no signal while protecting throughput.
+    public let requestTimeout: TimeInterval
+
     /// Cloud generation is non-deterministic — providers do not honour a seed
     /// reproducibly across requests, and `:free` slugs route to shifting
     /// backends. `Replayer` short-circuits with `.nonDeterministicBackend`
     /// when this is `false` rather than run a guaranteed-noisy replay.
     public var supportsDeterministicReplay: Bool { false }
 
-    public init(baseURL: URL, apiKey: String, modelName: String) {
+    public init(baseURL: URL, apiKey: String, modelName: String, requestTimeout: TimeInterval) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.modelName = modelName
+        self.requestTimeout = requestTimeout
     }
 
     public func makeHandle() async throws -> FuzzRunner.BackendHandle {
         let backend = OpenAIBackend()
         backend.configure(baseURL: baseURL, apiKey: apiKey, modelName: modelName)
+        // Bound the per-request HTTP idle window for the fuzz path. The shared
+        // session default (`URLSessionProvider`, 300s) is production-tuned for
+        // long generations; here a hung iteration should abandon promptly since
+        // the detectors already flag >60s. This is the per-iteration time bound —
+        // there is no separate runner deadline; the transport timeout is it.
+        backend.requestIdleTimeout = requestTimeout
         // Cloud `loadModel` is a no-op that only validates the base URL and
         // flips `isModelLoaded` — no network round-trip happens here, so the
         // factory stays cheap and the first request fires only on `generate`.

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -48,6 +48,13 @@ struct FuzzChatCLI {
         // explicit opt-out.
         var baseURLString: String?
         var apiKeyArg: String?
+        // Per-request HTTP idle timeout (seconds) for the cloud (`--backend
+        // openai`) path only. Default 90: slow/throttled free OpenRouter models
+        // otherwise hang the full 300s session default per request, and the
+        // detectors already flag anything over 60s — so 90s loses no signal
+        // while protecting throughput. Ignored for local backends.
+        var requestTimeout: TimeInterval = 90
+        var requestTimeoutProvided = false
 
         var i = argv.startIndex
         while i < argv.endIndex {
@@ -95,6 +102,13 @@ struct FuzzChatCLI {
                 i = argv.index(after: i)
                 guard i < argv.endIndex else { fail("--api-key requires a value") }
                 apiKeyArg = argv[i]
+            case "--request-timeout":
+                i = argv.index(after: i)
+                guard i < argv.endIndex, let seconds = Double(argv[i]), seconds > 0 else {
+                    fail("--request-timeout requires a positive number of seconds")
+                }
+                requestTimeout = seconds
+                requestTimeoutProvided = true
             case "--detector":
                 i = argv.index(after: i)
                 guard i < argv.endIndex else { fail("--detector requires a value") }
@@ -142,6 +156,12 @@ struct FuzzChatCLI {
             fail("MLX cannot run via `swift run` (needs Xcode-compiled metallib). Use scripts/fuzz.sh or xcodebuild.")
         }
 
+        // `--request-timeout` only bounds the cloud HTTP transport; local
+        // backends generate in-process with no per-request socket timeout.
+        if requestTimeoutProvided && backend != .openai {
+            FileHandle.standardError.write(Data("fuzz-chat: note — --request-timeout only applies to --backend openai; ignoring for \(backend.rawValue).\n".utf8))
+        }
+
         // Default termination if neither flag passed: 5 minutes.
         if minutes == nil && iterations == nil && replayHash == nil && shrinkHash == nil { minutes = 5 }
 
@@ -170,7 +190,8 @@ struct FuzzChatCLI {
                         corpusSubset: corpusSubset,
                         tools: tools,
                         rotateEvery: rotateEvery,
-                        outputDir: outputDir
+                        outputDir: outputDir,
+                        requestTimeout: requestTimeout
                     ),
                     slices: slices
                 )
@@ -221,7 +242,8 @@ struct FuzzChatCLI {
             factory = makeOpenAIFactory(
                 baseURLString: baseURLString,
                 apiKeyArg: apiKeyArg,
-                modelHint: modelHint
+                modelHint: modelHint,
+                requestTimeout: requestTimeout
             )
             #else
             fail("openai backend requires the Fuzz and CloudSaaS build traits. Run via: swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat --backend openai ... (or scripts/fuzz.sh --backend openai)")
@@ -306,6 +328,7 @@ struct FuzzChatCLI {
         var tools: Bool
         var rotateEvery: Int
         var outputDir: URL
+        var requestTimeout: TimeInterval
     }
 
     struct WorkerProcess {
@@ -425,6 +448,12 @@ struct FuzzChatCLI {
         // Forward the rotation block size so each worker's RotatingFuzzFactory
         // keeps the same amortisation behaviour as the parent invocation.
         args += ["--rotate-every", "\(options.rotateEvery)"]
+        // Forward the cloud per-request timeout so each openai worker inherits
+        // the same bound. Only for the openai backend — local backends ignore it
+        // (and would otherwise log a spurious "ignoring" note per worker).
+        if options.backend == .openai {
+            args += ["--request-timeout", "\(options.requestTimeout)"]
+        }
         return args
     }
 
@@ -555,6 +584,7 @@ struct FuzzChatCLI {
         baseURLString: String?,
         apiKeyArg: String?,
         modelHint: String?,
+        requestTimeout: TimeInterval,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> OpenAIFuzzFactory {
         guard let baseURLString, !baseURLString.isEmpty else {
@@ -573,7 +603,7 @@ struct FuzzChatCLI {
               !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             fail("--backend openai requires --model <slug> (e.g. --model deepseek/deepseek-r1:free).")
         }
-        return OpenAIFuzzFactory(baseURL: url, apiKey: apiKey, modelName: model)
+        return OpenAIFuzzFactory(baseURL: url, apiKey: apiKey, modelName: model, requestTimeout: requestTimeout)
     }
     #endif
 
@@ -621,6 +651,11 @@ struct FuzzChatCLI {
             "                      base = https://openrouter.ai/api",
             "  --api-key <key>     openai backend: API key (discouraged — leaks into ps/history).",
             "                      Prefer the OPENROUTER_API_KEY (or OPENAI_API_KEY) env var.",
+            "  --request-timeout N openai backend: per-request HTTP idle timeout in seconds",
+            "                      (default 90). Bounds how long a hung iteration waits before",
+            "                      abandoning. Slow/free OpenRouter models otherwise hang the",
+            "                      full 300s session default per request; detectors already",
+            "                      flag >60s, so 90s loses no signal. Ignored for local backends.",
             "  --detector ids      comma-separated detector ids to run",
             "  --single            shorthand for --iterations 1",
             "  --quiet             suppress live output (still prints findings)",

--- a/Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift
+++ b/Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift
@@ -3,6 +3,7 @@
 import XCTest
 import ManifoldFuzz
 import ManifoldInference
+import ManifoldBackends
 @testable import ManifoldFuzzBackends
 
 /// Unit tests for ``OpenAIFuzzFactory`` — the OpenAI-Chat-Completions-compatible
@@ -15,13 +16,17 @@ import ManifoldInference
 /// no `MockURLProtocol` stubs.
 final class OpenAIFuzzFactoryTests: XCTestCase {
 
-    private func makeFactory(model: String = "gpt-4o-mini") -> OpenAIFuzzFactory {
+    private func makeFactory(
+        model: String = "gpt-4o-mini",
+        requestTimeout: TimeInterval = 90
+    ) -> OpenAIFuzzFactory {
         OpenAIFuzzFactory(
             // No /v1 suffix — OpenAIBackend.buildRequest appends it. (No request
             // is built here regardless; this documents the contract.)
             baseURL: URL(string: "https://openrouter.ai/api")!,
             apiKey: "sk-test-never-sent-no-network",
-            modelName: model
+            modelName: model,
+            requestTimeout: requestTimeout
         )
     }
 
@@ -51,6 +56,23 @@ final class OpenAIFuzzFactoryTests: XCTestCase {
                        "modelURL must namespace the slug under the openai: scheme.")
         XCTAssertNotNil(handle.templateMarkers,
                         "Factory always sets a marker snapshot (manifest markers or the Qwen3 fallback).")
+    }
+
+    /// The factory's `requestTimeout` must propagate to the backend's per-request
+    /// HTTP idle override (`SSECloudBackend.requestIdleTimeout`). Without this the
+    /// fuzz path inherits the 300s session default and a hung free-model iteration
+    /// stalls ~300s before abandoning — even though the detectors flag >60s.
+    func test_makeHandle_propagatesRequestTimeoutToBackend() async throws {
+        let handle = try await makeFactory(requestTimeout: 42).makeHandle()
+
+        let backend = try XCTUnwrap(
+            handle.backend as? OpenAIBackend,
+            "openai fuzz handle must wrap an OpenAIBackend so the timeout override is observable."
+        )
+        XCTAssertEqual(
+            backend.requestIdleTimeout, 42,
+            "Factory must apply requestTimeout as the backend's per-request idle override."
+        )
     }
 }
 #endif

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -39,6 +39,10 @@ for arg in "$@"; do
             echo "  Adds the CloudSaaS trait automatically. Caveats: replay/shrink unavailable"
             echo "  (non-deterministic); free models are rate-limited (429) and ':free' slugs may"
             echo "  404 on data-policy gating; --base-url must omit /v1 (backend appends it)."
+            echo "  --request-timeout N   per-request HTTP idle timeout in seconds (default 90)."
+            echo "                        Slow/free models otherwise hang the 300s session default"
+            echo "                        per request; detectors flag >60s, so 90s loses no signal"
+            echo "                        while protecting throughput. openai path only."
             echo ""
             echo "Forwarding to: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h"
             echo "─────────────────────────────────────────────────────────────"
@@ -128,6 +132,10 @@ if [[ $CLOUD_BACKEND -eq 1 ]]; then
     echo "      can 404 on data-policy gating. Transient HTTP errors are recorded as"
     echo "      failed runs, NOT fuzz findings, so a throttled campaign stays honest."
     echo "    • --base-url must omit the /v1 suffix (OpenRouter base = https://openrouter.ai/api)."
+    echo "    • Per-request idle timeout defaults to 90s (--request-timeout N to override)."
+    echo "      Slow/free models otherwise hang the full 300s session default per request;"
+    echo "      detectors already flag >60s, so 90s captures the slow-but-real cases without"
+    echo "      destroying throughput."
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 else
     LLAMA_HIT="miss"
@@ -189,6 +197,23 @@ done
 
 if [[ $HAS_BUDGET -eq 0 ]]; then
     FORWARDED_ARGS=("--minutes" "5" "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}")
+fi
+
+# Cloud path: make the per-request idle bound explicit in the echoed command so
+# the throughput protection is visible. fuzz-chat already defaults to 90s; we
+# only inject when the caller didn't pass --request-timeout so an explicit value
+# always wins. Slow/free OpenRouter models otherwise hang the 300s session
+# default per request, and the detectors already flag anything over 60s.
+if [[ $CLOUD_BACKEND -eq 1 ]]; then
+    HAS_REQUEST_TIMEOUT=0
+    for arg in "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}"; do
+        case "$arg" in
+            --request-timeout|--request-timeout=*) HAS_REQUEST_TIMEOUT=1 ;;
+        esac
+    done
+    if [[ $HAS_REQUEST_TIMEOUT -eq 0 ]]; then
+        FORWARDED_ARGS=("--request-timeout" "90" "${FORWARDED_ARGS[@]+"${FORWARDED_ARGS[@]}"}")
+    fi
 fi
 
 build_mlx_env() {


### PR DESCRIPTION
## Problem

PR #1690 added `--backend openai` to `fuzz-chat` for fuzzing OpenAI-compatible cloud endpoints (OpenRouter). In live testing, slow/throttled free models hung up to **~300s per request** before timing out, because the shared cloud transport idle timeout (`URLSessionProvider`, `timeoutIntervalForRequest = 300`) governs the fuzz path. The fuzz detectors already flag anything over 60s (race-stall first-token > 60_000ms; timeout total > 60_000ms), so waiting 300s adds **no signal** — it just destroys throughput.

## Fix

Add a `--request-timeout <seconds>` CLI flag to `fuzz-chat` that bounds the per-request HTTP idle timeout for the cloud (`--backend openai`) path **only**. Default **90s**. A hung iteration now abandons at 90s instead of 300s while still capturing the slow-but-real cases the detectors flag at 60s.

Mechanism: the value is threaded into `OpenAIFuzzFactory` (new `requestTimeout: TimeInterval` init param) and applied to the backend's existing per-request override `SSECloudBackend.requestIdleTimeout` (already `public`, already wired into `URLRequest.timeoutInterval` in `makeGenerationTaskContext`). **No access level was widened** and the production session defaults (300s/600s in `URLSessionProvider`) are **untouched** — they remain for production chat where long generations legitimately need minutes.

Behavior:
- Rejected when `<= 0` or non-numeric (`fuzz-chat: --request-timeout requires a positive number of seconds`, exit 2).
- Ignored with a one-line stderr note for local backends (matches how `--base-url`/`--api-key` are non-fatal there).
- Forwarded to parallel `openai` workers (openai path only, to avoid spurious notes in local-worker logs).
- Documented in `--help` and `scripts/fuzz.sh` (help + cloud caveats), with the 300s-hang rationale. `scripts/fuzz.sh` injects an explicit `--request-timeout 90` on the cloud path when the caller omits it, so the bound is visible in the echoed command (an explicit caller value always wins).

## Invocation

```
swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat \
  --backend openai --base-url https://openrouter.ai/api \
  --model <slug> --request-timeout 90 --minutes 5
```

The detectors already flag >60s, so a 90s bound loses no signal.

## Test

`Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift` — added `test_makeHandle_propagatesRequestTimeoutToBackend` (network-free): constructs `OpenAIFuzzFactory(requestTimeout: 42, ...)`, runs `makeHandle()`, and asserts the wrapped `OpenAIBackend.requestIdleTimeout == 42`. Sabotage-verified (broke propagation → test failed) then reverted.

## Gate

- `swift build --traits Fuzz,CloudSaaS,MLX,Llama,Ollama` — builds fuzz-chat (green).
- `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — trait-combo sweep (green).
- `scripts/test.sh --profile local` — **PASSED**, zero failures.
- CLI behavior manually verified: `--help` lists the flag; `--request-timeout 0`/`abc` rejected; local-backend note prints.

## Scope notes

Per-iteration runner deadlines and detector thresholds were left untouched (a one-line comment near the factory notes the transport timeout is the per-iteration bound). `Package.resolved` not staged. No live fuzz campaign run (no API key available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)