### PR TITLE
ci(docs): unblock DocC publish with -skipMacroValidation and alert on failure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 jobs:
   build:
@@ -86,7 +87,8 @@ jobs:
             -scheme ManifoldKit \
             -destination 'generic/platform=macOS' \
             -derivedDataPath "$RUNNER_TEMP/docc-dd" \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            -skipMacroValidation
 
       - name: Transform for static hosting
         # Pick the umbrella archive (named ManifoldKit.doccarchive) as the site
@@ -121,6 +123,36 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs-site
+
+      - name: Open GitHub issue on failure
+        # Creates a tracking issue so a DocC build failure is visible without
+        # relying on GitHub's email digest. De-duplication: if an open issue
+        # with the same title prefix already exists, appends a comment instead
+        # of opening a second issue — avoids spam during multi-run failure streaks.
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          title="DocC publish failed"
+          existing=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search "${title} in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Open issue #${existing} already exists — adding comment."
+            gh issue comment "$existing" \
+              --repo "${{ github.repository }}" \
+              --body "Also failed on [run ${{ github.run_id }}](${run_url})."
+          else
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "${title}" \
+              --body "$(printf '## DocC publish failed\n\n**Run:** [%s](%s)\n\nThe DocC → GitHub Pages workflow failed. Check the run logs for the root cause and close this issue once resolved.' "${{ github.run_id }}" "${run_url}")"
+          fi
 
   deploy:
     needs: build


### PR DESCRIPTION
## Root cause

The DocC publish workflow (`docs.yml`) has failed all **15/15 runs since 2026-06-07** with:

```
/Users/runner/work/_temp/docc-dd/SourcePackages/checkouts/mlx-swift-lm/Package.swift:PACKAGE-TARGET:MLXHuggingFaceMacros: error: Macro "MLXHuggingFaceMacros" from package "mlx-swift-lm" must be enabled before it can be used
** BUILD DOCUMENTATION FAILED ** (ComputeTargetDependencyGraph)
```

Macro validation is a **separate gate** from package plugin validation. The existing `-skipPackagePluginValidation` flag suppresses plugin validation only. The `xcodebuild` flag `-skipMacroValidation` is required in addition to allow the dependency graph to build when macros from external packages (here `MLXHuggingFaceMacros` from `mlx-swift-lm`) are present.

## Changes

- **`-skipMacroValidation`** added to the `xcodebuild docbuild` invocation alongside `-skipPackagePluginValidation`.
- **Failure alerting** added: a new `if: failure()` step (mirroring the pattern in `nightly-slow-tests.yml`) opens a GitHub issue on failure. If an open issue with the same title already exists, it appends a comment instead of creating a duplicate. This prevents silent multi-day failure streaks like the 15-run window just observed.
- **`issues: write`** added to the top-level `permissions:` block to support the issue-create step. All other permissions (`pages: write`, `id-token: write`) are unchanged.

## Local verification

Ran the exact docbuild command from the workflow with the new flag on the worktree:

```
xcodebuild docbuild -scheme ManifoldKit -destination 'generic/platform=macOS' \
  -derivedDataPath $TMPDIR/docc-dd-verify2 \
  -skipPackagePluginValidation -skipMacroValidation
```

- At ~8s: package graph resolved, no macro error at `ComputeTargetDependencyGraph` (this is where all 15 prior runs aborted).
- At ~100s: build was deep into real compilation — SwiftSyntax Swift files compiling, Metal shaders from `mlx-swift` compiling, C targets from `swift-numerics` compiling. 13,199 log lines emitted.
- Zero `"must be enabled"` errors found in the log at any point.

The build was left running in the background to completion, but the critical gate (the dependency graph phase) was confirmed clear.

## actionlint

`actionlint` ran on the edited file and produced no output (exit 0 — no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)