### PR TITLE
feat: start pre-1.0 deprecation clocks for flagged back-compat aliases

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -108,7 +108,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     /// here — this only owns the agent registry membership.
     private func reconcileAgents(on session: ChatSession, with agents: [ManifoldInference.Agent]) {
         let desiredByID = Dictionary(agents.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
-        var existingByID: [UUID: Agent] = [:]
+        var existingByID: [UUID: PersistedAgent] = [:]
 
         // Remove rows no longer present in the record. Iterate a snapshot so we
         // can mutate `session.agents` while walking it.
@@ -126,7 +126,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
 
         // Insert rows for agents the session does not yet have.
         for agent in agents where existingByID[agent.id] == nil {
-            let row = Agent(
+            let row = PersistedAgent(
                 id: agent.id,
                 name: agent.name,
                 systemPrompt: agent.systemPrompt,

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
@@ -109,7 +109,7 @@ let bootstrap = try ManifoldBootstrap(
         try ModelContainer(
             for: Schema([
                 ChatSession.self, ChatMessage.self, APIEndpoint.self,
-                SamplerPreset.self, Agent.self,
+                SamplerPreset.self, PersistedAgent.self,
                 MyAppModel.self
             ]),
             migrationPlan: ManifoldMigrationPlan.self,

--- a/Sources/ManifoldPersistenceSwiftData/Schema/Agent.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/Agent.swift
@@ -13,6 +13,9 @@ public typealias PersistedAgent = ManifoldSchemaV9.Agent
 /// Back-compat alias for code that referenced ``Agent`` directly before
 /// the F3 disambiguation. Prefer ``PersistedAgent`` in new code.
 ///
-/// This alias may be deprecated in a future major version once host apps
-/// have migrated to the disambiguated name.
+/// > Deprecated: Renamed to ``PersistedAgent``. The bare name shadows
+/// > ``ManifoldInference/Agent`` when both modules are imported. Migrate to
+/// > `PersistedAgent` now — this alias will be removed in the 1.0-adjacent
+/// > major release (≥2 minors after this annotation was added, 0.x-era).
+@available(*, deprecated, renamed: "PersistedAgent", message: "Use PersistedAgent to avoid shadowing ManifoldInference.Agent. This alias will be removed in the 1.0-adjacent major release.")
 public typealias Agent = ManifoldSchemaV9.Agent

--- a/Tests/ManifoldPersistenceSwiftDataTests/AgentTypealiasTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/AgentTypealiasTests.swift
@@ -19,14 +19,22 @@ final class AgentTypealiasTests: XCTestCase {
         XCTAssertTrue(PersistedAgent.self == ManifoldSchemaV9.Agent.self)
     }
 
-    func test_agentTypealias_stillResolvesForBackCompat() {
-        // Back-compat alias kept so pre-F3 host apps keep compiling.
-        // Sabotage: remove the `Agent` typealias and this test fails to
-        // compile.
+    // The two tests below intentionally reference the deprecated `Agent`
+    // alias — that is the behavior under test. Marking the test methods
+    // themselves `@available(*, deprecated)` lets them use the alias without
+    // emitting deprecation warnings (deprecated code may freely call
+    // deprecated code); XCTest still discovers and runs them.
+
+    @available(*, deprecated, message: "Intentionally exercises the deprecated Agent alias.")
+    func test_agentDeprecatedAlias_stillResolvesForBackCompat() {
+        // Host-app code using the old name must keep compiling (with a
+        // migration warning pointing at `PersistedAgent`).
+        // Sabotage: remove the `Agent` typealias and this test fails to compile.
         XCTAssertTrue(Agent.self == ManifoldSchemaV9.Agent.self)
     }
 
-    func test_persistedAgentAndAgent_areIdentical() {
+    @available(*, deprecated, message: "Intentionally exercises the deprecated Agent alias.")
+    func test_persistedAgentAndDeprecatedAgent_areIdentical() {
         // Both aliases must point at the same class — diverging them
         // would silently fork the SwiftData identity model.
         XCTAssertTrue(PersistedAgent.self == Agent.self)

--- a/Tests/ManifoldPersistenceSwiftDataTests/SchemaMigrationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SchemaMigrationTests.swift
@@ -47,8 +47,8 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertEqual(ObjectIdentifier(ManifoldSchemaV9.ChatMessage.self), ObjectIdentifier(ManifoldSchemaV9.ChatMessage.self))
         // ChatSession is redefined at V9 to carry activeAgentID / activeSkillName / agents.
         XCTAssertEqual(ObjectIdentifier(ManifoldSchemaV9.ChatSession.self), ObjectIdentifier(ManifoldSchemaV9.ChatSession.self))
-        // Agent is introduced at V9.
-        XCTAssertEqual(ObjectIdentifier(Agent.self), ObjectIdentifier(ManifoldSchemaV9.Agent.self))
+        // PersistedAgent (formerly the back-compat `Agent` alias) is introduced at V9.
+        XCTAssertEqual(ObjectIdentifier(PersistedAgent.self), ObjectIdentifier(ManifoldSchemaV9.Agent.self))
         // Other model types remain at V4.
         XCTAssertEqual(ObjectIdentifier(SamplerPreset.self), ObjectIdentifier(ManifoldSchemaV4.SamplerPreset.self))
         XCTAssertEqual(ObjectIdentifier(APIEndpoint.self), ObjectIdentifier(ManifoldSchemaV4.APIEndpoint.self))


### PR DESCRIPTION
Starts the ≥2-minor deprecation window required before the pre-1.0 removal sweep, per the migration plan's deprecation-clocks note (#1740).

## Changes
- `Agent` typealias in `ManifoldPersistenceSwiftData/Schema/Agent.swift` now carries `@available(*, deprecated, renamed: "PersistedAgent")` — the bare name shadows `ManifoldInference.Agent` under `import ManifoldKit`.
- Internal call sites migrated to `PersistedAgent` (`SwiftDataPersistenceProvider`, `SchemaMigrationTests`) so our own build emits zero new warnings.
- The alias-identity tests still exercise the deprecated spelling, via `@available(*, deprecated)` test methods (deprecated code may call deprecated code warning-free).

## Deliberately not annotated
- `RuntimeScenario.userMessages` (ManifoldTestSupport) — its "backward compatibility" comment describes a derived-convenience property, not a removal promise.
- `ChatSessionRecord`/`ChatMessageRecord` — already deprecated and load-bearing against type ambiguity (#1717); untouched per plan.

## Gates
- `scripts/test.sh --profile local`: PASSED (full XCTest + 83 Swift Testing, 0 failures)
- All-traits sweep (`--build-tests`, 8 traits): clean
- Zero `'Agent' is deprecated` warnings from internal targets (pre-existing `ChatMessageRecord`/`TurnUsageRecord` warnings belong to the later removal sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)