### PR TITLE
refactor(ManifoldRuntime): de-tangle ConversationTurnExecutor into per-turn seams

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -35,6 +35,9 @@ struct ConversationTurnExecutor: Sendable {
     /// ``RuntimeBindingsBox`` for the rationale (host-app demo swaps per
     /// scenario card; full runtime rebuild would be overkill).
     private let bindings: RuntimeBindingsBox
+    /// Per-turn session-tool advertise/register/unregister seam. See
+    /// ``SessionToolDispatchBinder`` and #1606 (register-before-enqueue).
+    private let toolDispatch: SessionToolDispatchBinder
 
     init(
         persistence: ConversationPersistencePort,
@@ -74,6 +77,7 @@ struct ConversationTurnExecutor: Sendable {
         self.hostTurnContextProvider = hostTurnContextProvider
         self.legacyTurnContextProvider = turnContextProvider
         self.bindings = bindings
+        self.toolDispatch = SessionToolDispatchBinder(inferenceService: inferenceService)
     }
 
     // MARK: Send flow
@@ -746,7 +750,7 @@ struct ConversationTurnExecutor: Sendable {
         // tool but limiting which names go on the wire works without
         // unregistering the executor. Fetched on the main actor because the
         // registry and InferenceService accessors are both MainActor-isolated.
-        let advertisedTools: [ToolDefinition] = await readAdvertisedToolDefinitions(
+        let advertisedTools: [ToolDefinition] = await toolDispatch.advertisedToolDefinitions(
             sessionToolSources: turnSessionToolSources,
             sessionRecord: sessionRecord
         )
@@ -756,7 +760,7 @@ struct ConversationTurnExecutor: Sendable {
         // dispatch loop finds no registry executor and returns `unknownTool`
         // (#1606). Registered after `advertisedTools` is computed so advertising
         // is unaffected; unregistered once the stream fully drains below.
-        let registeredSessionToolNames = await registerSessionToolExecutors(
+        let registeredSessionToolNames = await toolDispatch.registerSessionToolExecutors(
             sources: turnSessionToolSources,
             sessionRecord: sessionRecord
         )
@@ -777,7 +781,7 @@ struct ConversationTurnExecutor: Sendable {
                 requestGroupID: sessionID
             )
         } catch {
-            await unregisterSessionToolExecutors(registeredSessionToolNames)
+            await toolDispatch.unregisterSessionToolExecutors(registeredSessionToolNames)
             let conversationError = ConversationError.inference(error)
             emit(.errorRaised(conversationError))
             await completeOutcome(
@@ -930,7 +934,7 @@ struct ConversationTurnExecutor: Sendable {
         // stale ``ChatSession`` binding into the next turn (#1606). All
         // remaining exit paths below are post-stream, so this is the single
         // cleanup point alongside the enqueue-failure path above.
-        await unregisterSessionToolExecutors(registeredSessionToolNames)
+        await toolDispatch.unregisterSessionToolExecutors(registeredSessionToolNames)
 
         // Flush remaining buffered tokens (normal end, error, or cancellation).
         if let batch = batcher.flush(now: ContinuousClock.now) {
@@ -1583,133 +1587,6 @@ struct ConversationTurnExecutor: Sendable {
     private func isCancelled(handle: ConversationStreamHandle) async -> Bool {
         if Task.isCancelled { return true }
         return await registry.isCancelled(handle)
-    }
-
-    private func readAdvertisedToolDefinitions(
-        sessionToolSources: [any SessionToolSource],
-        sessionRecord: ChatSession?
-    ) async -> [ToolDefinition] {
-        // Base registry definitions — host-installed tools the executor
-        // already advertises today. Read from MainActor.
-        let registryDefinitions: [ToolDefinition] = await MainActor.run {
-            inferenceService.toolRegistry?.advertisedDefinitions ?? []
-        }
-
-        // Per-session source contributions. Each source's
-        // `toolDefinitions(for:)` returns the definitions it owns for this
-        // session — e.g. ``HandoffToolSource`` synthesising one
-        // `transfer_to_<name>` per non-active agent. Skipped when we don't
-        // have a session record to scope the query.
-        var sourceDefinitions: [ToolDefinition] = []
-        if let sessionRecord {
-            for source in sessionToolSources {
-                let defs = await source.toolDefinitions(for: sessionRecord)
-                sourceDefinitions.append(contentsOf: defs)
-            }
-        }
-
-        // Union — sources can override the registry's view of a tool of
-        // the same name by appearing later, but in practice the namespaces
-        // don't overlap (registry: bespoke executors; sources: synthesised
-        // tools). De-dupe by name to keep the wire shape stable.
-        var unioned: [ToolDefinition] = registryDefinitions
-        var seen = Set(registryDefinitions.map(\.name))
-        for def in sourceDefinitions where !seen.contains(def.name) {
-            unioned.append(def)
-            seen.insert(def.name)
-        }
-
-        // Apply allowed-tools intersection across sources. A `nil` return
-        // from `allowedToolNames(for:)` means "no restriction" — only
-        // non-nil sets participate in the intersection. Skills uses this
-        // to clamp the model's tool surface while a skill is active.
-        if let sessionRecord {
-            var allowList: Set<String>? = nil
-            for source in sessionToolSources {
-                if let allowed = await source.allowedToolNames(for: sessionRecord) {
-                    if let current = allowList {
-                        allowList = current.intersection(allowed)
-                    } else {
-                        allowList = allowed
-                    }
-                }
-            }
-            if let allowList {
-                unioned = unioned.filter { allowList.contains($0.name) }
-            }
-        }
-
-        // When the active backend declares a hard cap on how many tools it can
-        // handle per turn, truncate the list before building the GenerationConfig.
-        // The definitions are already sorted alphabetically by ToolRegistry, so
-        // `prefix` always picks the same lexicographically-first N tools —
-        // deterministic ordering keeps the "X of Y tools enabled" UI stable.
-        let cap = await MainActor.run { inferenceService.capabilities?.maxAdvertisedToolCount }
-        if let cap, unioned.count > cap {
-            return Array(unioned.prefix(cap))
-        }
-        return unioned
-    }
-
-    /// Registers a ``ToolExecutor`` adapter for each session-source-advertised
-    /// tool so a model tool call actually reaches the source's `resolve`
-    /// instead of coming back as ``ToolResult/ErrorKind/unknownTool`` (#1606).
-    ///
-    /// Returns the set of tool names this call registered so the caller can
-    /// unregister exactly those when the turn ends — leaving a session-scoped
-    /// executor in the shared registry would bind later turns to a stale
-    /// ``ChatSession``.
-    ///
-    /// A tool already present in the registry (a host-installed executor) is
-    /// left untouched: the registry executor wins, matching the
-    /// advertising-path de-dupe in ``readAdvertisedToolDefinitions``. Like the
-    /// per-turn `setHandoffDetector` / `setPreToolUseHook` wiring, this mutates
-    /// shared `InferenceService` state and assumes one turn per service at a
-    /// time; concurrent turns on the same service are last-writer-wins.
-    private func registerSessionToolExecutors(
-        sources: [any SessionToolSource],
-        sessionRecord: ChatSession?
-    ) async -> Set<String> {
-        guard let sessionRecord, !sources.isEmpty else { return [] }
-
-        // Gather (source, definition) pairs off the main actor so the
-        // per-source async `toolDefinitions(for:)` calls don't pin MainActor.
-        var pairs: [(source: any SessionToolSource, definition: ToolDefinition)] = []
-        for source in sources {
-            let defs = await source.toolDefinitions(for: sessionRecord)
-            for def in defs {
-                pairs.append((source, def))
-            }
-        }
-        guard !pairs.isEmpty else { return [] }
-
-        return await MainActor.run {
-            guard let registry = inferenceService.toolRegistry else { return Set<String>() }
-            var registered: Set<String> = []
-            for pair in pairs {
-                // Don't clobber a host-installed executor of the same name.
-                guard registry.contains(name: pair.definition.name) == false else { continue }
-                registry.register(
-                    SessionToolSourceExecutor(
-                        definition: pair.definition,
-                        source: pair.source,
-                        session: sessionRecord
-                    )
-                )
-                registered.insert(pair.definition.name)
-            }
-            return registered
-        }
-    }
-
-    private func unregisterSessionToolExecutors(_ names: Set<String>) async {
-        guard !names.isEmpty else { return }
-        await MainActor.run {
-            guard let registry = inferenceService.toolRegistry else { return }
-            for name in names {
-                registry.unregister(name: name)
-            }
-        }
     }
 
     @MainActor

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -10,7 +10,9 @@ struct ConversationTurnExecutor: Sendable {
     /// Best-effort usage persistence. `nil` when the host did not wire a store.
     private let usageStore: (any UsageStore)?
     private let registry: InFlightStreamRegistry
-    private let eventSink: @Sendable (ConversationEvent) -> Void
+    /// Typed per-turn event seam. Wraps the host's `@Sendable` sink; the private
+    /// `emit` helper forwards through it. See ``TurnEventEmitter``.
+    private let events: TurnEventEmitter
     private let emptyResponseObserver: (@Sendable (ConversationRuntime.EmptyResponseDiagnostic) -> Void)?
     private let generationHooks: [any GenerationHook]
     private let compressionPolicy: (any CompressionPolicy)?
@@ -61,7 +63,7 @@ struct ConversationTurnExecutor: Sendable {
         self.ragService = ragService
         self.usageStore = usageStore
         self.registry = registry
-        self.eventSink = emit
+        self.events = TurnEventEmitter(emit)
         self.emptyResponseObserver = emptyResponseObserver
         self.generationHooks = generationHooks
         self.compressionPolicy = compressionPolicy
@@ -651,10 +653,13 @@ struct ConversationTurnExecutor: Sendable {
         // accepts. The adapter enforces the sanitize-only invariant and
         // emits `.hookFired(event: "preToolUse", ...)` on every call.
         if let turnHookRegistry {
-            let emit = self.eventSink
+            // Pass the bare `@Sendable` sink (not a main-actor-capturing
+            // wrapper) so the adapter closure stays free of `@MainActor` state
+            // — invariant 5.
+            let sink = events.sink
             let adapter = PreToolUseHookAdapter.make(
                 registry: turnHookRegistry,
-                eventEmitter: { event in emit(event) }
+                eventEmitter: { event in sink(event) }
             )
             await inferenceService.setPreToolUseHook(adapter)
         } else {
@@ -1279,7 +1284,7 @@ struct ConversationTurnExecutor: Sendable {
     // MARK: Helpers
 
     private func emit(_ event: ConversationEvent) {
-        eventSink(event)
+        events.emit(event)
     }
 
     private func completeOutcome(

--- a/Sources/ManifoldRuntime/Services/SessionToolDispatchBinder.swift
+++ b/Sources/ManifoldRuntime/Services/SessionToolDispatchBinder.swift
@@ -1,0 +1,162 @@
+import Foundation
+import ManifoldInference
+
+/// Named seam for the per-turn session-tool dispatch wiring that previously
+/// lived inline in ``ConversationTurnExecutor``. It owns the three-step lifecycle
+/// the turn loop depends on:
+///
+///   1. **advertise** — ``advertisedToolDefinitions(sessionToolSources:sessionRecord:)``
+///      unions the base registry's `advertisedDefinitions` with each
+///      ``SessionToolSource``'s per-session contributions, applies the
+///      allowed-tools intersection, and truncates to the backend's
+///      `maxAdvertisedToolCount` cap. This is what goes on the wire as
+///      `GenerationConfig.tools`.
+///   2. **register** — ``registerSessionToolExecutors(sources:sessionRecord:)``
+///      installs a ``SessionToolSourceExecutor`` for each advertised source tool
+///      on `InferenceService.toolRegistry`. This MUST happen *before*
+///      `enqueueAsync`, else the dispatch loop returns `unknownTool` (#1606).
+///   3. **unregister** — ``unregisterSessionToolExecutors(_:)`` removes exactly
+///      the names this binder registered once the stream has fully drained, so a
+///      session-scoped executor never leaks a stale ``ChatSession`` into the next
+///      turn.
+///
+/// Execution of the tool calls themselves happens producer-side in
+/// `ManifoldInference`'s GenerationQueue dispatch loop — this binder only
+/// advertises and binds. Like the per-turn `setHandoffDetector` /
+/// `setPreToolUseHook` wiring, register/unregister mutate shared
+/// `InferenceService` state and assume one turn per service at a time;
+/// concurrent turns are last-writer-wins.
+struct SessionToolDispatchBinder: Sendable {
+    private let inferenceService: InferenceService
+
+    init(inferenceService: InferenceService) {
+        self.inferenceService = inferenceService
+    }
+
+    /// Builds the advertised tool surface for this turn. See the type doc for
+    /// the union/intersection/cap semantics. Fetched on the main actor because
+    /// the registry and `InferenceService` accessors are MainActor-isolated.
+    func advertisedToolDefinitions(
+        sessionToolSources: [any SessionToolSource],
+        sessionRecord: ChatSession?
+    ) async -> [ToolDefinition] {
+        // Base registry definitions — host-installed tools the executor
+        // already advertises today. Read from MainActor.
+        let registryDefinitions: [ToolDefinition] = await MainActor.run {
+            inferenceService.toolRegistry?.advertisedDefinitions ?? []
+        }
+
+        // Per-session source contributions. Each source's
+        // `toolDefinitions(for:)` returns the definitions it owns for this
+        // session — e.g. ``HandoffToolSource`` synthesising one
+        // `transfer_to_<name>` per non-active agent. Skipped when we don't
+        // have a session record to scope the query.
+        var sourceDefinitions: [ToolDefinition] = []
+        if let sessionRecord {
+            for source in sessionToolSources {
+                let defs = await source.toolDefinitions(for: sessionRecord)
+                sourceDefinitions.append(contentsOf: defs)
+            }
+        }
+
+        // Union — sources can override the registry's view of a tool of
+        // the same name by appearing later, but in practice the namespaces
+        // don't overlap (registry: bespoke executors; sources: synthesised
+        // tools). De-dupe by name to keep the wire shape stable.
+        var unioned: [ToolDefinition] = registryDefinitions
+        var seen = Set(registryDefinitions.map(\.name))
+        for def in sourceDefinitions where !seen.contains(def.name) {
+            unioned.append(def)
+            seen.insert(def.name)
+        }
+
+        // Apply allowed-tools intersection across sources. A `nil` return
+        // from `allowedToolNames(for:)` means "no restriction" — only
+        // non-nil sets participate in the intersection. Skills uses this
+        // to clamp the model's tool surface while a skill is active.
+        if let sessionRecord {
+            var allowList: Set<String>? = nil
+            for source in sessionToolSources {
+                if let allowed = await source.allowedToolNames(for: sessionRecord) {
+                    if let current = allowList {
+                        allowList = current.intersection(allowed)
+                    } else {
+                        allowList = allowed
+                    }
+                }
+            }
+            if let allowList {
+                unioned = unioned.filter { allowList.contains($0.name) }
+            }
+        }
+
+        // When the active backend declares a hard cap on how many tools it can
+        // handle per turn, truncate the list before building the GenerationConfig.
+        // The definitions are already sorted alphabetically by ToolRegistry, so
+        // `prefix` always picks the same lexicographically-first N tools —
+        // deterministic ordering keeps the "X of Y tools enabled" UI stable.
+        let cap = await MainActor.run { inferenceService.capabilities?.maxAdvertisedToolCount }
+        if let cap, unioned.count > cap {
+            return Array(unioned.prefix(cap))
+        }
+        return unioned
+    }
+
+    /// Registers a ``ToolExecutor`` adapter for each session-source-advertised
+    /// tool so a model tool call actually reaches the source's `resolve`
+    /// instead of coming back as ``ToolResult/ErrorKind/unknownTool`` (#1606).
+    ///
+    /// Returns the set of tool names this call registered so the caller can
+    /// unregister exactly those when the turn ends — leaving a session-scoped
+    /// executor in the shared registry would bind later turns to a stale
+    /// ``ChatSession``.
+    ///
+    /// A tool already present in the registry (a host-installed executor) is
+    /// left untouched: the registry executor wins, matching the
+    /// advertising-path de-dupe in ``advertisedToolDefinitions``.
+    func registerSessionToolExecutors(
+        sources: [any SessionToolSource],
+        sessionRecord: ChatSession?
+    ) async -> Set<String> {
+        guard let sessionRecord, !sources.isEmpty else { return [] }
+
+        // Gather (source, definition) pairs off the main actor so the
+        // per-source async `toolDefinitions(for:)` calls don't pin MainActor.
+        var pairs: [(source: any SessionToolSource, definition: ToolDefinition)] = []
+        for source in sources {
+            let defs = await source.toolDefinitions(for: sessionRecord)
+            for def in defs {
+                pairs.append((source, def))
+            }
+        }
+        guard !pairs.isEmpty else { return [] }
+
+        return await MainActor.run {
+            guard let registry = inferenceService.toolRegistry else { return Set<String>() }
+            var registered: Set<String> = []
+            for pair in pairs {
+                // Don't clobber a host-installed executor of the same name.
+                guard registry.contains(name: pair.definition.name) == false else { continue }
+                registry.register(
+                    SessionToolSourceExecutor(
+                        definition: pair.definition,
+                        source: pair.source,
+                        session: sessionRecord
+                    )
+                )
+                registered.insert(pair.definition.name)
+            }
+            return registered
+        }
+    }
+
+    func unregisterSessionToolExecutors(_ names: Set<String>) async {
+        guard !names.isEmpty else { return }
+        await MainActor.run {
+            guard let registry = inferenceService.toolRegistry else { return }
+            for name in names {
+                registry.unregister(name: name)
+            }
+        }
+    }
+}

--- a/Sources/ManifoldRuntime/Services/TurnEventEmitter.swift
+++ b/Sources/ManifoldRuntime/Services/TurnEventEmitter.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ManifoldInference
+
+/// Narrow, typed seam over the runtime's `@Sendable (ConversationEvent) -> Void`
+/// event sink. The turn executor emits ~50 events across the four flows; routing
+/// them through this value type gives the emission path a single named owner
+/// without changing observable ordering — `emit` forwards straight to the sink.
+///
+/// Sendability discipline (invariant 5): this holds only the
+/// `@Sendable (ConversationEvent) -> Void` closure and MUST NOT capture
+/// `InferenceService` or any `@MainActor` state. Adapters that need the raw
+/// closure shape (e.g. ``PreToolUseHookAdapter``) read ``sink`` rather than a
+/// main-actor-capturing wrapper.
+struct TurnEventEmitter: Sendable {
+    /// The underlying `@Sendable` sink. Exposed for collaborators that require
+    /// the bare closure shape; it is the same value `emit` forwards to.
+    let sink: @Sendable (ConversationEvent) -> Void
+
+    init(_ sink: @escaping @Sendable (ConversationEvent) -> Void) {
+        self.sink = sink
+    }
+
+    func emit(_ event: ConversationEvent) {
+        sink(event)
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeRebindTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeRebindTests.swift
@@ -214,7 +214,7 @@ final class ConversationRuntimeRebindTests: XCTestCase {
         //   → turn2 advertised list stays empty; XCTAssertTrue trips.
         // Sabotage-evidence: M2 read bindings ONCE at init in the executor
         //   (revert to `let sessionToolSources`) → same trip.
-        // Sabotage-evidence: M3 return [] from `readAdvertisedToolDefinitions`'s
+        // Sabotage-evidence: M3 return [] from `SessionToolDispatchBinder.advertisedToolDefinitions`'s
         //   source branch → same trip.
     }
 

--- a/Tests/ManifoldRuntimeTests/FoundationBackendToolCapTests.swift
+++ b/Tests/ManifoldRuntimeTests/FoundationBackendToolCapTests.swift
@@ -103,7 +103,7 @@ final class FoundationBackendToolCapTests: XCTestCase {
         XCTAssertEqual(config.tools.count, cap,
             "backend should receive exactly \(cap) tools when more are registered")
 
-        // Sabotage check: removing the cap enforcement in readAdvertisedToolDefinitions
+        // Sabotage check: removing the cap enforcement in SessionToolDispatchBinder.advertisedToolDefinitions
         // would cause config.tools.count == 20, failing the assertion above.
         _ = handle
     }


### PR DESCRIPTION
Closes #1721 (P2c). Behavior-preserving internal refactor inside `ManifoldRuntime` — no module move. Every step diffs clean against the P0c golden harness (`ManifoldTurnLoopCharacterizationTests`).

## Seam decomposition landed

1. **`TurnEventEmitter`** (new) — typed `Sendable` wrapper over the host's `@Sendable (ConversationEvent) -> Void` sink. The executor's ~50 `emit` calls now route through it; the private `emit()` forwards. Collaborators needing the bare closure shape (`PreToolUseHookAdapter`) read `.sink` directly so no `@MainActor` state is captured.

2. **`SessionToolDispatchBinder`** (new) — owns the per-turn tool-dispatch lifecycle: `advertisedToolDefinitions` (advertise) → `registerSessionToolExecutors` (register-before-enqueue, #1606) → `unregisterSessionToolExecutors` (post-drain cleanup). The three methods moved verbatim out of the executor; the executor delegates. Register still happens before `enqueueAsync`, unregister after the stream drains.

3. **Persistence seam** — already present on `origin/main` as `ConversationPersistencePort` (insert/delete/fetch/update/touch/updateSession). The executor already routes every write through it and `updateSession` returns `Bool` (not session state), so invariant 1 was already structurally satisfied; no change needed.

4. **Flow thinning** — the four flows (`runSendFlow`/`runRegenerate`/`runEdit`/`runBranch`) already read as assemble → enqueue → consume → persist → post-turn and now delegate cross-cutting tool/event concerns to the two named collaborators. The executor shed ~130 lines (1740 → ~1610).

5. **Compression coordinator (optional)** — deliberately NOT extracted. The pre-turn and post-turn compress-and-replace sequences differ in their event/error handling and are not covered by the goldens; extracting them risked a golden-invisible behavior drift, so they stay in place per the brief's "if it risks behavior, stop" guidance.

## Per-step golden results
- Step 1 (TurnEventEmitter): 9 characterization tests green.
- Step 2/3 (SessionToolDispatchBinder): 9 green; plus 70 tests across ConversationRuntimeTests / SessionToolSource / HandoffScenario / PreCompactWiring / ConversationRuntimeRebind all green.
- Goldens run twice at the end: both clean (no snapshot re-record).

## 7-invariant checklist
1. **`sessionRecord` local re-pinned `var`** — UNTOUCHED. It is still fetched once (`fetchSession`) and re-pinned from `handoff.targetAgentID` after `updateSession` (which returns `Bool`, not session state). No port re-reads session mid-stream; the persistence seam was already void/Bool-returning on this path.
2. **#965 switch-cancel-resend** — empty-assistant-drop branch and `discardRequests(notMatching:)` ordering untouched (lives in `GenerationQueue`, not moved).
3. **#1606 register-before-enqueue** — preserved: executor advertises → `toolDispatch.registerSessionToolExecutors(...)` → `enqueueAsync`. Sabotage-verified: breaking the register seam reproduces the exact `unknownTool 'generate_image'` failure in `SessionToolSourceDispatchTest`; revert restores green.
4. **KV-cache read-after-async-write discipline** — stream-drain core (`runGenerationTurn`) reordering avoided; no reads moved across the async stream boundary.
5. **`@Sendable` sinks don't capture `@MainActor` state** — `TurnEventEmitter` holds only the `@Sendable` closure; the PreToolUse adapter binds `events.sink` (bare closure), not a main-actor wrapper. Full all-traits Swift 6 build clean (no `#SendingRisksDataRace`).
6. **preCompact hook observational in v1** — block:true still logged-and-ignored, untouched.
7. **Token-usage pinning** — per-turn `lastTokenUsage` read unchanged (golden-covered by `test_tokenUsage`, green).

Plus: transfer-only handoff still ends the turn (two-turn handoff golden unchanged).

## Final gate
`scripts/test.sh --profile local` (all traits, two-invocation): **RESULT: PASSED — 4856 passed, 0 failed, 56 skipped**.

Sabotage checks per QA-PRACTICES §3 were used to prove each seam is load-bearing (register seam → #1606 failure; advertise/event seams verified via broader suites) and removed before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)