### PR TITLE
perf: inline MLX tokenizer loader to drop swift-syntax from default builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -150,7 +150,8 @@ let package = Package(
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
         .package(url: "https://github.com/huggingface/AnyLanguageModel", from: "0.8.0"),
         // Explicit dep required: mlx-swift-lm no longer pulls swift-transformers transitively.
-        // The MLXHuggingFace macro generates `AutoTokenizer.from(modelFolder:)` which lives here.
+        // TransformersTokenizerLoader (hand-expanded MLXHuggingFace macro) calls
+        // `AutoTokenizer.from(modelFolder:)` which lives here.
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.2.0"),
         // Pinned EXACT to 2.9505.0 (Package.resolved rev 11efdff6cfadc8ed2f998dc6f50d68d3e35237f9).
         // Wraps llama.cpp as a pre-built xcframework binary. mattt/llama.swift auto-tags a new
@@ -439,7 +440,9 @@ let package = Package(
                 // mlx-community/gemma-4-26b-a4b-it-4bit) to VLMModelFactory.shared.loadContainer.
                 // See issue #752.
                 .product(name: "MLXVLM", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
-                .product(name: "MLXHuggingFace", package: "mlx-swift-lm", condition: .when(traits: ["MLX"])),
+                // No MLXHuggingFace product here: its macro plugin pulls swift-syntax into
+                // every default-trait build. The one macro we used is hand-expanded in
+                // Sources/ManifoldMLX/TransformersTokenizerLoader.swift on top of Tokenizers.
                 .product(name: "Tokenizers", package: "swift-transformers", condition: .when(traits: ["MLX"])),
                 // Hub is consumed directly by the FLUX diffusion backend (merged from
                 // the former ManifoldFlux target) for repository snapshot downloads.

--- a/Sources/ManifoldMLX/MLXBackend.swift
+++ b/Sources/ManifoldMLX/MLXBackend.swift
@@ -9,8 +9,7 @@ import MLX
 import MLXLLM
 import MLXLMCommon
 import MLXVLM
-import MLXHuggingFace
-import Tokenizers // required by the #huggingFaceTokenizerLoader macro expansion
+import Tokenizers
 import os
 import ManifoldInference
 
@@ -307,20 +306,21 @@ public final class MLXBackend: InferenceBackend, @unchecked Sendable {
             // stay on the LLM factory unless the model also declares
             // `vision_config` or `text_config.enable_moe_block`.
             //
-            // `#huggingFaceTokenizerLoader()` (from MLXHuggingFace) adapts
-            // swift-transformers' `AutoTokenizer` to the `TokenizerLoader`
-            // protocol both factories accept.
+            // `TransformersTokenizerLoader` (hand-expanded from MLXHuggingFace's
+            // `#huggingFaceTokenizerLoader()` macro) adapts swift-transformers'
+            // `AutoTokenizer` to the `TokenizerLoader` protocol both factories
+            // accept — inlined to keep swift-syntax out of default builds.
             let container: ModelContainer
             if routeThroughVLMFactory {
                 Self.logger.info("MLX routing via VLMModelFactory (MoE / VLM-only architecture)")
                 container = try await VLMModelFactory.shared.loadContainer(
                     from: url,
-                    using: #huggingFaceTokenizerLoader()
+                    using: TransformersTokenizerLoader()
                 )
             } else {
                 container = try await LLMModelFactory.shared.loadContainer(
                     from: url,
-                    using: #huggingFaceTokenizerLoader()
+                    using: TransformersTokenizerLoader()
                 )
             }
             let detectedDialect = MLXToolDialect.detect(at: url)

--- a/Sources/ManifoldMLX/TransformersTokenizerLoader.swift
+++ b/Sources/ManifoldMLX/TransformersTokenizerLoader.swift
@@ -1,0 +1,62 @@
+#if MLX
+import Foundation
+import MLXLMCommon
+import Tokenizers
+
+/// Hand-expanded equivalent of mlx-swift-lm's `#huggingFaceTokenizerLoader()` macro.
+///
+/// Inlined so ManifoldMLX does not depend on the `MLXHuggingFace` product, whose
+/// macro plugin (`MLXHuggingFaceMacros`) drags swift-syntax (~150 compile tasks)
+/// into every default-trait build. The body mirrors `TokenizerLoaderMacro` +
+/// `TokenizerAdaptorMacro` in
+/// `mlx-swift-lm/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift`
+/// exactly — keep them in sync if the upstream expansion changes.
+struct TransformersTokenizerLoader: MLXLMCommon.TokenizerLoader {
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let upstream = try await Tokenizers.AutoTokenizer.from(modelFolder: directory)
+        return TokenizerBridge(upstream)
+    }
+}
+
+private struct TokenizerBridge: MLXLMCommon.Tokenizer {
+    private let upstream: any Tokenizers.Tokenizer
+
+    init(_ upstream: any Tokenizers.Tokenizer) {
+        self.upstream = upstream
+    }
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
+    // swift-transformers uses `decode(tokens:)` instead of `decode(tokenIds:)`.
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        upstream.convertTokenToId(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        upstream.convertIdToToken(id)
+    }
+
+    var bosToken: String? { upstream.bosToken }
+    var eosToken: String? { upstream.eosToken }
+    var unknownToken: String? { upstream.unknownToken }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        do {
+            return try upstream.applyChatTemplate(
+                messages: messages, tools: tools, additionalContext: additionalContext)
+        } catch Tokenizers.TokenizerError.missingChatTemplate {
+            throw MLXLMCommon.TokenizerError.missingChatTemplate
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Why

Every default-trait build compiles all of swift-syntax (~103 SwiftSyntax/SwiftParser compile tasks) because of this dependency chain:

```
MLX trait → ManifoldMLX → MLXHuggingFace (mlx-swift-lm product)
          → MLXHuggingFaceMacros (macro plugin) → swift-syntax
```

We used exactly one macro from that product — `#huggingFaceTokenizerLoader()`, at two call sites in `MLXBackend.swift` — and its expansion is a trivial bridge struct adapting swift-transformers' `AutoTokenizer` to `MLXLMCommon.TokenizerLoader`.

## What

- New `Sources/ManifoldMLX/TransformersTokenizerLoader.swift`: the hand-written expansion, behavior-identical to upstream's `TokenizerLoaderMacro` + `TokenizerAdaptorMacro` output (including the `decode(tokens:)` bridging and `missingChatTemplate` error mapping). A doc comment points back at the upstream macro source for future sync.
- `MLXBackend.swift`: drop `import MLXHuggingFace`, replace both macro call sites with `TransformersTokenizerLoader()`.
- `Package.swift`: remove the `MLXHuggingFace` product from the ManifoldMLX target (`Tokenizers` was already a direct dep) and update the explanatory comments.

## Measured (clean builds, same machine, same concurrent load — load avg ~32)

| Metric | main | this PR |
|---|---|---|
| SwiftSyntax/SwiftParser compile tasks | 103 | **0** |
| Total build tasks | 2005 | 1757 (−248) |
| Compile tasks | 1338 | 1206 |
| User CPU time | 794.7s | 601.8s (**−24%**) |
| Wall clock | 186.3s | 194.4s (within noise under heavy load) |

The durable win is the CPU-time/task-count reduction; wall-clock delta will show up on less contended machines and in CI's cold compile.

## Verification

1. Clean default-trait `swift build`: success, `grep -c "Compiling SwiftSyntax\|Compiling SwiftParser"` = 0.
2. Trait-combo sweep `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`: success.
3. `scripts/test.sh --profile local`: exit 0 — XCTest 4784 executed / 56 skipped / 0 failures; Swift Testing 83 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)