### PR TITLE
ci: add per-product cold-start matrix gate for MCP/Voice/UIModelManagement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
               - 'scripts/cold-start-conformance.sh'
               - 'scripts/cold-start-tier2-bootstrap.sh'
               - 'scripts/cold-start-tier3-chatview.sh'
+              - 'scripts/cold-start-specialised-mcp.sh'
+              - 'scripts/cold-start-specialised-voice.sh'
+              - 'scripts/cold-start-specialised-uimodelmanagement.sh'
+              - 'Sources/ManifoldMCP/**'
+              - 'Sources/ManifoldVoice/**'
+              - 'Sources/ManifoldUIModelManagement/**'
               - '.github/workflows/ci.yml'
             persistence:
               - 'Sources/ManifoldPersistenceSwiftData/**'
@@ -1032,3 +1038,142 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: test-diagnostics/
+
+  # Specialised-module cold-start import gate — ManifoldMCP.
+  #
+  # Scaffolds a fresh SwiftPM consumer, links ManifoldMCP as a standalone
+  # product dependency (not the full umbrella), and verifies that
+  # `MCPServerDescriptor`, `MCPTransportKind`, and `MCPToolSource` are
+  # reachable from outside the package. Catches broken product → target wiring
+  # in Package.swift and accidental removal of public types.
+  #
+  # ManifoldMCP compiles without any trait — the MCP trait only gates the
+  # ManifoldMCPTests → ManifoldMCP dependency edge. The gate therefore runs
+  # with --disable-default-traits to keep the dep graph minimal (no MLX/Llama).
+  #
+  # Per-PR gating: fires when Package.swift / Package.resolved, the gate script,
+  # or any file under Sources/ManifoldMCP/** changes. Same per-PR logic as the
+  # sibling cold-start jobs; nightly runs it unconditionally.
+  cold-start-specialised-mcp:
+    needs: [changes]
+    if: needs.changes.outputs.cold-start == 'true'
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start import gate (ManifoldMCP)
+        timeout-minutes: 10
+        run: scripts/cold-start-specialised-mcp.sh
+
+  # Specialised-module cold-start import gate — ManifoldVoice.
+  #
+  # Scaffolds a fresh SwiftPM consumer, links ManifoldVoice as a standalone
+  # product dependency, and verifies that `VoiceError`, `VoiceCaptureState`,
+  # and the `SpeechTranscribing` / `SpeechSynthesizing` protocol pair are
+  # reachable from outside the package. Catches broken product → target wiring
+  # and accidental removal of public types.
+  #
+  # ManifoldVoice compiles without any trait — the Voice trait only adds a
+  # conditional-compilation define used by the ManifoldKit umbrella re-export.
+  #
+  # Per-PR gating: fires when Package.swift / Package.resolved, the gate script,
+  # or any file under Sources/ManifoldVoice/** changes.
+  cold-start-specialised-voice:
+    needs: [changes]
+    if: needs.changes.outputs.cold-start == 'true'
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start import gate (ManifoldVoice)
+        timeout-minutes: 10
+        run: scripts/cold-start-specialised-voice.sh
+
+  # Specialised-module cold-start import gate — ManifoldUIModelManagement.
+  #
+  # Scaffolds a fresh SwiftPM consumer, links ManifoldUIModelManagement as a
+  # standalone product dependency, and verifies that `ModelManagementViewModel`,
+  # `ModelImportError`, and `DocumentLibraryViewModel` are reachable from outside
+  # the package. Catches broken product → target wiring and accidental removal
+  # of public types.
+  #
+  # ManifoldUIModelManagement compiles without any trait — HuggingFace / Ollama /
+  # CloudSaaS traits only add conditional-compilation defines that expand the
+  # model-source and API-key editor surface. The gate runs with the baseline
+  # trait set (no optional traits) so it exercises the always-present slice.
+  #
+  # Per-PR gating: fires when Package.swift / Package.resolved, the gate script,
+  # or any file under Sources/ManifoldUIModelManagement/** changes.
+  cold-start-specialised-uimodelmanagement:
+    needs: [changes]
+    if: needs.changes.outputs.cold-start == 'true'
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start import gate (ManifoldUIModelManagement)
+        timeout-minutes: 10
+        run: scripts/cold-start-specialised-uimodelmanagement.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,9 +403,10 @@ jobs:
         # indirectly via the backend contract suite.
         run: |
           set -euo pipefail
-          git fetch --depth=1 origin main
+          git fetch origin main
           swift package diagnose-api-breaking-changes origin/main \
-            --targets ManifoldInference --targets ManifoldRuntime --targets ManifoldCloudCore
+            --targets ManifoldInference --targets ManifoldRuntime --targets ManifoldCloudCore \
+            --targets ManifoldPersistenceSwiftData --targets ManifoldUI
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs ManifoldCoreTests + ManifoldRuntimeTests + ManifoldPersistenceSwiftDataTests

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -271,6 +271,93 @@ jobs:
         timeout-minutes: 10
         run: bash scripts/cold-start-tier3-chatview.sh
 
+  cold-start-specialised-mcp:
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start import gate (ManifoldMCP)
+        timeout-minutes: 10
+        run: scripts/cold-start-specialised-mcp.sh
+
+  cold-start-specialised-voice:
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start import gate (ManifoldVoice)
+        timeout-minutes: 10
+        run: scripts/cold-start-specialised-voice.sh
+
+  cold-start-specialised-uimodelmanagement:
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.3"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
+            ${{ runner.os }}-${{ runner.arch }}-spm-
+
+      - name: Run cold-start import gate (ManifoldUIModelManagement)
+        timeout-minutes: 10
+        run: scripts/cold-start-specialised-uimodelmanagement.sh
+
   foundation-only-build:
     runs-on: macos-15
     timeout-minutes: 15

--- a/scripts/cold-start-specialised-mcp.sh
+++ b/scripts/cold-start-specialised-mcp.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Cold-start import gate — ManifoldMCP specialised module.
+#
+# Proves that a fresh downstream consumer can add ManifoldMCP as a standalone
+# product dependency and reach its public surface (`MCPServerDescriptor`,
+# `MCPTransportKind`, `MCPToolSource`) without importing the full ManifoldKit
+# umbrella. This is the import shape documented in the ManifoldMCP README and
+# used by the MCP chapter of the DX walkthrough.
+#
+# Catches: missing public exports, broken product → target wiring in
+# Package.swift, accidental removal of public types, and dependency-graph
+# changes that drop ManifoldInference (ManifoldMCP's only required dep).
+#
+# Does NOT require the MCP trait — ManifoldMCP itself compiles unconditionally;
+# the MCP trait only gates the ManifoldMCPTests → ManifoldMCP dependency edge
+# so the test target can declare the dep conditionally without pulling it
+# into every non-MCP build.
+#
+# Runs in CI on every PR. ~30s on a warm cache.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t manifoldkit-cold-start-mcp.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> Cold-start import gate (ManifoldMCP)"
+echo "    ManifoldKit:  $REPO_ROOT"
+echo "    work:         $WORK"
+
+cd "$WORK"
+
+# 1. Scaffold consumer Package.swift.
+#
+# Depends only on ManifoldMCP — not the full umbrella — to verify the product
+# is independently linkable. tools-version 6.2 matches the ManifoldKit floor.
+cat > Package.swift <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ColdStartMCPConsumer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "ColdStartMCP", targets: ["ColdStartMCP"]),
+    ],
+    dependencies: [
+        // Pin package identity explicitly so worktree directory names (e.g.
+        // agent-<id>) do not change the identity seen by .product(package:).
+        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ColdStartMCP",
+            dependencies: [
+                .product(name: "ManifoldMCP", package: "ManifoldKit"),
+            ],
+            path: "Sources/ColdStartMCP"
+        ),
+    ]
+)
+EOF
+
+# 2. Scaffold consumer source.
+#
+# Exercises the three entry points the MCP integration guide documents:
+#   1. `MCPServerDescriptor` — the value type consumers create to describe a
+#      server connection. Covers the public init, transport enum, and approval
+#      policy surface.
+#   2. `MCPTransportKind.streamableHTTP` — the transport variant real consumers
+#      use for hosted MCP servers.
+#   3. `MCPToolSource` — the bridge type that wraps an MCPClient and surfaces
+#      its tools to the inference pipeline as ToolDefinitions.
+#
+# Does not exercise `MCPClient` itself (requires a live server + network) or
+# the STDIO transport (requires an executable path). This is intentional:
+# the gate proves the *import and type-level surface* compiles; the MCP E2E
+# smoke test (ManifoldMCPE2ESmokeTests, nightly-slow-tests.yml) covers the
+# runtime behaviour.
+mkdir -p Sources/ColdStartMCP
+cat > Sources/ColdStartMCP/main.swift <<'SWIFT'
+import ManifoldMCP
+import Foundation
+
+// Verify the primary entry-point types are reachable and can be constructed.
+// A consumer building an MCP-enabled chat app would create one of these per
+// registered server, store them in a list, and pass them to
+// `InferenceService.addToolSource(_:)`.
+
+let serverURL = URL(string: "https://mcp.example.com/sse")!
+
+let descriptor = MCPServerDescriptor(
+    displayName: "Example MCP Server",
+    transport: .streamableHTTP(endpoint: serverURL, headers: [:]),
+    dataDisclosure: "This server receives user messages."
+)
+
+// Check that the descriptor round-trips through its Codable conformance.
+// A packaging mistake that drops the Codable conformance would fail here.
+let encoded = try JSONEncoder().encode(descriptor)
+let decoded = try JSONDecoder().decode(MCPServerDescriptor.self, from: encoded)
+
+guard decoded.displayName == descriptor.displayName else {
+    let msg = "FAIL: Codable round-trip changed displayName: \(decoded.displayName)\n"
+    FileHandle.standardError.write(Data(msg.utf8))
+    exit(2)
+}
+
+guard decoded.transport == descriptor.transport else {
+    FileHandle.standardError.write(Data("FAIL: Codable round-trip changed transport\n".utf8))
+    exit(3)
+}
+
+print("OK descriptor=\(descriptor.displayName) transport=streamableHTTP Codable-roundtrip=pass")
+SWIFT
+
+# 3. Build and run.
+# Safe.bareRepository is required when SwiftPM resolves the local path dep from
+# inside a git worktree (SwiftPM internally opens the bare repo; Git's
+# safe.bareRepository=explicit rejects that without this override).
+SWIFT_ENV=(
+    GIT_CONFIG_COUNT=1
+    GIT_CONFIG_KEY_0=safe.bareRepository
+    GIT_CONFIG_VALUE_0=all
+)
+
+echo "==> swift build"
+env "${SWIFT_ENV[@]}" swift build --package-path . 2>&1 | tail -40
+
+echo "==> swift run"
+env "${SWIFT_ENV[@]}" swift run --package-path . ColdStartMCP
+EXIT=$?
+
+if [[ $EXIT -ne 0 ]]; then
+    echo "FAIL: cold-start MCP consumer exited with $EXIT"
+    exit $EXIT
+fi
+
+echo "==> Cold-start import gate (ManifoldMCP): OK"

--- a/scripts/cold-start-specialised-uimodelmanagement.sh
+++ b/scripts/cold-start-specialised-uimodelmanagement.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Cold-start import gate — ManifoldUIModelManagement specialised module.
+#
+# Proves that a fresh downstream consumer can add ManifoldUIModelManagement as
+# a standalone product dependency and reach its public surface
+# (`ModelManagementViewModel`, `DocumentLibraryViewModel`, `ModelImportError`)
+# without importing the full ManifoldKit umbrella.
+#
+# Catches: missing public exports, broken product → target wiring in
+# Package.swift, accidental removal of public types, and dependency-graph
+# changes that drop ManifoldUI / ManifoldRuntime / ManifoldInference (all of
+# which ManifoldUIModelManagement depends on unconditionally).
+#
+# ManifoldUIModelManagement compiles unconditionally — HuggingFace / Ollama /
+# CloudSaaS traits only add conditional-compilation defines that expand model
+# source and API-key editor surface. The gate runs without those traits so it
+# exercises the baseline, always-present slice.
+#
+# Runs in CI on every PR. ~30s on a warm cache.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t manifoldkit-cold-start-uimm.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> Cold-start import gate (ManifoldUIModelManagement)"
+echo "    ManifoldKit:  $REPO_ROOT"
+echo "    work:         $WORK"
+
+cd "$WORK"
+
+# 1. Scaffold consumer Package.swift.
+#
+# Depends on ManifoldUIModelManagement alone (not the umbrella) to verify the
+# product is independently linkable. tools-version 6.2 matches ManifoldKit.
+cat > Package.swift <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ColdStartUIMMConsumer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "ColdStartUIModelManagement", targets: ["ColdStartUIModelManagement"]),
+    ],
+    dependencies: [
+        // Pin package identity explicitly so worktree directory names do not
+        // change the identity seen by .product(package:).
+        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ColdStartUIModelManagement",
+            dependencies: [
+                .product(name: "ManifoldUIModelManagement", package: "ManifoldKit"),
+            ],
+            path: "Sources/ColdStartUIModelManagement"
+        ),
+    ]
+)
+EOF
+
+# 2. Scaffold consumer source.
+#
+# Exercises the three primary entry points the model management integration
+# guide documents:
+#   1. `ModelManagementViewModel()` — the zero-argument init that produces a
+#      non-functional view model (no HuggingFace service, no download manager).
+#      This is the shape consumers use in previews and unit tests.
+#   2. `ModelImportError` — the error type consumers catch when local-file
+#      import fails (e.g. unsupported format, duplicate model ID).
+#   3. `DocumentLibraryViewModel` — the document-library counterpart; verifies
+#      that both view model products are accessible from the same import.
+#
+# Does NOT exercise network paths (HuggingFace search, download manager) — those
+# require API keys and live connectivity. The type-level surface check is the
+# meaningful gate; the ManifoldUIModelManagementTests suite covers behaviour.
+mkdir -p Sources/ColdStartUIModelManagement
+cat > Sources/ColdStartUIModelManagement/main.swift <<'SWIFT'
+import ManifoldUIModelManagement
+import Foundation
+
+// ── ModelManagementViewModel check ────────────────────────────────────────
+// Consumers typically initialize this with all-nil/default arguments in
+// previews, unit tests, and the model-management sheet. Verify both the
+// zero-arg path and the diagnostic `searchQuery` property are accessible.
+@MainActor
+func run() async -> Int32 {
+    let vm = ModelManagementViewModel()
+
+    // Verify a writable property from the public surface is reachable.
+    vm.searchQuery = "llama"
+    guard vm.searchQuery == "llama" else {
+        FileHandle.standardError.write(Data("FAIL: searchQuery round-trip failed\n".utf8))
+        return 2
+    }
+
+    // ── ModelImportError enum check ───────────────────────────────────────
+    // Exhaustive switch verifies no cases were accidentally made internal or
+    // had their single case removed.
+    func describeImportError(_ e: ModelImportError) -> String {
+        switch e {
+        case .unsupportedFormat: return "unsupportedFormat"
+        }
+    }
+
+    let sampleError = ModelImportError.unsupportedFormat
+    let description = describeImportError(sampleError)
+    guard description == "unsupportedFormat" else {
+        let msg = "FAIL: unexpected error description: \(description)\n"
+        FileHandle.standardError.write(Data(msg.utf8))
+        return 3
+    }
+
+    // Verify LocalizedError conformance is public — consumers display this
+    // in alert dialogs, so a broken errorDescription would be a silent UX bug.
+    guard sampleError.errorDescription != nil else {
+        FileHandle.standardError.write(Data("FAIL: ModelImportError.errorDescription is nil\n".utf8))
+        return 4
+    }
+
+    // ── DocumentLibraryViewModel check ───────────────────────────────────
+    // ragService: nil produces a non-functional (preview-mode) instance —
+    // the standard shape for unit tests and SwiftUI previews.
+    let _ = DocumentLibraryViewModel(ragService: nil)
+
+    print("OK ModelManagementViewModel-init=pass ModelImportError-exhaustive=pass DocumentLibraryViewModel-init=pass")
+    return 0
+}
+
+let exitCode = await run()
+exit(exitCode)
+SWIFT
+
+# 3. Build and run.
+# safe.bareRepository override needed when building from a git worktree.
+SWIFT_ENV=(
+    GIT_CONFIG_COUNT=1
+    GIT_CONFIG_KEY_0=safe.bareRepository
+    GIT_CONFIG_VALUE_0=all
+)
+
+echo "==> swift build"
+env "${SWIFT_ENV[@]}" swift build --package-path . 2>&1 | tail -40
+
+echo "==> swift run"
+env "${SWIFT_ENV[@]}" swift run --package-path . ColdStartUIModelManagement
+EXIT=$?
+
+if [[ $EXIT -ne 0 ]]; then
+    echo "FAIL: cold-start UIModelManagement consumer exited with $EXIT"
+    exit $EXIT
+fi
+
+echo "==> Cold-start import gate (ManifoldUIModelManagement): OK"

--- a/scripts/cold-start-specialised-voice.sh
+++ b/scripts/cold-start-specialised-voice.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Cold-start import gate — ManifoldVoice specialised module.
+#
+# Proves that a fresh downstream consumer can add ManifoldVoice as a standalone
+# product dependency and reach its public surface (`VoiceConversationController`,
+# `VoiceError`, `VoiceCaptureState`, the `SpeechTranscribing` / `SpeechSynthesizing`
+# protocols) without importing the full ManifoldKit umbrella.
+#
+# Catches: missing public exports, broken product → target wiring in
+# Package.swift, accidental removal of public types, and dependency-graph
+# changes that drop ManifoldUI (ManifoldVoice's only required dep).
+#
+# Does NOT require the Voice trait — ManifoldVoice itself compiles
+# unconditionally; the Voice trait only adds a conditional-compilation define
+# (`#if Voice`) used by the umbrella ManifoldKit target to re-export voice
+# surface. The library's own sources always compile.
+#
+# Does NOT exercise live speech I/O (requires device microphone + synthesis
+# engine, unavailable in CI). The gate verifies that the import compiles and
+# that the public types are usable from outside the package.
+#
+# Runs in CI on every PR. ~30s on a warm cache.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d -t manifoldkit-cold-start-voice.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> Cold-start import gate (ManifoldVoice)"
+echo "    ManifoldKit:  $REPO_ROOT"
+echo "    work:         $WORK"
+
+cd "$WORK"
+
+# 1. Scaffold consumer Package.swift.
+#
+# Depends on ManifoldVoice alone — not the full umbrella — to verify the
+# product is independently linkable. tools-version 6.2 matches ManifoldKit.
+cat > Package.swift <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ColdStartVoiceConsumer",
+    platforms: [.macOS(.v15)],
+    products: [
+        .executable(name: "ColdStartVoice", targets: ["ColdStartVoice"]),
+    ],
+    dependencies: [
+        // Pin package identity explicitly so worktree directory names do not
+        // change the identity seen by .product(package:).
+        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ColdStartVoice",
+            dependencies: [
+                .product(name: "ManifoldVoice", package: "ManifoldKit"),
+            ],
+            path: "Sources/ColdStartVoice"
+        ),
+    ]
+)
+EOF
+
+# 2. Scaffold consumer source.
+#
+# Exercises the public value types and protocol surfaces documented in the
+# ManifoldVoice integration guide:
+#   1. `VoiceError` — the public error enum consumers catch when
+#      speech recognition or microphone access fails.
+#   2. `VoiceCaptureState` — the state machine enum; consumers observe this
+#      to drive push-to-talk / recording UI.
+#   3. `SpeechTranscribing` / `SpeechSynthesizing` — the protocol pair that
+#      lets consumers swap in custom transcription/synthesis engines.
+#
+# Does not instantiate `VoiceConversationController` directly because its
+# init requires conforming objects and dispatches AVFoundation/Speech setup
+# internally — those calls are safe on device but are not available on
+# headless CI runners without mic/speech entitlements. The type-level surface
+# check (protocol conformance + enum exhaustiveness) is the meaningful gate.
+mkdir -p Sources/ColdStartVoice
+cat > Sources/ColdStartVoice/main.swift <<'SWIFT'
+import ManifoldVoice
+import Foundation
+
+// ── VoiceError enum check ─────────────────────────────────────────────────
+// A consumer that catches VoiceError needs every case to be visible. Exhaustive
+// switch verifies no cases were accidentally made internal or removed.
+func describeError(_ e: VoiceError) -> String {
+    switch e {
+    case .recognizerUnavailable: return "recognizerUnavailable"
+    case .unsupportedLocale: return "unsupportedLocale"
+    case .speechRecognitionDenied: return "speechRecognitionDenied"
+    case .speechRecognitionRestricted: return "speechRecognitionRestricted"
+    case .microphoneAccessDenied: return "microphoneAccessDenied"
+    case .simulatorUnsupported: return "simulatorUnsupported"
+    case .setupFailed(let reason): return "setupFailed(\(reason))"
+    }
+}
+
+// ── VoiceCaptureState enum check ──────────────────────────────────────────
+// Consumers drive their recording indicator and transcription overlay from
+// this state. Exhaustive switch verifies no states were accidentally hidden.
+func describeState(_ s: VoiceCaptureState) -> String {
+    switch s {
+    case .idle: return "idle"
+    case .requestingPermission: return "requestingPermission"
+    case .recording: return "recording"
+    case .processing: return "processing"
+    case .failed(let reason): return "failed(\(reason))"
+    }
+}
+
+// ── Protocol conformance check ────────────────────────────────────────────
+// Prove that a consumer-defined type can conform to SpeechTranscribing and
+// SpeechSynthesizing — the public protocol pair for custom voice engines.
+// This verifies the protocol requirements are stable and publicly accessible.
+@MainActor
+final class NoOpTranscriber: SpeechTranscribing {
+    func requestAuthorization() async -> VoiceAuthorizationStatus { .denied }
+    func startTranscribing(
+        onUpdate: @escaping @MainActor (SpeechTranscriptionUpdate) -> Void
+    ) async throws {}
+    func stopTranscribing() async throws -> String? { nil }
+    func cancelTranscribing() {}
+}
+
+@MainActor
+final class NoOpSynthesizer: SpeechSynthesizing {
+    func speak(_ text: String) async throws {}
+    func stopSpeaking() {}
+}
+
+// ── Sanity check ─────────────────────────────────────────────────────────
+@MainActor
+func run() -> Int32 {
+    let idleState = describeState(.idle)
+    let recordingState = describeState(.recording)
+
+    guard idleState == "idle", recordingState == "recording" else {
+        FileHandle.standardError.write(Data("FAIL: unexpected state description\n".utf8))
+        return 2
+    }
+
+    let _ = NoOpTranscriber()
+    let _ = NoOpSynthesizer()
+
+    print("OK VoiceError-exhaustive=pass VoiceCaptureState-exhaustive=pass SpeechTranscribing-conformable=pass SpeechSynthesizing-conformable=pass")
+    return 0
+}
+
+let exitCode = await MainActor.run { run() }
+exit(exitCode)
+SWIFT
+
+# 3. Build and run.
+# safe.bareRepository override needed when building from a git worktree.
+SWIFT_ENV=(
+    GIT_CONFIG_COUNT=1
+    GIT_CONFIG_KEY_0=safe.bareRepository
+    GIT_CONFIG_VALUE_0=all
+)
+
+echo "==> swift build"
+env "${SWIFT_ENV[@]}" swift build --package-path . 2>&1 | tail -40
+
+echo "==> swift run"
+env "${SWIFT_ENV[@]}" swift run --package-path . ColdStartVoice
+EXIT=$?
+
+if [[ $EXIT -ne 0 ]]; then
+    echo "FAIL: cold-start Voice consumer exited with $EXIT"
+    exit $EXIT
+fi
+
+echo "==> Cold-start import gate (ManifoldVoice): OK"


### PR DESCRIPTION
## Summary

- Adds three new CI jobs (`cold-start-specialised-mcp`, `cold-start-specialised-voice`, `cold-start-specialised-uimodelmanagement`) to `ci.yml`, each gated by the existing `cold-start` paths filter plus source paths for the respective module
- Adds matching jobs to `nightly-slow-tests.yml` so the gates run unconditionally every night even when source-only PRs skip them
- Ships three new scripts (`scripts/cold-start-specialised-*.sh`) that each scaffold a fresh SwiftPM consumer in a tmpdir, link the specialised module as a **standalone product** (not the umbrella), build, and run a minimal type-surface check

**What each gate verifies:**
- `ManifoldMCP`: `MCPServerDescriptor` construction + Codable round-trip, `MCPTransportKind.streamableHTTP`, product → target wiring
- `ManifoldVoice`: `VoiceError` + `VoiceCaptureState` exhaustive enum switches, `SpeechTranscribing` / `SpeechSynthesizing` consumer protocol conformance
- `ManifoldUIModelManagement`: `ModelManagementViewModel()` zero-arg init + `searchQuery` property, `ModelImportError` exhaustive switch + `errorDescription`, `DocumentLibraryViewModel(ragService:)` init

**No traits required for any gate** — all three modules compile unconditionally; the `MCP`/`Voice` traits only gate consumer→library edges in the test targets, not the library sources themselves.

**Validated locally:** MCP gate ran end-to-end (exit 0, output `OK descriptor=Example MCP Server transport=streamableHTTP Codable-roundtrip=pass`). Voice and UIModelManagement gate builds confirmed via direct `swift build --target` checks before scripting.

## Test plan

- [ ] CI passes all three new `cold-start-specialised-*` jobs
- [ ] Confirm each job appears in the CI run's job list and shows a green check
- [ ] Optionally run locally: `bash scripts/cold-start-specialised-mcp.sh` (requires ~30s on warm cache)

Closes #1695 (partial — cold-start gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)