### PR TITLE
test: golden coverage for turn-loop compression paths

### DIFF
--- a/Tests/ManifoldTurnLoopCharacterizationTests/CompressionGoldenTests.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/CompressionGoldenTests.swift
@@ -1,0 +1,399 @@
+import XCTest
+import SnapshotTesting
+@testable import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldTestSupport
+
+// MARK: - CompressionGoldenTests
+
+/// Golden-transcript harness for the turn-loop compression paths in
+/// ``ConversationTurnExecutor``.
+///
+/// **Purpose.** PR #1724 deliberately left the pre-turn and post-turn
+/// compress-and-replace sequences inside ``ConversationTurnExecutor`` because
+/// no golden harness covered them. Any future "behavior-preserving" extraction
+/// of those paths (P3a) was therefore unprovable. These tests provide the
+/// proof: the full ``ConversationEvent`` sequence and persisted record set for
+/// each compression path are snapshotted; any behavior-altering refactor of
+/// the executor's compression coordination will produce a diff here.
+///
+/// **What each test pins:**
+/// - ``test_postTurn_compressionTriggered`` — post-turn path: events include
+///   `compressionTriggered` then `historyCompressed`; records contain only the
+///   replacement summary message.
+/// - ``test_preTurn_compressionTriggered`` — pre-turn path: compression events
+///   fire before the user message is inserted; records reflect the compressed
+///   history followed by the new user and assistant messages.
+/// - ``test_postTurn_preCompactHook_observational`` — preCompact hook is
+///   observational (invariant 6 from P2c brief): a `block:true` result does
+///   not prevent compression; the ``hookFired`` event appears in the golden
+///   and compression still completes.
+///
+/// **No-compression control** is already goldened by
+/// ``TurnLoopCharacterizationTests/test_send_plainTurn`` (no compression
+/// policy wired, no compression events). Duplicating it here would be noise.
+///
+/// **Sabotage verification** was performed for each test during development;
+/// the PR body describes the mutation applied and the observed diff.
+@MainActor
+final class CompressionGoldenTests: XCTestCase {
+
+    // MARK: - Per-test state
+
+    private var persistenceStack: InMemoryPersistenceHarness.Stack!
+    private var tapDrain: EventTapDrain!
+    private var tapDrainTask: Task<Void, Never>?
+    private var sessionID: UUID!
+
+    // MARK: - setUp / tearDown
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistenceStack = try InMemoryPersistenceHarness.make()
+        tapDrain = EventTapDrain()
+        sessionID = UUID()
+    }
+
+    override func tearDown() async throws {
+        tapDrainTask?.cancel()
+        tapDrainTask = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Policy helpers (local to this suite)
+
+    /// Compression policy that always decides to compress (when contextSize > 0).
+    /// Returns a single summary record without calling `generate`, so no second
+    /// backend round-trip is needed and the generate closure is deterministic.
+    private struct AlwaysCompressPolicy: CompressionPolicy {
+        let summaryContent: String
+
+        func shouldCompress(promptTokens: Int, contextSize: Int, contextUtilization: Double) -> Bool {
+            contextSize > 0
+        }
+
+        func compress(
+            history: [ManifoldInference.ChatMessage],
+            sessionID: UUID,
+            generate: @Sendable ([ManifoldInference.ChatMessage]) async throws -> String
+        ) async throws -> [ManifoldInference.ChatMessage] {
+            // Return a single memory record summarising the history. Does NOT
+            // call `generate` so the test stays self-contained: no second
+            // backend round-trip means no non-determinism in the event stream.
+            [ManifoldInference.ChatMessage(
+                role: .system,
+                content: summaryContent,
+                sessionID: sessionID,
+                kind: .memory("summary")
+            )]
+        }
+    }
+
+    /// Pre-turn compression policy that fires when the history already contains
+    /// at least one message (messageCount >= 1). Like the post-turn variant,
+    /// it returns a single summary record without calling `generate`.
+    private struct AlwaysPreCompressPolicy: PreTurnCompressionPolicy {
+        let summaryContent: String
+
+        func shouldCompressBeforeTurn(messageCount: Int, lastPromptTokens: Int?) -> Bool {
+            // Fire whenever there is any existing history to compress.
+            messageCount >= 1
+        }
+
+        func compressBeforeTurn(
+            history: [ManifoldInference.ChatMessage],
+            sessionID: UUID,
+            generate: @Sendable ([ManifoldInference.ChatMessage]) async throws -> String
+        ) async throws -> [ManifoldInference.ChatMessage] {
+            [ManifoldInference.ChatMessage(
+                role: .system,
+                content: summaryContent,
+                sessionID: sessionID,
+                kind: .memory("summary")
+            )]
+        }
+    }
+
+    // MARK: - Backend helper
+
+    /// Returns a ``ScriptedGenerationBackend`` that emits a usage event so
+    /// the post-turn compression gate activates (requires non-nil promptTokens).
+    /// `maxContextTokens: 256` gives a non-zero context size; the executor's
+    /// `readContextWindowSize()` reads `capabilities.contextWindowSize` which
+    /// is `Int(maxContextTokens)`, so 256 is both representable and above zero.
+    private func makeUsageBackend(
+        promptTokens: Int = 50,
+        completionTokens: Int = 5,
+        textTokens: [String] = ["OK"],
+        maxContextTokens: Int32 = 256
+    ) -> ScriptedGenerationBackend {
+        ScriptedGenerationBackend(
+            turns: [.withUsage(prompt: promptTokens, completion: completionTokens, tokens: textTokens)],
+            capabilities: BackendCapabilities(
+                supportedParameters: [.temperature],
+                maxContextTokens: maxContextTokens,
+                requiresPromptTemplate: false,
+                supportsSystemPrompt: true,
+                supportsToolCalling: false,
+                supportsStructuredOutput: false,
+                cancellationStyle: .cooperative,
+                supportsTokenCounting: false
+            )
+        )
+    }
+
+    // MARK: - Drain helpers
+
+    /// Drains the tap until `afterGeneration` or an early-exit terminal event.
+    private func drainTurn() async -> [ConversationEvent] {
+        var events: [ConversationEvent] = []
+        let end = ContinuousClock.now.advanced(by: .seconds(10))
+        while let event = await tapDrain.next() {
+            events.append(event)
+            if case .afterGeneration = event { break }
+            if case .errorRaised = event { break }
+            if case .streamFinished(_, let r) = event, r == .cancelled { break }
+            if ContinuousClock.now > end { break }
+        }
+        return events
+    }
+
+    /// Continues draining after `afterGeneration` until the post-turn
+    /// `historyCompressed` event fires. Post-turn compression runs AFTER
+    /// `afterGeneration` in the executor's call chain, so the normal
+    /// `drainTurn()` terminal misses it. This drain runs for up to `deadline`
+    /// after `drainTurn()` returns.
+    ///
+    /// The deadline is enforced by racing the drain against a `Task.sleep`
+    /// using `withThrowingTaskGroup`. When the sleep wins, the group is
+    /// cancelled and `next()` — which uses `withCheckedContinuation` — is
+    /// unblocked via `EventTapDrain.drainRemaining()` (a batch flush that
+    /// resumes all pending waiters with `nil`).
+    private func drainPostTurnCompression(deadline: Duration = .seconds(5)) async -> [ConversationEvent] {
+        // Capture the actor reference (Sendable) separately to avoid capturing
+        // the non-Sendable XCTestCase self into the task closure.
+        let drain = tapDrain!
+        do {
+            return try await withThrowingTaskGroup(of: [ConversationEvent].self) { group in
+                group.addTask { () throws -> [ConversationEvent] in
+                    var events: [ConversationEvent] = []
+                    while let event = await drain.next() {
+                        events.append(event)
+                        if case .historyCompressed = event { break }
+                        try Task.checkCancellation()
+                    }
+                    return events
+                }
+                group.addTask {
+                    try await Task.sleep(for: deadline)
+                    return []
+                }
+                // First task to finish wins.
+                let result = try await group.next() ?? []
+                group.cancelAll()
+                // Unblock any suspended .next() waiters so the drain child can
+                // observe cancellation (or finish) without hanging.
+                await drain.drainRemaining()
+                return result
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: - Snapshot helper
+
+    private func assertGolden(
+        events: [ConversationEvent],
+        records: [ManifoldInference.ChatMessage],
+        file: StaticString = #filePath,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        var c = EventTraceCanonicalizer()
+        assertSnapshot(
+            of: c.serialize(events: events),
+            as: .lines,
+            named: "events",
+            record: .missing,
+            file: file,
+            testName: testName,
+            line: line
+        )
+        assertSnapshot(
+            of: c.serialize(records: records),
+            as: .lines,
+            named: "records",
+            record: .missing,
+            file: file,
+            testName: testName,
+            line: line
+        )
+    }
+
+    // MARK: - Test: post-turn compression triggered
+
+    /// Post-turn compression golden.
+    ///
+    /// The backend emits `usage(prompt:50, completion:5)` before text tokens.
+    /// The executor reads `promptTokens = 50` and `contextSize = 256` (from
+    /// `maxContextTokens`), so `AlwaysCompressPolicy.shouldCompress` returns
+    /// `true`. The executor calls `compress`, which returns one summary record.
+    /// The original messages are deleted and replaced.
+    ///
+    /// Events pinned:
+    /// - Normal turn skeleton (beforeContextAssembly → ... → afterGeneration)
+    /// - `compressionTriggered` with the removed message IDs
+    /// - `historyCompressed` with the inserted summary record
+    ///
+    /// Records pinned:
+    /// - Only the summary replacement record (user + assistant replaced)
+    func test_postTurn_compressionTriggered() async throws {
+        let policy = AlwaysCompressPolicy(summaryContent: "Compression summary.")
+        let backend = makeUsageBackend(promptTokens: 50, completionTokens: 5, textTokens: ["OK"])
+        let service = InferenceService(backend: backend, name: "CompressionMock")
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            compressionPolicy: policy
+        )
+
+        tapDrainTask = await tapDrain.start(consuming: runtime.addEventTap())
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Compress me"))
+        )
+        var events = await drainTurn()
+        // Post-turn compression fires after afterGeneration; drain it separately.
+        events += await drainPostTurnCompression()
+        _ = await handle?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: events, records: records)
+    }
+
+    // MARK: - Test: pre-turn compression triggered
+
+    /// Pre-turn compression golden.
+    ///
+    /// The store is seeded with one prior user message before the send turn.
+    /// `AlwaysPreCompressPolicy.shouldCompressBeforeTurn` returns `true` when
+    /// `messageCount >= 1`. The executor compresses before inserting the new
+    /// user message, so the compression events appear early in the event stream
+    /// (before `messageInserted(user)` for the *new* user message).
+    ///
+    /// Events pinned:
+    /// - `compressionTriggered` + `historyCompressed` before the user message
+    ///   for the new turn is inserted
+    /// - Normal turn skeleton follows the compression events
+    ///
+    /// Records pinned:
+    /// - The summary record (replacing the prior message) + the new user
+    ///   message + the new assistant reply
+    func test_preTurn_compressionTriggered() async throws {
+        // Seed the store with a prior message so shouldCompressBeforeTurn fires.
+        let priorMsg = ManifoldInference.ChatMessage(
+            role: .user,
+            content: "Prior message to be compressed.",
+            sessionID: sessionID
+        )
+        try await persistenceStack.provider.insertMessage(priorMsg)
+
+        let policy = AlwaysPreCompressPolicy(summaryContent: "Pre-turn summary.")
+        let backend = ScriptedGenerationBackend(
+            turns: [.tokens(["Pre-turn response."])],
+            capabilities: BackendCapabilities(
+                supportedParameters: [.temperature],
+                maxContextTokens: 256,
+                requiresPromptTemplate: false,
+                supportsSystemPrompt: true,
+                supportsToolCalling: false,
+                supportsStructuredOutput: false,
+                cancellationStyle: .cooperative,
+                supportsTokenCounting: false
+            )
+        )
+        let service = InferenceService(backend: backend, name: "PreTurnMock")
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            preTurnCompressionPolicy: policy
+        )
+
+        tapDrainTask = await tapDrain.start(consuming: runtime.addEventTap())
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "New turn after compression"))
+        )
+        let events = await drainTurn()
+        _ = await handle?.outcome
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: events, records: records)
+    }
+
+    // MARK: - Test: preCompact hook is observational
+
+    /// preCompact hook observational golden (invariant 6 from P2c brief).
+    ///
+    /// A `HookRegistry` is wired with a `preCompact` handler that returns
+    /// `block: true`. Per the v1 contract, `block: true` is ignored — compression
+    /// still runs, and the executor logs a warning. The golden pins:
+    /// - `hookFired(event: "preCompact")` appears in the event stream
+    /// - `compressionTriggered` and `historyCompressed` follow it
+    /// - The final record set is the compressed output (not the original history)
+    ///
+    /// This confirms the executor's "preCompact observational" invariant is
+    /// structurally enforced: extracting the compression coordinator in P3a
+    /// cannot accidentally honour `block: true` without diffing this golden.
+    func test_postTurn_preCompactHook_observational() async throws {
+        let policy = AlwaysCompressPolicy(summaryContent: "Hook-gated summary.")
+        let backend = makeUsageBackend(promptTokens: 60, completionTokens: 6, textTokens: ["Done"])
+
+        let hookRegistry = HookRegistry()
+        // Register a blocking preCompact hook — the v1 contract says this is a
+        // no-op for blocking, but the hook MUST still fire.
+        await hookRegistry.register(.preCompact) { _ in
+            HookOutput(block: true, denyReason: "test-block")
+        }
+
+        let service = InferenceService(backend: backend, name: "HookMock")
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            compressionPolicy: policy,
+            hookRegistry: hookRegistry
+        )
+
+        tapDrainTask = await tapDrain.start(consuming: runtime.addEventTap())
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Hook test turn"))
+        )
+        var events = await drainTurn()
+        events += await drainPostTurnCompression()
+        _ = await handle?.outcome
+
+        // Direct assertion: the hook must have fired and compression must have
+        // run. This is load-bearing on top of the snapshot so a
+        // re-record cannot silently absorb a regression that drops one of them.
+        let hookFired = events.contains {
+            if case .hookFired(let name, _) = $0 { return name == "preCompact" }
+            return false
+        }
+        XCTAssertTrue(hookFired, "hookFired(preCompact) must appear even when block:true")
+
+        let compressionRan = events.contains {
+            if case .historyCompressed = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(compressionRan, "compression must proceed even when preCompact hook returns block:true")
+
+        let records = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        assertGolden(events: events, records: records)
+    }
+}

--- a/Tests/ManifoldTurnLoopCharacterizationTests/SessionToolSourceDispatchTest.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/SessionToolSourceDispatchTest.swift
@@ -152,9 +152,11 @@ final class SessionToolSourceDispatchTest: XCTestCase {
 
         let registry = ToolRegistry()
         let service = InferenceService(backend: backend, name: "DispatchMock", toolRegistry: registry)
+        // sessionStore: nil so touchSession() is a no-op — this test only cares
+        // about the tool registry and must not race SwiftData against stack deallocation.
         let runtime = ConversationRuntime(
             messageStore: stack.provider,
-            sessionStore: stack.provider,
+            sessionStore: nil,
             inferenceService: service
         )
         await runtime.updateSessionToolSources([StubGenerateImageToolSource()])

--- a/Tests/ManifoldTurnLoopCharacterizationTests/TurnLoopCharacterizationTests.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/TurnLoopCharacterizationTests.swift
@@ -54,6 +54,15 @@ actor EventTapDrain {
         for waiter in waiters { waiter.resume(returning: nil) }
         waiters.removeAll()
     }
+
+    /// Resumes all pending `next()` waiters with `nil` without marking the
+    /// drain as done. Use from a timeout handler to unblock a suspended
+    /// `next()` call so an outer `withThrowingTaskGroup` can observe
+    /// cancellation instead of hanging indefinitely.
+    func drainRemaining() {
+        for waiter in waiters { waiter.resume(returning: nil) }
+        waiters.removeAll()
+    }
 }
 
 // MARK: - TurnLoopCharacterizationTests

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_compressionTriggered.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_compressionTriggered.events.txt
@@ -1,0 +1,11 @@
+0  messageInserted  id:<uuid:1> role:user content:"Compress me"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Compress me" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"OK"
+5  tokenUsageRecorded  id:<uuid:3> prompt:50 completion:5
+6  messageInserted  id:<uuid:3> role:assistant content:"OK"
+7  streamFinished  id:<uuid:3> reason:stop
+8  afterGeneration  id:<uuid:3> finalText:"OK"
+9  compressionTriggered  removed:2 reason:contextWindowExceeded
+10  historyCompressed  session:<uuid:2> inserted:1

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_compressionTriggered.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_compressionTriggered.records.txt
@@ -1,0 +1,1 @@
+0  id:<uuid:4> role:system content:"Compression summary." agentID:nil sessionID:<uuid:2> promptTokens:nil completionTokens:nil

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_preCompactHook_observational.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_preCompactHook_observational.events.txt
@@ -1,0 +1,12 @@
+0  messageInserted  id:<uuid:1> role:user content:"Hook test turn"
+1  beforeContextAssembly  session:<uuid:2> prompt:"Hook test turn" msgCount:1
+2  contextAssembled  slots:0
+3  streamStarted  id:<uuid:3>
+4  tokenEmitted  id:<uuid:3> delta:"Done"
+5  tokenUsageRecorded  id:<uuid:3> prompt:60 completion:6
+6  messageInserted  id:<uuid:3> role:assistant content:"Done"
+7  streamFinished  id:<uuid:3> reason:stop
+8  afterGeneration  id:<uuid:3> finalText:"Done"
+9  hookFired  event:preCompact
+10  compressionTriggered  removed:2 reason:contextWindowExceeded
+11  historyCompressed  session:<uuid:2> inserted:1

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_preCompactHook_observational.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_postTurn_preCompactHook_observational.records.txt
@@ -1,0 +1,1 @@
+0  id:<uuid:4> role:system content:"Hook-gated summary." agentID:nil sessionID:<uuid:2> promptTokens:nil completionTokens:nil

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_preTurn_compressionTriggered.events.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_preTurn_compressionTriggered.events.txt
@@ -1,0 +1,10 @@
+0  compressionTriggered  removed:1 reason:contextWindowExceeded
+1  historyCompressed  session:<uuid:1> inserted:1
+2  messageInserted  id:<uuid:2> role:user content:"New turn after compression"
+3  beforeContextAssembly  session:<uuid:1> prompt:"New turn after compression" msgCount:2
+4  contextAssembled  slots:0
+5  streamStarted  id:<uuid:3>
+6  tokenEmitted  id:<uuid:3> delta:"Pre-turn response."
+7  messageInserted  id:<uuid:3> role:assistant content:"Pre-turn response."
+8  streamFinished  id:<uuid:3> reason:stop
+9  afterGeneration  id:<uuid:3> finalText:"Pre-turn response."

--- a/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_preTurn_compressionTriggered.records.txt
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/__Snapshots__/CompressionGoldenTests/test_preTurn_compressionTriggered.records.txt
@@ -1,0 +1,3 @@
+0  id:<uuid:4> role:system content:"Pre-turn summary." agentID:nil sessionID:<uuid:1> promptTokens:nil completionTokens:nil
+1  id:<uuid:2> role:user content:"New turn after compression" agentID:nil sessionID:<uuid:1> promptTokens:nil completionTokens:nil
+2  id:<uuid:3> role:assistant content:"Pre-turn response." agentID:nil sessionID:<uuid:1> promptTokens:nil completionTokens:nil


### PR DESCRIPTION
## What each golden pins

**`test_postTurn_compressionTriggered`** — pins the full event sequence when `CompressionPolicy.shouldCompress` returns `true` after a turn. Confirms: `compressionTriggered` fires after `afterGeneration`, `historyCompressed` follows with the replaced record, and the final persisted history contains only the summary `ChatMessage` (not the original user+assistant pair).

**`test_preTurn_compressionTriggered`** — pins the pre-turn path for `.send` turns. Confirms: `compressionTriggered` and `historyCompressed` fire *before* the new `messageInserted` event for the user's message (ordering invariant). After compression the new user message and assistant reply are appended normally, yielding 3 persisted records total.

**`test_postTurn_preCompactHook_observational`** — pins invariant 6 from the P2c brief: the `preCompact` hook fires (pinned by `hookFired event:preCompact` in the event trace) but `block:true` is silently logged and compression continues. The post-hook records snapshot contains exactly one summary record, proving the hook did not suppress compression.

**No-compression control case** — already covered by `test_send_plainTurn` in `TurnLoopCharacterizationTests.swift`. No duplication needed.

## Sabotage verification checklist

- [x] **Sabotage 1 — suppress post-turn compression emit** (`compressionTriggered`/`historyCompressed` events removed from `ConversationTurnExecutor`): `test_postTurn_compressionTriggered` FAILED (snapshot diff: both compression events missing); `test_postTurn_preCompactHook_observational` FAILED (XCTAssertTrue failures + snapshot diff showing `hookFired` still present but compression events absent); `test_preTurn_compressionTriggered` correctly PASSED (unaffected path). Reverted before commit.

- [x] **Sabotage 2 — suppress pre-turn compression emit** (pre-turn `compressionTriggered`/`historyCompressed` removed from executor): `test_preTurn_compressionTriggered` FAILED on both the events snapshot (compression events missing, `messageInserted` is now first) and the records snapshot (only 2 records instead of 3); post-turn tests correctly PASSED. Reverted before commit.

## P3a unblocking

Per PR #1724's documented gap, the compress-and-replace sequences inside `ConversationTurnExecutor` had no golden coverage — making any "behavior-preserving" extraction unprovable. These three goldens close that gap and unblock P3a: a `SingleTurnDriver` extraction can now assert it does not regress any of the three pinned event/record sequences.

## Architectural note (P3 planning input)

`completeOutcome` fires immediately after `afterGeneration`, **before** post-turn compression runs. This means `handle.outcome` resolving is not sufficient to guarantee compression events have been emitted. Any `SingleTurnDriver` extraction must account for this: turn "fully settled" ≠ turn outcome resolved. The drain required a separate `drainPostTurnCompression()` window with an explicit `historyCompressed` terminal, distinct from the main `drainTurn()` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)