### PR TITLE
refactor: route all ConversationRuntime construction through one wiring function

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -241,22 +241,12 @@ public final class ManifoldBootstrap {
             // that run on iOS 26+ / macOS 26+ can wire their own auxiliary service
             // via `runtimeOptions.auxiliaryInferenceService`.
             // See ManifoldFoundation.FoundationBackend for the recommended setup.
-            self.conversationRuntime = ConversationRuntime(
-                messageStore: resolvedPersistence,
-                sessionStore: resolvedPersistence,
+            self.conversationRuntime = Self.makeConversationRuntime(
+                persistence: resolvedPersistence,
                 inferenceService: resolvedInferenceService,
-                pipeline: runtimeOptions.pipeline,
-                budgetPlanner: runtimeOptions.budgetPlanner,
                 ragService: resolvedRAGService,
-                auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
                 usageStore: resolvedUsageStore,
-                generationHooks: runtimeOptions.generationHooks,
-                compressionPolicy: runtimeOptions.compressionPolicy,
-                preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
-                historyShaper: runtimeOptions.historyShaper,
-                historyProviders: runtimeOptions.historyProviders,
-                hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
-                turnContextProvider: runtimeOptions.turnContextProvider,
+                runtimeOptions: runtimeOptions,
                 sessionToolSources: sessionToolSources,
                 hookRegistry: hookRegistry
             )
@@ -309,22 +299,12 @@ public final class ManifoldBootstrap {
         self.usageStore = usageStore
         self.ragService = ragService
         self._isInMemory = isInMemory
-        self.conversationRuntime = ConversationRuntime(
-            messageStore: persistence,
-            sessionStore: persistence,
+        self.conversationRuntime = Self.makeConversationRuntime(
+            persistence: persistence,
             inferenceService: inferenceService,
-            pipeline: runtimeOptions.pipeline,
-            budgetPlanner: runtimeOptions.budgetPlanner,
             ragService: ragService,
-            auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
             usageStore: usageStore,
-            generationHooks: runtimeOptions.generationHooks,
-            compressionPolicy: runtimeOptions.compressionPolicy,
-            preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
-            historyShaper: runtimeOptions.historyShaper,
-            historyProviders: runtimeOptions.historyProviders,
-            hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
-            turnContextProvider: runtimeOptions.turnContextProvider,
+            runtimeOptions: runtimeOptions,
             sessionToolSources: sessionToolSources,
             hookRegistry: hookRegistry
         )
@@ -347,6 +327,47 @@ public final class ManifoldBootstrap {
             self.videoRuntime = nil
         }
         self.webSearchRuntime = webSearchRuntime
+    }
+
+    /// Constructs the ``ConversationRuntime`` from fully-resolved, path-specific
+    /// inputs.
+    ///
+    /// Shared by the public synchronous `init` and the internal `init` (which
+    /// the async ``build()`` factory delegates to) so all construction paths
+    /// wire the runtime identically. A forgotten argument can only be forgotten
+    /// in one place — before this was factored out, the public `init` and the
+    /// internal `init` duplicated the 17-argument construction block verbatim,
+    /// which historically caused `build()` to ship with RAG silently missing
+    /// (the ``makeRAGService(_:_:)`` refactor fixed the equivalent RAG bug;
+    /// this factory closes the runtime-wiring gap).
+    private static func makeConversationRuntime(
+        persistence: SwiftDataPersistenceProvider,
+        inferenceService: InferenceService,
+        ragService: RAGService?,
+        usageStore: SwiftDataUsageStore,
+        runtimeOptions: ConversationRuntimeOptions,
+        sessionToolSources: [any SessionToolSource],
+        hookRegistry: HookRegistry?
+    ) -> ConversationRuntime {
+        ConversationRuntime(
+            messageStore: persistence,
+            sessionStore: persistence,
+            inferenceService: inferenceService,
+            pipeline: runtimeOptions.pipeline,
+            budgetPlanner: runtimeOptions.budgetPlanner,
+            ragService: ragService,
+            auxiliaryInferenceService: runtimeOptions.auxiliaryInferenceService,
+            usageStore: usageStore,
+            generationHooks: runtimeOptions.generationHooks,
+            compressionPolicy: runtimeOptions.compressionPolicy,
+            preTurnCompressionPolicy: runtimeOptions.preTurnCompressionPolicy,
+            historyShaper: runtimeOptions.historyShaper,
+            historyProviders: runtimeOptions.historyProviders,
+            hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
+            turnContextProvider: runtimeOptions.turnContextProvider,
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry
+        )
     }
 
     /// Constructs the ``RAGService`` for the given configuration, or returns

--- a/Sources/ManifoldUI/ViewModels/InMemoryMessageStore.swift
+++ b/Sources/ManifoldUI/ViewModels/InMemoryMessageStore.swift
@@ -10,6 +10,12 @@ import ManifoldRuntime
 /// ``ChatViewModel/configure(runtime:)`` so chat history outlives the process.
 /// This in-memory store keeps tests and ad-hoc surfaces functional without
 /// requiring every caller to assemble a ``ConversationRuntime`` themselves.
+///
+/// This type lives in `ManifoldUI` rather than `ManifoldRuntime` because
+/// `ManifoldRuntimeTests` already declares its own test-local `InMemoryMessageStore`
+/// (with a different shape) in `InMemoryMessageStore+TestHelpers.swift`. Moving
+/// this type would require renaming one of the two, which constitutes a
+/// behaviour-visible change — deferred to a follow-up.
 @MainActor
 final class InMemoryMessageStore: MessageStore {
     private var messages: [UUID: ChatMessage] = [:]

--- a/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ManifoldBootstrapRuntimeOptionsTests.swift
@@ -188,4 +188,52 @@ final class ManifoldBootstrapRuntimeOptionsTests: XCTestCase {
         let conversationRuntime: ConversationRuntime = bootstrap.conversationRuntime
         _ = conversationRuntime
     }
+
+    // MARK: - Wiring parity between sync init and async build()
+    //
+    // Regression gate for the class of bug where a new ConversationRuntimeOptions
+    // field is wired in the public `init` but silently omitted from the `build()`
+    // path (or vice versa). The historical incident: `build()` shipped with RAG
+    // wiring missing; `makeRAGService` fixed that. `makeConversationRuntime`
+    // closes the equivalent gap for all ConversationRuntime arguments.
+    //
+    // We use `auxiliaryInferenceService` as the probe because it is the most
+    // directly observable runtime property that flows through runtimeOptions.
+    // If both paths call the same factory, both will thread the option through.
+    // If either path regresses to a hand-rolled construction, the assertion fails.
+
+    func test_initAndBuild_wireAuxiliaryInferenceServiceIdentically() async throws {
+        let original = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = original }
+
+        let auxiliaryBackend = MockInferenceBackend()
+        let auxiliaryService = InferenceService(backend: auxiliaryBackend, name: "AuxService")
+
+        var options = ConversationRuntimeOptions()
+        options.auxiliaryInferenceService = auxiliaryService
+
+        // Sync init path
+        let syncBootstrap = try ManifoldBootstrap(
+            configuration: makeConfig(tag: "aux-wiring-sync"),
+            runtimeOptions: options,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        XCTAssertTrue(
+            syncBootstrap.conversationRuntime.auxiliaryInferenceService === auxiliaryService,
+            "sync init: auxiliaryInferenceService must be threaded through to ConversationRuntime"
+        )
+
+        // Async build() path — delegates to the same internal init and makeConversationRuntime
+        let (progress, task) = ManifoldBootstrap.build(
+            configuration: makeConfig(tag: "aux-wiring-build"),
+            runtimeOptions: options,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+        )
+        for await _ in progress {}
+        let buildBootstrap = try await task.value
+        XCTAssertTrue(
+            buildBootstrap.conversationRuntime.auxiliaryInferenceService === auxiliaryService,
+            "build() path: auxiliaryInferenceService must be threaded through to ConversationRuntime"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Extracts `private static func makeConversationRuntime(...)` in `ManifoldBootstrap` so the public synchronous `init` and the internal `init` (which the async `build()` path delegates to) both call the same 17-argument `ConversationRuntime` construction block.
- Adds a regression test (`test_initAndBuild_wireAuxiliaryInferenceServiceIdentically`) proving both paths wire `auxiliaryInferenceService` identically — the observable proxy for the class of silent-miss bug that previously caused `build()` to ship without RAG wiring.
- Adds a doc comment to `InMemoryMessageStore` noting why the module move was deferred.

## Before / after — wiring paths

**Before:** two verbatim copies of the 17-argument `ConversationRuntime(...)` block, one in the public `init` (sync path) and one in the internal `init` (async `build()` path). An extension or new `ConversationRuntimeOptions` field had to be added in two places; a copy-paste miss was the documented root cause of the prior RAG-missing incident.

**After:**
```
public init(...)            → Self.makeConversationRuntime(...)
internal init(...)          → Self.makeConversationRuntime(...)
static func build(...)      → internal init(...)  [unchanged delegation chain]
static func makeInMemory()  → public init(...)    [unchanged delegation chain]
```
One place to wire a new argument.

## What was intentionally NOT unified and why

**ChatViewModel's in-memory runtime construction** (`ChatViewModel+PersistenceAdapter.swift`): the `onPersistenceConfigured` callback constructs `ConversationRuntime(messageStore:sessionStore:inferenceService:)` with only 3 arguments — this is the intentional "late-bind persistence with defaults" path for when a host passes no runtime at construction time and subsequently wires persistence. It deliberately does NOT re-apply `runtimeOptions` because `ChatViewModel` never received a `runtimeOptions` parameter. Unifying it with Bootstrap's 17-argument factory would require either threading `runtimeOptions` through `ChatViewModel` (new public API) or creating a misleading factory that silently discards most options. Left as-is with no coupling added.

**`InMemoryMessageStore` module location** (ManifoldUI → ManifoldRuntime): the move was blocked by a naming collision — `ManifoldRuntimeTests` already defines its own test-local `InMemoryMessageStore` in `InMemoryMessageStore+TestHelpers.swift` with a different shape (`private(set) var messages` vs the UI version's `private var messages`). Moving would require renaming one of the two, which is a behaviour-visible change. The type stays in `ManifoldUI/ViewModels/` with a doc comment noting the deferral.

## Gate results

`scripts/test.sh --profile local --skip-update`:

```
XCTest (classic runner):   Passed: 150 / Failed: 0 / Skipped: 0
Swift Testing (parallel):  Passed: 262 / Failed: 0 / Skipped: 0
TOTAL: 412 passed, 0 failed  — RESULT: PASSED
```

New test `ManifoldBootstrapRuntimeOptionsTests.test_initAndBuild_wireAuxiliaryInferenceServiceIdentically` passed in 0.004 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)