### PR TITLE
ci: add per-PR all-traits build gate and complete CLAUDE.md targets table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       api-cloudcore: ${{ steps.filter.outputs.api-cloudcore }}
       api-persistence: ${{ steps.filter.outputs.api-persistence }}
       api-ui: ${{ steps.filter.outputs.api-ui }}
+      # Consumed by `all-traits-build`: true when Sources, Package.swift, or this
+      # workflow file changes — the same set that triggers the main `test` job.
+      all-traits: ${{ steps.filter.outputs.all-traits }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -160,6 +163,15 @@ jobs:
               - 'Sources/ManifoldPersistenceSwiftData/**'
             api-ui:
               - 'Sources/ManifoldUI/**'
+            # Used by the `all-traits-build` job below. Matches any Swift source,
+            # Package.swift, and ci.yml itself so the job self-validates on edits
+            # (per CI path-filter self-validation rule: a gate that doesn't track
+            # its own workflow file bypasses the gate when the file is changed).
+            all-traits:
+              - 'Sources/**'
+              - 'Package.swift'
+              - 'Package.resolved'
+              - '.github/workflows/ci.yml'
 
       # Tier 0 selective testing (issue #1588).
       #
@@ -927,3 +939,58 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: test-diagnostics/
+
+  # All-traits build gate (trait-combo exhaustiveness check).
+  #
+  # WHY: The main `test` job and `--profile ci` both run with
+  # `--disable-default-traits`, which compiles only the default-traits-off
+  # subset of the package.  Trait-gated `switch` exhaustiveness and other
+  # trait-combo breakage is therefore invisible to per-PR CI.  Two canonical
+  # failure shapes have already burned CI time:
+  #   - #1382: a KV-cache reuse race that only manifests under `--traits MLX,Llama`
+  #   - #1660: a BackendRegistrar break that only manifests under `--traits Ollama`
+  # Both merged green on the `--disable-default-traits` lane and were caught by
+  # the nightly all-traits build — *after* landing on main.
+  #
+  # This job adds a *per-PR* build-only gate: `swift build --build-tests` with the
+  # full trait sweep.  Build only — no `swift test`.  Metal/metallib is only a
+  # test-*run* hazard (the compiler emits valid dylib; the crash happens on load);
+  # build-modes.yml's nightly `full` leg already proves all-traits builds work on
+  # these runners.  The compile step catches switch exhaustiveness gaps,
+  # conditional-compilation errors, and missing conformances before merge.
+  #
+  # `Macros` and `Server` are deliberately excluded: swift-syntax (~647 files)
+  # and Hummingbird have their own path-filtered jobs (`macros-tests`,
+  # `server-tests`) and their build time would dominate the step budget.
+  # The documented trait-combo sweep in CLAUDE.md also omits them.
+  #
+  # Path-gated via the `all-traits` filter, which matches `Sources/**`,
+  # `Package.swift`, `Package.resolved`, and `.github/workflows/ci.yml` — the
+  # same set as the main `test` job.  Including `.github/workflows/ci.yml` is
+  # required per the CI path-filter self-validation rule: a gate that does not
+  # track its own workflow file would bypass itself when this file changes.
+  all-traits-build:
+    needs: [changes]
+    if: needs.changes.outputs.all-traits == 'true'
+    runs-on: macos-15  # match the `test` job runner so cache keys collide
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Setup Swift CI environment
+        uses: ./.github/actions/setup-swift-ci
+        with:
+          verify-toolchain: "true"
+
+      # Build-only — no swift test.  Metal/metallib is only a test-run-time
+      # hazard; the compiler produces valid objects on these runners.
+      # `--skip-update` avoids ~10-15s of remote contact per invocation.
+      - name: Build — all-traits sweep (trait-combo exhaustiveness)
+        timeout-minutes: 25
+        run: |
+          swift build --build-tests \
+            --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz \
+            --skip-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -972,7 +972,7 @@ jobs:
   all-traits-build:
     needs: [changes]
     if: needs.changes.outputs.all-traits == 'true'
-    runs-on: macos-15  # match the `test` job runner so cache keys collide
+    runs-on: macos-15
 
     steps:
       - name: Checkout
@@ -983,14 +983,22 @@ jobs:
       - name: Setup Swift CI environment
         uses: ./.github/actions/setup-swift-ci
         with:
+          # Own cache namespace: this job's dependency slice (llama.cpp
+          # xcframework, mlx-swift checkouts) never appears in the standard
+          # --disable-default-traits cache, so sharing the key would re-download
+          # the heavy artifacts every run AND restore stale bare repos.
+          # restore-keys still falls back to the standard key for the rest.
+          cache-key-suffix: "-all-traits"
           verify-toolchain: "true"
 
       # Build-only — no swift test.  Metal/metallib is only a test-run-time
       # hazard; the compiler produces valid objects on these runners.
-      # `--skip-update` avoids ~10-15s of remote contact per invocation.
+      # No --skip-update: a fallback-restored cache can hold bare repos that
+      # predate a pinned tag (first red run: llama.swift 2.9553.0 unresolvable
+      # from the stale shared cache), and --skip-update suppresses the fetch
+      # that would repair it. The ~10-15s of remote contact is correctness here.
       - name: Build — all-traits sweep (trait-combo exhaustiveness)
         timeout-minutes: 25
         run: |
           swift build --build-tests \
-            --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz \
-            --skip-update
+            --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@
 | `ManifoldTools` | End-to-end tool-calling validation harness: fixed reference toolset, declarative scenario runner, JSONL transcript logger. Depends on `ManifoldInference`. | None |
 | `ManifoldAppIntents` | AppIntent ↔ ToolDefinition bridge. Depends on `ManifoldInference`. | None |
 | `ManifoldSkills` | Claude-Code-compatible SKILL.md filesystem discovery and `invoke_skill` dispatcher (macOS-only via `#if os(macOS)`). Default-on (the `Skills` trait is in the default trait set). Depends on `ManifoldInference` + `ManifoldRuntime`. | None |
+| `ManifoldMacrosPlugin` | Swift macro compiler plugin implementing `@ToolSchema`. Runs at build time (not linked into app binaries). Trait-gated behind `Macros` (off by default) to keep swift-syntax's ~647 files out of default builds. | None |
 
 ### UI modules
 
@@ -56,7 +57,9 @@
 | `ManifoldHuggingFace` | HuggingFace Hub search, browse, and download integration. Depends on `ManifoldInference`. | None |
 | `ManifoldServer` | OpenAI-compatible HTTP server executable (Hummingbird). Trait-gated behind `Server`. | None |
 | `ManifoldFuzz` | Fuzzing engine: corpus, runner, capture, detectors, sink. Backend-agnostic; depends on `ManifoldInference`. | None |
-| `ManifoldFuzzBackends` | Real-backend factories for fuzz campaigns (shared by CLI + Xcode-hosted MLX fuzz). | MLX, LlamaSwift |
+| `ManifoldFuzzBackends` | Real-backend factory shim shared by `fuzz-chat` CLI and Xcode-hosted MLX fuzz tests. Depends on `ManifoldFuzz` + `ManifoldBackends`. | MLX, LlamaSwift |
+| `fuzz-chat` | Executable driver for fuzz campaigns against Ollama / Llama / Foundation. Gated on `Fuzz` trait. Run via `scripts/fuzz.sh`. | None |
+| `manifold-tools` | CLI executable for running tool-call validation scenarios from `ManifoldTools`. Gated on `Tools` trait. | None |
 
 ### Vendored sources (not standalone products)
 


### PR DESCRIPTION
## Summary

### Problem

Per-PR CI runs `swift build --build-tests --disable-default-traits`, which is blind to trait-gated switch exhaustiveness, conditional-compilation gaps, and missing conformances that only surface under non-default trait combinations. Two canonical failures already merged green and were caught only by the nightly all-traits build:

- **#1382**: KV-cache reuse race visible only under `--traits MLX,Llama`
- **#1660**: BackendRegistrar break visible only under `--traits Ollama`

The documented "trait-combo sweep" in CLAUDE.md has always been a *local discipline*. This PR closes the gap at the pre-merge CI level.

### Changes

**`.github/workflows/ci.yml`** — new `all-traits-build` job:

- Runs `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` on every PR touching `Sources/**`, `Package.swift`, `Package.resolved`, or `ci.yml` itself.
- **Build-only** — no `swift test`. Metal/metallib is only a test-*run* hazard; the compiler produces valid objects on macOS-15 runners (proven by build-modes.yml's existing nightly `full` leg).
- `Macros` and `Server` deliberately excluded — they have their own path-filtered jobs and their compile time would dominate the step budget.
- Path-gated via a new `all-traits` filter in the `changes` job. `ci.yml` itself is in the filter per the CI path-filter self-validation rule.
- Reuses the `.github/actions/setup-swift-ci` composite action, matching all other macOS jobs in the file.

**`CLAUDE.md`** — three missing production targets added to the Targets table:

- `ManifoldMacrosPlugin` — `@ToolSchema` compiler plugin (MCP + tool + app-extension section)
- `fuzz-chat` — executable fuzz campaign driver (Discovery + server + fuzz section)
- `manifold-tools` — CLI for tool-call validation scenarios (same section)

### Validation

Local sweep build (Apple Silicon, this branch): **Build complete! (712.45s)** — exit 0. No Swift sources changed so the full test gate is not required; the build result proves the command we're putting in CI actually works.

actionlint and `python3 -c "import yaml; yaml.safe_load(...)"` both pass on the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)