### PR TITLE
perf: extract slow-to-type-check SwiftUI bodies (478ms/292ms/272ms → <200ms)

### DIFF
--- a/Sources/ManifoldUI/Views/Sidebar/SessionListView.swift
+++ b/Sources/ManifoldUI/Views/Sidebar/SessionListView.swift
@@ -22,158 +22,7 @@ public struct SessionListView: View {
     public init() {}
 
     public var body: some View {
-        @Bindable var sessionManager = sessionManager
-
-        Group {
-            if sessionManager.sessions.isEmpty && searchText.isEmpty {
-                ContentUnavailableView {
-                    Label("No Chats", systemImage: "bubble.left.and.bubble.right")
-                } description: {
-                    Text("Tap the + button to start a new chat.")
-                }
-            } else if sessionManager.hasNoSearchResults {
-                ContentUnavailableView.search(text: searchText)
-            } else {
-                List(selection: $sessionManager.activeSession) {
-                    let pinned = sessionManager.pinnedSessions
-                    let unpinned: [ChatSession] = {
-                        let trimmed = sessionManager.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard trimmed.isEmpty else { return sessionManager.displayedSessions }
-                        let pinnedIDs = Set(pinned.map(\.id))
-                        return sessionManager.sessions.filter { !pinnedIDs.contains($0.id) }
-                    }()
-
-                    if !pinned.isEmpty {
-                        Section("Pinned") {
-                            ForEach(pinned) { session in
-                                rowContent(for: session)
-                                    .tag(session)
-                                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                        Button(role: .destructive) {
-                                            sessionToDelete = session
-                                        } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                    }
-                                    .swipeActions(edge: .leading) {
-                                        Button {
-                                            Task {
-                                                do {
-                                                    try await sessionManager.unpinSession(session)
-                                                } catch {
-                                                    errorMessage = "Failed to unpin session: \(error.localizedDescription)"
-                                                }
-                                            }
-                                        } label: {
-                                            Label("Unpin", systemImage: "pin.slash")
-                                        }
-                                        .tint(.orange)
-                                        Button {
-                                            renameText = session.title
-                                            sessionToRename = session
-                                        } label: {
-                                            Label("Rename", systemImage: "pencil")
-                                        }
-                                        .tint(.blue)
-                                    }
-                                    .contextMenu {
-                                        Button {
-                                            Task {
-                                                do {
-                                                    try await sessionManager.unpinSession(session)
-                                                } catch {
-                                                    errorMessage = "Failed to unpin session: \(error.localizedDescription)"
-                                                }
-                                            }
-                                        } label: {
-                                            Label("Unpin", systemImage: "pin.slash")
-                                        }
-                                        Button {
-                                            renameText = session.title
-                                            sessionToRename = session
-                                        } label: {
-                                            Label("Rename", systemImage: "pencil")
-                                        }
-                                        Button(role: .destructive) {
-                                            sessionToDelete = session
-                                        } label: {
-                                            Label("Delete", systemImage: "trash")
-                                        }
-                                    }
-                            }
-                        }
-                    }
-
-                    Section(pinned.isEmpty ? "" : "Chats") {
-                        ForEach(unpinned) { session in
-                            rowContent(for: session)
-                                .tag(session)
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button(role: .destructive) {
-                                        sessionToDelete = session
-                                    } label: {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                                .swipeActions(edge: .leading) {
-                                    Button {
-                                        Task {
-                                            do {
-                                                try await sessionManager.pinSession(session)
-                                            } catch {
-                                                errorMessage = "Failed to pin session: \(error.localizedDescription)"
-                                            }
-                                        }
-                                    } label: {
-                                        Label("Pin", systemImage: "pin")
-                                    }
-                                    .tint(.yellow)
-                                    Button {
-                                        renameText = session.title
-                                        sessionToRename = session
-                                    } label: {
-                                        Label("Rename", systemImage: "pencil")
-                                    }
-                                    .tint(.blue)
-                                }
-                                .contextMenu {
-                                    Button {
-                                        Task {
-                                            do {
-                                                try await sessionManager.pinSession(session)
-                                            } catch {
-                                                errorMessage = "Failed to pin session: \(error.localizedDescription)"
-                                            }
-                                        }
-                                    } label: {
-                                        Label("Pin", systemImage: "pin")
-                                    }
-                                    Button {
-                                        renameText = session.title
-                                        sessionToRename = session
-                                    } label: {
-                                        Label("Rename", systemImage: "pencil")
-                                    }
-                                    Button(role: .destructive) {
-                                        sessionToDelete = session
-                                    } label: {
-                                        Label("Delete", systemImage: "trash")
-                                    }
-                                }
-                                .onAppear {
-                                    // Trigger pagination only for the unfiltered list — search
-                                    // results already pull from a wider window in the VM.
-                                    if sessionManager.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                                       session.id == sessionManager.sessions.last?.id {
-                                        Task { await sessionManager.loadNextPage() }
-                                    }
-                                }
-                        }
-                    }
-                }
-                .accessibilityIdentifier("session-list")
-            }
-        }
+        mainContent
         .animation(.default, value: sessionManager.sessions.isEmpty)
         .task {
             // Hosts that configure with `autoLoad: false` (notably tests, but
@@ -200,10 +49,7 @@ public struct SessionListView: View {
             sessionManager.searchScope = newScope
             runSearch(query: searchText, scope: newScope)
         }
-        .alert("Rename Chat", isPresented: .init(
-            get: { sessionToRename != nil },
-            set: { if !$0 { sessionToRename = nil } }
-        )) {
+        .alert("Rename Chat", isPresented: isRenamePresented) {
             TextField("Chat title", text: $renameText)
             Button("Cancel", role: .cancel) { sessionToRename = nil }
             Button("Rename") {
@@ -220,10 +66,7 @@ public struct SessionListView: View {
                 sessionToRename = nil
             }
         }
-        .alert("Delete Chat?", isPresented: .init(
-            get: { sessionToDelete != nil },
-            set: { if !$0 { sessionToDelete = nil } }
-        ), presenting: sessionToDelete) { session in
+        .alert("Delete Chat?", isPresented: isDeletePresented, presenting: sessionToDelete) { session in
             Button("Delete", role: .destructive) {
                 Task {
                     do {
@@ -238,14 +81,178 @@ public struct SessionListView: View {
         } message: { session in
             Text("This will permanently delete \"\(session.title)\" and all its messages.")
         }
-        .alert("Error", isPresented: Binding(
-            get: { errorMessage != nil },
-            set: { if !$0 { errorMessage = nil } }
-        )) {
+        .alert("Error", isPresented: isErrorPresented) {
             Button("OK") { errorMessage = nil }
         } message: {
             if let errorMessage { Text(errorMessage) }
         }
+    }
+
+    // MARK: - Subtrees
+    //
+    // Each subtree is a separate declaration so the type checker solves it
+    // independently — the monolithic `body` expression previously took >200ms
+    // to type-check (see -warn-long-function-bodies).
+
+    @ViewBuilder
+    private var mainContent: some View {
+        if sessionManager.sessions.isEmpty && searchText.isEmpty {
+            ContentUnavailableView {
+                Label("No Chats", systemImage: "bubble.left.and.bubble.right")
+            } description: {
+                Text("Tap the + button to start a new chat.")
+            }
+        } else if sessionManager.hasNoSearchResults {
+            ContentUnavailableView.search(text: searchText)
+        } else {
+            sessionList
+        }
+    }
+
+    private var sessionList: some View {
+        @Bindable var sessionManager = sessionManager
+        return List(selection: $sessionManager.activeSession) {
+            let pinned = sessionManager.pinnedSessions
+            let unpinned = unpinnedSessions(excluding: pinned)
+
+            if !pinned.isEmpty {
+                Section("Pinned") {
+                    ForEach(pinned) { session in
+                        pinnedRow(for: session)
+                    }
+                }
+            }
+
+            Section(pinned.isEmpty ? "" : "Chats") {
+                ForEach(unpinned) { session in
+                    unpinnedRow(for: session)
+                }
+            }
+        }
+        .accessibilityIdentifier("session-list")
+    }
+
+    private func unpinnedSessions(excluding pinned: [ChatSession]) -> [ChatSession] {
+        let trimmed = sessionManager.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty else { return sessionManager.displayedSessions }
+        let pinnedIDs = Set(pinned.map(\.id))
+        return sessionManager.sessions.filter { !pinnedIDs.contains($0.id) }
+    }
+
+    private func pinnedRow(for session: ChatSession) -> some View {
+        rowContent(for: session)
+            .tag(session)
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                deleteButton(for: session)
+            }
+            .swipeActions(edge: .leading) {
+                unpinButton(for: session)
+                    .tint(.orange)
+                renameButton(for: session)
+                    .tint(.blue)
+            }
+            .contextMenu {
+                unpinButton(for: session)
+                renameButton(for: session)
+                deleteButton(for: session)
+            }
+    }
+
+    private func unpinnedRow(for session: ChatSession) -> some View {
+        rowContent(for: session)
+            .tag(session)
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                deleteButton(for: session)
+            }
+            .swipeActions(edge: .leading) {
+                pinButton(for: session)
+                    .tint(.yellow)
+                renameButton(for: session)
+                    .tint(.blue)
+            }
+            .contextMenu {
+                pinButton(for: session)
+                renameButton(for: session)
+                deleteButton(for: session)
+            }
+            .onAppear {
+                // Trigger pagination only for the unfiltered list — search
+                // results already pull from a wider window in the VM.
+                if sessionManager.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                   session.id == sessionManager.sessions.last?.id {
+                    Task { await sessionManager.loadNextPage() }
+                }
+            }
+    }
+
+    // MARK: - Row actions
+
+    private func deleteButton(for session: ChatSession) -> some View {
+        Button(role: .destructive) {
+            sessionToDelete = session
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+    }
+
+    private func renameButton(for session: ChatSession) -> some View {
+        Button {
+            renameText = session.title
+            sessionToRename = session
+        } label: {
+            Label("Rename", systemImage: "pencil")
+        }
+    }
+
+    private func pinButton(for session: ChatSession) -> some View {
+        Button {
+            Task {
+                do {
+                    try await sessionManager.pinSession(session)
+                } catch {
+                    errorMessage = "Failed to pin session: \(error.localizedDescription)"
+                }
+            }
+        } label: {
+            Label("Pin", systemImage: "pin")
+        }
+    }
+
+    private func unpinButton(for session: ChatSession) -> some View {
+        Button {
+            Task {
+                do {
+                    try await sessionManager.unpinSession(session)
+                } catch {
+                    errorMessage = "Failed to unpin session: \(error.localizedDescription)"
+                }
+            }
+        } label: {
+            Label("Unpin", systemImage: "pin.slash")
+        }
+    }
+
+    // MARK: - Alert bindings
+
+    private var isRenamePresented: Binding<Bool> {
+        Binding(
+            get: { sessionToRename != nil },
+            set: { if !$0 { sessionToRename = nil } }
+        )
+    }
+
+    private var isDeletePresented: Binding<Bool> {
+        Binding(
+            get: { sessionToDelete != nil },
+            set: { if !$0 { sessionToDelete = nil } }
+        )
+    }
+
+    private var isErrorPresented: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
     }
 
     @ViewBuilder

--- a/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift
@@ -32,6 +32,40 @@ public struct DocumentLibraryView: View {
     }
 
     public var body: some View {
+        // Split into separately type-checked subtrees — the monolithic `body`
+        // expression previously took >200ms to type-check (see
+        // -warn-long-function-bodies).
+        baseContent
+        .alert(
+            "Delete Document",
+            isPresented: isDeleteAlertPresented,
+            presenting: pendingDelete
+        ) { document in
+            deleteAlertActions(for: document)
+        } message: { document in
+            Text("Remove \"\(document.title)\" from the knowledge base? Its chunks will be deleted from the vector index.")
+        }
+        .alert(
+            "Document Library",
+            isPresented: isErrorAlertPresented
+        ) {
+            Button("OK", role: .cancel) {
+                viewModel.errorMessage = nil
+            }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+        .task {
+            await viewModel.refresh()
+        }
+        #if os(macOS)
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers: providers)
+        }
+        #endif
+    }
+
+    private var baseContent: some View {
         Group {
             if viewModel.ragService == nil {
                 disabledStateView
@@ -61,45 +95,33 @@ public struct DocumentLibraryView: View {
         ) { result in
             handleImport(result)
         }
-        .alert(
-            "Delete Document",
-            isPresented: Binding(
-                get: { pendingDelete != nil },
-                set: { if !$0 { pendingDelete = nil } }
-            ),
-            presenting: pendingDelete
-        ) { document in
-            Button("Delete", role: .destructive) {
-                Task { await viewModel.delete(document) }
-                pendingDelete = nil
-            }
-            Button("Cancel", role: .cancel) {
-                pendingDelete = nil
-            }
-        } message: { document in
-            Text("Remove \"\(document.title)\" from the knowledge base? Its chunks will be deleted from the vector index.")
+    }
+
+    @ViewBuilder
+    private func deleteAlertActions(for document: DocumentRecord) -> some View {
+        Button("Delete", role: .destructive) {
+            Task { await viewModel.delete(document) }
+            pendingDelete = nil
         }
-        .alert(
-            "Document Library",
-            isPresented: Binding(
-                get: { viewModel.errorMessage != nil },
-                set: { if !$0 { viewModel.errorMessage = nil } }
-            )
-        ) {
-            Button("OK", role: .cancel) {
-                viewModel.errorMessage = nil
-            }
-        } message: {
-            Text(viewModel.errorMessage ?? "")
+        Button("Cancel", role: .cancel) {
+            pendingDelete = nil
         }
-        .task {
-            await viewModel.refresh()
-        }
-        #if os(macOS)
-        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
-            handleDrop(providers: providers)
-        }
-        #endif
+    }
+
+    // MARK: - Alert bindings
+
+    private var isDeleteAlertPresented: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { if !$0 { pendingDelete = nil } }
+        )
+    }
+
+    private var isErrorAlertPresented: Binding<Bool> {
+        Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )
     }
 
     // MARK: - Content

--- a/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
@@ -54,249 +54,28 @@ struct HuggingFaceBrowserView: View {
     }
 
     var body: some View {
-        @Bindable var viewModel = viewModel
-
+        // Split into separately type-checked subtrees — the monolithic `body`
+        // expression previously took >200ms to type-check (see
+        // -warn-long-function-bodies).
         List {
-            Section {
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
-                        .accessibilityHidden(true)
-                    TextField("Search HuggingFace models...", text: $viewModel.searchQuery)
-                        .textFieldStyle(.plain)
-                        .autocorrectionDisabled()
-                        #if os(iOS)
-                        .keyboardType(.webSearch)
-                        .submitLabel(.search)
-                        #endif
-                        .onSubmit {
-                            Task { await viewModel.search() }
-                        }
-                        .accessibilityLabel("Search HuggingFace models")
-                    if !viewModel.searchQuery.isEmpty {
-                        Button {
-                            viewModel.searchQuery = ""
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Clear search")
-                    }
-                }
-
-                Button {
-                    importSuccessMessage = nil
-                    importErrorMessage = nil
-                    showImporter = true
-                } label: {
-                    Label("Import Local Model", systemImage: "plus.circle")
-                }
-                .accessibilityLabel("Import local model")
-            }
-
+            searchAndImportSection
             WhyDownloadView()
-
-            if let message = importSuccessMessage {
-                Section {
-                    Label(message, systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                        .accessibilityLabel(message)
-                }
-            }
-
-            if let recommendationTitle, let recommendationMessage {
-                Section {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(recommendationTitle)
-                            .font(.headline)
-
-                        Text(recommendationMessage)
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 2)
-                }
-            }
-
-            Section("Recommended for Your Device") {
-                if viewModel.recommendedModels.isEmpty {
-                    Text("No recommendations available.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(viewModel.recommendedModels) { model in
-                        DownloadableModelRow(model: model)
-                    }
-                }
-            }
-
-            if viewModel.isSearching {
-                Section {
-                    HStack {
-                        Spacer()
-                        ProgressView("Searching...")
-                            .accessibilityLabel("Searching for models")
-                        Spacer()
-                    }
-                }
-            }
-
-            if !viewModel.searchResults.isEmpty {
-                Section {
-                    // Use-case picker — biases the fit ranking. Ranks, never filters:
-                    // every model below stays visible regardless of selection.
-                    Picker("Optimize for", selection: $viewModel.selectedUseCase) {
-                        ForEach(ModelUseCase.allCases, id: \.self) { useCase in
-                            Text(useCaseLabel(useCase)).tag(useCase)
-                        }
-                    }
-                    .accessibilityLabel("Optimize recommendations for use case")
-
-                    // Sort escape hatch — power users who distrust the recommendation
-                    // can fall back to the deterministic size / downloads order.
-                    Picker("Sort", selection: $viewModel.sortMode) {
-                        ForEach(ModelManagementViewModel.SortMode.allCases, id: \.self) { mode in
-                            Text(mode.label).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .accessibilityLabel("Sort order")
-                }
-
-                let groups = sortedGroups()
-                let topModelID = (viewModel.sortMode == .recommended)
-                    ? viewModel.rankedVariants().first?.0.id
-                    : nil
-                Section(viewModel.isDirectRepoLookup ? "Files in \(viewModel.searchQuery)" : "Search Results") {
-                    ForEach(groups) { group in
-                        if group.variants.count == 1 {
-                            let variant = group.variants[0]
-                            DownloadableModelRow(
-                                model: variant,
-                                showFitGuidance: true,
-                                rationale: rationale(for: variant, topModelID: topModelID)
-                            )
-                        } else {
-                            // "Best for your device": the top-ranked quant for the use
-                            // case when ranking is active, else the legacy memory-fit pick.
-                            let recommended = bestVariant(for: group)
-                            let noVariantFits = recommended != nil && !group.variants.contains(where: {
-                                $0.sizeBytes > 0 && viewModel.canRunModel(sizeBytes: $0.sizeBytes)
-                            })
-                            let sortedVariants = recommended.map { rec in
-                                [rec] + group.variants.filter { $0.id != rec.id }
-                            } ?? group.variants
-                            DisclosureGroup {
-                                ForEach(sortedVariants) { variant in
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        DownloadableModelRow(
-                                            model: variant,
-                                            showFitGuidance: true,
-                                            rationale: variant.id == recommended?.id
-                                                ? viewModel.fitScore(for: variant)?.rationale
-                                                : nil
-                                        )
-                                        if variant.id == recommended?.id {
-                                            Text(bestForDeviceLabel(noVariantFits: noVariantFits))
-                                                .font(.caption2)
-                                                .padding(.horizontal, 4)
-                                                .padding(.vertical, 1)
-                                                .background(.green.opacity(0.15), in: Capsule())
-                                                .foregroundStyle(.green)
-                                                .padding(.leading, 22)
-                                                .padding(.bottom, 2)
-                                        }
-                                    }
-                                }
-                            } label: {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(group.displayName)
-                                        .font(.headline)
-                                        .lineLimit(2)
-                                    HStack(spacing: 6) {
-                                        Text("\(group.variants.count) variants")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        if let sizeRange = group.sizeRange {
-                                            Text(sizeRange)
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if let error = importErrorMessage ?? viewModel.searchError {
-                Section {
-                    Label {
-                        Text(error)
-                            .foregroundStyle(.secondary)
-                    } icon: {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                    }
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("Search error: \(error)")
-
-                    if viewModel.searchError != nil {
-                        Button("Retry") {
-                            Task { await viewModel.search() }
-                        }
-                    }
-                }
-            }
+            importSuccessSection
+            recommendationBannerSection
+            recommendedSection
+            searchingSection
+            searchResultsSections
+            errorSection
         }
         .onChange(of: viewModel.completedDownloadCount) {
-            viewModel.invalidateModelCache()
-            refreshModels()
-
-            // After refreshing, offer to switch to the newly completed model if it
-            // isn't already the active selection and no prompt is already pending.
-            // We filter by `promptedModelIDs` so that stale completed entries that
-            // remain in `trackedDownloads` across multiple download cycles are never
-            // re-offered when the count increments for a later download.
-            guard pendingUseNowModel == nil else { return }
-            let justCompleted = viewModel.trackedDownloads.values
-                .filter {
-                    if case .completed = $0.status { return true }
-                    return false
-                }
-                .map(\.model)
-                .first {
-                    $0.fileName != modelRegistry.selectedModel?.fileName
-                        && !promptedModelIDs.contains($0.id)
-                }
-            if let model = justCompleted {
-                promptedModelIDs.insert(model.id)
-                pendingUseNowModel = model
-            }
+            handleDownloadCompleted()
         }
         .alert(
             "Use \(pendingUseNowModel?.displayName ?? "") now?",
-            isPresented: Binding(
-                get: { pendingUseNowModel != nil },
-                set: { if !$0 { pendingUseNowModel = nil } }
-            ),
+            isPresented: isUseNowAlertPresented,
             presenting: pendingUseNowModel
         ) { model in
-            Button("Use Now") {
-                if let match = modelRegistry.availableModels.first(where: { $0.fileName == model.fileName }) {
-                    modelRegistry.selectedModel = match
-                } else {
-                    // refreshModels() runs synchronously in onChange, so this branch is
-                    // only reachable if the file was deleted between download completion
-                    // and the user tapping "Use Now".
-                    Log.download.warning("Use Now: \(model.fileName) not found in availableModels — file may have been deleted")
-                }
-                pendingUseNowModel = nil
-            }
-            Button("Not Now", role: .cancel) {
-                pendingUseNowModel = nil
-            }
+            useNowAlertActions(for: model)
         } message: { _ in
             Text("The download is complete. Switch to this model?")
         }
@@ -313,6 +92,296 @@ struct HuggingFaceBrowserView: View {
         .onAppear {
             viewModel.activeModelFileName = modelRegistry.selectedModel?.fileName
             viewModel.loadRecommendations(preferredModelIDs: recommendedModelIDs)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var searchAndImportSection: some View {
+        @Bindable var viewModel = viewModel
+
+        return Section {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                TextField("Search HuggingFace models...", text: $viewModel.searchQuery)
+                    .textFieldStyle(.plain)
+                    .autocorrectionDisabled()
+                    #if os(iOS)
+                    .keyboardType(.webSearch)
+                    .submitLabel(.search)
+                    #endif
+                    .onSubmit {
+                        Task { await viewModel.search() }
+                    }
+                    .accessibilityLabel("Search HuggingFace models")
+                if !viewModel.searchQuery.isEmpty {
+                    Button {
+                        viewModel.searchQuery = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+
+            Button {
+                importSuccessMessage = nil
+                importErrorMessage = nil
+                showImporter = true
+            } label: {
+                Label("Import Local Model", systemImage: "plus.circle")
+            }
+            .accessibilityLabel("Import local model")
+        }
+    }
+
+    @ViewBuilder
+    private var importSuccessSection: some View {
+        if let message = importSuccessMessage {
+            Section {
+                Label(message, systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .accessibilityLabel(message)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recommendationBannerSection: some View {
+        if let recommendationTitle, let recommendationMessage {
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(recommendationTitle)
+                        .font(.headline)
+
+                    Text(recommendationMessage)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    private var recommendedSection: some View {
+        Section("Recommended for Your Device") {
+            if viewModel.recommendedModels.isEmpty {
+                Text("No recommendations available.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(viewModel.recommendedModels) { model in
+                    DownloadableModelRow(model: model)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var searchingSection: some View {
+        if viewModel.isSearching {
+            Section {
+                HStack {
+                    Spacer()
+                    ProgressView("Searching...")
+                        .accessibilityLabel("Searching for models")
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var searchResultsSections: some View {
+        if !viewModel.searchResults.isEmpty {
+            rankingControlsSection
+
+            let groups = sortedGroups()
+            let topModelID = (viewModel.sortMode == .recommended)
+                ? viewModel.rankedVariants().first?.0.id
+                : nil
+            Section(viewModel.isDirectRepoLookup ? "Files in \(viewModel.searchQuery)" : "Search Results") {
+                ForEach(groups) { group in
+                    groupRow(for: group, topModelID: topModelID)
+                }
+            }
+        }
+    }
+
+    private var rankingControlsSection: some View {
+        @Bindable var viewModel = viewModel
+
+        return Section {
+            // Use-case picker — biases the fit ranking. Ranks, never filters:
+            // every model below stays visible regardless of selection.
+            Picker("Optimize for", selection: $viewModel.selectedUseCase) {
+                ForEach(ModelUseCase.allCases, id: \.self) { useCase in
+                    Text(useCaseLabel(useCase)).tag(useCase)
+                }
+            }
+            .accessibilityLabel("Optimize recommendations for use case")
+
+            // Sort escape hatch — power users who distrust the recommendation
+            // can fall back to the deterministic size / downloads order.
+            Picker("Sort", selection: $viewModel.sortMode) {
+                ForEach(ModelManagementViewModel.SortMode.allCases, id: \.self) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Sort order")
+        }
+    }
+
+    @ViewBuilder
+    private func groupRow(for group: DownloadableModelGroup, topModelID: String?) -> some View {
+        if group.variants.count == 1 {
+            let variant = group.variants[0]
+            DownloadableModelRow(
+                model: variant,
+                showFitGuidance: true,
+                rationale: rationale(for: variant, topModelID: topModelID)
+            )
+        } else {
+            multiVariantGroupRow(for: group)
+        }
+    }
+
+    private func multiVariantGroupRow(for group: DownloadableModelGroup) -> some View {
+        // "Best for your device": the top-ranked quant for the use
+        // case when ranking is active, else the legacy memory-fit pick.
+        let recommended = bestVariant(for: group)
+        let noVariantFits = recommended != nil && !group.variants.contains(where: {
+            $0.sizeBytes > 0 && viewModel.canRunModel(sizeBytes: $0.sizeBytes)
+        })
+        let sortedVariants = recommended.map { rec in
+            [rec] + group.variants.filter { $0.id != rec.id }
+        } ?? group.variants
+        return DisclosureGroup {
+            ForEach(sortedVariants) { variant in
+                VStack(alignment: .leading, spacing: 2) {
+                    DownloadableModelRow(
+                        model: variant,
+                        showFitGuidance: true,
+                        rationale: variant.id == recommended?.id
+                            ? viewModel.fitScore(for: variant)?.rationale
+                            : nil
+                    )
+                    if variant.id == recommended?.id {
+                        bestForDeviceBadge(noVariantFits: noVariantFits)
+                    }
+                }
+            }
+        } label: {
+            groupLabel(for: group)
+        }
+    }
+
+    private func bestForDeviceBadge(noVariantFits: Bool) -> some View {
+        Text(bestForDeviceLabel(noVariantFits: noVariantFits))
+            .font(.caption2)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(.green.opacity(0.15), in: Capsule())
+            .foregroundStyle(.green)
+            .padding(.leading, 22)
+            .padding(.bottom, 2)
+    }
+
+    private func groupLabel(for group: DownloadableModelGroup) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(group.displayName)
+                .font(.headline)
+                .lineLimit(2)
+            HStack(spacing: 6) {
+                Text("\(group.variants.count) variants")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let sizeRange = group.sizeRange {
+                    Text(sizeRange)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var errorSection: some View {
+        if let error = importErrorMessage ?? viewModel.searchError {
+            Section {
+                Label {
+                    Text(error)
+                        .foregroundStyle(.secondary)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Search error: \(error)")
+
+                if viewModel.searchError != nil {
+                    Button("Retry") {
+                        Task { await viewModel.search() }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Download completion
+
+    private func handleDownloadCompleted() {
+        viewModel.invalidateModelCache()
+        refreshModels()
+
+        // After refreshing, offer to switch to the newly completed model if it
+        // isn't already the active selection and no prompt is already pending.
+        // We filter by `promptedModelIDs` so that stale completed entries that
+        // remain in `trackedDownloads` across multiple download cycles are never
+        // re-offered when the count increments for a later download.
+        guard pendingUseNowModel == nil else { return }
+        let justCompleted = viewModel.trackedDownloads.values
+            .filter {
+                if case .completed = $0.status { return true }
+                return false
+            }
+            .map(\.model)
+            .first {
+                $0.fileName != modelRegistry.selectedModel?.fileName
+                    && !promptedModelIDs.contains($0.id)
+            }
+        if let model = justCompleted {
+            promptedModelIDs.insert(model.id)
+            pendingUseNowModel = model
+        }
+    }
+
+    private var isUseNowAlertPresented: Binding<Bool> {
+        Binding(
+            get: { pendingUseNowModel != nil },
+            set: { if !$0 { pendingUseNowModel = nil } }
+        )
+    }
+
+    @ViewBuilder
+    private func useNowAlertActions(for model: DownloadableModel) -> some View {
+        Button("Use Now") {
+            if let match = modelRegistry.availableModels.first(where: { $0.fileName == model.fileName }) {
+                modelRegistry.selectedModel = match
+            } else {
+                // refreshModels() runs synchronously in onChange, so this branch is
+                // only reachable if the file was deleted between download completion
+                // and the user tapping "Use Now".
+                Log.download.warning("Use Now: \(model.fileName) not found in availableModels — file may have been deleted")
+            }
+            pendingUseNowModel = nil
+        }
+        Button("Not Now", role: .cancel) {
+            pendingUseNowModel = nil
         }
     }
 


### PR DESCRIPTION
## Summary

A build-time audit with `-warn-long-function-bodies=200` flagged exactly three SwiftUI `body` getters over the threshold — the only type-checker warnings across 669 files. Each monolithic `body` expression is now split into separately type-checked private `@ViewBuilder` computed properties/functions, with inline `Binding(get:set:)` alert presentations hoisted into computed `Binding<Bool>` properties (closure-heavy `Binding.init` inference was a large share of the cost).

No new view types were introduced — computed properties are inlined into the same runtime hierarchy — so view behavior, accessibility identifiers, and hierarchy-dump snapshots are unchanged. `SessionListView` additionally dedupes the pinned/unpinned swipe-action/context-menu buttons that were copy-pasted between the two sections.

## Type-check timings (`-warn-long-function-bodies=200`)

| File | Audit baseline | This machine (before) | After |
|------|---------------|----------------------|-------|
| `ManifoldUIModelManagement/Views/Documents/DocumentLibraryView.swift` `body` | 478ms | 650ms | no warning (<200ms) |
| `ManifoldUI/Views/Sidebar/SessionListView.swift` `body` | 292ms | 319ms | no warning (<200ms) |
| `ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift` `body` | 272ms | 412ms | no warning (<200ms) |

Verified by touching all three files and rebuilding with the flag — zero `took Nms to type-check` warnings emitted for them.

Out-of-scope observation: a full `ManifoldUI` rebuild on this machine also flagged `Views/Settings/GenerationSettingsView.swift` `body` at 250ms once (machine-dependent; not in the audit's list). Left untouched per scope.

## Gates run

- `swift build -Xswiftc -Xfrontend -Xswiftc -warn-long-function-bodies=200 --skip-update` — no warnings for the three files
- `swift test --filter ManifoldUITests --skip-update` — 643 tests, 0 failures
- `swift test --filter ManifoldUIModelManagementTests --skip-update` — 115 tests, 0 failures
- `swift test --filter SidebarAndSheetControlTests --skip-update` (extra: hierarchy-dump snapshots of SessionListView) — 14 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)