### PR TITLE
test: fix flaky diffusion-download tests and traffic-boundary allowlist

### DIFF
--- a/Tests/ManifoldHuggingFaceTests/DiffusionDownloadDelegateTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/DiffusionDownloadDelegateTests.swift
@@ -39,7 +39,7 @@ final class DiffusionDownloadDelegateTests: XCTestCase {
 
     /// `totalBytesExpectedToWrite == -1` (NSURLSessionTransferSizeUnknown) must
     /// be surfaced as `0` so callers treat progress as indeterminate.
-    func test_didWriteData_normalisesUnknownExpectedBytesToZero() {
+    func test_didWriteData_normalisesUnknownExpectedBytesToZero() async {
         // Create a real download task just to obtain a stable taskIdentifier.
         let fakeTask = URLSession.shared.downloadTask(with: URL(string: "https://example.com/normalise")!)
 
@@ -71,6 +71,11 @@ final class DiffusionDownloadDelegateTests: XCTestCase {
             }
         }
 
+        // Let the registration Task reach `register(...)` before firing the
+        // callback — otherwise `didWriteData` finds no entry and `onChunk`
+        // never fires (mirrors the error-path tests below).
+        await Task.yield()
+
         // Fire the delegate callback with NSURLSessionTransferSizeUnknown (-1).
         delegate.urlSession(
             URLSession.shared,
@@ -80,12 +85,12 @@ final class DiffusionDownloadDelegateTests: XCTestCase {
             totalBytesExpectedToWrite: -1
         )
 
-        waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [expectation], timeout: 2.0)
         XCTAssertEqual(captured.get(), 0, "totalBytesExpected == -1 must be normalised to 0")
     }
 
     /// Positive `totalBytesExpectedToWrite` must pass through unchanged.
-    func test_didWriteData_passesPositiveExpectedBytesThrough() {
+    func test_didWriteData_passesPositiveExpectedBytesThrough() async {
         let fakeTask = URLSession.shared.downloadTask(with: URL(string: "https://example.com/positive")!)
 
         final class Box<T>: @unchecked Sendable {
@@ -111,6 +116,10 @@ final class DiffusionDownloadDelegateTests: XCTestCase {
             }
         }
 
+        // Let the registration Task reach `register(...)` before firing the
+        // callback (see the normalisation test above).
+        await Task.yield()
+
         delegate.urlSession(
             URLSession.shared,
             downloadTask: fakeTask,
@@ -119,7 +128,7 @@ final class DiffusionDownloadDelegateTests: XCTestCase {
             totalBytesExpectedToWrite: 1_000
         )
 
-        waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [expectation], timeout: 2.0)
         XCTAssertEqual(captured.get(), 1_000, "Positive totalBytesExpected should pass through unchanged")
     }
 

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -84,7 +84,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
     /// usage is approved. These do legitimate network I/O — cloud backends,
     /// the model-download manager, test infra.
     ///
-    /// **Cap: 47 entries.** Adding to this list weakens Rule 1; require
+    /// **Cap: 48 entries.** Adding to this list weakens Rule 1; require
     /// reviewer sign-off and prefer to route new network code through
     /// `URLSessionProvider` (which is itself in this allowlist).
     private static let networkIOAllowlist: Set<String> = [
@@ -201,6 +201,13 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // GGUF/MLX path above, kept in its own file so the existing
         // background-download manager stays untouched.
         "ManifoldHuggingFace/DiffusionDownload.swift",
+        // URLSessionDownloadDelegate for the diffusion multi-file download
+        // path (#... per-chunk progress). Owns only the delegate callbacks
+        // (didWriteData/didFinishDownloadingTo/didCompleteWithError); it does
+        // not construct a session of its own — the session is built in
+        // DiffusionDownload.swift above. Sibling to
+        // BackgroundDownloadManager+URLSessionDelegate.swift.
+        "ManifoldHuggingFace/DiffusionDownloadDelegate.swift",
         "ManifoldInference/Services/SSEStreamParser.swift",
         "ManifoldUI/ViewModels/ModelManagementViewModel.swift",
 
@@ -342,7 +349,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         Self.assertNoOffenders(offenders)
 
         XCTAssertLessThanOrEqual(
-            Self.networkIOAllowlist.count, 47,
+            Self.networkIOAllowlist.count, 48,
             "networkIOAllowlist exceeds cap. Each new entry weakens the rule — re-architect rather than expand the list."
         )
     }


### PR DESCRIPTION
## What

Fixes two pre-existing test failures on `main` introduced by `890960b5` (*fix(image-gen): background URLSession + per-chunk progress*), surfaced by the local/nightly gate. **Test-only — no production code changes** (the source normalization was already correct).

### 1. `DiffusionDownloadDelegateTests` registration race
The two `didWriteData` byte-normalization tests registered the `onChunk` closure inside an async `Task` but then fired `urlSession(_:didWriteData:...)` **synchronously** before that Task ran. No task entry existed yet → `onChunk` never fired → expectation timed out. (The `999 != 0` / `0 != 1000` assertion mismatches were just the un-updated capture defaults after the timeout.)

Fix: made both tests `async` with `await Task.yield()` before firing the callback and `await fulfillment(of:)` — mirroring the already-correct error-path tests in the same file.

### 2. `TrafficBoundaryAuditTest.test_rule1` allowlist gap
`890960b5` added `DiffusionDownloadDelegate.swift` (a genuine `URLSessionDownloadDelegate`, sibling to `BackgroundDownloadManager+URLSessionDelegate.swift`) without allowlisting it. Added it to `networkIOAllowlist` with a justification and bumped the cap 47→48.

## Testing

```
swift test --traits HuggingFace --filter DiffusionDownloadDelegateTests   # 5/5 pass
swift test --filter 'TrafficBoundaryAuditTest/test_rule1'                  # pass
```

Both previously-failing suites now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)