### PR TITLE
feat(ManifoldHardware): add structured content sidecar to ToolResult

### DIFF
--- a/Sources/ManifoldHardware/ToolTypes.swift
+++ b/Sources/ManifoldHardware/ToolTypes.swift
@@ -167,6 +167,76 @@ public struct ToolCall: Sendable, Codable, Equatable, Hashable {
     }
 }
 
+// MARK: - ToolResultPart
+
+/// A typed content part carried by ``ToolResult/structuredContent``.
+///
+/// ## v1 vocabulary
+///
+/// The only case today is ``text(_:)``, which mirrors the existing string
+/// carried by ``ToolResult/content``. Future 1.x releases will add cases such
+/// as `image(data:mimeType:)` and `json(_:)` without breaking the existing
+/// wire format, because this enum is decoded with tolerance for unknown types.
+///
+/// ## Vocabulary growth (1.x)
+///
+/// New cases will be added in minor releases. Consumers **must** handle
+/// ``unknown(type:)`` — either by ignoring it or by forwarding the raw `type`
+/// string to the host for logging. When switching over this enum in your code,
+/// always include a `default:` branch or an explicit `case .unknown:` arm so
+/// your app does not need to be updated every time a new part type ships.
+///
+/// ## Decode tolerance
+///
+/// Payloads carrying a `type` value that is not yet known to this SDK are
+/// decoded into ``unknown(type:)`` rather than throwing, keeping old readers
+/// forward-compatible with payloads produced by newer tool executors.
+public enum ToolResultPart: Sendable, Codable, Equatable, Hashable {
+
+    /// A plain-text content part. The `text` value is the literal string the
+    /// tool produced — equivalent to ``ToolResult/content`` for text-only tools.
+    case text(String)
+
+    /// A part whose `type` discriminator is not recognised by this SDK version.
+    ///
+    /// The raw `type` string is preserved so callers can log or forward it.
+    /// The payload beyond the `type` field is not decoded and is silently
+    /// discarded — this is the intentional trust-boundary optional-decode
+    /// exception: we prefer decode-to-unknown over a thrown error that would
+    /// break forward compatibility.
+    case unknown(type: String)
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case type, text
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeString = try container.decode(String.self, forKey: .type)
+        switch typeString {
+        case "text":
+            let text = try container.decode(String.self, forKey: .text)
+            self = .text(text)
+        default:
+            // Forward-compatible: unknown part types are preserved, not thrown.
+            self = .unknown(type: typeString)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let text):
+            try container.encode("text", forKey: .type)
+            try container.encode(text, forKey: .text)
+        case .unknown(let typeString):
+            try container.encode(typeString, forKey: .type)
+        }
+    }
+}
+
 // MARK: - ToolResult
 
 /// The outcome of executing a ``ToolCall``.
@@ -184,6 +254,20 @@ public struct ToolCall: Sendable, Codable, Equatable, Hashable {
 /// host UI can speak or render verbatim to the user. Tools that don't
 /// produce a separate dialog leave the field `nil`, and the on-wire JSON
 /// omits the key entirely so existing consumers see no shape change.
+///
+/// ## Structured content sidecar
+///
+/// ``structuredContent`` is an optional typed payload that future 1.x releases
+/// will use to carry multimodal or richly-typed tool output (images, JSON
+/// objects, citations, etc.). In v1 it is always `nil` at runtime — the
+/// canonical model-facing value remains ``content``. When non-`nil`, the array
+/// is encoded on the wire; when `nil` the key is absent, keeping the wire
+/// shape identical to pre-sidecar payloads for all existing producers and
+/// consumers.
+///
+/// See ``ToolResultPart`` for the part vocabulary and its forward-compatibility
+/// contract (new cases land as minor releases; consumers must handle
+/// ``ToolResultPart/unknown(type:)``).
 public struct ToolResult: Sendable, Codable, Equatable, Hashable {
 
     /// Categorises why a tool call failed.
@@ -314,31 +398,56 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
     /// format.
     public let dialog: String?
 
+    /// Forward-compatible typed content parts, or `nil` for v1 string-only tools.
+    ///
+    /// This sidecar locks a shape before the 1.0 freeze so that 1.x releases
+    /// can carry multimodal or richly-typed tool output (images, JSON objects,
+    /// citations) without a breaking wire-format change.
+    ///
+    /// **v1 behaviour:** always `nil` at runtime. The model-facing canonical
+    /// value remains ``content`` — backends read that string today and will
+    /// continue to do so until a future release activates the typed path.
+    ///
+    /// **Forward compatibility:** when non-`nil`, the array is encoded under
+    /// `"structuredContent"`. When `nil` the key is absent entirely, so
+    /// existing producers and consumers see no wire-shape change. Old decoders
+    /// that don't know this key will silently ignore it, and new decoders
+    /// receiving a payload without it will decode `nil` — both directions are
+    /// safe.
+    ///
+    /// See ``ToolResultPart`` for the part vocabulary and the
+    /// ``ToolResultPart/unknown(type:)`` forward-compatibility contract.
+    public let structuredContent: [ToolResultPart]?
+
     /// Creates a tool result.
     ///
     /// - Parameters:
     ///   - callId: The ``ToolCall/id`` this result belongs to.
-    ///   - content: The tool's output string.
+    ///   - content: The tool's output string (model-facing canonical value).
     ///   - errorKind: Failure classification, or `nil` on success. Defaults to `nil`.
     ///   - dialog: Optional human-facing speech/display text, e.g. the
     ///     resolved string from an AppIntent's `ProvidesDialog` channel.
     ///     Defaults to `nil`.
+    ///   - structuredContent: Optional typed content parts for forward-compatible
+    ///     multimodal output. Defaults to `nil` (v1 behaviour: string-only).
     public init(
         callId: String,
         content: String,
         errorKind: ErrorKind? = nil,
-        dialog: String? = nil
+        dialog: String? = nil,
+        structuredContent: [ToolResultPart]? = nil
     ) {
         self.callId = callId
         self.content = content
         self.errorKind = errorKind
         self.dialog = dialog
+        self.structuredContent = structuredContent
     }
 
     // MARK: Codable
 
     private enum CodingKeys: String, CodingKey {
-        case callId, content, errorKind, isError, dialog
+        case callId, content, errorKind, isError, dialog, structuredContent
     }
 
     public init(from decoder: Decoder) throws {
@@ -356,6 +465,7 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
             errorKind = nil
         }
         dialog = try c.decodeIfPresent(String.self, forKey: .dialog)
+        structuredContent = try c.decodeIfPresent([ToolResultPart].self, forKey: .structuredContent)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -368,6 +478,9 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
         // `dialog` uses encodeIfPresent so non-dialog tools emit the exact
         // pre-dialog JSON shape (no `"dialog"` key at all).
         try c.encodeIfPresent(dialog, forKey: .dialog)
+        // `structuredContent` uses encodeIfPresent so v1 string-only results
+        // emit no extra key, keeping the wire shape backward-compatible.
+        try c.encodeIfPresent(structuredContent, forKey: .structuredContent)
     }
 }
 

--- a/Tests/ManifoldInferenceTests/ToolResultStructuredContentTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolResultStructuredContentTests.swift
@@ -1,0 +1,188 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Tests for the ``ToolResult/structuredContent`` sidecar and the
+/// ``ToolResultPart`` vocabulary introduced as P2.5a future-proofing.
+///
+/// Classification: Unit — no I/O, no SwiftData, no actor hops.
+final class ToolResultStructuredContentTests: XCTestCase {
+
+    // MARK: - ToolResultPart round-trips
+
+    func test_textPart_roundTrips() throws {
+        let part = ToolResultPart.text("Sunny, 22°C")
+
+        let encoded = try JSONEncoder().encode(part)
+        let decoded = try JSONDecoder().decode(ToolResultPart.self, from: encoded)
+
+        // Sabotage check: removing the "text" case from ToolResultPart.init(from:)
+        // would decode into .unknown(type: "text") and fail XCTAssertEqual.
+        XCTAssertEqual(decoded, .text("Sunny, 22°C"))
+    }
+
+    func test_textPart_encodesWithTypeDiscriminator() throws {
+        let part = ToolResultPart.text("hello")
+        let encoded = try JSONEncoder().encode(part)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertEqual(obj["type"] as? String, "text")
+        XCTAssertEqual(obj["text"] as? String, "hello")
+    }
+
+    // MARK: - Unknown type decode tolerance
+
+    func test_unknownPartType_decodesWithoutThrowing() throws {
+        // A future server sends a part type this SDK doesn't know yet.
+        let futurePayload = #"{"type":"image","url":"https://example.com/img.png"}"#.data(using: .utf8)!
+
+        // Must NOT throw — forward-compat contract.
+        let decoded = try JSONDecoder().decode(ToolResultPart.self, from: futurePayload)
+
+        // Sabotage check: throwing in the default branch of init(from:) would
+        // cause this test to fail with a DecodingError.
+        if case .unknown(let typeString) = decoded {
+            XCTAssertEqual(typeString, "image")
+        } else {
+            XCTFail("Expected .unknown(type:), got \(decoded)")
+        }
+    }
+
+    func test_unknownPartType_roundTripPreservesTypeString() throws {
+        // .unknown can be re-encoded and the type field survives.
+        let part = ToolResultPart.unknown(type: "video")
+        let encoded = try JSONEncoder().encode(part)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertEqual(obj["type"] as? String, "video")
+    }
+
+    // MARK: - ToolResult round-trips with structuredContent populated
+
+    func test_toolResult_roundTrips_withStructuredContent() throws {
+        let parts: [ToolResultPart] = [.text("line1"), .text("line2")]
+        let result = ToolResult(
+            callId: "c-1",
+            content: "line1\nline2",
+            structuredContent: parts
+        )
+
+        let encoded = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
+
+        // Sabotage check: not encoding structuredContent causes decoded.structuredContent to be nil.
+        XCTAssertEqual(decoded.callId, "c-1")
+        XCTAssertEqual(decoded.content, "line1\nline2")
+        XCTAssertEqual(decoded.structuredContent, parts)
+        XCTAssertFalse(decoded.isError)
+    }
+
+    func test_toolResult_roundTrips_withMixedParts() throws {
+        let parts: [ToolResultPart] = [.text("Known"), .unknown(type: "future")]
+        let result = ToolResult(
+            callId: "c-2",
+            content: "Known",
+            structuredContent: parts
+        )
+
+        let encoded = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
+
+        XCTAssertEqual(decoded.structuredContent?.count, 2)
+        XCTAssertEqual(decoded.structuredContent?[0], .text("Known"))
+        XCTAssertEqual(decoded.structuredContent?[1], .unknown(type: "future"))
+    }
+
+    // MARK: - Legacy decode (no structuredContent key) → nil
+
+    func test_legacyPayload_decodesWithNilStructuredContent() throws {
+        // Pre-sidecar payloads have no "structuredContent" key. They must decode
+        // successfully with structuredContent == nil.
+        let legacy = #"{"callId":"x","content":"y"}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: legacy)
+
+        // Sabotage check: using `decode` instead of `decodeIfPresent` for
+        // structuredContent would throw a keyNotFound error here.
+        XCTAssertNil(decoded.structuredContent)
+        XCTAssertEqual(decoded.callId, "x")
+        XCTAssertEqual(decoded.content, "y")
+    }
+
+    // MARK: - Encode nil structuredContent → key absent
+
+    func test_nilStructuredContent_omitsKeyFromJSON() throws {
+        let result = ToolResult(callId: "c", content: "ok")
+        let encoded = try JSONEncoder().encode(result)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        // Sabotage check: using `encode` instead of `encodeIfPresent` would
+        // emit a null or empty-array value for the key, breaking backward compat.
+        XCTAssertNil(obj["structuredContent"], "nil structuredContent must not appear in encoded JSON")
+        // Confirm other fields are still present
+        XCTAssertNotNil(obj["callId"])
+        XCTAssertNotNil(obj["content"])
+    }
+
+    // MARK: - All existing call sites compile unchanged (default nil)
+
+    func test_existingCallSites_compilesWithNoStructuredContent() throws {
+        // Verifies the defaulted parameter keeps all pre-existing construction
+        // sites source-compatible. The compiler enforces this; this runtime
+        // test just confirms the field is nil when omitted.
+        let a = ToolResult(callId: "a", content: "x")
+        let b = ToolResult(callId: "b", content: "x", errorKind: .timeout)
+        let c = ToolResult(callId: "c", content: "x", errorKind: nil, dialog: "Hello")
+
+        XCTAssertNil(a.structuredContent)
+        XCTAssertNil(b.structuredContent)
+        XCTAssertNil(c.structuredContent)
+    }
+
+    // MARK: - Equatable / Hashable
+
+    func test_resultsWithDifferentStructuredContent_areNotEqual() {
+        let a = ToolResult(callId: "c", content: "x", structuredContent: [.text("foo")])
+        let b = ToolResult(callId: "c", content: "x", structuredContent: nil)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func test_resultsWithEqualStructuredContent_areEqual() {
+        let a = ToolResult(callId: "c", content: "x", structuredContent: [.text("foo")])
+        let b = ToolResult(callId: "c", content: "x", structuredContent: [.text("foo")])
+        XCTAssertEqual(a, b)
+    }
+
+    func test_toolResultPart_equatable_textVsUnknown() {
+        XCTAssertNotEqual(ToolResultPart.text("x"), ToolResultPart.unknown(type: "x"))
+    }
+
+    func test_toolResultPart_hashable_canBeUsedInSet() {
+        let parts: Set<ToolResultPart> = [.text("a"), .text("a"), .unknown(type: "b")]
+        XCTAssertEqual(parts.count, 2)
+    }
+
+    // MARK: - Array of unknown parts in full payload
+
+    func test_fullPayloadWithUnknownPart_decodesWithoutThrowing() throws {
+        // Simulate a future server response containing an unknown part alongside
+        // a known text part.
+        let payload = """
+        {
+          "callId": "abc",
+          "content": "fallback",
+          "structuredContent": [
+            {"type": "text", "text": "known"},
+            {"type": "audio", "url": "https://example.com/audio.mp3"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: payload)
+
+        XCTAssertEqual(decoded.callId, "abc")
+        XCTAssertEqual(decoded.content, "fallback")
+        XCTAssertEqual(decoded.structuredContent?.count, 2)
+        XCTAssertEqual(decoded.structuredContent?[0], .text("known"))
+        XCTAssertEqual(decoded.structuredContent?[1], .unknown(type: "audio"))
+    }
+}

--- a/Tests/ManifoldInferenceTests/ToolResultStructuredContentTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolResultStructuredContentTests.swift
@@ -56,6 +56,24 @@ final class ToolResultStructuredContentTests: XCTestCase {
         XCTAssertEqual(obj["type"] as? String, "video")
     }
 
+    func test_unknownPart_reencodeIsLossy_extraFieldsDropped() throws {
+        // When a future payload has extra fields beyond "type", those fields are
+        // not preserved — .unknown only retains the type discriminator.
+        // This test pins the documented intentional lossy behaviour so any
+        // accidental preservation or unexpected key leakage is caught.
+        let futurePayload = #"{"type":"image","url":"https://example.com/img.png","width":800}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ToolResultPart.self, from: futurePayload)
+        let reencoded = try JSONEncoder().encode(decoded)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: reencoded) as? [String: Any])
+
+        // Type is preserved.
+        XCTAssertEqual(obj["type"] as? String, "image")
+        // Extra fields are intentionally dropped on re-encode.
+        XCTAssertNil(obj["url"], "Extra payload fields must not survive re-encode of .unknown")
+        XCTAssertNil(obj["width"], "Extra payload fields must not survive re-encode of .unknown")
+        XCTAssertEqual(obj.count, 1, "Re-encoded .unknown must contain only the type key")
+    }
+
     // MARK: - ToolResult round-trips with structuredContent populated
 
     func test_toolResult_roundTrips_withStructuredContent() throws {
@@ -121,6 +139,37 @@ final class ToolResultStructuredContentTests: XCTestCase {
         // Confirm other fields are still present
         XCTAssertNotNil(obj["callId"])
         XCTAssertNotNil(obj["content"])
+    }
+
+    // MARK: - Empty array vs nil are distinct
+
+    func test_emptyStructuredContent_encodesKeyPresent() throws {
+        // structuredContent: [] is semantically distinct from nil.
+        // encodeIfPresent encodes non-nil optionals, including empty arrays, so
+        // the key MUST appear in the JSON when the caller explicitly passes [].
+        // Sabotage check: if encodeIfPresent were replaced with encode-when-non-empty
+        // logic, this test would fail because the key would be absent.
+        let result = ToolResult(callId: "c", content: "ok", structuredContent: [])
+        let encoded = try JSONEncoder().encode(result)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        let arr = try XCTUnwrap(obj["structuredContent"] as? [Any],
+                                 "empty [] must encode the key, not omit it")
+        XCTAssertTrue(arr.isEmpty)
+    }
+
+    func test_emptyStructuredContent_roundTripsDistinctlyFromNil() throws {
+        // Encode [] then decode: must give [] not nil.
+        let result = ToolResult(callId: "c", content: "ok", structuredContent: [])
+        let encoded = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: encoded)
+
+        // Sabotage check: if the decoder coerced [] to nil this would assert.
+        XCTAssertNotNil(decoded.structuredContent)
+        XCTAssertEqual(decoded.structuredContent?.count, 0)
+        // Distinct from a nil-sidecar result with the same other fields.
+        let nilResult = ToolResult(callId: "c", content: "ok")
+        XCTAssertNotEqual(decoded, nilResult)
     }
 
     // MARK: - All existing call sites compile unchanged (default nil)


### PR DESCRIPTION
## Summary

- Adds `ToolResultPart` enum with a `text(String)` case and a forward-compatible `unknown(type:)` case. Encoded with an explicit `type` discriminator field so unknown types decode cleanly rather than throwing.
- Adds `ToolResult.structuredContent: [ToolResultPart]?` sidecar, mirroring the existing `dialog` pattern. Defaults to `nil`; `encodeIfPresent` keeps the JSON key absent when nil, preserving full wire-shape backward compatibility.
- All existing `ToolResult(callId:content:...)` call sites compile unchanged — `structuredContent` parameter defaults to `nil`.
- Documents the v1 / 1.x vocabulary-growth contract on both `ToolResultPart` and `ToolResult`.

## Design notes

- `content: String` is unchanged — it remains the canonical model-facing value in v1.
- `structuredContent` is purely additive and `nil` at runtime until a future release activates the typed path.
- Unknown part `type` discriminators are decoded into `.unknown(type:)` (not thrown), which is the intentional trust-boundary exception to the `try?` ban: we decode-to-unknown rather than silencing via `try?`, keeping the error visible and the type available for logging.
- No `Package.resolved` staged; no unrelated files touched.

## Test plan

- [ ] `ToolResultStructuredContentTests` (14 new XCTest unit tests): round-trip with parts, legacy decode → nil, nil-encode omits key, unknown type tolerant decode, Equatable/Hashable, full-payload with mixed known/unknown parts
- [ ] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — passes
- [ ] `scripts/test.sh --profile local --skip-update` — 1340 XCTest + 83 Swift Testing, 0 failures
- [ ] `git diff origin/main --stat` — only `ToolTypes.swift` and `ToolResultStructuredContentTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)