### PR TITLE
feat!: convert BackendName to an extensible identifier struct

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -1,7 +1,22 @@
 API breakage: class GenerationStream has been removed
 API breakage: class SSEEventIDTracker has been removed
 API breakage: class StreamingArgumentAccumulator has been removed
-API breakage: enum BackendName has been removed
+API breakage: enum BackendName has been changed to a struct
+API breakage: enum BackendName has removed conformance to CaseIterable
+API breakage: enumelement BackendName.foundation is now static
+API breakage: enumelement BackendName.foundation has declared type change from (ManifoldContract.BackendName.Type) -> ManifoldContract.BackendName to ManifoldContract.BackendName
+API breakage: enumelement BackendName.ollama is now static
+API breakage: enumelement BackendName.ollama has declared type change from (ManifoldContract.BackendName.Type) -> ManifoldContract.BackendName to ManifoldContract.BackendName
+API breakage: enumelement BackendName.claude is now static
+API breakage: enumelement BackendName.claude has declared type change from (ManifoldContract.BackendName.Type) -> ManifoldContract.BackendName to ManifoldContract.BackendName
+API breakage: enumelement BackendName.openAI is now static
+API breakage: enumelement BackendName.openAI has declared type change from (ManifoldContract.BackendName.Type) -> ManifoldContract.BackendName to ManifoldContract.BackendName
+API breakage: enumelement BackendName.mlx is now static
+API breakage: enumelement BackendName.mlx has declared type change from (ManifoldContract.BackendName.Type) -> ManifoldContract.BackendName to ManifoldContract.BackendName
+API breakage: enumelement BackendName.llama is now static
+API breakage: enumelement BackendName.llama has declared type change from (ManifoldContract.BackendName.Type) -> ManifoldContract.BackendName to ManifoldContract.BackendName
+API breakage: constructor BackendName.init(rawValue:) has return type change from ManifoldContract.BackendName? to ManifoldContract.BackendName
+API breakage: typealias BackendName.AllCases has been removed
 API breakage: enum BackendVisionCapability has been removed
 API breakage: enum EmbeddingError has been removed
 API breakage: enum GenerationEvent has been removed

--- a/Sources/ManifoldContract/BackendName.swift
+++ b/Sources/ManifoldContract/BackendName.swift
@@ -1,7 +1,27 @@
-/// Typed identifiers for the local-engine and SaaS backends BCK ships.
+/// A stable, extensible identifier for inference backends.
 ///
-/// Use these instead of raw string literals when branching on the active
-/// backend:
+/// `BackendName` uses the `Notification.Name` / `URLResourceKey` pattern: a
+/// thin `RawRepresentable` struct wrapping a `String`, with well-known values
+/// exposed as `public static let` constants. Any backend — including
+/// third-party backends added after ManifoldKit 1.0 ships — can mint a new
+/// name by extending this type or simply using `BackendName(rawValue: "myBackend")`.
+///
+/// ## Extensibility rationale
+///
+/// The previous `enum BackendName` was a closed set. Switching on a closed set
+/// requires callers to keep exhaustive `switch` statements in sync with every
+/// new backend, coupling downstream code to ManifoldKit internals. With a
+/// struct, unknown names decode and round-trip safely, and switch sites that
+/// only care about a subset of backends can match the constants they know and
+/// use `default:` for the rest.
+///
+/// ## Wire and persistence compatibility
+///
+/// JSON encoding/decoding uses a **single-value string container** (identical
+/// to the old `enum: String` synthesis), so all persisted and wire payloads
+/// are byte-identical to those produced by pre-1.0 builds.
+///
+/// ## Usage
 ///
 /// ```swift
 /// if vm.activeBackendName == BackendName.foundation.rawValue {
@@ -11,45 +31,117 @@
 ///
 /// `activeBackendName` is still typed as `String?` because the lifecycle
 /// coordinator also surfaces cloud providers (`lmStudio`, `custom`,
-/// `openAIResponses`) and free-form labels from test backends, neither of
-/// which fit a closed enum. For the six cases below — the engines and
-/// SaaS providers BCK has first-class support for — `BackendName.<case>.rawValue`
-/// is the canonical comparison shape.
+/// `openAIResponses`) and free-form labels from test backends. For the six
+/// well-known backends below, `BackendName.<name>.rawValue` is the canonical
+/// comparison shape.
+///
+/// ## Migration from 0.19.x (enum)
+///
+/// `switch` statements over `BackendName` must add a `default:` arm now that
+/// the type is open. `CaseIterable` is replaced by `BackendName.wellKnown`
+/// (also accessible as `BackendName.allCases` for source compatibility with
+/// existing call sites).
 ///
 /// ## Migration from 0.18.x
 ///
-/// In 0.18 and earlier, `BackendName` was a no-instances container of
-/// `static let` strings whose values were the *display* names emitted by
+/// In 0.18 and earlier, `BackendName` was a no-instances container of `static
+/// let` strings whose values were the *display* names emitted by
 /// `InferenceService.activeBackendName` (`"Apple"`, `"Ollama"`, …). 0.19
-/// converts it into a real `enum: String` whose raw values are the
-/// canonical lowercase identifiers (`"foundation"`, `"ollama"`, …).
-///
-/// Comparison sites that always wrote `vm.activeBackendName == BackendName.foundation`
-/// continue to compile and behave correctly — the right-hand side moves with
-/// the lifecycle coordinator's emitted strings.
-///
-/// Code that hardcoded the legacy strings (`if name == "Apple"`) needs to
-/// switch to the typed accessor or use ``parse(_:)`` to accept both shapes.
-public enum BackendName: String, Sendable, CaseIterable, Codable, Hashable {
+/// converted it to an `enum: String` with canonical lowercase identifiers.
+/// Use ``parse(_:)`` at trust boundaries that may still hold 0.18.x strings.
+public struct BackendName: RawRepresentable, Sendable, Codable, Hashable,
+                           ExpressibleByStringLiteral, CustomStringConvertible {
+    /// The canonical lowercase identifier for this backend.
+    ///
+    /// This value is stable across ManifoldKit releases; you may persist or
+    /// transmit it freely.
+    public let rawValue: String
+
+    /// Creates a `BackendName` from any string.
+    ///
+    /// This initialiser is non-failable: every string is a valid backend
+    /// identifier. Unrecognised names decode and round-trip safely, enabling
+    /// forward-compat when a new backend is introduced.
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    // MARK: ExpressibleByStringLiteral
+
+    public init(stringLiteral value: StringLiteralType) {
+        self.rawValue = value
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String { rawValue }
+
+    // MARK: Codable — single-value string container (wire-identical to the old enum)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.rawValue = try container.decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+// MARK: - Well-known backends
+
+extension BackendName {
+
+    // Ordering matches the original enum declaration; preserved for allCases / wellKnown.
+
     /// The Apple Foundation Models backend (canonical raw value: `"foundation"`).
     /// Legacy 0.18 raw value: `"Apple"`.
-    case foundation = "foundation"
+    public static let foundation = BackendName(rawValue: "foundation")
+
     /// The Ollama backend (canonical raw value: `"ollama"`).
     /// Legacy 0.18 raw value: `"Ollama"`.
-    case ollama = "ollama"
+    public static let ollama = BackendName(rawValue: "ollama")
+
     /// The Claude (Anthropic) backend (canonical raw value: `"claude"`).
     /// Legacy 0.18 raw value: `"Claude"`.
-    case claude = "claude"
+    public static let claude = BackendName(rawValue: "claude")
+
     /// The OpenAI Chat-Completions / OpenAI-compatible backend (canonical raw value: `"openAI"`).
     /// Legacy 0.18 raw value: `"OpenAI"`.
-    case openAI = "openAI"
+    public static let openAI = BackendName(rawValue: "openAI")
+
     /// The MLX backend (canonical raw value: `"mlx"`).
     /// Legacy 0.18 raw value: `"MLX"`.
-    case mlx = "mlx"
+    public static let mlx = BackendName(rawValue: "mlx")
+
     /// The llama.cpp (GGUF) backend (canonical raw value: `"llama"`).
     /// Legacy 0.18 raw value: `"llama.cpp"`.
-    case llama = "llama"
+    public static let llama = BackendName(rawValue: "llama")
+
+    /// The complete set of well-known backends shipped with ManifoldKit.
+    ///
+    /// This list is stable across patch releases. A new backend family would
+    /// increment the minor version and add an entry here. Third-party backends
+    /// are not listed but are fully supported via `BackendName(rawValue:)`.
+    ///
+    /// Replaces the `CaseIterable.allCases` synthesised property from the
+    /// former `enum BackendName`. Existing code that wrote `BackendName.allCases`
+    /// continues to compile via the `allCases` alias below.
+    public static let wellKnown: [BackendName] = [
+        .foundation, .ollama, .claude, .openAI, .mlx, .llama,
+    ]
+
+    /// Source-compatibility alias for `wellKnown`.
+    ///
+    /// Code that iterated `BackendName.allCases` when the type was a `CaseIterable`
+    /// enum continues to compile and produce the same ordered list. New code
+    /// should prefer `BackendName.wellKnown` to make the open-world nature of
+    /// the identifier explicit.
+    public static let allCases: [BackendName] = wellKnown
 }
+
+// MARK: - 0.18.x migration helper
 
 extension BackendName {
     /// Accepts the 0.19+ canonical raw values *and* the 0.18.x legacy
@@ -58,22 +150,27 @@ extension BackendName {
     /// Use this at every trust boundary that reads a backend-name string
     /// from disk, wire formats, or persisted user defaults that may
     /// pre-date the rename. Comparing two freshly produced 0.19 strings
-    /// can use `BackendName(rawValue:)`; ``parse(_:)`` is the migration
-    /// affordance that absorbs the legacy shape so we don't strand any
-    /// already-installed apps on the old form.
+    /// can use `BackendName(rawValue:)` directly; ``parse(_:)`` is the
+    /// migration affordance that absorbs the legacy shape so we don't
+    /// strand any already-installed apps on the old form.
     ///
-    /// Returns `nil` for any string that doesn't match either form so the
-    /// caller can decide whether to log, reject, or fall back.
+    /// Unlike `BackendName(rawValue:)`, this function returns `nil` for
+    /// strings that don't match either the canonical or legacy forms. Use
+    /// it when you want to distinguish "a known backend" from "an arbitrary
+    /// string".
     public static func parse(_ string: String) -> BackendName? {
-        if let canonical = BackendName(rawValue: string) { return canonical }
+        // Fast path: check well-known raw values first.
+        let candidate = BackendName(rawValue: string)
+        if wellKnown.contains(candidate) { return candidate }
+        // Legacy 0.18.x display-name fallbacks.
         switch string {
-        case "Apple": return .foundation
-        case "Ollama": return .ollama
-        case "Claude": return .claude
-        case "OpenAI": return .openAI
-        case "MLX": return .mlx
+        case "Apple":     return .foundation
+        case "Ollama":    return .ollama
+        case "Claude":    return .claude
+        case "OpenAI":    return .openAI
+        case "MLX":       return .mlx
         case "llama.cpp": return .llama
-        default: return nil
+        default:          return nil
         }
     }
 }

--- a/Sources/ManifoldContract/BackendName.swift
+++ b/Sources/ManifoldContract/BackendName.swift
@@ -42,6 +42,17 @@
 /// (also accessible as `BackendName.allCases` for source compatibility with
 /// existing call sites).
 ///
+/// ## Why `ExpressibleByStringLiteral` is NOT conformed to
+///
+/// Unlike `Notification.Name` (AppKit-era), `BackendName` is a **persisted
+/// dispatch discriminator**: a typo'd string literal silently mints a new,
+/// unrecognised name that routes to no backend and is impossible to distinguish
+/// from a legitimate unknown name at runtime. `Notification.Name` accepts the
+/// typo risk because misrouted notifications fail silently and visibly; a
+/// silently minted `BackendName` would cause hard-to-diagnose inference failures.
+/// Use `BackendName(rawValue:)` or one of the `public static let` constants
+/// instead — the compiler will catch the extra keystroke.
+///
 /// ## Migration from 0.18.x
 ///
 /// In 0.18 and earlier, `BackendName` was a no-instances container of `static
@@ -50,7 +61,7 @@
 /// converted it to an `enum: String` with canonical lowercase identifiers.
 /// Use ``parse(_:)`` at trust boundaries that may still hold 0.18.x strings.
 public struct BackendName: RawRepresentable, Sendable, Codable, Hashable,
-                           ExpressibleByStringLiteral, CustomStringConvertible {
+                           CustomStringConvertible {
     /// The canonical lowercase identifier for this backend.
     ///
     /// This value is stable across ManifoldKit releases; you may persist or
@@ -64,12 +75,6 @@ public struct BackendName: RawRepresentable, Sendable, Codable, Hashable,
     /// forward-compat when a new backend is introduced.
     public init(rawValue: String) {
         self.rawValue = rawValue
-    }
-
-    // MARK: ExpressibleByStringLiteral
-
-    public init(stringLiteral value: StringLiteralType) {
-        self.rawValue = value
     }
 
     // MARK: CustomStringConvertible

--- a/Tests/ManifoldInferenceTests/BackendNameMigrationTests.swift
+++ b/Tests/ManifoldInferenceTests/BackendNameMigrationTests.swift
@@ -3,7 +3,8 @@ import XCTest
 
 /// Tests for ``BackendName`` raw-value migration from 0.18.x display strings
 /// (`"Apple"`, `"Ollama"`, `"llama.cpp"`) to the 0.19+ canonical lowercase
-/// identifiers (`"foundation"`, `"ollama"`, `"llama"`).
+/// identifiers (`"foundation"`, `"ollama"`, `"llama"`), and for the
+/// struct-based extensible identifier introduced in v1.0.
 ///
 /// These cover both fresh decoding through `BackendName(rawValue:)` and the
 /// migration helper ``BackendName/parse(_:)`` that absorbs both shapes so
@@ -51,7 +52,7 @@ final class BackendNameMigrationTests: XCTestCase {
     func test_parse_canonicalAllSixCases_roundTrip() {
         for backend in BackendName.allCases {
             XCTAssertEqual(BackendName.parse(backend.rawValue), backend,
-                           "parse(\"\(backend.rawValue)\") should round-trip to .\(backend)")
+                           "parse(\"\(backend.rawValue)\") should round-trip to \(backend)")
         }
     }
 
@@ -102,15 +103,73 @@ final class BackendNameMigrationTests: XCTestCase {
                      "parse() must not lowercase-fold; only the exact legacy spellings migrate.")
     }
 
-    // MARK: - allCases tripwire
+    // MARK: - wellKnown / allCases tripwire
 
-    /// The number of ``BackendName`` cases is load-bearing for switch
-    /// exhaustiveness. Bumping the count means every `switch` over the type
-    /// elsewhere in the codebase needs a new branch — this assertion is the
-    /// tripwire that forces a code review when a new backend lands.
-    func test_allCases_countIsSix() {
-        XCTAssertEqual(BackendName.allCases.count, 6,
-                       "BackendName ships six first-class cases (foundation, ollama, claude, openAI, mlx, llama). "
-                       + "Adding one means updating switch statements that branch on the type.")
+    /// The number of well-known ``BackendName`` constants is load-bearing for
+    /// completeness. Bumping the count means every site that iterates
+    /// `BackendName.wellKnown` (or the `allCases` alias) needs a code review
+    /// — this assertion is the tripwire that forces that review when a new
+    /// backend lands.
+    ///
+    /// Note: with the struct-based open identifier, switch statements over
+    /// `BackendName` values no longer need to be exhaustive — they should
+    /// carry a `default:` arm for unrecognised values.
+    func test_wellKnown_countIsSix() {
+        XCTAssertEqual(BackendName.wellKnown.count, 6,
+                       "BackendName ships six well-known identifiers (foundation, ollama, claude, openAI, mlx, llama). "
+                       + "Adding one requires updating sites that iterate wellKnown/allCases.")
+    }
+
+    /// allCases is a source-compat alias for wellKnown — both must return identical ordered lists.
+    func test_allCases_aliasMatchesWellKnown() {
+        XCTAssertEqual(BackendName.allCases, BackendName.wellKnown,
+                       "allCases must be identical to wellKnown (it is just a source-compat alias).")
+    }
+
+    // MARK: - Codable wire compatibility
+
+    /// JSON encoding must produce a bare string (single-value container), not
+    /// `{"rawValue":"foundation"}`, so persisted and wire payloads are
+    /// byte-identical to those produced by the former `enum BackendName: String`.
+    func test_jsonEncoding_producesBareSingleValueString() throws {
+        let encoded = try JSONEncoder().encode(BackendName.foundation)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(json, "\"foundation\"",
+                       "BackendName must encode as a bare JSON string, not a keyed object.")
+    }
+
+    func test_jsonDecoding_fromBareSingleValueString() throws {
+        let json = Data("\"ollama\"".utf8)
+        let decoded = try JSONDecoder().decode(BackendName.self, from: json)
+        XCTAssertEqual(decoded, .ollama)
+    }
+
+    func test_jsonRoundTrip_allWellKnown() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for name in BackendName.wellKnown {
+            let data = try encoder.encode(name)
+            let decoded = try decoder.decode(BackendName.self, from: data)
+            XCTAssertEqual(decoded, name,
+                           "JSON round-trip must produce an identical BackendName for \(name).")
+        }
+    }
+
+    // MARK: - Forward-compat (unrecognised names decode successfully)
+
+    /// An unrecognised backend name from a future ManifoldKit release must
+    /// decode without throwing — the struct-based design explicitly supports
+    /// this forward-compat case, unlike the closed enum.
+    func test_decoding_unrecognisedNameSucceeds() throws {
+        let json = Data("\"futureBackend\"".utf8)
+        let decoded = try JSONDecoder().decode(BackendName.self, from: json)
+        XCTAssertEqual(decoded.rawValue, "futureBackend",
+                       "An unrecognised BackendName should decode and preserve its raw string.")
+    }
+
+    func test_init_unrecognisedName_isDistinctFromWellKnown() {
+        let unknown = BackendName(rawValue: "unknownBackend")
+        XCTAssertFalse(BackendName.wellKnown.contains(unknown),
+                       "An unrecognised name must not accidentally equal a well-known constant.")
     }
 }

--- a/Tests/ManifoldInferenceTests/BackendNameMigrationTests.swift
+++ b/Tests/ManifoldInferenceTests/BackendNameMigrationTests.swift
@@ -172,4 +172,19 @@ final class BackendNameMigrationTests: XCTestCase {
         XCTAssertFalse(BackendName.wellKnown.contains(unknown),
                        "An unrecognised name must not accidentally equal a well-known constant.")
     }
+
+    /// Sabotage guard: if the custom Codable were accidentally removed and synthesis
+    /// restored, the encoded form would be `{"rawValue":"foundation"}`. Decoding
+    /// *that* keyed representation into `BackendName` must fail with a type error,
+    /// confirming the single-value container path is active.
+    ///
+    /// If this test starts *passing* when it should throw, the custom Codable has
+    /// been removed — restore `init(from:)` / `encode(to:)` in BackendName.swift.
+    func test_jsonDecoding_keyedContainerFails() {
+        let keyedJSON = Data(#"{"rawValue":"foundation"}"#.utf8)
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(BackendName.self, from: keyedJSON),
+            "Decoding from a keyed JSON object must fail: BackendName uses a single-value container."
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- Converts `BackendName` from a closed `enum: String, CaseIterable` to a `RawRepresentable` struct following the `Notification.Name` / `URLResourceKey` pattern
- Well-known values (`.foundation`, `.ollama`, `.claude`, `.openAI`, `.mlx`, `.llama`) remain as `public static let` constants with **identical raw strings** — all leading-dot usage at call sites continues to compile unchanged
- Custom `Codable` implementation uses a single-value string container, making wire and persistence payloads **byte-identical** to the former enum synthesis
- `CaseIterable` replaced by `BackendName.wellKnown` static array + `allCases` alias for source compatibility
- `BackendName.parse(_:)` preserved with identical semantics (returns `nil` for unrecognised strings; `BackendName(rawValue:)` is now non-failable)

## Breaking changes

> **BREAKING CHANGE:** `BackendName` is now a struct. Callers that have exhaustive `switch` statements over `BackendName` values must add a `default:` arm — the type is now open. `CaseIterable` conformance is removed; use `BackendName.wellKnown` or the `allCases` alias. `BackendName(rawValue:)` is non-failable (returns `BackendName`, not `BackendName?`); remove any `if let` / force-unwrap patterns wrapping the initialiser.

No exhaustive switches over `BackendName` exist in this codebase — the only switch that dispatches on backend identity is over `APIProvider` and `ModelType`, which are unaffected.

## API-break gate

The `diagnose-api-breaking-changes` gate is satisfied via `.github/api-breakage-allowlist.txt`. The 16 breakages produced by the enum→struct conversion are all intentional and documented in that file. Gate verified clean locally: `No breaking changes detected in ManifoldContract`.

## Extensibility rationale

The closed-enum design required every `switch` downstream to track every new backend, coupling app code to ManifoldKit internals. With the struct design, an unknown backend name (e.g. from a future ManifoldKit release or a third-party backend) decodes and round-trips safely without requiring a new allowlist entry or a downstream recompile.

## Opportunity note (out of scope)

The registry-driven descriptor routing from commit `7c44636c` already provides a better home for dispatch-table logic that previously branched on `BackendName` values. This PR is intentionally a mechanical conversion; refactoring dispatch sites to the registry pattern is a natural follow-on.

## Test plan

- [x] Trait-combo build sweep: `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — **Build complete** (59 s, warnings only)
- [x] API-break gate: `diagnose-api-breaking-changes origin/main --targets ManifoldContract --breakage-allowlist-path ...` — **No breaking changes detected**
- [x] `scripts/test.sh --profile local --skip-update` — **PASSED** (XCTest: 1349 tests, 0 failures; Swift Testing: 83 tests, 0 failures)
- [x] New tests: JSON encoding produces bare `"foundation"` string (not `{"rawValue":"foundation"}`), JSON round-trip for all 6 well-known names, forward-compat decode of an unrecognised name succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)