### PR TITLE
feat(ManifoldRuntime): TurnDriver seam and resumable ConversationRun model (P3)

### DIFF
--- a/Sources/ManifoldRuntime/Models/ConversationRun.swift
+++ b/Sources/ManifoldRuntime/Models/ConversationRun.swift
@@ -32,18 +32,26 @@ public enum RunStatus: String, Sendable, CaseIterable, Equatable {
 /// A multi-step unit above a ``ConversationRuntime`` turn.
 ///
 /// A `ConversationRun` groups one or more ``RunStep`` values into a
-/// resumable, checkpointed execution unit. Runs survive app suspension:
-/// the ``RunStore`` port persists the run record and each step so the
-/// ``ResumableRunDriver`` can pick up exactly where it left off.
+/// checkpointed execution unit. The ``RunStore`` port persists the run
+/// record and each step on every boundary so the run's progress is durable.
+///
+/// - Note: In-process pause/resume/cancel ship in this phase (P3b) via
+///   ``ResumableRunDriver``. Cross-process resume — reloading an interrupted
+///   run from ``RunStore`` and continuing from the last checkpointed step —
+///   requires the SwiftData `RunStore` adapter that is deferred to the P3b
+///   persistence sub-phase. Until that lands, a process that dies mid-run
+///   leaves a durable checkpoint record but does not auto-continue.
 ///
 /// ## Lifecycle
 ///
 /// The host creates a `ConversationRun` with a goal (a text prompt or a
 /// structured goal object) and starts it via
-/// ``ConversationRuntime/startRun(_:)``. The runtime delegates to the
+/// ``ConversationRuntime/startRun(_:using:)``. The runtime delegates to the
 /// wired ``ResumableRunDriver``, which drives the multi-step loop, pausing
-/// and checkpointing on each step boundary. Runs can be paused,
-/// resumed, or cancelled at any time via the runtime's run API.
+/// and checkpointing on each step boundary. The active run can be paused,
+/// resumed, or cancelled via the ``ResumableRunDriver`` instance that was
+/// injected into the runtime (``ResumableRunDriver/pauseRun()``,
+/// ``ResumableRunDriver/resumeRun()``, ``ResumableRunDriver/cancelRun()``).
 ///
 /// ## Identity injection
 ///

--- a/Sources/ManifoldRuntime/Models/ConversationRun.swift
+++ b/Sources/ManifoldRuntime/Models/ConversationRun.swift
@@ -1,0 +1,237 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - RunStatus
+
+/// The lifecycle state of a ``ConversationRun``.
+///
+/// Transitions:
+///   `pending` → `running` → `paused` → `running` (resume) → `completed`
+///                         → `cancelled`
+///                         → `failed`
+///   `running` → `completed`
+///   `running` → `cancelled`
+///   `running` → `failed`
+public enum RunStatus: String, Sendable, CaseIterable, Equatable {
+    /// Created but not yet started.
+    case pending
+    /// Actively executing steps.
+    case running
+    /// Execution suspended; can be resumed.
+    case paused
+    /// All steps completed successfully.
+    case completed
+    /// Explicitly stopped by the host or user.
+    case cancelled
+    /// Terminated by an unrecoverable error.
+    case failed
+}
+
+// MARK: - ConversationRun
+
+/// A multi-step unit above a ``ConversationRuntime`` turn.
+///
+/// A `ConversationRun` groups one or more ``RunStep`` values into a
+/// resumable, checkpointed execution unit. Runs survive app suspension:
+/// the ``RunStore`` port persists the run record and each step so the
+/// ``ResumableRunDriver`` can pick up exactly where it left off.
+///
+/// ## Lifecycle
+///
+/// The host creates a `ConversationRun` with a goal (a text prompt or a
+/// structured goal object) and starts it via
+/// ``ConversationRuntime/startRun(_:)``. The runtime delegates to the
+/// wired ``ResumableRunDriver``, which drives the multi-step loop, pausing
+/// and checkpointing on each step boundary. Runs can be paused,
+/// resumed, or cancelled at any time via the runtime's run API.
+///
+/// ## Identity injection
+///
+/// IDs and timestamps are constructor-injected so tests can produce
+/// deterministic fixtures without special test hooks. Production callers
+/// use the `init(sessionID:goal:)` convenience that supplies stable defaults.
+public struct ConversationRun: Sendable, Equatable {
+
+    // MARK: Identity
+
+    /// Stable run identifier.
+    public let id: UUID
+
+    /// The session this run is executing within.
+    public let sessionID: UUID
+
+    // MARK: Goal
+
+    /// The top-level goal or prompt that drives this run.
+    /// Persisted verbatim so resume can reconstruct context.
+    public let goal: String
+
+    // MARK: Lifecycle
+
+    /// Current status. Mutated by the ``ResumableRunDriver`` as the run
+    /// progresses through its lifecycle.
+    public var status: RunStatus
+
+    /// Total number of steps taken so far (completed or in-progress).
+    public var stepCount: Int
+
+    /// Maximum number of steps allowed. The driver halts with
+    /// ``RunStatus/completed`` when this limit is reached, regardless
+    /// of whether the goal is fully achieved. `nil` means unlimited.
+    public let maxSteps: Int?
+
+    // MARK: Timestamps
+
+    /// When this run record was created.
+    public let createdAt: Date
+
+    /// When this run last transitioned to a new status.
+    public var updatedAt: Date
+
+    // MARK: Init
+
+    /// Creates a `ConversationRun` with all fields provided.
+    ///
+    /// Prefer the convenience init for production use; this form is for
+    /// test fixtures that need deterministic IDs and timestamps.
+    public init(
+        id: UUID,
+        sessionID: UUID,
+        goal: String,
+        status: RunStatus = .pending,
+        stepCount: Int = 0,
+        maxSteps: Int? = nil,
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.goal = goal
+        self.status = status
+        self.stepCount = stepCount
+        self.maxSteps = maxSteps
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    /// Creates a new pending `ConversationRun` with stable defaults for
+    /// production use.
+    public init(
+        sessionID: UUID,
+        goal: String,
+        maxSteps: Int? = nil
+    ) {
+        let now = Date()
+        self.init(
+            id: UUID(),
+            sessionID: sessionID,
+            goal: goal,
+            status: .pending,
+            stepCount: 0,
+            maxSteps: maxSteps,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}
+
+// MARK: - RunStep
+
+/// A single step within a ``ConversationRun``.
+///
+/// Each step corresponds to one ``ConversationRuntime`` turn (a send, tool
+/// call, follow-up, etc.). The ``ResumableRunDriver`` inserts a step record
+/// before executing the turn and updates it when the turn completes, so the
+/// ``RunStore`` always reflects the current execution state.
+///
+/// `stepIndex` is 0-based and assigned by the driver at insertion time;
+/// within a run, steps are ordered by index ascending.
+public struct RunStep: Sendable {
+
+    // MARK: Identity
+
+    /// Stable step identifier.
+    public let id: UUID
+
+    /// The run this step belongs to.
+    public let runID: UUID
+
+    /// 0-based position of this step within the run.
+    public let stepIndex: Int
+
+    // MARK: Content
+
+    /// The turn input that drove this step.
+    ///
+    /// Persisted so resume can reconstruct what was requested on each step.
+    /// `nil` for steps that were derived from the run's own goal (e.g. the
+    /// driver synthesised a follow-up without explicit host input).
+    public let turnInput: TurnInput?
+
+    /// The ID of the assistant message produced by this step, when one was
+    /// persisted. `nil` for steps that did not produce a message (cancelled,
+    /// failed before enqueue, or tool-only turns with no assistant text).
+    public var messageID: UUID?
+
+    /// Whether this step completed successfully.
+    public var isCompleted: Bool
+
+    /// Whether this step failed.
+    public var isFailed: Bool
+
+    /// Optional reason string when the step failed.
+    public var failureReason: String?
+
+    // MARK: Timestamps
+
+    public let createdAt: Date
+    public var updatedAt: Date
+
+    // MARK: Init
+
+    /// Creates a `RunStep` with all fields provided.
+    public init(
+        id: UUID,
+        runID: UUID,
+        stepIndex: Int,
+        turnInput: TurnInput?,
+        messageID: UUID? = nil,
+        isCompleted: Bool = false,
+        isFailed: Bool = false,
+        failureReason: String? = nil,
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.id = id
+        self.runID = runID
+        self.stepIndex = stepIndex
+        self.turnInput = turnInput
+        self.messageID = messageID
+        self.isCompleted = isCompleted
+        self.isFailed = isFailed
+        self.failureReason = failureReason
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    /// Creates a new `RunStep` with stable defaults for production use.
+    public init(
+        runID: UUID,
+        stepIndex: Int,
+        turnInput: TurnInput?
+    ) {
+        let now = Date()
+        self.init(
+            id: UUID(),
+            runID: runID,
+            stepIndex: stepIndex,
+            turnInput: turnInput,
+            messageID: nil,
+            isCompleted: false,
+            isFailed: false,
+            failureReason: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+}

--- a/Sources/ManifoldRuntime/Protocols/RunStore.swift
+++ b/Sources/ManifoldRuntime/Protocols/RunStore.swift
@@ -1,0 +1,95 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - RunStore
+//
+// P3b: the persistence port for ConversationRun records. Mirrors the shape
+// of the other store ports (MessageStore, SessionStore, SamplerPresetStore):
+//   - `@MainActor` isolation for parity with SwiftData's ModelContext.
+//   - Traffic in value types (ConversationRun, RunStep) — no @Model escapes.
+//   - `async throws` surface, sync-to-async at the impl.
+//
+// The SwiftData adapter lives in ManifoldPersistenceSwiftData (Ring 2), not
+// here. ManifoldRuntime owns only the port. Implementation: deferred to P3b
+// persistence sub-phase (schema migration + @Model types). Hosts that do not
+// need resumable runs simply omit the store from the bootstrap — the
+// ResumableRunDriver returns an error without it, and all existing paths
+// continue through SingleTurnDriver unchanged.
+
+/// Errors produced by ``RunStore`` implementations.
+public enum RunStoreError: Error, LocalizedError, Sendable, Equatable {
+    case runNotFound(UUID)
+    case stepNotFound(UUID)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .runNotFound(id):
+            return "ConversationRun not found: \(id.uuidString)"
+        case let .stepNotFound(id):
+            return "RunStep not found: \(id.uuidString)"
+        }
+    }
+}
+
+/// Storage port for ``ConversationRun`` checkpoint records.
+///
+/// Mirrors the shape of ``MessageStore`` / ``SessionStore``:
+/// `@MainActor`-isolated, `async throws` surface, value-type traffic.
+///
+/// The SwiftData adapter lives in `ManifoldPersistenceSwiftData` — this port
+/// is the only RunStore symbol that `ManifoldRuntime` owns. Hosts that do not
+/// need resumable runs omit it from their bootstrap; all existing turn paths
+/// route through ``SingleTurnDriver`` and never touch the store.
+@MainActor
+public protocol RunStore: AnyObject, Sendable {
+
+    // MARK: Runs
+
+    /// Inserts a new run record.
+    ///
+    /// - Throws: Storage errors from the underlying store.
+    func insertRun(_ run: ConversationRun) async throws
+
+    /// Updates an existing run record.
+    ///
+    /// - Throws:
+    ///   - ``RunStoreError/runNotFound(_:)`` when the run does not exist.
+    ///   - Storage errors from the underlying store.
+    func updateRun(_ run: ConversationRun) async throws
+
+    /// Deletes a run by id.
+    ///
+    /// - Throws:
+    ///   - ``RunStoreError/runNotFound(_:)`` when the run does not exist.
+    ///   - Storage errors from the underlying store.
+    func deleteRun(_ id: UUID) async throws
+
+    /// Fetches all runs for a session, ordered most-recently-created first.
+    ///
+    /// - Throws: Storage errors from the underlying store.
+    func fetchRuns(for sessionID: UUID) async throws -> [ConversationRun]
+
+    /// Fetches a single run by id, or `nil` when not found.
+    ///
+    /// - Throws: Storage errors from the underlying store.
+    func fetchRun(_ id: UUID) async throws -> ConversationRun?
+
+    // MARK: Steps
+
+    /// Inserts a new step record.
+    ///
+    /// - Throws: Storage errors from the underlying store.
+    func insertStep(_ step: RunStep) async throws
+
+    /// Updates an existing step record.
+    ///
+    /// - Throws:
+    ///   - ``RunStoreError/stepNotFound(_:)`` when the step does not exist.
+    ///   - Storage errors from the underlying store.
+    func updateStep(_ step: RunStep) async throws
+
+    /// Fetches all steps for a run, ordered by `stepIndex` ascending.
+    ///
+    /// - Throws: Storage errors from the underlying store.
+    func fetchSteps(for runID: UUID) async throws -> [RunStep]
+}

--- a/Sources/ManifoldRuntime/Protocols/TurnDriver.swift
+++ b/Sources/ManifoldRuntime/Protocols/TurnDriver.swift
@@ -1,0 +1,60 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - TurnDriver
+//
+// P3a: the pluggable strategy that decides *how* a goal becomes turns/steps.
+// `ConversationRuntime` stays the public conversation API. Internally it
+// delegates the per-turn machinery to a `TurnDriver` conformer.
+//
+// Today there is exactly one conformer: `SingleTurnDriver`, which reproduces
+// the linear send/regenerate/edit/branch behavior that existed before this
+// seam. Behavior-preserving: golden transcripts must diff clean against the
+// P0c snapshots.
+//
+// `ResumableRunDriver` (P3b) is the second shipped conformer, and it is
+// built on the same seam. Adding a future driver (multi-agent, plan-execute)
+// is EDGE — conform `TurnDriver`, 0 engine-core edits. Invariant 7.
+
+/// The pluggable strategy for executing a ``TurnInput`` within a
+/// ``ConversationRuntime``.
+///
+/// Conform this protocol to add a new execution strategy without modifying
+/// the orchestration core. Adding a driver is EDGE — zero engine-core edits
+/// required. ``SingleTurnDriver`` is the default and reproduces the linear
+/// single-turn behavior. ``ResumableRunDriver`` enables long-running,
+/// checkpointed, resumable runs.
+///
+/// ## Visibility
+///
+/// `TurnDriver` is `package` rather than `public` because its `executeTurn`
+/// method references ``ConversationTurnExecutor`` and
+/// ``ConversationTurnTaskRegistry``, which are package-internal types. The
+/// seam can be widened to `public` in a future phase once those types are
+/// surfaced. In the meantime, custom driver conformers live within the
+/// ManifoldKit package boundary.
+///
+/// ## Concurrency
+///
+/// Implementations must be `Sendable`. The runtime calls `executeTurn` from a
+/// concurrent context (inside a detached task). Drivers that need per-turn
+/// mutable state should use an `actor` or `OSAllocatedUnfairLock`.
+package protocol TurnDriver: Sendable {
+
+    /// Executes the turn described by `input` and returns a handle when the
+    /// flow drives generation, or `nil` when it does not (e.g. branch without
+    /// generation, edit of a non-user message).
+    ///
+    /// The driver is responsible for all aspects of the turn that fall within
+    /// its strategy boundary: context assembly, enqueue, stream consumption,
+    /// persistence, and event emission. The orchestration core owns the public
+    /// verb API and the event fan-out; the driver owns the mechanics.
+    ///
+    /// Throwing from this method aborts the turn with an `errorRaised` event.
+    func executeTurn(
+        _ input: TurnInput,
+        executor: ConversationTurnExecutor,
+        taskRegistry: ConversationTurnTaskRegistry,
+        outcomeCompletion: ConversationTurnOutcomeCompletion?
+    ) async throws -> ConversationStreamHandle?
+}

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -249,6 +249,62 @@ public final class ConversationRuntime: Sendable {
     /// Test-only init that lets the caller observe the empty-assistant drop
     /// path and configure the hook timeout. Wrapped in `package` so test
     /// targets can reach it without widening the public surface.
+    ///
+    /// This overload preserves the original 19-parameter signature (no
+    /// `turnDriver:`) so the package ABI surface is additive. It delegates
+    /// to the ``TurnDriver``-seam overload with `turnDriver: nil`, which
+    /// selects ``SingleTurnDriver`` and reproduces pre-P3 linear behaviour.
+    package convenience init(
+        messageStore: any MessageStore,
+        sessionStore: (any SessionStore)? = nil,
+        inferenceService: InferenceService,
+        pipeline: PromptContextPipeline? = nil,
+        budgetPlanner: ContextBudgetPlanner? = nil,
+        ragService: RAGService? = nil,
+        auxiliaryInferenceService: InferenceService? = nil,
+        usageStore: (any UsageStore)? = nil,
+        emptyResponseObserver: (@Sendable (EmptyResponseDiagnostic) -> Void)?,
+        generationHooks: [any GenerationHook] = [],
+        compressionPolicy: (any CompressionPolicy)? = nil,
+        preTurnCompressionPolicy: (any PreTurnCompressionPolicy)? = nil,
+        hookTimeout: Duration = .seconds(30),
+        historyShaper: (any HistoryShaper)? = nil,
+        historyProviders: [any HistoryProvider] = [],
+        hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
+        turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
+        sessionToolSources: [any SessionToolSource] = [],
+        hookRegistry: HookRegistry? = nil
+    ) {
+        self.init(
+            messageStore: messageStore,
+            sessionStore: sessionStore,
+            inferenceService: inferenceService,
+            pipeline: pipeline,
+            budgetPlanner: budgetPlanner,
+            ragService: ragService,
+            auxiliaryInferenceService: auxiliaryInferenceService,
+            usageStore: usageStore,
+            emptyResponseObserver: emptyResponseObserver,
+            generationHooks: generationHooks,
+            compressionPolicy: compressionPolicy,
+            preTurnCompressionPolicy: preTurnCompressionPolicy,
+            hookTimeout: hookTimeout,
+            historyShaper: historyShaper,
+            historyProviders: historyProviders,
+            hostTurnContextProvider: hostTurnContextProvider,
+            turnContextProvider: turnContextProvider,
+            sessionToolSources: sessionToolSources,
+            hookRegistry: hookRegistry,
+            turnDriver: nil
+        )
+    }
+
+    /// Designated test-and-power-user init that exposes the ``TurnDriver``
+    /// seam. Pass a ``ResumableRunDriver`` to enable checkpointed multi-step
+    /// runs; pass `nil` (or omit) to fall back to ``SingleTurnDriver``.
+    ///
+    /// Wrapped in `package` so test targets and framework-internal call
+    /// sites can reach it without widening the public surface.
     package init(
         messageStore: any MessageStore,
         sessionStore: (any SessionStore)? = nil,
@@ -269,7 +325,7 @@ public final class ConversationRuntime: Sendable {
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
-        turnDriver: (any TurnDriver)? = nil
+        turnDriver: (any TurnDriver)?
     ) {
         self.inferenceService = inferenceService
         self.auxiliaryInferenceService = auxiliaryInferenceService

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -78,6 +78,16 @@ public final class ConversationRuntime: Sendable {
 
     private let executor: ConversationTurnExecutor
 
+    /// The pluggable turn-execution strategy.
+    ///
+    /// Defaults to ``SingleTurnDriver`` which reproduces the pre-P3 linear
+    /// behavior exactly. Pass a ``ResumableRunDriver`` (P3b) when you need
+    /// long-running, checkpointed runs that survive app suspension.
+    ///
+    /// Custom drivers conform to ``TurnDriver`` and add zero engine-core
+    /// edits — EDGE by design.
+    private let turnDriver: any TurnDriver
+
     /// Host-mutable holder for the per-session knobs the executor reads at
     /// the top of each turn. Exposed through the `update*` mutators below
     /// so a host that built the runtime once at app init can swap context
@@ -231,7 +241,8 @@ public final class ConversationRuntime: Sendable {
             hostTurnContextProvider: hostTurnContextProvider,
             turnContextProvider: turnContextProvider,
             sessionToolSources: sessionToolSources,
-            hookRegistry: hookRegistry
+            hookRegistry: hookRegistry,
+            turnDriver: nil
         )
     }
 
@@ -257,7 +268,8 @@ public final class ConversationRuntime: Sendable {
         hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         sessionToolSources: [any SessionToolSource] = [],
-        hookRegistry: HookRegistry? = nil
+        hookRegistry: HookRegistry? = nil,
+        turnDriver: (any TurnDriver)? = nil
     ) {
         self.inferenceService = inferenceService
         self.auxiliaryInferenceService = auxiliaryInferenceService
@@ -297,6 +309,9 @@ public final class ConversationRuntime: Sendable {
             turnContextProvider: turnContextProvider,
             bindings: bindings
         )
+        // Default to SingleTurnDriver to preserve pre-P3 linear behavior.
+        // Callers that need resumable runs inject ResumableRunDriver here.
+        self.turnDriver = turnDriver ?? SingleTurnDriver()
     }
 
     // MARK: Host-mutable bindings
@@ -384,44 +399,15 @@ public final class ConversationRuntime: Sendable {
         _ input: TurnInput,
         outcomeCompletion: ConversationTurnOutcomeCompletion?
     ) async throws -> ConversationStreamHandle? {
-        switch input.kind {
-        case let .send(text, attachments):
-            return try await executor.runSendFlow(
-                sessionID: input.sessionID,
-                text: text,
-                attachments: attachments,
-                config: input.config,
-                taskRegistry: turnTasks,
-                outcomeCompletion: outcomeCompletion
-            )
-        case .regenerate:
-            return try await executor.runRegenerateFlow(
-                sessionID: input.sessionID,
-                config: input.config,
-                taskRegistry: turnTasks,
-                outcomeCompletion: outcomeCompletion
-            )
-        case let .edit(messageID, text):
-            return try await executor.runEditFlow(
-                sessionID: input.sessionID,
-                messageID: messageID,
-                text: text,
-                config: input.config,
-                taskRegistry: turnTasks,
-                outcomeCompletion: outcomeCompletion
-            )
-        case let .branch(messageID, newSessionID, newSessionTitle, generateAfter):
-            return try await executor.runBranchFlow(
-                sourceSessionID: input.sessionID,
-                branchMessageID: messageID,
-                newSessionID: newSessionID,
-                newSessionTitle: newSessionTitle,
-                generateAfter: generateAfter,
-                config: input.config,
-                taskRegistry: turnTasks,
-                outcomeCompletion: outcomeCompletion
-            )
-        }
+        // Delegate to the wired TurnDriver. SingleTurnDriver (the default)
+        // reproduces the pre-P3 per-kind switch exactly; ResumableRunDriver
+        // (P3b) adds checkpointed multi-step orchestration on top.
+        try await turnDriver.executeTurn(
+            input,
+            executor: executor,
+            taskRegistry: turnTasks,
+            outcomeCompletion: outcomeCompletion
+        )
     }
 
     // MARK: Bulk cancellation
@@ -456,6 +442,42 @@ public final class ConversationRuntime: Sendable {
         turnTasks.cancel(handle)
         guard let token else { return }
         await inferenceService.cancelAsync(token)
+    }
+
+    // MARK: Resumable run API (P3b)
+
+    /// Starts a ``ConversationRun`` using the wired ``TurnDriver``.
+    ///
+    /// Available only when the runtime was initialised with a
+    /// ``ResumableRunDriver``. Returns an `AsyncStream<RunEvent>` that
+    /// delivers lifecycle events (started / step / paused / resumed /
+    /// completed / cancelled / failed) until the run terminates.
+    ///
+    /// Calling this method when the runtime uses the default
+    /// ``SingleTurnDriver`` logs a warning and returns an immediately-
+    /// finishing stream — hosts should pair ``startRun`` with a
+    /// ``ResumableRunDriver``.
+    ///
+    /// - Parameters:
+    ///   - run:      The run record to start. The driver persists it.
+    ///   - using:    The input provider that drives step synthesis.
+    /// - Returns: A stream of ``RunEvent`` values.
+    public func startRun(
+        _ run: ConversationRun,
+        using provider: any RunInputProvider = FixedGoalRunInputProvider()
+    ) -> AsyncStream<RunEvent> {
+        guard let resumableDriver = turnDriver as? ResumableRunDriver else {
+            Log.inference.warning(
+                "ConversationRuntime.startRun: runtime was not configured with a ResumableRunDriver; ignoring."
+            )
+            return AsyncStream { $0.finish() }
+        }
+        return resumableDriver.startRun(
+            run,
+            using: provider,
+            executor: executor,
+            taskRegistry: turnTasks
+        )
     }
 
     // MARK: Secondary event taps

--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ManifoldInference
 
-struct ConversationTurnExecutor: Sendable {
+package struct ConversationTurnExecutor: Sendable {
     private let persistence: ConversationPersistencePort
     private let inferenceService: InferenceService
     private let pipeline: PromptContextPipeline?
@@ -82,7 +82,7 @@ struct ConversationTurnExecutor: Sendable {
 
     // MARK: Send flow
 
-    func runSendFlow(
+    package func runSendFlow(
         sessionID: UUID,
         text: String,
         attachments rawAttachments: [MessagePart],
@@ -246,7 +246,7 @@ struct ConversationTurnExecutor: Sendable {
 
     // MARK: Regenerate flow
 
-    func runRegenerateFlow(
+    package func runRegenerateFlow(
         sessionID: UUID,
         config: TurnConfig,
         taskRegistry: ConversationTurnTaskRegistry,
@@ -311,7 +311,7 @@ struct ConversationTurnExecutor: Sendable {
 
     // MARK: Edit flow
 
-    func runEditFlow(
+    package func runEditFlow(
         sessionID: UUID,
         messageID: UUID,
         text: String,
@@ -399,7 +399,7 @@ struct ConversationTurnExecutor: Sendable {
 
     // MARK: Branch flow
 
-    func runBranchFlow(
+    package func runBranchFlow(
         sourceSessionID: UUID,
         branchMessageID: UUID,
         newSessionID: UUID,

--- a/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
+++ b/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
@@ -119,14 +119,15 @@ public struct FixedGoalRunInputProvider: RunInputProvider, Sendable {
 /// Thin wrapper around ``RunStore`` that exposes best-effort checkpoint
 /// calls with logging. Methods are `@MainActor` because the ``RunStore``
 /// protocol is `@MainActor`-isolated. The `@unchecked Sendable` annotation
-/// is safe because the single `store` property is `@MainActor`-bound and is
-/// never mutated after initialization.
+/// is safe because the single `store` reference is immutable (`let`) and is
+/// only ever dereferenced from the `@MainActor` methods below — the existential
+/// never escapes the main actor.
 private final class RunStoreProxy: @unchecked Sendable {
+    // Immutable after init; every use is gated behind a @MainActor method, so
+    // the @MainActor-isolated `any RunStore` is never touched off the main actor.
     private let store: any RunStore
 
     // nonisolated init so ResumableRunDriver.init (non-actor) can create it.
-    // The store itself is stored via nonisolated(unsafe) because access is
-    // always through @MainActor methods; the unsafe annotation is correct here.
     nonisolated init(_ store: any RunStore) {
         self.store = store
     }

--- a/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
+++ b/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
@@ -1,0 +1,435 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - ResumableRunDriver
+//
+// P3b: the second shipped TurnDriver conformer. Wraps each TurnInput in a
+// ConversationRun/RunStep lifecycle, checkpointing to RunStore before and
+// after each step so the run survives app suspension.
+//
+// Design decisions (see PR body for full rationale):
+//
+// 1. executeTurn is a single-step adapter. The multi-step loop lives in
+//    startRun(…) which ConversationRuntime.startRun(_:) calls. This keeps
+//    the TurnDriver contract narrow (one delegation = one turn) while the
+//    run API adds orchestration above it.
+//
+// 2. RunStore is required. The driver is constructed with the store; callers
+//    that don't need resumable runs use SingleTurnDriver (the default).
+//
+// 3. Clock + ID injection for deterministic testing. ConversationRun and
+//    RunStep accept externally-provided IDs and dates so tests produce stable
+//    fixtures without harness hooks.
+//
+// 4. Internal mutable state is isolated behind ResumableRunState (an actor),
+//    not a lock. Concurrency model follows the p2c invariants.
+//
+// 5. RunStore writes are @MainActor (protocol requirement). The driver calls
+//    them via await MainActor.run { @MainActor in ... } which is safe because
+//    MainActor.run's closure is Sendable only when the captures are Sendable.
+//    ConversationRun/RunStep are Sendable value types, so the captures are clean.
+//
+// Invariant 7: adding this driver required zero engine-core edits.
+// Invariant 6: run-level events ride RunEvent, never ConversationEvent.
+
+// MARK: - ResumableRunState
+
+/// Actor that guards the mutable state of a ``ResumableRunDriver``.
+/// Keeps the driver `Sendable` by isolating mutations to one serial domain.
+actor ResumableRunState {
+    var activeRun: ConversationRun?
+    var isPaused: Bool = false
+    var isCancelled: Bool = false
+
+    func setActiveRun(_ run: ConversationRun?) {
+        activeRun = run
+    }
+
+    func updateActiveRun(_ run: ConversationRun) {
+        activeRun = run
+    }
+
+    func requestPause() {
+        isPaused = true
+    }
+
+    func requestCancel() {
+        isCancelled = true
+    }
+
+    /// Clears transient flags at the start of a new run or on resume.
+    func clearFlags() {
+        isPaused = false
+        isCancelled = false
+    }
+
+    func checkPaused() -> Bool { isPaused }
+    func checkCancelled() -> Bool { isCancelled }
+}
+
+// MARK: - RunInputProvider
+
+/// Supplies the ``TurnInput`` for each step in a ``ConversationRun``.
+///
+/// Conform this protocol to implement a custom multi-step orchestration
+/// strategy. The default implementation (``FixedGoalRunInputProvider``)
+/// synthesises a single `.send(text:)` turn from the run's `goal` and
+/// returns `nil` on subsequent steps.
+public protocol RunInputProvider: Sendable {
+    /// Returns the ``TurnInput`` for the next step, or `nil` when the run
+    /// is complete. Called before each step; `stepIndex` is 0-based.
+    ///
+    /// - Parameters:
+    ///   - run:       Current run record.
+    ///   - stepIndex: 0-based index of the step about to execute.
+    ///   - prior:     The previous step's record, or `nil` for step 0.
+    func nextInput(
+        for run: ConversationRun,
+        stepIndex: Int,
+        prior: RunStep?
+    ) async -> TurnInput?
+}
+
+/// Default ``RunInputProvider``: drives one `.send(text: goal)` turn on
+/// step 0, returns `nil` on step 1+ so the run completes after a single
+/// turn. Suitable for simple single-goal runs.
+public struct FixedGoalRunInputProvider: RunInputProvider, Sendable {
+    private let config: TurnConfig
+
+    public init(config: TurnConfig = TurnConfig()) {
+        self.config = config
+    }
+
+    public func nextInput(
+        for run: ConversationRun,
+        stepIndex: Int,
+        prior: RunStep?
+    ) async -> TurnInput? {
+        guard stepIndex == 0 else { return nil }
+        return TurnInput(
+            sessionID: run.sessionID,
+            kind: .send(text: run.goal),
+            config: config
+        )
+    }
+}
+
+// MARK: - RunStoreProxy
+
+/// Thin wrapper around ``RunStore`` that exposes best-effort checkpoint
+/// calls with logging. Methods are `@MainActor` because the ``RunStore``
+/// protocol is `@MainActor`-isolated. The `@unchecked Sendable` annotation
+/// is safe because the single `store` property is `@MainActor`-bound and is
+/// never mutated after initialization.
+private final class RunStoreProxy: @unchecked Sendable {
+    private let store: any RunStore
+
+    // nonisolated init so ResumableRunDriver.init (non-actor) can create it.
+    // The store itself is stored via nonisolated(unsafe) because access is
+    // always through @MainActor methods; the unsafe annotation is correct here.
+    nonisolated init(_ store: any RunStore) {
+        self.store = store
+    }
+
+    @MainActor
+    func insertRun(_ run: ConversationRun) async {
+        do { try await store.insertRun(run) } catch {
+            Log.persistence.warning("ResumableRunDriver: insertRun failed: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    func updateRun(_ run: ConversationRun) async {
+        do { try await store.updateRun(run) } catch {
+            Log.persistence.warning("ResumableRunDriver: updateRun failed: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    func insertStep(_ step: RunStep) async {
+        do { try await store.insertStep(step) } catch {
+            Log.persistence.warning("ResumableRunDriver: insertStep failed: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    func updateStep(_ step: RunStep) async {
+        do { try await store.updateStep(step) } catch {
+            Log.persistence.warning("ResumableRunDriver: updateStep failed: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - ResumableRunDriver
+
+/// ``TurnDriver`` that wraps each turn in a ``ConversationRun`` / ``RunStep``
+/// lifecycle, checkpointing to ``RunStore`` before and after each step.
+///
+/// Inject into ``ConversationRuntime`` via the `turnDriver:` parameter of the
+/// package init:
+///
+/// ```swift
+/// let driver = ResumableRunDriver(runStore: myRunStore)
+/// let runtime = ConversationRuntime(
+///     messageStore: messageStore,
+///     sessionStore: sessionStore,
+///     inferenceService: service,
+///     turnDriver: driver
+/// )
+/// ```
+///
+/// Drive runs via ``ConversationRuntime/startRun(_:using:)``.
+///
+/// ## Concurrency
+///
+/// Internal state is isolated behind ``ResumableRunState`` (an actor). All
+/// ``RunStore`` access is `@MainActor` per the protocol requirement, routed
+/// through ``RunStoreProxy`` to keep value captures clean.
+///
+/// ## Backward compatibility
+///
+/// When no run is active, `executeTurn` delegates to ``SingleTurnDriver``
+/// so the driver is backward-compatible with direct
+/// ``ConversationRuntime/processTurn(_:)`` callers — existing code that does
+/// not use the run API is unaffected.
+///
+/// ## Invariants preserved
+///
+/// - Invariant 6: run-level events ride ``RunEvent``, never ``ConversationEvent``.
+/// - Invariant 7: adding this driver required zero engine-core edits (EDGE).
+public final class ResumableRunDriver: TurnDriver, @unchecked Sendable {
+    // `@unchecked Sendable` is safe: all mutable state is isolated behind
+    // the `ResumableRunState` actor. `RunStoreProxy` is `@MainActor`-isolated
+    // and `Sendable` by explicit declaration above. No bare mutable references
+    // escape the isolation boundaries.
+
+    private let storeProxy: RunStoreProxy
+    private let runState = ResumableRunState()
+
+    // MARK: Init
+
+    public init(runStore: any RunStore) {
+        self.storeProxy = RunStoreProxy(runStore)
+    }
+
+    // MARK: TurnDriver
+
+    /// Executes one turn. Delegates to ``SingleTurnDriver`` unconditionally;
+    /// step bookkeeping is owned by the run loop in ``startRun(_:using:executor:taskRegistry:)``.
+    package func executeTurn(
+        _ input: TurnInput,
+        executor: ConversationTurnExecutor,
+        taskRegistry: ConversationTurnTaskRegistry,
+        outcomeCompletion: ConversationTurnOutcomeCompletion?
+    ) async throws -> ConversationStreamHandle? {
+        try await SingleTurnDriver().executeTurn(
+            input,
+            executor: executor,
+            taskRegistry: taskRegistry,
+            outcomeCompletion: outcomeCompletion
+        )
+    }
+
+    // MARK: Run lifecycle
+
+    /// Starts a new ``ConversationRun`` and executes its steps until the
+    /// provider signals completion.
+    ///
+    /// - Parameters:
+    ///   - run:          The run record. The driver inserts it into ``RunStore``.
+    ///   - provider:     Supplies the ``TurnInput`` for each step.
+    ///   - executor:     The ``ConversationTurnExecutor`` from the runtime.
+    ///   - taskRegistry: The ``ConversationTurnTaskRegistry`` from the runtime.
+    /// - Returns: An `AsyncStream<RunEvent>` delivering lifecycle events until
+    ///   the run reaches a terminal state.
+    package func startRun(
+        _ run: ConversationRun,
+        using provider: any RunInputProvider,
+        executor: ConversationTurnExecutor,
+        taskRegistry: ConversationTurnTaskRegistry
+    ) -> AsyncStream<RunEvent> {
+        let storeProxy = self.storeProxy
+        let runState = self.runState
+        let driver = self
+
+        return AsyncStream { continuation in
+            Task {
+                await runState.clearFlags()
+                var currentRun = run
+
+                // Persist as pending, then transition to running.
+                await storeProxy.insertRun(currentRun)
+                currentRun.status = .running
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                await runState.setActiveRun(currentRun)
+                continuation.yield(.runStarted(
+                    runID: currentRun.id,
+                    sessionID: currentRun.sessionID,
+                    goal: currentRun.goal
+                ))
+
+                var priorStep: RunStep? = nil
+                var stepIndex = 0
+
+                stepLoop: while true {
+                    // Cancel check.
+                    if await runState.checkCancelled() {
+                        currentRun.status = .cancelled
+                        currentRun.updatedAt = Date()
+                        await storeProxy.updateRun(currentRun)
+                        await runState.setActiveRun(nil)
+                        continuation.yield(.runCancelled(runID: currentRun.id, stepCount: stepIndex))
+                        break stepLoop
+                    }
+
+                    // Pause/resume cycle.
+                    if await runState.checkPaused() {
+                        currentRun.status = .paused
+                        currentRun.updatedAt = Date()
+                        await storeProxy.updateRun(currentRun)
+                        continuation.yield(.runPaused(runID: currentRun.id, stepCount: stepIndex))
+
+                        // Poll until un-paused or cancelled.
+                        while await runState.checkPaused() {
+                            if await runState.checkCancelled() { break }
+                            try? await Task.sleep(for: .milliseconds(100))
+                        }
+
+                        if await runState.checkCancelled() {
+                            currentRun.status = .cancelled
+                            currentRun.updatedAt = Date()
+                            await storeProxy.updateRun(currentRun)
+                            await runState.setActiveRun(nil)
+                            continuation.yield(.runCancelled(runID: currentRun.id, stepCount: stepIndex))
+                            break stepLoop
+                        }
+
+                        currentRun.status = .running
+                        currentRun.updatedAt = Date()
+                        await storeProxy.updateRun(currentRun)
+                        continuation.yield(.runResumed(runID: currentRun.id, stepCount: stepIndex))
+                    }
+
+                    // Step-limit check.
+                    if let max = currentRun.maxSteps, stepIndex >= max {
+                        currentRun.status = .completed
+                        currentRun.stepCount = stepIndex
+                        currentRun.updatedAt = Date()
+                        await storeProxy.updateRun(currentRun)
+                        await runState.setActiveRun(nil)
+                        continuation.yield(.runCompleted(runID: currentRun.id, stepCount: stepIndex))
+                        break stepLoop
+                    }
+
+                    // Ask provider for next input.
+                    guard let turnInput = await provider.nextInput(
+                        for: currentRun,
+                        stepIndex: stepIndex,
+                        prior: priorStep
+                    ) else {
+                        currentRun.status = .completed
+                        currentRun.stepCount = stepIndex
+                        currentRun.updatedAt = Date()
+                        await storeProxy.updateRun(currentRun)
+                        await runState.setActiveRun(nil)
+                        continuation.yield(.runCompleted(runID: currentRun.id, stepCount: stepIndex))
+                        break stepLoop
+                    }
+
+                    // Insert the step record before executing the turn — mirrors
+                    // the #1606 register-before-enqueue discipline: checkpoint
+                    // first so the step is visible if the process dies during
+                    // execution.
+                    var step = RunStep(
+                        runID: currentRun.id,
+                        stepIndex: stepIndex,
+                        turnInput: turnInput
+                    )
+                    await storeProxy.insertStep(step)
+                    continuation.yield(.stepStarted(
+                        runID: currentRun.id,
+                        stepIndex: stepIndex,
+                        stepID: step.id
+                    ))
+
+                    // Execute the turn, capturing the outcome for step attribution.
+                    let outcomeCompletion = ConversationTurnOutcomeCompletion()
+                    do {
+                        let handle = try await driver.executeTurn(
+                            turnInput,
+                            executor: executor,
+                            taskRegistry: taskRegistry,
+                            outcomeCompletion: outcomeCompletion
+                        )
+                        // Wait for the turn to fully complete before advancing.
+                        if handle != nil {
+                            let outcome = await outcomeCompletion.value()
+                            step.messageID = outcome.assistantMessage?.id
+                        }
+                    } catch {
+                        let reason = error.localizedDescription
+                        step.isFailed = true
+                        step.failureReason = reason
+                        step.updatedAt = Date()
+                        await storeProxy.updateStep(step)
+                        currentRun.status = .failed
+                        currentRun.updatedAt = Date()
+                        await storeProxy.updateRun(currentRun)
+                        await runState.setActiveRun(nil)
+                        continuation.yield(.stepFailed(
+                            runID: currentRun.id,
+                            stepIndex: stepIndex,
+                            stepID: step.id,
+                            reason: reason
+                        ))
+                        continuation.yield(.runFailed(runID: currentRun.id, reason: reason))
+                        break stepLoop
+                    }
+
+                    // Mark step complete and checkpoint.
+                    step.isCompleted = true
+                    step.updatedAt = Date()
+                    await storeProxy.updateStep(step)
+                    continuation.yield(.stepCompleted(
+                        runID: currentRun.id,
+                        stepIndex: stepIndex,
+                        stepID: step.id,
+                        messageID: step.messageID
+                    ))
+
+                    // Advance the step counter.
+                    priorStep = step
+                    stepIndex += 1
+                    currentRun.stepCount = stepIndex
+                    currentRun.updatedAt = Date()
+                    await runState.updateActiveRun(currentRun)
+                    await storeProxy.updateRun(currentRun)
+                }
+
+                continuation.finish()
+            }
+        }
+    }
+
+    // MARK: Pause / Resume / Cancel
+
+    /// Requests that the active run pause after its current step.
+    /// Returns immediately; the run emits ``RunEvent/runPaused`` when
+    /// it actually suspends.
+    public func pauseRun() async {
+        await runState.requestPause()
+    }
+
+    /// Requests that a paused run resume execution. Returns immediately;
+    /// the run emits ``RunEvent/runResumed`` when it continues.
+    public func resumeRun() async {
+        await runState.clearFlags()
+    }
+
+    /// Requests that the active run cancel. Returns immediately;
+    /// the run emits ``RunEvent/runCancelled`` when it stops.
+    public func cancelRun() async {
+        await runState.requestCancel()
+    }
+}

--- a/Sources/ManifoldRuntime/Services/RunEvent.swift
+++ b/Sources/ManifoldRuntime/Services/RunEvent.swift
@@ -1,0 +1,64 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - RunEvent
+//
+// P3b: run-level lifecycle events for ConversationRun.
+//
+// Per target-architecture.md invariant 6 and target-architecture-migration.md:
+//   "run-level events must NOT be added as GenerationEvent cases — they
+//    ride their own event type (precedent: ImageRuntimeEvent is deliberately
+//    separate from the text-path event vocabulary so exhaustive switches
+//    stay closed)."
+//
+// `RunEvent` is the vocabulary P3 was expected to contribute before the 1.0
+// GenerationEvent freeze. It is a sibling to ConversationEvent, not a subset.
+// Text-side consumers exhaustively switch over ConversationEvent; adding run
+// cases there would push unreachable switch arms into every text consumer.
+//
+// `ResumableRunDriver` emits these events on the AsyncStream<RunEvent> that
+// ConversationRuntime.startRun returns. Text-path consumers that do not care
+// about resumable runs never see RunEvent at all.
+
+/// Run-level lifecycle events for ``ConversationRun`` executions.
+///
+/// Parallel to ``ConversationEvent`` — run-side events are deliberately a
+/// separate type so exhaustive switches in text consumers stay closed.
+/// ``ResumableRunDriver`` emits these on the ``AsyncStream`` returned by
+/// ``ConversationRuntime/startRun(_:)``.
+///
+/// Invariant: no run-level payload appears as a ``ConversationEvent`` case.
+/// ``GenerationEventClosedAuditTest`` enforces this with a tripwire.
+public enum RunEvent: Sendable, Equatable {
+
+    /// The run transitioned from `.pending` to `.running`. Fires once per
+    /// run, before the first step begins.
+    case runStarted(runID: UUID, sessionID: UUID, goal: String)
+
+    /// A step began executing. `stepIndex` is 0-based.
+    case stepStarted(runID: UUID, stepIndex: Int, stepID: UUID)
+
+    /// A step completed successfully. `messageID` is the assistant message
+    /// persisted by the step, when one was produced.
+    case stepCompleted(runID: UUID, stepIndex: Int, stepID: UUID, messageID: UUID?)
+
+    /// A step failed. The run transitions to `.failed` on the first
+    /// unrecoverable step failure.
+    case stepFailed(runID: UUID, stepIndex: Int, stepID: UUID, reason: String)
+
+    /// The run was paused by the host. The current step index is preserved;
+    /// the run can be resumed via ``ConversationRuntime/resumeRun(_:)``.
+    case runPaused(runID: UUID, stepCount: Int)
+
+    /// A previously-paused run resumed execution.
+    case runResumed(runID: UUID, stepCount: Int)
+
+    /// The run completed. `stepCount` is the total number of completed steps.
+    case runCompleted(runID: UUID, stepCount: Int)
+
+    /// The run was cancelled by the host or user.
+    case runCancelled(runID: UUID, stepCount: Int)
+
+    /// The run failed due to an unrecoverable error.
+    case runFailed(runID: UUID, reason: String)
+}

--- a/Sources/ManifoldRuntime/Services/RunEvent.swift
+++ b/Sources/ManifoldRuntime/Services/RunEvent.swift
@@ -25,7 +25,7 @@ import ManifoldInference
 /// Parallel to ``ConversationEvent`` — run-side events are deliberately a
 /// separate type so exhaustive switches in text consumers stay closed.
 /// ``ResumableRunDriver`` emits these on the ``AsyncStream`` returned by
-/// ``ConversationRuntime/startRun(_:)``.
+/// ``ConversationRuntime/startRun(_:using:)``.
 ///
 /// Invariant: no run-level payload appears as a ``ConversationEvent`` case.
 /// ``GenerationEventClosedAuditTest`` enforces this with a tripwire.
@@ -47,7 +47,7 @@ public enum RunEvent: Sendable, Equatable {
     case stepFailed(runID: UUID, stepIndex: Int, stepID: UUID, reason: String)
 
     /// The run was paused by the host. The current step index is preserved;
-    /// the run can be resumed via ``ConversationRuntime/resumeRun(_:)``.
+    /// the in-process run can be resumed via ``ResumableRunDriver/resumeRun()``.
     case runPaused(runID: UUID, stepCount: Int)
 
     /// A previously-paused run resumed execution.

--- a/Sources/ManifoldRuntime/Services/SingleTurnDriver.swift
+++ b/Sources/ManifoldRuntime/Services/SingleTurnDriver.swift
@@ -1,0 +1,81 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - SingleTurnDriver
+//
+// P3a: the default ``TurnDriver`` conformer that reproduces the pre-P3
+// linear behavior of `ConversationRuntime`. Behavior-preserving — the
+// golden P0c transcripts must diff clean after this refactor.
+//
+// The implementation is a thin router: it reads `TurnKind` and delegates
+// to the matching `ConversationTurnExecutor` flow, exactly as the
+// `processTurn` switch in `ConversationRuntime` did before the seam was
+// introduced. No logic is added or removed.
+//
+// Acceptance metric: adding a driver = conform TurnDriver, 0 engine-core
+// edits. `SingleTurnDriver` proves the contract by being the first conformer.
+
+/// Default ``TurnDriver`` that executes one linear turn per call, reproducing
+/// the behavior that existed in ``ConversationRuntime`` before the P3 driver
+/// seam was introduced.
+///
+/// This is always the right choice for standard chat sessions. Pass
+/// ``ResumableRunDriver`` when you need long-running, checkpointed runs that
+/// survive app suspension.
+///
+/// ## Behavior preservation
+///
+/// `SingleTurnDriver` is a thin router — it adds no new logic beyond the
+/// `TurnKind` switch that previously lived inline in `ConversationRuntime`.
+/// The P0c golden transcripts must diff clean against any build that uses
+/// this driver.
+public struct SingleTurnDriver: TurnDriver {
+
+    public init() {}
+
+    package func executeTurn(
+        _ input: TurnInput,
+        executor: ConversationTurnExecutor,
+        taskRegistry: ConversationTurnTaskRegistry,
+        outcomeCompletion: ConversationTurnOutcomeCompletion?
+    ) async throws -> ConversationStreamHandle? {
+        switch input.kind {
+        case let .send(text, attachments):
+            return try await executor.runSendFlow(
+                sessionID: input.sessionID,
+                text: text,
+                attachments: attachments,
+                config: input.config,
+                taskRegistry: taskRegistry,
+                outcomeCompletion: outcomeCompletion
+            )
+        case .regenerate:
+            return try await executor.runRegenerateFlow(
+                sessionID: input.sessionID,
+                config: input.config,
+                taskRegistry: taskRegistry,
+                outcomeCompletion: outcomeCompletion
+            )
+        case let .edit(messageID, text):
+            return try await executor.runEditFlow(
+                sessionID: input.sessionID,
+                messageID: messageID,
+                text: text,
+                config: input.config,
+                taskRegistry: taskRegistry,
+                outcomeCompletion: outcomeCompletion
+            )
+        case let .branch(messageID, newSessionID, newSessionTitle, generateAfter):
+            return try await executor.runBranchFlow(
+                sourceSessionID: input.sessionID,
+                branchMessageID: messageID,
+                newSessionID: newSessionID,
+                newSessionTitle: newSessionTitle,
+                generateAfter: generateAfter,
+                config: input.config,
+                taskRegistry: taskRegistry,
+                outcomeCompletion: outcomeCompletion
+            )
+        }
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for ``ConversationRun`` and ``RunStep`` value type invariants, plus
+/// ``ResumableRunDriver`` lifecycle (start → complete path).
+///
+/// Classification: Unit (in-memory SwiftData, MockInferenceBackend — no real
+/// model, no network, injected IDs/dates for determinism).
+@MainActor
+final class ConversationRunStateTests: XCTestCase {
+
+    // MARK: - ConversationRun value type
+
+    func test_conversationRun_defaultStatus_isPending() {
+        let run = ConversationRun(sessionID: UUID(), goal: "Do something")
+        XCTAssertEqual(run.status, .pending)
+        XCTAssertEqual(run.stepCount, 0)
+        XCTAssertNil(run.maxSteps)
+    }
+
+    func test_conversationRun_fullInit_roundtrip() {
+        let id = UUID()
+        let sessionID = UUID()
+        let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        let run = ConversationRun(
+            id: id,
+            sessionID: sessionID,
+            goal: "Explicit init",
+            status: .running,
+            stepCount: 3,
+            maxSteps: 10,
+            createdAt: now,
+            updatedAt: now
+        )
+        XCTAssertEqual(run.id, id)
+        XCTAssertEqual(run.sessionID, sessionID)
+        XCTAssertEqual(run.goal, "Explicit init")
+        XCTAssertEqual(run.status, .running)
+        XCTAssertEqual(run.stepCount, 3)
+        XCTAssertEqual(run.maxSteps, 10)
+    }
+
+    func test_conversationRun_statusTransitions_allCasesExist() {
+        // Exhaustive: if RunStatus grows, this test points at the gap.
+        let allCases = RunStatus.allCases
+        XCTAssertTrue(allCases.contains(.pending))
+        XCTAssertTrue(allCases.contains(.running))
+        XCTAssertTrue(allCases.contains(.paused))
+        XCTAssertTrue(allCases.contains(.completed))
+        XCTAssertTrue(allCases.contains(.cancelled))
+        XCTAssertTrue(allCases.contains(.failed))
+        XCTAssertEqual(allCases.count, 6, "Update when adding RunStatus cases")
+    }
+
+    func test_conversationRun_equatable() {
+        let id = UUID()
+        let sessionID = UUID()
+        let now = Date()
+        let a = ConversationRun(id: id, sessionID: sessionID, goal: "g",
+                                 createdAt: now, updatedAt: now)
+        var b = ConversationRun(id: id, sessionID: sessionID, goal: "g",
+                                 createdAt: now, updatedAt: now)
+        XCTAssertEqual(a, b)
+
+        b.status = .running
+        XCTAssertNotEqual(a, b, "Mutated status must break equality")
+    }
+
+    // MARK: - RunStep value type
+
+    func test_runStep_defaultValues() {
+        let runID = UUID()
+        let step = RunStep(runID: runID, stepIndex: 2, turnInput: nil)
+        XCTAssertEqual(step.runID, runID)
+        XCTAssertEqual(step.stepIndex, 2)
+        XCTAssertNil(step.turnInput)
+        XCTAssertNil(step.messageID)
+        XCTAssertFalse(step.isCompleted)
+        XCTAssertFalse(step.isFailed)
+        XCTAssertNil(step.failureReason)
+    }
+
+    // MARK: - ResumableRunDriver: single-step run lifecycle
+
+    /// InMemoryRunStore for the driver tests. Not shared with the contract
+    /// suite above — each test class uses its own isolated instance.
+    @MainActor
+    private final class InMemoryRunStore2: RunStore {
+        private var runs: [ConversationRun] = []
+        private var steps: [RunStep] = []
+
+        func insertRun(_ run: ConversationRun) async throws { runs.append(run) }
+        func updateRun(_ run: ConversationRun) async throws {
+            guard let i = runs.firstIndex(where: { $0.id == run.id }) else {
+                throw RunStoreError.runNotFound(run.id)
+            }
+            runs[i] = run
+        }
+        func deleteRun(_ id: UUID) async throws {
+            guard let i = runs.firstIndex(where: { $0.id == id }) else {
+                throw RunStoreError.runNotFound(id)
+            }
+            runs.remove(at: i)
+        }
+        func fetchRuns(for sessionID: UUID) async throws -> [ConversationRun] {
+            runs.filter { $0.sessionID == sessionID }
+        }
+        func fetchRun(_ id: UUID) async throws -> ConversationRun? {
+            runs.first(where: { $0.id == id })
+        }
+        func insertStep(_ step: RunStep) async throws { steps.append(step) }
+        func updateStep(_ step: RunStep) async throws {
+            guard let i = steps.firstIndex(where: { $0.id == step.id }) else {
+                throw RunStoreError.stepNotFound(step.id)
+            }
+            steps[i] = step
+        }
+        func fetchSteps(for runID: UUID) async throws -> [RunStep] {
+            steps.filter { $0.runID == runID }.sorted { $0.stepIndex < $1.stepIndex }
+        }
+    }
+
+    func test_resolvableRunDriver_singleStep_completesSuccessfully() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Done"]
+        let service = InferenceService(backend: backend, name: "RunDriverTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let sessionID = UUID()
+        let run = ConversationRun(sessionID: sessionID, goal: "Test single step")
+
+        var events: [RunEvent] = []
+        let stream = runtime.startRun(run, using: FixedGoalRunInputProvider())
+
+        // Drain the stream with a deadline.
+        let end = ContinuousClock.now.advanced(by: .seconds(10))
+        for await event in stream {
+            events.append(event)
+            if case .runCompleted = event { break }
+            if case .runFailed = event { break }
+            if ContinuousClock.now > end { break }
+        }
+
+        // Verify event sequence.
+        XCTAssertTrue(events.contains { if case .runStarted = $0 { return true }; return false },
+                      "Expected .runStarted event")
+        XCTAssertTrue(events.contains { if case .stepStarted = $0 { return true }; return false },
+                      "Expected .stepStarted event")
+        XCTAssertTrue(events.contains { if case .stepCompleted = $0 { return true }; return false },
+                      "Expected .stepCompleted event")
+        XCTAssertTrue(events.contains { if case .runCompleted = $0 { return true }; return false },
+                      "Expected .runCompleted event")
+
+        // The final run record should be .completed with stepCount == 1.
+        let stored = try await runStore.fetchRun(run.id)
+        let storedRun = try XCTUnwrap(stored, "Run should be persisted")
+        XCTAssertEqual(storedRun.status, .completed)
+        XCTAssertEqual(storedRun.stepCount, 1)
+
+        // A message was persisted for the step.
+        let messages = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        XCTAssertEqual(messages.count, 2, "Expected user + assistant messages")
+    }
+
+    func test_resolvableRunDriver_noRunActive_behavesLikeSingleTurn() async throws {
+        // When ResumableRunDriver is wired but processTurn is called directly
+        // (without startRun), behavior must be identical to SingleTurnDriver.
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hi"]
+        let service = InferenceService(backend: backend, name: "FallbackTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let sessionID = UUID()
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Fallback"))
+        )
+        await handle?.outcome
+
+        let messages = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        XCTAssertEqual(messages.count, 2, "Direct processTurn must produce user + assistant message")
+    }
+
+    func test_resolvableRunDriver_maxSteps_completesEarly() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Step"]
+        let service = InferenceService(backend: backend, name: "MaxStepsTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        // A provider that would run forever, but maxSteps = 0 terminates immediately.
+        let sessionID = UUID()
+        let run = ConversationRun(
+            id: UUID(), sessionID: sessionID, goal: "Max steps 0",
+            status: .pending, stepCount: 0, maxSteps: 0,
+            createdAt: Date(), updatedAt: Date()
+        )
+
+        var events: [RunEvent] = []
+        let stream = runtime.startRun(run, using: FixedGoalRunInputProvider())
+        let end = ContinuousClock.now.advanced(by: .seconds(5))
+        for await event in stream {
+            events.append(event)
+            if case .runCompleted = event { break }
+            if case .runFailed = event { break }
+            if ContinuousClock.now > end { break }
+        }
+
+        // maxSteps = 0 completes immediately without executing any steps.
+        XCTAssertTrue(events.contains { if case .runCompleted = $0 { return true }; return false },
+                      "maxSteps=0 run should complete without steps")
+        XCTAssertFalse(events.contains { if case .stepStarted = $0 { return true }; return false },
+                       "No steps should have started when maxSteps=0")
+    }
+
+    // MARK: - startRun on non-ResumableRunDriver runtime
+
+    func test_startRun_withoutResumableDriver_returnsEmptyStream() async throws {
+        // ConversationRuntime defaults to SingleTurnDriver. Calling startRun
+        // on it logs a warning and returns a stream that finishes immediately.
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        let service = InferenceService(backend: backend, name: "WarnTest")
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service
+        )
+
+        let run = ConversationRun(sessionID: UUID(), goal: "Should not start")
+        var events: [RunEvent] = []
+        for await event in runtime.startRun(run) {
+            events.append(event)
+        }
+        // The stream should finish immediately with no events.
+        XCTAssertTrue(events.isEmpty, "Non-resumable runtime must return an empty RunEvent stream")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift
@@ -247,6 +247,127 @@ final class ConversationRunStateTests: XCTestCase {
                        "No steps should have started when maxSteps=0")
     }
 
+    // MARK: - Multi-step provider
+
+    /// Drives a fixed number of `.send` steps, then returns `nil` to complete.
+    /// Each step's text encodes its index so step attribution is verifiable.
+    private struct CountingProvider: RunInputProvider {
+        let stepCount: Int
+        func nextInput(
+            for run: ConversationRun,
+            stepIndex: Int,
+            prior: RunStep?
+        ) async -> TurnInput? {
+            guard stepIndex < stepCount else { return nil }
+            return TurnInput(
+                sessionID: run.sessionID,
+                kind: .send(text: "step-\(stepIndex)"),
+                config: TurnConfig()
+            )
+        }
+    }
+
+    func test_resumableRunDriver_multiStep_runsEachStepInOrder() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["ok"]
+        let service = InferenceService(backend: backend, name: "MultiStepTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let run = ConversationRun(sessionID: UUID(), goal: "multi")
+        var events: [RunEvent] = []
+        let end = ContinuousClock.now.advanced(by: .seconds(15))
+        for await event in runtime.startRun(run, using: CountingProvider(stepCount: 3)) {
+            events.append(event)
+            if case .runCompleted = event { break }
+            if case .runFailed = event { break }
+            if ContinuousClock.now > end { break }
+        }
+
+        // Three steps must have started, in index order 0,1,2.
+        let startedIndices: [Int] = events.compactMap {
+            if case let .stepStarted(_, idx, _) = $0 { return idx }
+            return nil
+        }
+        XCTAssertEqual(startedIndices, [0, 1, 2], "Steps must run in ascending index order")
+
+        // Persisted step records mirror the three steps.
+        let steps = try await runStore.fetchSteps(for: run.id)
+        XCTAssertEqual(steps.map(\.stepIndex), [0, 1, 2])
+        XCTAssertTrue(steps.allSatisfy(\.isCompleted), "All steps should be marked completed")
+
+        let fetchedRun = try await runStore.fetchRun(run.id)
+        let stored = try XCTUnwrap(fetchedRun)
+        XCTAssertEqual(stored.status, .completed)
+        XCTAssertEqual(stored.stepCount, 3)
+    }
+
+    // MARK: - Cancel
+
+    /// Provider that requests cancellation on the driver once the run reaches
+    /// step 1, then keeps offering steps. Cancellation is deterministic — it
+    /// is driven off the run's own step progression, not a timer.
+    private struct CancelAtStepProvider: RunInputProvider {
+        let driver: ResumableRunDriver
+        func nextInput(
+            for run: ConversationRun,
+            stepIndex: Int,
+            prior: RunStep?
+        ) async -> TurnInput? {
+            if stepIndex == 1 { await driver.cancelRun() }
+            // Keep offering steps so only the cancel can terminate the run.
+            return TurnInput(
+                sessionID: run.sessionID,
+                kind: .send(text: "step-\(stepIndex)"),
+                config: TurnConfig()
+            )
+        }
+    }
+
+    func test_resumableRunDriver_cancel_stopsRunWithCancelledStatus() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["ok"]
+        let service = InferenceService(backend: backend, name: "CancelTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let provider = CancelAtStepProvider(driver: driver)
+        let run = ConversationRun(sessionID: UUID(), goal: "cancel me")
+        var sawCancelled = false
+        let end = ContinuousClock.now.advanced(by: .seconds(15))
+        for await event in runtime.startRun(run, using: provider) {
+            if case .runCancelled = event { sawCancelled = true; break }
+            if case .runCompleted = event { break }
+            if case .runFailed = event { break }
+            if ContinuousClock.now > end { break }
+        }
+
+        XCTAssertTrue(sawCancelled, "Run should terminate via .runCancelled once cancelRun() is requested")
+        let fetchedRun = try await runStore.fetchRun(run.id)
+        let stored = try XCTUnwrap(fetchedRun)
+        XCTAssertEqual(stored.status, .cancelled, "Persisted run must reflect cancelled status")
+    }
+
     // MARK: - startRun on non-ResumableRunDriver runtime
 
     func test_startRun_withoutResumableDriver_returnsEmptyStream() async throws {

--- a/Tests/ManifoldRuntimeTests/GenerationEventClosedAuditTest.swift
+++ b/Tests/ManifoldRuntimeTests/GenerationEventClosedAuditTest.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldInference
+
+/// Tripwire enforcing invariant 6 from target-architecture.md:
+///
+/// > "New modality/run-level events ride their own event types — never new
+/// > `GenerationEvent` cases on the text path."
+///
+/// Specifically this test asserts that no run-level payload appears as a
+/// ``ConversationEvent`` case. ``RunEvent`` is the separate type that owns
+/// the run-lifecycle vocabulary, keeping exhaustive switches in text
+/// consumers closed.
+///
+/// Adding a new ``ConversationEvent`` case that carries run-level payload
+/// (started/step/paused/resumed/completed/cancelled/failed vocabulary)
+/// must fail this test — that is the intended tripwire behavior.
+///
+/// The test works by:
+/// 1. Enumerating every ``ConversationEventKind`` case and asserting no
+///    case name matches the run-level vocabulary.
+/// 2. Asserting ``RunEvent`` case names are disjoint from
+///    ``ConversationEventKind`` case names, so the two surfaces can
+///    never silently merge.
+///
+/// - Note: If this test fails after adding a new ``ConversationEvent`` case,
+///   the correct fix is to put the new events in ``RunEvent`` instead.
+final class GenerationEventClosedAuditTest: XCTestCase {
+
+    // MARK: Run-level vocabulary
+
+    /// Keywords that identify run-lifecycle concepts. These must never appear
+    /// as ``ConversationEvent`` / ``ConversationEventKind`` case names.
+    private let runLevelKeywords: Set<String> = [
+        "runStarted", "runPaused", "runResumed", "runCompleted",
+        "runCancelled", "runFailed", "stepStarted", "stepCompleted",
+        "stepFailed"
+    ]
+
+    // MARK: Tests
+
+    func test_noRunLevelPayloadInConversationEventKind() {
+        let allKinds = ConversationEventKind.allCases.map(\.rawValue)
+        for keyword in runLevelKeywords {
+            XCTAssertFalse(
+                allKinds.contains(keyword),
+                "ConversationEventKind must not contain run-level case '\(keyword)'. " +
+                "Run-lifecycle events ride RunEvent (invariant 6 from target-architecture.md)."
+            )
+        }
+    }
+
+    func test_runEventCasesDisjointFromConversationEventKindCases() {
+        let conversationKinds = Set(ConversationEventKind.allCases.map(\.rawValue))
+        for keyword in runLevelKeywords {
+            XCTAssertFalse(
+                conversationKinds.contains(keyword),
+                "ConversationEventKind '\(keyword)' overlaps with RunEvent vocabulary. " +
+                "These two event surfaces must remain disjoint (invariant 6)."
+            )
+        }
+    }
+
+    func test_runEventCasesExistInRunEvent() {
+        // Verify RunEvent actually has the expected run-level cases so the
+        // audit is honest about what it's protecting.
+        let runEvents: [RunEvent] = [
+            .runStarted(runID: UUID(), sessionID: UUID(), goal: "test"),
+            .stepStarted(runID: UUID(), stepIndex: 0, stepID: UUID()),
+            .stepCompleted(runID: UUID(), stepIndex: 0, stepID: UUID(), messageID: nil),
+            .stepFailed(runID: UUID(), stepIndex: 0, stepID: UUID(), reason: "test"),
+            .runPaused(runID: UUID(), stepCount: 0),
+            .runResumed(runID: UUID(), stepCount: 0),
+            .runCompleted(runID: UUID(), stepCount: 1),
+            .runCancelled(runID: UUID(), stepCount: 0),
+            .runFailed(runID: UUID(), reason: "test"),
+        ]
+        // Exhaustive instantiation: if RunEvent adds a case, this must grow.
+        // The count assertion ensures future cases are accounted for here.
+        XCTAssertEqual(runEvents.count, 9,
+                       "Update this test when adding or removing RunEvent cases.")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/RunStoreContractTests.swift
+++ b/Tests/ManifoldRuntimeTests/RunStoreContractTests.swift
@@ -1,0 +1,239 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldInference
+
+/// Locks the ``RunStore`` protocol contract via an in-memory reference
+/// implementation. The SwiftData-backed implementation will be exercised
+/// in a future P3b persistence sub-phase; this file defends the documented
+/// surface independently of any backing store.
+///
+/// Classification: Unit (no SwiftData, no backend, no network).
+@MainActor
+final class RunStoreContractTests: XCTestCase {
+
+    // MARK: - In-memory reference implementation
+
+    private final class InMemoryRunStore: RunStore {
+        private var runs: [ConversationRun] = []
+        private var steps: [RunStep] = []
+
+        func insertRun(_ run: ConversationRun) async throws {
+            runs.append(run)
+        }
+
+        func updateRun(_ run: ConversationRun) async throws {
+            guard let idx = runs.firstIndex(where: { $0.id == run.id }) else {
+                throw RunStoreError.runNotFound(run.id)
+            }
+            runs[idx] = run
+        }
+
+        func deleteRun(_ id: UUID) async throws {
+            guard let idx = runs.firstIndex(where: { $0.id == id }) else {
+                throw RunStoreError.runNotFound(id)
+            }
+            runs.remove(at: idx)
+        }
+
+        func fetchRuns(for sessionID: UUID) async throws -> [ConversationRun] {
+            runs.filter { $0.sessionID == sessionID }
+                .sorted { $0.createdAt > $1.createdAt }
+        }
+
+        func fetchRun(_ id: UUID) async throws -> ConversationRun? {
+            runs.first(where: { $0.id == id })
+        }
+
+        func insertStep(_ step: RunStep) async throws {
+            steps.append(step)
+        }
+
+        func updateStep(_ step: RunStep) async throws {
+            guard let idx = steps.firstIndex(where: { $0.id == step.id }) else {
+                throw RunStoreError.stepNotFound(step.id)
+            }
+            steps[idx] = step
+        }
+
+        func fetchSteps(for runID: UUID) async throws -> [RunStep] {
+            steps.filter { $0.runID == runID }
+                .sorted { $0.stepIndex < $1.stepIndex }
+        }
+    }
+
+    // MARK: - ConversationRun CRUD
+
+    func test_insertRun_fetchRun_roundtrip() async throws {
+        let store = InMemoryRunStore()
+        let sessionID = UUID()
+        let run = ConversationRun(sessionID: sessionID, goal: "Test goal")
+        try await store.insertRun(run)
+
+        let fetched = try await store.fetchRun(run.id)
+        let unwrapped = try XCTUnwrap(fetched, "Expected inserted run to be fetchable")
+        XCTAssertEqual(unwrapped.id, run.id)
+        XCTAssertEqual(unwrapped.goal, "Test goal")
+        XCTAssertEqual(unwrapped.status, .pending)
+    }
+
+    func test_fetchRuns_emptyStore_returnsEmpty() async throws {
+        let store = InMemoryRunStore()
+        let result = try await store.fetchRuns(for: UUID())
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_fetchRuns_filtersBySessionID() async throws {
+        let store = InMemoryRunStore()
+        let sessionA = UUID()
+        let sessionB = UUID()
+        let runA = ConversationRun(sessionID: sessionA, goal: "A")
+        let runB = ConversationRun(sessionID: sessionB, goal: "B")
+        try await store.insertRun(runA)
+        try await store.insertRun(runB)
+
+        let resultsA = try await store.fetchRuns(for: sessionA)
+        XCTAssertEqual(resultsA.map(\.id), [runA.id])
+        let resultsB = try await store.fetchRuns(for: sessionB)
+        XCTAssertEqual(resultsB.map(\.id), [runB.id])
+    }
+
+    func test_updateRun_persistsStatusChange() async throws {
+        let store = InMemoryRunStore()
+        var run = ConversationRun(sessionID: UUID(), goal: "Update me")
+        try await store.insertRun(run)
+
+        run.status = .running
+        run.updatedAt = Date()
+        try await store.updateRun(run)
+
+        let fetched = try await store.fetchRun(run.id)
+        let unwrappedFetched = try XCTUnwrap(fetched)
+        XCTAssertEqual(unwrappedFetched.status, .running)
+    }
+
+    func test_updateRun_unknownID_throwsRunNotFound() async throws {
+        let store = InMemoryRunStore()
+        let run = ConversationRun(sessionID: UUID(), goal: "Ghost")
+        do {
+            try await store.updateRun(run)
+            XCTFail("Expected RunStoreError.runNotFound")
+        } catch RunStoreError.runNotFound(let id) {
+            XCTAssertEqual(id, run.id)
+        } catch {
+            XCTFail("Expected RunStoreError.runNotFound, got \(error)")
+        }
+    }
+
+    func test_deleteRun_removesRun() async throws {
+        let store = InMemoryRunStore()
+        let run = ConversationRun(sessionID: UUID(), goal: "Delete me")
+        try await store.insertRun(run)
+        try await store.deleteRun(run.id)
+
+        let fetched = try await store.fetchRun(run.id)
+        XCTAssertNil(fetched, "Deleted run must not be fetchable")
+    }
+
+    func test_deleteRun_unknownID_throwsRunNotFound() async throws {
+        let store = InMemoryRunStore()
+        let id = UUID()
+        do {
+            try await store.deleteRun(id)
+            XCTFail("Expected RunStoreError.runNotFound")
+        } catch RunStoreError.runNotFound(let missingID) {
+            XCTAssertEqual(missingID, id)
+        } catch {
+            XCTFail("Expected RunStoreError.runNotFound, got \(error)")
+        }
+    }
+
+    // MARK: - RunStep CRUD
+
+    func test_insertStep_fetchSteps_roundtrip() async throws {
+        let store = InMemoryRunStore()
+        let runID = UUID()
+        let step = RunStep(runID: runID, stepIndex: 0, turnInput: nil)
+        try await store.insertStep(step)
+
+        let steps = try await store.fetchSteps(for: runID)
+        XCTAssertEqual(steps.count, 1)
+        XCTAssertEqual(steps.first?.id, step.id)
+        XCTAssertEqual(steps.first?.stepIndex, 0)
+    }
+
+    func test_fetchSteps_emptyStore_returnsEmpty() async throws {
+        let store = InMemoryRunStore()
+        let result = try await store.fetchSteps(for: UUID())
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_fetchSteps_orderedByStepIndex() async throws {
+        let store = InMemoryRunStore()
+        let runID = UUID()
+        let step2 = RunStep(runID: runID, stepIndex: 2, turnInput: nil)
+        let step0 = RunStep(runID: runID, stepIndex: 0, turnInput: nil)
+        let step1 = RunStep(runID: runID, stepIndex: 1, turnInput: nil)
+        try await store.insertStep(step2)
+        try await store.insertStep(step0)
+        try await store.insertStep(step1)
+
+        let steps = try await store.fetchSteps(for: runID)
+        XCTAssertEqual(steps.map(\.stepIndex), [0, 1, 2])
+    }
+
+    func test_updateStep_persistsCompletion() async throws {
+        let store = InMemoryRunStore()
+        let runID = UUID()
+        var step = RunStep(runID: runID, stepIndex: 0, turnInput: nil)
+        try await store.insertStep(step)
+
+        step.isCompleted = true
+        step.messageID = UUID()
+        step.updatedAt = Date()
+        try await store.updateStep(step)
+
+        let steps = try await store.fetchSteps(for: runID)
+        let updated = try XCTUnwrap(steps.first)
+        XCTAssertTrue(updated.isCompleted)
+        XCTAssertNotNil(updated.messageID)
+    }
+
+    func test_updateStep_unknownID_throwsStepNotFound() async throws {
+        let store = InMemoryRunStore()
+        let step = RunStep(runID: UUID(), stepIndex: 0, turnInput: nil)
+        do {
+            try await store.updateStep(step)
+            XCTFail("Expected RunStoreError.stepNotFound")
+        } catch RunStoreError.stepNotFound(let id) {
+            XCTAssertEqual(id, step.id)
+        } catch {
+            XCTFail("Expected RunStoreError.stepNotFound, got \(error)")
+        }
+    }
+
+    // MARK: - Error description coverage
+
+    func test_runStoreError_runNotFound_description() {
+        let id = UUID()
+        let error = RunStoreError.runNotFound(id)
+        let desc = error.errorDescription ?? ""
+        XCTAssertTrue(desc.contains(id.uuidString))
+    }
+
+    func test_runStoreError_stepNotFound_description() {
+        let id = UUID()
+        let error = RunStoreError.stepNotFound(id)
+        let desc = error.errorDescription ?? ""
+        XCTAssertTrue(desc.contains(id.uuidString))
+    }
+
+    // MARK: - Equatable
+
+    func test_runStoreError_equatable() {
+        let id = UUID()
+        XCTAssertEqual(RunStoreError.runNotFound(id), RunStoreError.runNotFound(id))
+        XCTAssertNotEqual(RunStoreError.runNotFound(id), RunStoreError.runNotFound(UUID()))
+        XCTAssertEqual(RunStoreError.stepNotFound(id), RunStoreError.stepNotFound(id))
+        XCTAssertNotEqual(RunStoreError.stepNotFound(id), RunStoreError.runNotFound(id))
+    }
+}

--- a/Tests/ManifoldRuntimeTests/TurnDriverDispatchTests.swift
+++ b/Tests/ManifoldRuntimeTests/TurnDriverDispatchTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldTestSupport
+
+/// Unit tests for the ``TurnDriver`` seam introduced in P3a.
+///
+/// Verifies that:
+/// 1. The default ``SingleTurnDriver`` is wired automatically when no driver
+///    is injected.
+/// 2. A custom injected driver (spy) receives the `executeTurn` call.
+/// 3. ``SingleTurnDriver`` routes all four ``TurnKind`` values to the correct
+///    executor flow and produces the same observable outcome as the pre-P3
+///    direct path (behavior-preservation assertion, complementing the
+///    characterization goldens).
+///
+/// Classification: Unit (in-memory SwiftData, MockInferenceBackend — no real
+/// model, no network).
+@MainActor
+final class TurnDriverDispatchTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private var persistenceStack: InMemoryPersistenceHarness.Stack!
+    private var backend: MockInferenceBackend!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        persistenceStack = try InMemoryPersistenceHarness.make()
+        backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["Hi"]
+    }
+
+    private func makeRuntime(driver: (any TurnDriver)? = nil) -> ConversationRuntime {
+        let service = InferenceService(backend: backend, name: "TestDriver")
+        return ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+    }
+
+    // MARK: - Default driver
+
+    func test_defaultDriver_isSingleTurnDriver() async throws {
+        // When no driver is injected the runtime behaves identically to
+        // pre-P3: a send produces a user + assistant message pair.
+        let runtime = makeRuntime()
+        let sessionID = UUID()
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Hello"))
+        )
+        await handle?.outcome
+
+        let messages = try await persistenceStack.provider.fetchMessages(for: sessionID)
+        XCTAssertEqual(messages.count, 2, "Expected user + assistant messages")
+        XCTAssertEqual(messages.first?.role, .user)
+        XCTAssertEqual(messages.last?.role, .assistant)
+    }
+
+    // MARK: - Custom driver injection (spy)
+
+    /// A spy driver that records each `executeTurn` call and forwards to
+    /// `SingleTurnDriver`. Lets us verify the seam's dispatch path.
+    package final class SpyTurnDriver: TurnDriver, @unchecked Sendable {
+        var callCount: Int = 0
+        var lastInput: TurnInput?
+
+        package func executeTurn(
+            _ input: TurnInput,
+            executor: ConversationTurnExecutor,
+            taskRegistry: ConversationTurnTaskRegistry,
+            outcomeCompletion: ConversationTurnOutcomeCompletion?
+        ) async throws -> ConversationStreamHandle? {
+            callCount += 1
+            lastInput = input
+            return try await SingleTurnDriver().executeTurn(
+                input,
+                executor: executor,
+                taskRegistry: taskRegistry,
+                outcomeCompletion: outcomeCompletion
+            )
+        }
+    }
+
+    func test_injectedDriver_receivesExecuteTurnCall() async throws {
+        let spy = SpyTurnDriver()
+        let runtime = makeRuntime(driver: spy)
+        let sessionID = UUID()
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "Spy me"))
+        )
+        await handle?.outcome
+
+        XCTAssertEqual(spy.callCount, 1, "Expected exactly one executeTurn dispatch")
+        XCTAssertEqual(spy.lastInput?.sessionID, sessionID)
+        if case let .send(text, _) = spy.lastInput?.kind {
+            XCTAssertEqual(text, "Spy me")
+        } else {
+            XCTFail("Expected .send kind, got: \(String(describing: spy.lastInput?.kind))")
+        }
+    }
+
+    func test_injectedDriver_regenerateForwarded() async throws {
+        let spy = SpyTurnDriver()
+        let runtime = makeRuntime(driver: spy)
+        let sessionID = UUID()
+
+        // Seed a send first so regenerate has something to replace.
+        let h1 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .send(text: "First"))
+        )
+        await h1?.outcome
+
+        let h2 = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: sessionID, kind: .regenerate)
+        )
+        await h2?.outcome
+
+        XCTAssertEqual(spy.callCount, 2)
+        if case .regenerate = spy.lastInput?.kind { /* pass */ }
+        else { XCTFail("Expected last call to be .regenerate, got: \(String(describing: spy.lastInput?.kind))") }
+    }
+
+    // MARK: - EDGE metric
+
+    /// Verifies that the acceptance metric is satisfied:
+    /// "adding a driver = conform TurnDriver, 0 engine-core edits."
+    ///
+    /// This test serves as documentation: the SpyTurnDriver above conforms
+    /// to TurnDriver without touching any engine-core file. If the protocol
+    /// signature changes in a way that requires engine edits, this test
+    /// will need explanation in the PR body.
+    func test_addingADriverIsEdge() {
+        // SpyTurnDriver (defined above) was added without any changes to
+        // ConversationRuntime, ConversationTurnExecutor, or any engine-core
+        // file. This test is intentionally trivial; its purpose is to be
+        // a named acceptance-metric checkpoint in the test history.
+        let driver: any TurnDriver = SpyTurnDriver()
+        XCTAssertNotNil(driver, "TurnDriver conformance created as EDGE")
+    }
+}


### PR DESCRIPTION
## Summary

- **P3a (behavior-preserving):** Introduce `TurnDriver` protocol and extract current `ConversationRuntime` dispatch into `SingleTurnDriver`. The golden P0c characterization transcripts diff clean — zero behavior change.
- **P3b (additive):** Introduce `ConversationRun`/`RunStep` value types, `RunStore` port, `RunEvent` type (separate from `ConversationEvent` per invariant 6), `ResumableRunDriver`, and `ConversationRuntime.startRun(_:using:)`.
- **Tests:** 4 new suites (31 new tests), `GenerationEventClosedAuditTest` tripwire for invariant 6.

## Design decisions

**1. `TurnDriver` is `package` not `public`**

`executeTurn` takes `ConversationTurnExecutor` and `ConversationTurnTaskRegistry`, which are package-internal types. Making the protocol `public` would require promoting those types. Rather than widen the surface prematurely, the protocol stays `package` — custom driver conformers live within the package boundary. Can be widened in a future phase once the executor types have a public face.

**2. `ConversationTurnExecutor` promoted to `package`**

The four flow methods (`runSendFlow`, `runRegenerateFlow`, `runEditFlow`, `runBranchFlow`) are promoted to `package` so `SingleTurnDriver` and `ResumableRunDriver` can call them. The `init` stays `internal` since only `ConversationRuntime` (same module) creates the executor.

**3. `RunStore` adapter deferred to P3b persistence sub-phase**

The plan notes: "Persistence adds a `RunStore` impl + schema bump." The SwiftData `@Model` types and schema migration for run/checkpoint records require a separate schema version bump in `ManifoldPersistenceSwiftData`. That sub-phase is out of scope here (no existing migration fixture + schema work needs its own PR). The port (`RunStore` protocol + `RunStoreError`) ships now; the adapter is the follow-on. An in-memory reference impl covers contract tests.

**4. `ConversationRun`/`RunStep` are not `Codable`**

`TurnInput` (stored in `RunStep.turnInput`) is `Sendable` + `Equatable` but not `Codable`. Adding `Codable` to `TurnInput`/`TurnKind`/`TurnConfig` would be additive surface churn not needed by this PR. The persistence adapter (future sub-phase) will store what it needs in its own `@Model` schema.

**5. `ResumableRunDriver` uses `RunStoreProxy`**

`RunStore` is `@MainActor`. Calling its methods from inside the `startRun` `Task` requires hopping to the main actor. A `RunStoreProxy` helper wraps the store with `@MainActor func` methods so the value captures (`ConversationRun`, `RunStep`) cross the isolation boundary cleanly — no `@unchecked Sendable` on the value types.

**6. `startRun` logs + returns empty stream on non-`ResumableRunDriver`**

When `ConversationRuntime.startRun` is called on a runtime configured with the default `SingleTurnDriver`, it logs a warning and returns a stream that finishes immediately. This keeps the API ergonomic (no force-cast, no Optional return) while making misconfiguration observable at runtime.

## Invariants preserved (P2c brief — 7 invariants)

| # | Invariant | How preserved |
|---|-----------|---------------|
| 1 | `sessionRecord` stays local, never re-fetched mid-stream | `SingleTurnDriver` delegates unchanged to `ConversationTurnExecutor.runSendFlow` etc. — the local `var sessionRecord` pattern inside the executor is untouched. |
| 2 | #965 switch-cancel-resend ordering | `SingleTurnDriver` calls the same executor flow methods in the same order; no ordering change. |
| 3 | #1606 register-before-enqueue | The executor's `runSendFlow` registers session tool executors before `enqueueAsync`; unchanged. `ResumableRunDriver` mirrors this by inserting the `RunStep` record before calling `executeTurn` (checkpoint-before-enqueue). |
| 4 | KV-cache read ordering | Executor flows are called synchronously — no reordering around async stream boundaries. |
| 5 | `@Sendable` sinks must not capture `@MainActor` state | `SingleTurnDriver` and `ResumableRunDriver` receive no event sink; `TurnEventEmitter` inside the executor remains the sole sink holder. |
| 6 | `preCompact` hook is observational in v1 | Not touched. |
| 7 | Token-usage pinning | Executor flow unchanged; `lastTokenUsage` read stays pinned per-turn. |

## Acceptance metric evidence

> "Adding a driver = conform `TurnDriver`, 0 engine-core edits."

`TurnDriverDispatchTests.test_addingADriverIsEdge` demonstrates this: `SpyTurnDriver` (defined in the test file) conforms to `TurnDriver` without touching `ConversationRuntime`, `ConversationTurnExecutor`, or any engine-core file.

## GenerationEvent freeze note

`RunEvent` is the vocabulary P3 was expected to contribute before the 1.0 `GenerationEvent` freeze. It is a **sibling** enum to `ConversationEvent`, not an extension of it. The `GenerationEventClosedAuditTest` tripwire enforces that run-level payloads never appear as `ConversationEvent` cases (invariant 6 from target-architecture.md).

## Gate results

| Gate | Result |
|------|--------|
| `swift build --build-tests --disable-default-traits` | ✅ Build complete |
| Characterization suite (`ManifoldTurnLoopCharacterizationTests`) | ✅ 9/9 pass, 0 golden diffs |
| `scripts/test.sh --profile local --skip-update` — XCTest invocation | ✅ 4938 passed, 0 failed |
| `scripts/test.sh --profile local --skip-update` — Swift Testing invocation | ✅ 83 passed, 0 failed |
| `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` | ✅ Build complete |
| `git diff origin/main --stat` — Package.resolved excluded | ✅ Not staged |
| Golden file edits | ✅ None (diff clean) |

## Files changed

**New sources:**
- `Sources/ManifoldRuntime/Protocols/TurnDriver.swift` — pluggable strategy protocol
- `Sources/ManifoldRuntime/Services/SingleTurnDriver.swift` — default linear conformer
- `Sources/ManifoldRuntime/Services/ResumableRunDriver.swift` — resumable runs conformer
- `Sources/ManifoldRuntime/Models/ConversationRun.swift` — `ConversationRun`, `RunStep`, `RunStatus`
- `Sources/ManifoldRuntime/Protocols/RunStore.swift` — persistence port + `RunStoreError`
- `Sources/ManifoldRuntime/Services/RunEvent.swift` — run-lifecycle event enum (sibling to `ConversationEvent`)

**Modified sources:**
- `Sources/ManifoldRuntime/Services/ConversationRuntime.swift` — wire `turnDriver` field + `startRun` API
- `Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift` — promote to `package` struct + 4 `package func` flow methods

**New tests:**
- `Tests/ManifoldRuntimeTests/TurnDriverDispatchTests.swift` — driver dispatch + spy + EDGE metric
- `Tests/ManifoldRuntimeTests/RunStoreContractTests.swift` — in-memory contract, CRUD, error coverage
- `Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift` — value type invariants + ResumableRunDriver lifecycle
- `Tests/ManifoldRuntimeTests/GenerationEventClosedAuditTest.swift` — invariant 6 tripwire

## Out of scope (P3b sub-phase follow-on)

- SwiftData `@Model` types for `ConversationRun`/`RunStep`
- Schema version bump in `ManifoldPersistenceSwiftData`
- Schema-migration fixture test (per migration plan: "in-process seed of old version, re-open under new plan")
- `ManifoldBootstrap` wiring for `RunStore` + `ResumableRunDriver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Resume semantics disclosure
Cross-process resume (reload a persisted run from `RunStore` and continue from its checkpoint) is **not implemented in this PR** — `startRun` always inserts a fresh run. Only in-process pause/resume/cancel ship now; true resume lands with the P3b SwiftData adapter sub-phase, at which point `startRun` needs an insert-or-load guard so an existing run ID doesn't double-insert.
