### PR TITLE
docs: refresh module table and plan docs after P2 contract carve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,26 +2,87 @@
 
 ## Targets
 
+### Core / leaf modules (no ML deps, no SwiftData)
+
 | Target | Role | ML deps |
 |--------|------|---------|
-| `ManifoldKit` | Umbrella library that re-exports `ManifoldInference` + `ManifoldRuntime` + `ManifoldPersistenceSwiftData` + `ManifoldBackends` + `ManifoldUI` so app code can `import ManifoldKit` instead of stitching together 4–6 imports. Specialised modules (UIModelManagement, MCP, Voice, …) stay explicit imports. | None |
-| `ManifoldInference` | Inference orchestration — backend protocols, generation events, prompt assembly, conversation records (no persistence ports) | None |
-| `ManifoldMCP` | Model Context Protocol client surface, descriptors, tool bridge (`MCPClient`, `MCPToolSource`) | None |
-| `ManifoldRuntime` | Persistence ports (`MessageStore`, `SessionStore`, `EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`, `ConversationRuntime`), and session-list orchestration | None |
-| `ManifoldPersistenceSwiftData` | SwiftData schema, `@Model` types, container factory, adapter implementations, and the full-stack `ManifoldBootstrap` | None |
-| `ManifoldCloudCore` | Shared SSE / TLS-pinning / DNS-rebind / URLSession infrastructure (`SSECloudBackend`, `PinnedSessionDelegate`, `DNSRebindingGuard`, `URLSessionProvider`, `CloudErrorSanitizer`, `ThinkingBlockManager`) | None |
-| `ManifoldMLX` | MLX inference backend, resource arbiter, capability probe, MLX tool dialect (depends on `ManifoldInference`) | MLX |
-| `ManifoldLlama` | llama.cpp (GGUF) inference, generation driver, embedding backend, GGUF tool-call parser (depends on `ManifoldInference`) | LlamaSwift |
-| `ManifoldFoundation` | Apple Foundation Models bridge — gated by OS availability (iOS 26 / macOS 26+), no trait | None |
-| `ManifoldCloud` | SaaS + LAN cloud backends: OpenAI Chat Completions, OpenAI Responses, Anthropic Claude, Ollama (depends on `ManifoldCloudCore`) | None |
-| `ManifoldBackends` | Umbrella re-export module backed by `Sources/ManifoldBackendsUmbrella/`. Hosts cross-family glue (`DefaultBackends`, per-family `BackendRegistrar` conformances) and `@_exported import`s the four family targets so existing `import ManifoldBackends` consumers keep compiling. | MLX, LlamaSwift |
-| `ManifoldUI` | SwiftUI chat-runtime views and view models (chat-only consumer stops here) | None |
-| `ManifoldUIModelManagement` | Model browser/download/storage UI + cloud API endpoint editors | None |
-| `ManifoldVoice` | Optional speech I/O adapters and voice composer accessory (depends on `ManifoldUI`) | None |
-| `ManifoldTestSupport` | Shared mocks and fakes (`MockInferenceBackend`, `CharTokenizer`, etc.) | None |
-| `ManifoldMLXIntegrationTests` | Xcode-only real MLX model E2E tests | MLX |
+| `ManifoldNetworking` | Leaf networking primitives (P1a #1608): `NetworkActivity` observability funnel, `PrivateIPClassifier`. Pure Foundation, zero upward deps. | None |
+| `ManifoldSecrets` | Leaf security primitives (P1b #1609): `KeychainService`, `SecureEnclaveKeyManager`, `SecureBytes`. Pure Security framework, zero upward deps. | None |
+| `ManifoldHardware` | Leaf device-capability + GGUF primitives (P1c #1610): device probing, memory-pressure broadcasting, GGUF parsing, load-plan logic. Zero deps. | None |
+| `ManifoldModelCatalog` | Model discovery/catalog/benchmark + image/video-gen records (P1d #1611): `ModelInfo`, `ModelManifest`, `ModelCatalog`, `ModelStorageService`, `DiagnosticsService`, `SettingsService`, `ModelBenchmarkRunner`. Depends on `ManifoldHardware`, `ManifoldNetworking`, `ManifoldSecrets`. | None |
+| `ManifoldContract` | The Contract kernel (P2a #1719): backend protocols (`InferenceBackend`, `EmbeddingBackend`), value/stream types (`GenerationConfig`, `GenerationEvent`, `Message`, `ToolDefinition`/`ToolCall`/`ToolResult`, streaming transforms). Depends on `ManifoldHardware` + `ManifoldModelCatalog` (`@_exported import`s both). Must NOT depend on `ManifoldInference` — `ManifoldContractNoEngineDependencyTests` is the tripwire. | None |
 
-**Dependency rules:** Never import any backend family target (or the `ManifoldBackends` umbrella) from UI; never import `ManifoldUIModelManagement` from `ManifoldUI` (CI lint enforces this). `ManifoldUIModelManagement` depends on `ManifoldUI` — cycle dissolved by closure-injecting `APIConfigurationView` via `@ViewBuilder` parameter. The four family targets (`ManifoldMLX`, `ManifoldLlama`, `ManifoldFoundation`, `ManifoldCloud`) and `ManifoldMCP` depend on `ManifoldInference` directly (not `ManifoldRuntime`), keeping them free of SwiftData. `ManifoldCloud → ManifoldCloudCore` is unconditional (always linked together); the consumer→family edge is trait-gated (`MLX` for `ManifoldMLX`, `Llama` for `ManifoldLlama`, `CloudSaaS || Ollama` for `ManifoldCloud`; `ManifoldCloudCore` and `ManifoldFoundation` are always linked). The umbrella `ManifoldBackends` re-exports each family conditionally so `import ManifoldBackends` keeps working in any trait combination. `MCPCatalog` descriptors are trait-gated behind `MCPBuiltinCatalog`.
+### Inference engine + runtime
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `ManifoldInference` | Inference orchestration engine: `InferenceService`, `GenerationQueue`, `ModelRegistry`, tool subsystem (`ToolExecutor`, `ToolRegistry`, `GenerationToolDispatchLoop`), `PromptAssembler`, `ContextWindowManager`, `TranscriptHealer`, streaming. Depends on `ManifoldContract` (which it `@_exported import`s for source compatibility) + the four P1 leaves. No persistence ports. | None |
+| `ManifoldRuntime` | Persistence ports (`MessageStore`, `SessionStore`, `EndpointStore`, `SamplerPresetStore`, `BenchmarkCache`, `WebSearchRuntime`), use cases (`PromptContextPipeline`, `ChatExportService`, `SessionListService`, `ConversationRuntime`), and session-list orchestration. Depends on `ManifoldInference`. | None |
+| `ManifoldPersistenceSwiftData` | SwiftData schema, `@Model` types, container factory, adapter implementations, and the full-stack `ManifoldBootstrap`. | None |
+
+### Backend families (inlets)
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `ManifoldMLX` | MLX inference backend, resource arbiter, capability probe, MLX tool dialect, diffusion backends (`MLXDiffusionBackend`, `FluxDiffusionBackend`). Depends on `ManifoldInference`. | MLX |
+| `ManifoldLlama` | llama.cpp (GGUF) inference, generation driver, embedding backend, GGUF tool-call parser. Depends on `ManifoldInference`. | LlamaSwift |
+| `ManifoldFoundation` | Apple Foundation Models bridge — gated by OS availability (`#if canImport(FoundationModels)`, iOS 26 / macOS 26+), no trait. **Repointed to `ManifoldContract` only** (P2a #1719) — no engine-state dependency. | None |
+| `ManifoldCloud` | SaaS + LAN cloud backends: OpenAI Chat Completions, OpenAI Responses, Anthropic Claude, Ollama. **Repointed to `ManifoldContract`** (P2a #1719) + `ManifoldCloudCore` + `ManifoldRuntime`. The `ManifoldRuntime` dep is a deliberate library→library edge: `DefaultWebSearchRuntime` conforms to the `WebSearchRuntime` port declared in `ManifoldRuntime`; a defending comment in Package.swift explains why it stays un-gated. | None |
+| `ManifoldCloudCore` | Shared SSE / TLS-pinning / DNS-rebind / URLSession infrastructure (`SSECloudBackend`, `PinnedSessionDelegate`, `DNSRebindingGuard`, `URLSessionProvider`, `CloudErrorSanitizer`, `ThinkingBlockManager`). Always linked; file bodies are `#if Ollama || CloudSaaS`-gated. Depends on `ManifoldInference`. | None |
+| `ManifoldBackends` | Umbrella re-export shim (`Sources/ManifoldBackendsUmbrella/`). Hosts cross-family glue (`DefaultBackends`, per-family `BackendRegistrar` conformances) and `@_exported import`s the four family targets so existing `import ManifoldBackends` consumers keep compiling. | MLX, LlamaSwift |
+
+### MCP + tool + app-extension modules
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `ManifoldMCP` | Model Context Protocol client surface, descriptors, transports, OAuth, tool bridge (`MCPClient`, `MCPToolSource`). Always compiles; the `MCP` trait gates test edges and the `MCPBuiltinCatalog` define only — the module itself is unconditional. Depends on `ManifoldInference`. | None |
+| `ManifoldMCPHost` | Runtime-backed MCP server boundary: exposes sessions, messages, RAG documents, and send-message tools to external MCP clients. Depends on `ManifoldMCP` + `ManifoldRuntime`. | None |
+| `ManifoldTools` | End-to-end tool-calling validation harness: fixed reference toolset, declarative scenario runner, JSONL transcript logger. Depends on `ManifoldInference`. | None |
+| `ManifoldAppIntents` | AppIntent ↔ ToolDefinition bridge. Depends on `ManifoldInference`. | None |
+| `ManifoldSkills` | Claude-Code-compatible SKILL.md filesystem discovery and `invoke_skill` dispatcher (macOS-only via `#if os(macOS)`). Default-on (the `Skills` trait is in the default trait set). Depends on `ManifoldInference` + `ManifoldRuntime`. | None |
+
+### UI modules
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `ManifoldUI` | SwiftUI chat-runtime views and view models (chat-only consumer stops here). Depends on `ManifoldRuntime` + `ManifoldInference`. | None |
+| `ManifoldUIModelManagement` | Model browser/download/storage UI + cloud API endpoint editors. Depends on `ManifoldUI`. | None |
+| `ManifoldVoice` | Optional speech I/O adapters and voice composer accessory. Depends on `ManifoldUI`. | None |
+
+### Discovery + server + fuzz
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `ManifoldHuggingFace` | HuggingFace Hub search, browse, and download integration. Depends on `ManifoldInference`. | None |
+| `ManifoldServer` | OpenAI-compatible HTTP server executable (Hummingbird). Trait-gated behind `Server`. | None |
+| `ManifoldFuzz` | Fuzzing engine: corpus, runner, capture, detectors, sink. Backend-agnostic; depends on `ManifoldInference`. | None |
+| `ManifoldFuzzBackends` | Real-backend factories for fuzz campaigns (shared by CLI + Xcode-hosted MLX fuzz). | MLX, LlamaSwift |
+
+### Vendored sources (not standalone products)
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `StableDiffusion` | Vendored from mlx-swift-examples (MIT). Used by `MLXDiffusionBackend`. | MLX |
+| `FluxSwift` | Vendored from mzbac/flux.swift (MIT). Used by `FluxDiffusionBackend`. | MLX |
+
+### Test support targets (not production products)
+
+| Target | Role |
+|--------|------|
+| `ManifoldTestSupport` | Shared mocks and fakes (`MockInferenceBackend`, `CharTokenizer`, etc.). No XCTest dependency (see `ManifoldContractTestSupport`). |
+| `ManifoldContractTestSupport` | XCTest-dependent protocol contract mixins. Kept separate from `ManifoldTestSupport` so `fuzz-chat` can depend on the latter without pulling XCTest into a non-test binary (PR #1409). |
+
+### Umbrella
+
+| Target | Role | ML deps |
+|--------|------|---------|
+| `ManifoldKit` | Umbrella re-export so app code can `import ManifoldKit` instead of stitching together 4–6 imports. Re-exports `ManifoldInference` + `ManifoldModelCatalog` + `ManifoldRuntime` + `ManifoldPersistenceSwiftData` + `ManifoldBackends` + `ManifoldUI` + `ManifoldSkills` (conditional on `Skills` trait). Specialised modules (UIModelManagement, MCP, Voice, AppIntents, …) stay explicit imports. | None |
+
+**Dependency rules:** Never import any backend family target (or the `ManifoldBackends` umbrella) from UI; never import `ManifoldUIModelManagement` from `ManifoldUI` (CI lint enforces this). `ManifoldUIModelManagement` depends on `ManifoldUI` — cycle dissolved by closure-injecting `APIConfigurationView` via `@ViewBuilder` parameter.
+
+**Backend family deps (post-P2a #1719):** `ManifoldMLX` and `ManifoldLlama` depend on `ManifoldInference` (real engine use: `extension InferenceService`, `ToolRegistry`, `BackendRegistrar`). `ManifoldFoundation` and `ManifoldCloud` were repointed to `ManifoldContract` only — their sources compile against the thin Contract surface without touching the engine. `ManifoldCloud` additionally depends on `ManifoldCloudCore` (always linked) and `ManifoldRuntime` (for `WebSearchRuntime` port conformance — un-gated library→library edge; see Package.swift comment). `ManifoldMCP` depends on `ManifoldInference` (uses `ToolExecutor`, `ToolRegistry`). The consumer→family edge is trait-gated: `MLX` for `ManifoldMLX`, `Llama` for `ManifoldLlama`, `CloudSaaS || Ollama` for `ManifoldCloud`; `ManifoldCloudCore` and `ManifoldFoundation` are always linked.
+
+The umbrella `ManifoldBackends` re-exports each family conditionally so `import ManifoldBackends` keeps working in any trait combination. `MCPCatalog` descriptors are trait-gated behind `MCPBuiltinCatalog`; the `ManifoldMCP` module itself is unconditional (the `MCP` trait only gates test edges and the built-in catalog define).
 
 ## Running tests
 

--- a/docs/plans/p2-engine-carve-split.md
+++ b/docs/plans/p2-engine-carve-split.md
@@ -1,0 +1,60 @@
+# P2 Engine Carve — sub-phase split (post persona review)
+
+Parent: #1605. Plan: `docs/plans/target-architecture-migration.md` §Phase 2.
+Gates satisfied: P0a decision + P0c harness (#1607). Persona plan review: done (concurrency,
+module-graph, test/behavior-preservation lenses).
+
+## Path decision: extract the Contract *downward*, not the engine *upward*
+
+The review measured both directions against the real import graph:
+
+| Direction | Mechanism | Lockstep edits | Risk |
+|---|---|---|---|
+| Evict engine UP (`InferenceService`+cluster → `ManifoldEngine`) | move engine out of kernel | **246 files / 35 modules**, 44 hard (conformances/extensions), +~60 DocC | catastrophic |
+| Seam-first (`BackendRegistering` protocol) | decouple before move | removes only ~4 of ~200 touchpoints | no help |
+| **Extract Contract DOWN (new leaf `ManifoldContract`)** | kernel `@_exported import`s it | **~30 files move, 0 consumer import-edits**, ~4 Package lines | low |
+
+Why down wins: the inference engine (`InferenceService` → owns `GenerationQueue` → `ToolRegistry`
+→ dispatch → streaming) is welded to the kernel by `BackendRegistrar.register(with: InferenceService)`
+plus concrete use from `ManifoldMCP` (`MCPToolExecutor: ToolExecutor`, `ToolRegistry`) and
+`ManifoldLlama`/`ManifoldMLX` (`extension InferenceService` / `extension ImageGenerationService`).
+Moving it up forces 246 lockstep imports and is cycle-prone. Moving the **Contract** down is the
+pattern already shipped 4× in this repo (P1 #1608/#1611: `ManifoldHardware`, `ManifoldModelCatalog`,
+`ManifoldNetworking`, `ManifoldSecrets`), is cycle-legal (`@_exported` shim points down), and needs
+zero consumer source edits. Same end-state dependency shape, ~1/8th the churn.
+
+End state: `ManifoldContract` (leaf, thin kernel) ← backends ; `ManifoldInference` (the engine,
+keeps its name, never moves, `@_exported import ManifoldContract`) ; `ManifoldRuntime` (turn loop,
+stays put).
+
+## Naming decision (resolved): keep `ManifoldInference`
+No rename to `ManifoldEngine`. The heavy module keeps `InferenceService`+queue and stays
+`ManifoldInference`; "Inference" is metaphor-neutral and the name is liked. **Consequence:** there
+is no `ManifoldEngine` module to create and nothing to fold — the target doc's "ManifoldEngine =
+Runtime + evicted orchestration" motion is dropped. The clean 3-layer shape (Contract ← Inference ←
+Runtime) is delivered by the downward Contract extraction alone. This removes the MED-risk
+rename/rehome/CI-lockstep phase entirely.
+
+## The split (separate issues, parent #1605 → P2)
+
+The original P2 conflated two things the review shows are independent. Decoupled into three:
+
+- **[#1719] P2a — Extract `ManifoldContract` leaf (delivers the thin Contract kernel).** ~30 protocol/
+  event/config/stream/message files move down; `@_exported import ManifoldContract` shim in
+  `ManifoldInference`; repoint `ManifoldFoundation`+`ManifoldCloud` deps to Contract-only; leave
+  MLX/Llama/MCP on `ManifoldInference` (real engine use); `BackendRegistrar` stays with the engine.
+  Closure-taint check per file. New target has zero deps (tripwire test). Behavior-neutral. **Risk: LOW.**
+- **[#1720] P2b — Grow the P0c harness (test-only, prereq for P2c).** Extend `EventTraceCanonicalizer`
+  to emit `agentID`/`sessionID`/`promptTokens`/`completionTokens` (today dropped → handoff/usage
+  bugs diff clean). Add `test_handoff_midStream` + `test_tokenUsage` goldens. **Risk: LOW.**
+  Parallel-able with P2a (disjoint files; serialize pushes).
+- **[#1721] P2c — De-tangle `ConversationTurnExecutor` (the real refactor, inside `ManifoldRuntime`).**
+  1,740 L → thin per-turn executor; lift `eventSink` emissions + persistence writes behind narrow
+  ports; make the tool-dispatch seam explicit. No module move. INVARIANTS: `sessionRecord` stays a
+  function-local re-pinned var, never re-fetched mid-stream (the headline race trap); #965; #1606;
+  KV discipline; `@Sendable` sinks don't capture `@MainActor` state. Diff clean vs the grown goldens.
+  Persona-review the diff. **Risk: HIGH.** Depends on P2b.
+
+Sequencing: (P2a ∥ P2b) → P2c. P2a/P2b are parallel-safe (disjoint files, serialize the push);
+P2c is sequential after P2b (needs the grown goldens) and rewrites the turn-loop files. The
+migration's "fewer, larger units" exception applies; cap in-flight PRs.

--- a/docs/plans/p2c-detangle-brief.md
+++ b/docs/plans/p2c-detangle-brief.md
@@ -1,0 +1,106 @@
+# P2c — De-tangle `ConversationTurnExecutor` (dispatch-ready brief)
+
+Issue: #1721. Parent: #1605. Plan: `docs/plans/p2-engine-carve-split.md`.
+**Risk: HIGH. Single sequential worker — NOT parallelizable** (rewrites the shared turn-loop file).
+**The one real refactor of P2.** Behavior-preserving: every step diffs clean against the P0c goldens.
+
+## Preconditions (do NOT start until both are true)
+- **#1722 merged** (P2b grown goldens: `agentID`/`sessionID`/token fields in the canonicalizer +
+  `test_handoff_midStream` + `test_tokenUsage`). This is the safety net — the de-tangle is unsafe
+  without it.
+- **#1723 merged** (P2a `ManifoldContract` leaf). Not strictly required for this file, but branch off
+  the `main` that contains both so the worktree matches CI.
+
+Branch off fresh `origin/main` after both land. If they merge mid-work, rebase (verify checkout +
+HEAD movement) before pushing.
+
+## Target file
+`Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift` — a 1,740-line `struct` with four
+public entry flows (`runSendFlow` ~L79, `runRegenerateFlow` ~L243, `runEditFlow` ~L308,
+`runBranchFlow` ~L396) converging on a shared `runGenerationTurn`. No module move — this is an
+internal refactor within `ManifoldRuntime`.
+
+## Goal
+Reduce the monolith to a thin per-turn executor by lifting cross-cutting concerns behind narrow,
+testable seams — WITHOUT changing observable behavior:
+- **Persistence writes** (`ConversationPersistencePort`: `insertMessage`/`deleteMessage`/
+  `fetchMessages`/`fetchSession`/`updateSession`/`touchSession`, ~12 call sites) behind a narrow
+  turn-scoped port.
+- **Event emission** (~50 `emit(...)` calls via the `eventSink` @Sendable closure, private `emit`
+  ~L1281) behind a typed per-turn emitter.
+- **Tool-dispatch seam** (advertise `readAdvertisedToolDefinitions` ~L744, register
+  `registerSessionToolExecutors` ~L754, unregister ~L1700; execute happens in `ManifoldInference`'s
+  `GenerationQueue`/dispatch loop) made explicit instead of cross-cutting-implicit.
+- Optionally extract the pre-turn (~L130–184) and post-turn (~L1199–1275) **compression** coordination
+  (shared `makeCompressionGenerateClosure` ~L1481) into its own coordinator.
+
+The four flows should read as: assemble context → enqueue → consume stream → persist → post-turn,
+with each concern a named collaborator rather than inline.
+
+## INVARIANTS — must be preserved exactly (from the concurrency persona review)
+1. **`sessionRecord` stays a function-local, re-pinned `var` — NEVER re-fetched from the store
+   mid-stream.** It is fetched once (~L611) and re-pinned from `handoff.targetAgentID` AFTER the
+   async `updateSession` (~L894). The executor is a `struct` and `runGenerationTurn` is a single
+   non-reentrant async function, so the local is the authoritative copy and nothing else can observe
+   it between the write and the re-pin. **Do NOT replace this with a "single source of truth" port
+   that re-reads session state on the next loop iteration** — that inserts an async read-after-async-
+   write where the store write may not yet be visible, reintroducing a race the current design avoids.
+   If you lift `updateSession` behind a port, the port returns void and the local re-pin stays.
+2. **#965 switch-cancel-resend** — the empty-assistant-drop branch (~L1082–1087) relies on
+   `GenerationQueue.discardRequests(notMatching:)`. Preserve the ordering.
+3. **#1606 register-before-enqueue** — session tool executors MUST be registered on the
+   `InferenceService.toolRegistry` BEFORE `enqueueAsync` (~L737–775), else the dispatch loop returns
+   `unknownTool`. Keep this ordering when extracting the tool-dispatch seam.
+4. **KV-cache re-read-after-async-write discipline** — don't reorder reads of backend state around
+   the async stream-consume boundary.
+5. **`@Sendable` event sinks must not capture `@MainActor` state.** Any extracted emitter/port that
+   receives `eventSink` takes it as `@Sendable (ConversationEvent) -> Void` and must NOT close over
+   `InferenceService` or any `@MainActor` member. Main-actor reads stay behind the existing
+   `@MainActor read*()` hops (`readActiveBackendName` ~L1716, etc.). Watch the Swift 6 gotcha:
+   a non-isolated async helper receiving a `@MainActor`-capturing closure triggers
+   `#SendingRisksDataRace` — annotate the closure or keep the read behind the hop.
+6. **preCompact hook is observational in v1** (~L1217–1236) — `block:true` is ignored. Don't
+   "fix" that here; it's documented contract.
+7. **Token-usage pinning** (~L967–981) — the per-turn `lastTokenUsage` read must stay pinned to the
+   turn so back-to-back sends don't cross-contaminate counts. Now golden-covered by `test_tokenUsage`.
+
+## Approach: incremental, each step golden-verified
+Do NOT big-bang this. Land it as a sequence of behavior-preserving commits (the issue allows 1–2 PRs;
+prefer a stack of small commits on one branch, or two PRs split at a natural seam):
+
+1. **Extract the event emitter** (lowest risk). Introduce a `TurnEventEmitter` (or similar) wrapping
+   the `@Sendable` sink with typed phase methods; replace the ~50 inline `emit(...)` calls. Run the
+   goldens — must diff clean (event order/identity unchanged).
+2. **Extract the persistence seam.** Narrow turn-scoped writes behind a port; keep `sessionRecord`
+   local per invariant 1. Run goldens — clean.
+3. **Extract the tool-dispatch binding** (advertise/register/unregister lifecycle), preserving #1606
+   ordering. Run goldens — clean (`test_tool_roundTrip` + `test_handoff_midStream` are the guards).
+4. **Thin the four flows** over the extracted collaborators. Run goldens — clean.
+5. (Optional) **Compression coordinator** extraction.
+
+After EACH step, the grown P0c goldens must diff clean. If a step forces a golden change, STOP — a
+behavior-preserving refactor must not change goldens; investigate before re-recording.
+
+When changing any behavior touchpoint, grep ALL of `Tests/` for references (not just the obvious
+file) — `ConversationRuntimeTests`, `HandoffScenarioTests`, `CompressionPolicyTests`,
+`PreCompactWiringTests`, `SessionToolSource*Tests`, the characterization harness.
+
+## Gate (before push)
+- `scripts/test.sh --profile local` (full all-traits XCTest + Swift-Testing two-invocation shape).
+- The grown characterization goldens diff clean:
+  `swift test --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits` (twice).
+- Add sabotage checks per QA-PRACTICES §3 to prove each extracted seam fails the test when broken;
+  **remove before committing**.
+- Never stage `Package.resolved`.
+
+## Mandatory diff review (before merge)
+Because this is the HIGH-risk refactor, after the worker has a green branch, run **2–3 persona
+reviewers on the DIFF in parallel** (concurrency / turn-loop-correctness / test-coverage lenses),
+specifically checking the 7 invariants above survived. Only open/finalize the PR once they clear.
+Do NOT `--auto`/`--merge`; report the PR URL for maintainer merge.
+
+## Commit / PR
+- Conventional: `refactor(ManifoldRuntime): de-tangle ConversationTurnExecutor into per-turn seams`
+  (refactor → no release), trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- PR body: `Closes #1721`, the seam decomposition, per-step golden results, the 7 invariants checklist,
+  and the persona-review verdicts.

--- a/docs/plans/target-architecture-migration.md
+++ b/docs/plans/target-architecture-migration.md
@@ -1,5 +1,37 @@
 # Plan — Target Architecture Migration
 
+> **Superseded (2026-06) — P2 executed differently than written here. Read before using
+> phase labels.**
+>
+> The P2 engine carve took a different path after the persona review. Details in
+> `docs/plans/p2-engine-carve-split.md`; PRs #1722/#1723/#1724. Key deltas:
+>
+> 1. **`ManifoldEngine` was not created.** The "P2a — Create `ManifoldEngine`" step was dropped.
+>    Instead a new `ManifoldContract` leaf was extracted *downward* from `ManifoldInference`
+>    (see p2-engine-carve-split.md for the direction decision). `ManifoldInference` keeps its
+>    name.
+>
+> 2. **P2 was split into three sub-phases (not two).** What this doc called P2a and P2b became:
+>    - **P2a** (#1719/#1723): Extract `ManifoldContract` leaf; repoint `ManifoldFoundation` and
+>      `ManifoldCloud` to Contract-only.
+>    - **P2b** (#1720/#1722): Grow the P0c characterization harness (new goldens for `agentID`,
+>      `sessionID`, token usage, `test_handoff_midStream`). Inserted as a prereq for P2c.
+>    - **P2c** (#1721/#1724): De-tangle `ConversationTurnExecutor` (this doc's original "P2b").
+>
+> 3. **"P2a … move orchestration in (`PromptAssembler`, `ContextWindowManager`,
+>    `GenerationQueue`, …)"** is stale. None of those types moved. They stay in
+>    `ManifoldInference`.
+>
+> 4. **"New test targets: `ManifoldNetworkingTests`, `ManifoldSecretsTests` (P1);
+>    `ManifoldEngineTests` (P2)"** — `ManifoldNetworkingTests` and `ManifoldSecretsTests` are
+>    live (P1 complete). `ManifoldEngineTests` was never created (no `ManifoldEngine` module).
+>
+> 5. **P1c: "Device-capability + GGUF readers → adapter-side (MLX/Llama only)"** is stale.
+>    These landed in the shared `ManifoldHardware` leaf (not adapter-side).
+>
+> The overall sequencing rationale, phase gates, per-phase adopter impact table, and P3–P7
+> plans remain accurate. Phase references from P3 onward use the original numbering.
+
 Sequenced path from today's structure to the end state in
 [`target-architecture.md`](./target-architecture.md). This is a **planning artifact** —
 decisions, sequencing, and test/CI prerequisites before code, so reviewers argue with the

--- a/docs/plans/target-architecture.md
+++ b/docs/plans/target-architecture.md
@@ -1,5 +1,42 @@
 # Plan — Target Architecture ("The Manifold")
 
+> **Superseded (2026-06) — read before acting on module names or ring assignments.**
+>
+> Several structural decisions in this document were revised after the P2 persona review.
+> The changes are recorded in `docs/plans/p2-engine-carve-split.md` and implemented in PRs
+> #1722/#1723/#1724. Key deltas:
+>
+> 1. **`ManifoldEngine` was dropped.** The plan originally called for a new `ManifoldEngine`
+>    module (= today's `ManifoldRuntime` + orchestration evicted from the kernel). The P2
+>    review found that moving the engine *up* required 246 lockstep edits across 35 modules.
+>    Instead, the Contract was extracted *downward* as a new `ManifoldContract` leaf. No
+>    module was renamed: `ManifoldInference` keeps its name and remains the engine.
+>
+> 2. **The kernel is `ManifoldContract`, not a slimmed `ManifoldInference`.** `ManifoldContract`
+>    is the new leaf that holds backend protocols, generation events, message/tool contracts,
+>    and streaming transforms. It depends on `ManifoldHardware` + `ManifoldModelCatalog` (the
+>    P1 leaves). `ManifoldInference` `@_exported import`s it for source compatibility.
+>
+> 3. **"RING 0 — CONTRACT … product: `ManifoldInference` (target ~3.4k LOC)"** is stale.
+>    The Contract product is now `ManifoldContract`. `ManifoldInference` is the engine (RING 1).
+>
+> 4. **"RING 1 — ENGINE · product: `ManifoldEngine`"** is stale. The engine ring is served by
+>    `ManifoldInference` (orchestration) + `ManifoldRuntime` (turn loop + ports) — no new
+>    product was created.
+>
+> 5. **The migration's "P2b de-tangle" was renumbered P2c.** A grow-the-golden-harness step
+>    was inserted as the new P2b (#1722) before the de-tangle (now P2c, #1724). The migration
+>    doc's P2a/P2b labels no longer match the executed sequence.
+>
+> 6. **"Utility leaves → Device-capability + GGUF readers → adapter-side (MLX/Llama only)"**
+>    is stale. These landed in the shared `ManifoldHardware` leaf (P1c #1610), not adapter-side.
+>    Both `ManifoldMLX` and `ManifoldLlama` consume `ManifoldHardware` via `ManifoldInference`'s
+>    transitive dep — the leaf is shared, not duplicated per-family.
+>
+> The Consumption Ladder's `ManifoldEngine` column is stale; substitute `ManifoldInference` for
+> the engine row. Everything else in this document — the manifold metaphor, ring model, invariants,
+> moat thesis, expansion axes, and trait disposition — remains accurate.
+
 This is a **planning artifact**, not user-facing documentation and not an implementation
 plan. It captures the agreed *end state* for ManifoldKit's module architecture so a
 subsequent migration plan can be argued against a fixed target. When the structure


### PR DESCRIPTION
## Summary

- **CLAUDE.md Targets table** completely rebuilt from Package.swift ground truth:
  - Adds 14 missing modules: `ManifoldContract`, `ManifoldHardware`, `ManifoldModelCatalog`, `ManifoldNetworking`, `ManifoldSecrets`, `ManifoldSkills`, `ManifoldTools`, `ManifoldAppIntents`, `ManifoldHuggingFace`, `ManifoldMCPHost`, `ManifoldFuzz`/`ManifoldFuzzBackends`, `ManifoldServer`, `ManifoldContractTestSupport`, `StableDiffusion`, `FluxSwift`
  - Corrects `ManifoldInference` row: it is the *engine* (`InferenceService`, `GenerationQueue`, tool subsystem), not "backend protocols/events" — those now live in `ManifoldContract`
  - Documents `ManifoldFoundation` and `ManifoldCloud` repointed to `ManifoldContract` only (P2a #1719)
  - Documents `ManifoldCloud`'s deliberate `ManifoldRuntime` dep (`WebSearchRuntime` port conformance)
  - Clarifies `ManifoldMCP` module is unconditional — the `MCP` trait only gates test edges + `MCPBuiltinCatalog` define
  - Notes `ManifoldMLX` and `ManifoldLlama` still depend on `ManifoldInference` (real engine use: `extension InferenceService`, `BackendRegistrar`)
  - Notes `ManifoldKit` umbrella also re-exports `ManifoldModelCatalog` + `ManifoldSkills` (conditional on `Skills` trait, which is default-on)

- **`docs/plans/target-architecture.md`**: supersession block at top covering dropped `ManifoldEngine` rename, Contract-down extraction outcome, stale ring-0/ring-1 product labels, P2b→P2c renumber, and P1c device-capability placement in `ManifoldHardware` (not adapter-side)

- **`docs/plans/target-architecture-migration.md`**: supersession block at top covering dropped "P2a Create ManifoldEngine" step, P2 three-sub-phase split (P2a/P2b/P2c), stale "move orchestration in" claim, missing `ManifoldEngineTests` note, and P1c correction

- **Commits `p2-engine-carve-split.md` and `p2c-detangle-brief.md`** (were untracked on origin/main; referenced by the supersession notes as the authoritative P2 decision record)

## What was stale vs. what the code says

All factual claims were verified against Package.swift in the worktree before being written. No discrepancies found between what this prompt described and what origin/main actually contains.

## Test plan

- [ ] Docs-only change — no build required
- [ ] Verify no `Package.resolved` was staged (confirmed: none)
- [ ] Spot-check CLAUDE.md table rows against Package.swift target definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)