### PR TITLE
ci: gate API-break check on changed modules, move full run to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,13 @@ jobs:
       # sentinel FULL / NONE. DRY-RUN — published for a later PR to wire into the
       # test --filter; nothing consumes it to change execution yet.
       affected: ${{ steps.affected.outputs.affected }}
+      # Per-module API surface flags — consumed by the per-PR API-break gate to
+      # limit diagnose-api-breaking-changes to only the modules that changed.
+      api-inference: ${{ steps.filter.outputs.api-inference }}
+      api-runtime: ${{ steps.filter.outputs.api-runtime }}
+      api-cloudcore: ${{ steps.filter.outputs.api-cloudcore }}
+      api-persistence: ${{ steps.filter.outputs.api-persistence }}
+      api-ui: ${{ steps.filter.outputs.api-ui }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -129,6 +136,21 @@ jobs:
               - 'Sources/ManifoldFoundation/**'
               - 'scripts/check-foundation-only-bundle.sh'
               - '.github/workflows/ci.yml'
+            # Per-module API surface filters — used to gate and narrow the
+            # per-PR diagnose-api-breaking-changes check to only the targets
+            # that actually changed. Intentionally omit Package.swift /
+            # Package.resolved: a dep-graph change can't introduce an API
+            # break in the Swift source; the nightly full-run will catch it.
+            api-inference:
+              - 'Sources/ManifoldInference/**'
+            api-runtime:
+              - 'Sources/ManifoldRuntime/**'
+            api-cloudcore:
+              - 'Sources/ManifoldCloudCore/**'
+            api-persistence:
+              - 'Sources/ManifoldPersistenceSwiftData/**'
+            api-ui:
+              - 'Sources/ManifoldUI/**'
 
       # Tier 0 selective testing — DRY-RUN ONLY (issue #1588).
       #
@@ -388,35 +410,42 @@ jobs:
           }
           echo "Tier 0 affected-suites graph snapshot OK."
 
-      - name: Public API source-compatibility check
+      - name: Public API source-compatibility check (changed modules only)
         # Guards `import ManifoldKit` source-compat for downstream consumers
         # (TavernPad / localclaw): a public symbol removed by accident from the
-        # umbrella's core targets would break those builds. `diagnose-api-
-        # breaking-changes` exits non-zero on a real break, so this is a plain
-        # failing step — no env-var/baseline-file plumbing.
+        # umbrella's core targets would break those builds.
+        #
+        # Only runs when at least one of the five checked modules changed
+        # (path-gated via the `changes` job) and only checks those modules —
+        # avoiding the ~12 min compile cost on PRs that only touch tests,
+        # docs, or unrelated modules. The nightly full run (nightly-slow-tests.yml)
+        # always checks all five targets so Sources-only regressions in modules
+        # not touched by a PR are still caught within 24 h.
         #
         # `--targets` is REQUIRED: whole-package mode fails on the trait-gated
         # `llama` C module — swift-api-digester reports "missing required module
         # 'llama'" when checking out the baseline source.
         #
-        # The umbrella `ManifoldKit` target is DELIBERATELY NOT listed: it
-        # `@_exported`-re-exports `ManifoldBackends`, which transitively pulls in
-        # the llama-dependent family targets, so digesting its public interface
-        # hits the same "missing required module 'llama'" failure
-        # (`baseline for ManifoldKit contains no symbols`). Instead we name the
-        # umbrella's trait-free re-exported faces directly — `ManifoldUI` (the
-        # chat-consumer surface) and `ManifoldPersistenceSwiftData` (which owns
-        # the public `ManifoldBootstrap` entry point) — alongside the inference
-        # core. Together these cover everything `import ManifoldKit` consumers
-        # (TavernPad / localclaw) actually touch except the backend families,
-        # which are pinned indirectly via the backend contract suite. All five
-        # targets digest cleanly against the baseline (verified locally).
+        # The umbrella `ManifoldKit` target is DELIBERATELY NOT listed — see the
+        # comment above the full-run equivalent step in nightly-slow-tests.yml.
+        if: |
+          needs.changes.outputs.api-inference == 'true' ||
+          needs.changes.outputs.api-runtime == 'true' ||
+          needs.changes.outputs.api-cloudcore == 'true' ||
+          needs.changes.outputs.api-persistence == 'true' ||
+          needs.changes.outputs.api-ui == 'true'
         run: |
           set -euo pipefail
-          git fetch origin main
-          swift package diagnose-api-breaking-changes origin/main \
-            --targets ManifoldInference --targets ManifoldRuntime --targets ManifoldCloudCore \
-            --targets ManifoldPersistenceSwiftData --targets ManifoldUI
+          TARGETS=""
+          [[ "${{ needs.changes.outputs.api-inference }}" == "true" ]]   && TARGETS="$TARGETS --targets ManifoldInference"
+          [[ "${{ needs.changes.outputs.api-runtime }}" == "true" ]]     && TARGETS="$TARGETS --targets ManifoldRuntime"
+          [[ "${{ needs.changes.outputs.api-cloudcore }}" == "true" ]]   && TARGETS="$TARGETS --targets ManifoldCloudCore"
+          [[ "${{ needs.changes.outputs.api-persistence }}" == "true" ]] && TARGETS="$TARGETS --targets ManifoldPersistenceSwiftData"
+          [[ "${{ needs.changes.outputs.api-ui }}" == "true" ]]          && TARGETS="$TARGETS --targets ManifoldUI"
+          echo "Checking API surface for:${TARGETS}"
+          git fetch --depth=1 origin main
+          # shellcheck disable=SC2086
+          swift package diagnose-api-breaking-changes origin/main $TARGETS
 
       # CI smoke profile (GitHub macOS Apple Silicon runners):
       # - Runs ManifoldCoreTests + ManifoldRuntimeTests + ManifoldPersistenceSwiftDataTests

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -140,6 +140,29 @@ jobs:
             --skip-update
           scripts/check-coverage.sh
 
+      - name: Public API source-compatibility check (full — all five modules)
+        # Full unconditional check across all five trait-free public targets.
+        # The per-PR gate in ci.yml only runs on modules that changed in the PR
+        # and skips entirely on doc/test/script-only changes — this step
+        # catches any API break that slipped through, within 24 h.
+        #
+        # `--targets` is REQUIRED: whole-package mode fails on the trait-gated
+        # `llama` C module ("missing required module 'llama'").
+        #
+        # The umbrella `ManifoldKit` target is DELIBERATELY NOT listed: it
+        # `@_exported`-re-exports `ManifoldBackends`, which transitively pulls in
+        # the llama-dependent family targets, producing "baseline for ManifoldKit
+        # contains no symbols". The five targets below cover everything
+        # `import ManifoldKit` consumers touch except the backend families,
+        # which are pinned indirectly via the backend contract suite.
+        id: api-check
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin main
+          swift package diagnose-api-breaking-changes origin/main \
+            --targets ManifoldInference --targets ManifoldRuntime --targets ManifoldCloudCore \
+            --targets ManifoldPersistenceSwiftData --targets ManifoldUI
+
       - name: Stage test diagnostics
         # Mirrors ci.yml: each step writes to a unique workspace log path so
         # diagnostics from earlier failures are preserved.
@@ -152,6 +175,7 @@ jobs:
           MCP_E2E_SMOKE_FAILED: ${{ steps.test-mcp-e2e-smoke.outcome == 'failure' }}
           OPERATIONAL_FAILED: ${{ steps.test-operational.outcome == 'failure' }}
           COVERAGE_THRESHOLDS_FAILED: ${{ steps.test-coverage-thresholds.outcome == 'failure' }}
+          API_CHECK_FAILED: ${{ steps.api-check.outcome == 'failure' }}
         run: |
           mkdir -p test-diagnostics
           {
@@ -165,6 +189,7 @@ jobs:
             echo "mcp-e2e-smoke-failed=${MCP_E2E_SMOKE_FAILED}"
             echo "operational-failed=${OPERATIONAL_FAILED}"
             echo "coverage-thresholds-failed=${COVERAGE_THRESHOLDS_FAILED}"
+            echo "api-check-failed=${API_CHECK_FAILED}"
           } > test-diagnostics/failed-steps.txt
 
       - name: Upload test diagnostics on failure

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -33,6 +33,9 @@ jobs:
   slow:
     runs-on: macos-15
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
     env:
       RUN_SLOW_TESTS: "1"
 
@@ -200,6 +203,36 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: test-diagnostics/
+
+      - name: Open GitHub issue on failure
+        # Creates a tracking issue so a nightly failure is visible without
+        # relying on GitHub's email digest. De-duplication: if an open issue
+        # with the same title prefix already exists, appends a comment instead
+        # of opening a second issue — avoids spam during multi-day failure runs.
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          title="Nightly slow tests failed"
+          existing=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search "${title} in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Open issue #${existing} already exists — adding comment."
+            gh issue comment "$existing" \
+              --repo "${{ github.repository }}" \
+              --body "Also failed on [run ${{ github.run_id }}](${run_url})."
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "${title}" \
+              --body "$(printf '## Nightly slow tests failed\n\n**Run:** [%s](%s)\n\nCheck the run logs for which steps failed and close this issue once resolved.' "${{ github.run_id }}" "${run_url}")"
+          fi
 
   # Cold-start conformance gates (tier 1/2/3) and the FoundationOnly bundle
   # audit. These were per-PR gates in ci.yml until they were carved out here:


### PR DESCRIPTION
## Summary

- The per-PR `diagnose-api-breaking-changes` step was compiling all five targets unconditionally, costing ~12 min per run (measured: run [27093591154](https://github.com/roryford/ManifoldKit/actions/runs/27093591154), 11m40s for this step alone in a 27 min total)
- Per-PR check is now path-gated: skips on test/docs/script-only PRs, only checks the modules that actually changed (~2-3 min for a single-module PR)
- Full five-target check moved to `nightly-slow-tests.yml` as a ≤24h backstop
- Nightly now opens a GitHub issue on failure — TrafficBoundaryAuditTest failed silently for **6 consecutive days** (Jun 1–6) with no notification beyond email digest; de-duplication logic comments on the existing issue instead of opening duplicates during multi-day failures

## What changed

**ci.yml**
- Added five `api-*` path filters to the `changes` job (`Sources/<Module>/**`) — intentionally excludes `Package.swift`/`Package.resolved` since a dep-graph change can't introduce a Swift API break
- API check step skips unless at least one of the five flags is true, and dynamically builds `--targets` from whichever flags are set

**nightly-slow-tests.yml**
- Added full five-target `diagnose-api-breaking-changes` step as unconditional nightly backstop
- Added `permissions: issues: write` to the `slow` job
- Added "Open GitHub issue on failure" step — creates a tracking issue on first failure, comments on the existing open issue on subsequent failures

## Test plan

- [ ] Push a PR that only touches `Tests/` — verify API check step is skipped
- [ ] Push a PR that touches `Sources/ManifoldUI/` only — verify step runs with `--targets ManifoldUI` only
- [ ] Trigger nightly via `workflow_dispatch` with a known-good build — verify it passes and no issue is opened
- [ ] (Optional) Trigger nightly on a broken branch — verify issue is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)