### PR TITLE
fix: close DNS-rebinding TOCTOU in MCP HTTP/SSE transport (Gap C)

### DIFF
--- a/Sources/ManifoldMCP/InternalMCPTransport.swift
+++ b/Sources/ManifoldMCP/InternalMCPTransport.swift
@@ -369,7 +369,7 @@ internal actor MCPStdioTransport: MCPTransport {
         var parser = MCPStdioFrameCodec.Parser()
         do {
             while Task.isCancelled == false {
-                guard let chunk = try await stdoutHandle.read(upToCount: 4096), chunk.isEmpty == false else {
+                guard let chunk = try stdoutHandle.read(upToCount: 4096), chunk.isEmpty == false else {
                     break
                 }
                 try parser.append(chunk)

--- a/Sources/ManifoldMCP/InternalMCPTransport.swift
+++ b/Sources/ManifoldMCP/InternalMCPTransport.swift
@@ -87,15 +87,24 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
             request.setValue(header, forHTTPHeaderField: "Authorization")
         }
 
+        let connectionGuard = MCPRedirectCapDelegate(
+            maxRedirects: 3,
+            validator: MCPSSRFPolicy.validateTransportRedirectURL
+        )
         let (bytes, response) = try await configuration.session().bytes(
             for: request,
-            delegate: MCPRedirectCapDelegate(
-                maxRedirects: 3,
-                validator: MCPSSRFPolicy.validateTransportRedirectURL
-            )
+            delegate: connectionGuard
         )
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response")
+        }
+        // Gap C — DNS-rebinding TOCTOU. If the connection's metrics already report a
+        // private/reserved remote address by the time headers arrive, block before
+        // consuming any stream bytes. The guard also cancels the task on violation,
+        // so a poisoned long-lived SSE connection detected mid-stream is torn down
+        // and surfaces as a stream error below.
+        if let blocked = connectionGuard.blockedConnectedURL {
+            throw MCPError.ssrfBlocked(blocked)
         }
 
         if http.statusCode == 401 || http.statusCode == 403 {
@@ -128,7 +137,12 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
                 }
                 continuation.finish()
             } catch {
-                if error is CancellationError || Task.isCancelled {
+                // A connection that rebinds to a private address mid-stream is
+                // cancelled by the guard's metrics hook; surface it as ssrfBlocked
+                // rather than a silent finish.
+                if let blocked = connectionGuard.blockedConnectedURL {
+                    continuation.finish(throwing: MCPError.ssrfBlocked(blocked))
+                } else if error is CancellationError || Task.isCancelled {
                     continuation.finish()
                 } else {
                     continuation.finish(throwing: error)
@@ -159,13 +173,22 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
             request.setValue(header, forHTTPHeaderField: "Authorization")
         }
 
+        let connectionGuard = MCPRedirectCapDelegate(
+            maxRedirects: 3,
+            validator: MCPSSRFPolicy.validateTransportRedirectURL
+        )
         let (data, response) = try await configuration.session().data(
             for: request,
-            delegate: MCPRedirectCapDelegate(
-                maxRedirects: 3,
-                validator: MCPSSRFPolicy.validateTransportRedirectURL
-            )
+            delegate: connectionGuard
         )
+        // Gap C — DNS-rebinding TOCTOU. `data(for:)` returns after the task
+        // completes, by which point the connection's metrics report the address
+        // URLSession actually connected to. If it was private/reserved, the
+        // pre-flight check was bypassed by DNS rebinding — block before yielding
+        // any response body.
+        if let blocked = connectionGuard.blockedConnectedURL {
+            throw MCPError.ssrfBlocked(blocked)
+        }
         guard let http = response as? HTTPURLResponse else {
             throw MCPError.transportFailure("Missing HTTP response")
         }

--- a/Sources/ManifoldMCP/MCPSSRFPolicy.swift
+++ b/Sources/ManifoldMCP/MCPSSRFPolicy.swift
@@ -166,11 +166,11 @@ internal enum MCPSSRFPolicy {
     }
 }
 
-// MARK: - IP pinning follow-up
-// `MCPRedirectCapDelegate` lives in OAuthSecurity.swift with the other OAuth
-// redirect/security helpers.
-// TODO: IP pinning — see PinnedSessionDelegate.swift for the certificate-pinning
-// pattern.  Full IP pinning (Gap C) requires capturing the resolved address at
-// connect time via URLSessionDelegate.connection(_:didConnect:) and comparing it
-// against a pre-resolution result from getaddrinfo.  Retrofit is deferred until
-// a larger URLSession refactor lands.
+// MARK: - IP pinning (Gap C — closed)
+// The pre-resolution checks above (`validateResolvedHostNotBlocked`) close the
+// "guard saw a private IP" half of the DNS-rebinding window. The other half —
+// the guard's getaddrinfo query returning a public IP while URLSession's separate
+// connect-time query returns a private one — is closed by connect-time IP pinning
+// in `MCPRedirectCapDelegate` (OAuthSecurity.swift): it inspects the address
+// URLSession actually connected to via `URLSessionTaskTransactionMetrics.remoteAddress`
+// and blocks/cancels if it classifies as private/reserved per `PrivateIPClassifier`.

--- a/Sources/ManifoldMCP/OAuthSecurity.swift
+++ b/Sources/ManifoldMCP/OAuthSecurity.swift
@@ -2,6 +2,7 @@ import Foundation
 import Darwin
 import Security
 import CryptoKit
+import ManifoldInference
 
 // MARK: - PKCE Verifier (D7)
 
@@ -34,11 +35,52 @@ struct PKCEVerifier {
 
 // MARK: - Redirect-cap delegate (D6 — Gap B)
 
-/// Limits redirect chains to at most one hop to prevent SSRF-via-redirect attacks.
+/// Limits redirect chains to at most one hop to prevent SSRF-via-redirect attacks,
+/// and closes the DNS-rebinding TOCTOU (Gap C) by pinning the address URLSession
+/// actually connected to.
+///
+/// ## Gap C — DNS-rebinding TOCTOU
+///
+/// `MCPSSRFPolicy.validateResolvedHostNotBlocked` resolves the hostname with its
+/// own `getaddrinfo` query at check time, but `URLSession.bytes(for:)` /
+/// `data(for:)` re-resolve the hostname at connect time with a *separate* query.
+/// An attacker controlling DNS can return a public IP to the guard's query, then
+/// serve a private IP (loopback, RFC1918, `169.254.169.254`, etc.) to URLSession's
+/// query — reaching internal services despite the pre-flight check passing.
+///
+/// This delegate closes the window by inspecting the address URLSession *actually*
+/// connected to (`URLSessionTaskTransactionMetrics.remoteAddress`) and cancelling
+/// the task if any connected address classifies as private/reserved per
+/// ``PrivateIPClassifier``. The caller reads ``blockedConnectedURL`` after the
+/// request returns (or after the stream errors) and surfaces ``MCPError/ssrfBlocked``.
+///
+/// Localhost literals (`localhost`, `127.0.0.1`, `::1`) bypass the connected-address
+/// check — they are explicitly configured local servers, mirroring the bypass in
+/// ``MCPSSRFPolicy``.
+///
+/// - Note: This mirrors the connect-time pinning shape that `ManifoldCloudCore`'s
+///   `DNSRebindingGuard` *omits* — the cloud side currently relies on pre-resolution
+///   fail-closed only. ManifoldMCP depends on `ManifoldInference`, not
+///   `ManifoldCloudCore` (see CLAUDE.md dependency rules), so this guard is
+///   MCP-local rather than a shared type. `PrivateIPClassifier` (the IP-classification
+///   logic) *is* reused across both.
 final class MCPRedirectCapDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
     private let maxRedirects: Int?
     private let validator: @Sendable (URL) throws -> Void
     private var redirectCount = 0
+
+    /// Lock guarding `_blockedConnectedURL`. URLSession delivers
+    /// `didFinishCollecting` on an arbitrary background queue, so the violation
+    /// flag must be written under a lock and read back on the caller's actor.
+    private let connectedLock = NSLock()
+    private var _blockedConnectedURL: URL?
+
+    /// The URL whose connection resolved to a blocked (private/reserved) address,
+    /// or `nil` if every connected address was acceptable. Read by the transport
+    /// after the request completes to decide whether to throw ``MCPError/ssrfBlocked``.
+    var blockedConnectedURL: URL? {
+        connectedLock.withLock { _blockedConnectedURL }
+    }
 
     init(
         maxRedirects: Int? = 1,
@@ -69,6 +111,43 @@ final class MCPRedirectCapDelegate: NSObject, URLSessionTaskDelegate, @unchecked
         } else {
             completionHandler(request)
         }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        // Inspect every transaction (the original request plus any redirect hops):
+        // each carries the address URLSession actually connected to. If any one is
+        // private/reserved, the connection touched an internal host — block it.
+        for transaction in metrics.transactionMetrics {
+            guard let requestURL = transaction.request.url,
+                  let remote = transaction.remoteAddress,
+                  let category = Self.classifyConnectedAddress(remote, for: requestURL) else {
+                continue
+            }
+            Log.network.error(
+                "MCP transport: blocked connection — \(requestURL.host ?? "?", privacy: .public) connected to \(remote, privacy: .public) (\(category.description, privacy: .public)). DNS rebinding TOCTOU.")
+            connectedLock.withLock {
+                if _blockedConnectedURL == nil { _blockedConnectedURL = requestURL }
+            }
+            // Cancel so no further bytes flow over the offending connection.
+            task.cancel()
+            return
+        }
+    }
+
+    /// Classifies the address URLSession connected to, returning the blocked
+    /// category or `nil` when the address is public (or the request targets an
+    /// explicitly configured localhost server, which always bypasses).
+    ///
+    /// `remoteAddress` from `URLSessionTaskTransactionMetrics` is a bare numeric
+    /// host (no port), but may carry an IPv6 zone identifier (`fe80::1%en0`);
+    /// ``PrivateIPClassifier`` strips the zone, so we pass it through unchanged.
+    static func classifyConnectedAddress(_ remoteAddress: String, for url: URL) -> BlockedAddressCategory? {
+        if PrivateIPClassifier.isLocalhostURL(url) { return nil }
+        return PrivateIPClassifier.classifyIPLiteral(remoteAddress)
     }
 }
 

--- a/Tests/ManifoldMCPTests/MCPConnectedAddressGuardTests.swift
+++ b/Tests/ManifoldMCPTests/MCPConnectedAddressGuardTests.swift
@@ -1,0 +1,95 @@
+#if MCP
+import Foundation
+import XCTest
+@testable import ManifoldMCP
+import ManifoldInference
+
+/// Gap C — DNS-rebinding TOCTOU.
+///
+/// `MCPSSRFPolicy.validateResolvedHostNotBlocked` resolves the hostname with its
+/// own `getaddrinfo` query at check time. `URLSession.bytes(for:)` / `data(for:)`
+/// re-resolve the hostname with a *separate* query at connect time. An attacker
+/// controlling DNS returns a public IP to the guard's query (so the pre-flight
+/// check passes) and a private IP to URLSession's query — reaching internal hosts.
+///
+/// These tests exercise the connect-time pin in `MCPRedirectCapDelegate`, which
+/// inspects the address URLSession *actually* connected to
+/// (`URLSessionTaskTransactionMetrics.remoteAddress`) and blocks it if private.
+/// `URLSessionTaskMetrics` has no public initializer, so we drive the decision
+/// point — `classifyConnectedAddress(_:for:)` — directly. That function is the
+/// sole gate between an observed connected address and the
+/// `MCPError.ssrfBlocked` the transport throws.
+final class MCPConnectedAddressGuardTests: XCTestCase {
+
+    // MARK: - The TOCTOU is closed: guard saw public, connection went private
+
+    func test_connectionToPrivateAddress_isBlocked_evenWhenHostIsPublicName() {
+        // Pre-flight resolved `mcp.example.com` to a public IP (the attacker's
+        // first answer); URLSession then connected to 169.254.169.254 (cloud IMDS).
+        // The connect-time pin must classify that as a block.
+        let publicHostURL = URL(string: "https://mcp.example.com/mcp")!
+
+        let blockedAddresses = [
+            "169.254.169.254", // link-local / cloud IMDS
+            "127.0.0.1",       // loopback
+            "10.0.0.5",        // RFC1918
+            "192.168.1.20",    // RFC1918
+            "172.16.4.4",      // RFC1918
+            "::1",             // IPv6 loopback
+            "fd00::1",         // IPv6 unique-local
+            "::ffff:127.0.0.1" // IPv4-mapped loopback
+        ]
+
+        for address in blockedAddresses {
+            let category = MCPRedirectCapDelegate.classifyConnectedAddress(address, for: publicHostURL)
+            XCTAssertNotNil(
+                category,
+                "Connection to \(address) for a public hostname must be blocked (DNS rebinding TOCTOU)"
+            )
+        }
+    }
+
+    // MARK: - Legitimate public connections still pass
+
+    func test_connectionToPublicAddress_isAllowed() {
+        let url = URL(string: "https://mcp.example.com/mcp")!
+        // 93.184.216.34 is example.com's public IP — must not be blocked.
+        XCTAssertNil(
+            MCPRedirectCapDelegate.classifyConnectedAddress("93.184.216.34", for: url),
+            "A public connected address must not be blocked"
+        )
+    }
+
+    // MARK: - Explicit localhost servers bypass the pin
+
+    func test_explicitLocalhostURL_bypassesConnectedAddressPin() {
+        // An explicitly configured local MCP server (http://127.0.0.1) connecting
+        // to 127.0.0.1 is legitimate — the pin must not block it. This mirrors the
+        // isLocalhostURL bypass in MCPSSRFPolicy.
+        let localhostURL = URL(string: "http://127.0.0.1:3000/mcp")!
+        XCTAssertNil(
+            MCPRedirectCapDelegate.classifyConnectedAddress("127.0.0.1", for: localhostURL),
+            "Explicitly configured localhost server must bypass the connected-address pin"
+        )
+
+        let localhostNameURL = URL(string: "http://localhost:3000/mcp")!
+        XCTAssertNil(
+            MCPRedirectCapDelegate.classifyConnectedAddress("127.0.0.1", for: localhostNameURL),
+            "localhost name must bypass the connected-address pin"
+        )
+    }
+
+    // MARK: - Non-localhost host connecting to loopback is still an attack
+
+    func test_publicHostConnectingToLoopback_isBlocked() {
+        // A remote domain that connects to 127.0.0.1 is a rebinding attack even
+        // though 127.0.0.1 is loopback — only an *explicitly configured* localhost
+        // URL bypasses, not any connection that happens to land on loopback.
+        let url = URL(string: "https://totally-legit.example.com/mcp")!
+        XCTAssertNotNil(
+            MCPRedirectCapDelegate.classifyConnectedAddress("127.0.0.1", for: url),
+            "A public hostname connecting to loopback must be blocked (rebinding attack)"
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## The TOCTOU (Gap C)

`MCPSSRFPolicy.validateResolvedHostNotBlocked` resolves the MCP transport hostname with its own `getaddrinfo` query at *check* time. `URLSession.bytes(for:)` / `data(for:)` re-resolve the same hostname with a **separate** query at *connect* time. An attacker controlling DNS for the endpoint can:

1. Return a **public** IP to the guard's query → the pre-flight check passes.
2. Return a **private** IP (loopback, RFC1918, `169.254.169.254` cloud IMDS, `fc00::/7`, IPv4-mapped loopback, …) to URLSession's query → the connection reaches an internal service.

The pre-resolution checks (and the SERVFAIL fail-closed already in place) only close the "guard *saw* a private IP" half of the window. The other half — guard sees public, connection goes private — was an acknowledged `TODO` in `MCPSSRFPolicy.swift` deferring "full IP pinning."

## The fix

Connect-time IP pinning in `MCPRedirectCapDelegate` (the per-request `URLSessionTaskDelegate` already wired into both transport paths):

- Implements `urlSession(_:task:didFinishCollecting:)` and inspects `URLSessionTaskTransactionMetrics.remoteAddress` — the address URLSession **actually** connected to (including each redirect hop).
- Classifies it with the shared `PrivateIPClassifier` (reused, not reinvented). If any connected address is private/reserved, it records the blocked URL and **cancels** the task so no further bytes flow.
- `MCPStreamableHTTPTransport` throws `MCPError.ssrfBlocked` after `data(for:)` returns (POST path) and when a rebinding SSE connection is torn down mid-stream (GET/stream path).
- Explicit localhost servers (`localhost`, `127.0.0.1`, `::1`) bypass the pin, mirroring `MCPSSRFPolicy`'s existing localhost bypass. A *public* hostname that connects to loopback is still blocked (that's the attack).

### Why MCP-local, not shared

`ManifoldMCP` depends on `ManifoldInference`, **not** `ManifoldCloudCore` (CLAUDE.md dependency rules). The cloud side's `DNSRebindingGuard` relies on pre-resolution fail-closed only and does **not** itself do connect-time metrics pinning, so there was no reusable shared type to adopt without an undesired module edge. The guard is therefore MCP-local; only `PrivateIPClassifier` (the IP-classification logic) is shared across both. A code comment documents this.

> Note: the cloud `DNSRebindingGuard` has the same residual connect-time TOCTOU (pre-resolution only). Out of scope for this focused MCP change; flagging for a follow-up decision rather than ballooning scope here.

## Test that proves it

`Tests/ManifoldMCPTests/MCPConnectedAddressGuardTests.swift` drives the decision point — `MCPRedirectCapDelegate.classifyConnectedAddress(_:for:)` — directly (`URLSessionTaskMetrics` has no public initializer):

- **`test_connectionToPrivateAddress_isBlocked_evenWhenHostIsPublicName`** — the TOCTOU case: a public hostname whose connection lands on `169.254.169.254` / RFC1918 / loopback / `fd00::1` / IPv4-mapped loopback is blocked.
- Public connected address still allowed; explicit-localhost URL bypasses; public host → loopback still blocked.

Sabotage-verified: neutering the classifier (return `nil`) flips the 9 block assertions to failures while the allow/bypass tests stay green; reverted before commit (per CLAUDE.md).

## Gate

- `scripts/test.sh --profile local --filter ManifoldMCPTests` → **218 passed, 0 failed**.
- Trait-combo sweep `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` → **Build complete**.
- No `try?`, no `assertionFailure`/`fatalError`; Swift 6 strict-concurrency clean; `remoteAddress` is available on the macOS 15 / iOS 18 floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)