### PR TITLE
fix: security hardening bundle (action pins, file protection, output bounds)

### DIFF
--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -108,7 +108,7 @@ jobs:
           xcode-version: "26.3"
 
       - name: Cache SwiftPM
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .build/artifacts
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload audit artifacts (${{ matrix.mode }})
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-modes-audit-${{ matrix.mode }}-${{ github.run_id }}
           # 90-day retention is the procurement-evidence requirement called

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       # workflow file changes — the same set that triggers the main `test` job.
       all-traits: ${{ steps.filter.outputs.all-traits }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
@@ -225,7 +225,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # paths-filter needs the parent commit to diff against on `push` events;
           # `pull_request` works with the default shallow clone.
@@ -659,7 +659,7 @@ jobs:
         # watchdog stall snapshots/backtrace tails, plus any xcresult bundles
         # if they exist).
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcresult-${{ github.run_attempt }}
           if-no-files-found: ignore
@@ -679,7 +679,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # paths-filter needs the parent commit to diff against on `push` events;
           # `pull_request` works with the default shallow clone.
@@ -712,7 +712,7 @@ jobs:
 
       - name: Upload test diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcresult-server-${{ github.run_attempt }}
           if-no-files-found: ignore
@@ -731,7 +731,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # paths-filter needs the parent commit to diff against on `push` events;
           # `pull_request` works with the default shallow clone.
@@ -764,7 +764,7 @@ jobs:
 
       - name: Upload test diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcresult-macros-${{ github.run_attempt }}
           if-no-files-found: ignore
@@ -794,7 +794,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
@@ -875,7 +875,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
@@ -906,7 +906,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
@@ -933,7 +933,7 @@ jobs:
 
       - name: Upload test diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcresult-ios-file-protection-${{ github.run_attempt }}
           if-no-files-found: ignore
@@ -976,7 +976,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,14 +42,14 @@ jobs:
         language: [actions, python]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: none
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/cold-start-human.yml
+++ b/.github/workflows/cold-start-human.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
@@ -98,7 +98,7 @@ jobs:
       # contents (a script change can shift the consumer's Package.swift
       # shape, which would invalidate cached dep object files).
       - name: Cache cold-start consumer build path
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/manifoldkit-cold-start-human

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: macos-15  # Apple Silicon arm64 — matches ci.yml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -59,7 +59,7 @@ jobs:
           xcode-version: "26.3"
 
       - name: Cache SwiftPM dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -120,7 +120,7 @@ jobs:
           HTML
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./docs-site
 
@@ -163,4 +163,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/example-ui-smoke.yml
+++ b/.github/workflows/example-ui-smoke.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1

--- a/.github/workflows/fuzz-weekly.yml
+++ b/.github/workflows/fuzz-weekly.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run fuzz (weekly, 30 min, --model all)
         run: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload findings artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-weekly-findings-${{ github.run_id }}
           path: tmp/fuzz/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
       # The cost is small on Ubuntu so we pay it unconditionally rather than
       # checking out twice.
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -89,6 +89,34 @@ jobs:
       - name: actionlint — lint GitHub Actions workflows
         if: always()
         run: ${{ steps.install_actionlint.outputs.executable }} -color
+
+      # ── action-pin-audit ──────────────────────────────────────────────────
+      # Supply-chain guard: every third-party action must be pinned to a full
+      # 40-hex commit SHA, not a mutable tag (`@v4`) or branch (`@main`). A tag
+      # can be silently retargeted at a malicious commit; a SHA cannot. We let
+      # Dependabot (`.github/dependabot.yml`, github-actions ecosystem) bump the
+      # pins weekly so this stays sustainable. Local (`./…`) and reusable
+      # in-repo workflow refs are exempt — they are not third-party.
+      #
+      # NOTE: the `push:` paths filter above includes `.github/workflows/**`, so
+      # this guard runs whenever a workflow changes (gate-validates-itself rule).
+      - name: action-pin-audit — require SHA-pinned third-party actions
+        if: always()
+        run: |
+          set -euo pipefail
+          # Match `uses: <ref>`, skipping local `./` refs. A pinned ref is
+          # owner/repo[/path]@<40 hex chars>. Anything else (a `@vX` tag, a
+          # branch, or a short SHA) is a finding.
+          violations=$(grep -rEn '^\s*-?\s*uses:\s*[^.]' .github/workflows/ \
+            | grep -vE 'uses:\s*\./' \
+            | grep -vE 'uses:\s*[^@]+@[0-9a-fA-F]{40}(\s|$|#)' \
+            || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Unpinned GitHub Actions found. Pin to a 40-char commit SHA (e.g. owner/action@<sha> # vX.Y.Z):"
+            echo "$violations"
+            exit 1
+          fi
+          echo "All third-party actions are SHA-pinned."
 
       # ── changelog-lint ────────────────────────────────────────────────────
       - name: changelog-lint — skip for non-Release-Please PRs
@@ -292,7 +320,7 @@ jobs:
         # Security > Dependency graph). Without it the action exits non-zero and
         # this step hard-fails — that is intentional supply-chain pressure, not
         # a misconfiguration to paper over with continue-on-error.
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
           vulnerability-check: true

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Swift CI environment
         uses: ./.github/actions/setup-swift-ci
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload test diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-slow-tests-diagnostics-${{ github.run_id }}
           if-no-files-found: ignore
@@ -246,7 +246,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Swift CI environment
         uses: ./.github/actions/setup-swift-ci
@@ -286,7 +286,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Swift CI environment
         uses: ./.github/actions/setup-swift-ci

--- a/.github/workflows/qa-telemetry.yml
+++ b/.github/workflows/qa-telemetry.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Compute CI / QA telemetry
         env:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload metrics artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-metrics-${{ github.run_id }}
           path: docs/ci-metrics.jsonl

--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -93,7 +93,7 @@ jobs:
         # set, so caching .build/checkouts + .build/repositories pays for
         # itself even though the snippet-package's own .build is ephemeral.
         # We key on Package.resolved exactly like ci.yml.
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,7 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Extract changelog entry
         env:

--- a/.github/workflows/release-provenance-rehearsal.yml
+++ b/.github/workflows/release-provenance-rehearsal.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout PR commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
@@ -61,7 +61,7 @@ jobs:
           '
 
       - name: Persist rehearsal artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-provenance-rehearsal-${{ github.sha }}
           path: artifacts/

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # `release.published` already checks out the tag; for workflow_dispatch
           # we need to fetch and check out the supplied tag explicitly.
@@ -103,12 +103,12 @@ jobs:
           '
 
       - name: Attest SBOM build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: artifacts/sbom.cdx.json
 
       - name: Attest dependency-tree build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: artifacts/dependency-tree.json
 
@@ -126,7 +126,7 @@ jobs:
         # Belt-and-suspenders: if the release upload step is rate-limited or
         # removed, the artifacts (and their attestations in the transparency
         # log) are still recoverable from the workflow run itself.
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-supply-chain-${{ steps.tag.outputs.name }}
           path: artifacts/

--- a/.github/workflows/release-server-binary.yml
+++ b/.github/workflows/release-server-binary.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
             --clobber
 
       - name: Persist artifacts on the workflow run
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: manifold-server-binary-${{ steps.tag.outputs.name }}
           path: artifacts/

--- a/Sources/ManifoldContract/ToolCallTransform.swift
+++ b/Sources/ManifoldContract/ToolCallTransform.swift
@@ -51,6 +51,15 @@ public struct ToolCallMarker: Sendable {
 public struct ToolCallTransform: StreamTransform {
     public let markers: [ToolCallMarker]
 
+    /// Upper bound (in UTF-8 bytes) on a single buffered tool-call body before
+    /// the active block is abandoned as malformed. A well-formed tool call is a
+    /// small JSON object; an unbounded body means we never saw a close tag (a
+    /// truncated, runaway, or adversarial stream). Without this cap the body
+    /// buffer grows for the whole remaining stream and is then handed to an
+    /// O(n)+ `parseBody`. 256 KB is far above any legitimate call and well
+    /// below a memory-pressure threat.
+    private static let maxBodyBytes = 256 * 1024
+
     private var buffer = ""
     /// Index into `markers` of the dialect whose open tag is currently active,
     /// or `nil` when not inside a tool-call block.
@@ -99,6 +108,18 @@ public struct ToolCallTransform: StreamTransform {
                     if buffer.count > holdLen {
                         bodyBuffer += String(buffer.prefix(buffer.count - holdLen))
                         buffer = holdLen > 0 ? String(buffer.suffix(holdLen)) : ""
+                    }
+                    // Guard against an unbounded body: a close tag that never
+                    // arrives would otherwise buffer the entire rest of the
+                    // stream. Drop the malformed call and resume scanning the
+                    // held-back buffer for a fresh open tag.
+                    if bodyBuffer.utf8.count > Self.maxBodyBytes {
+                        Log.inference.warning(
+                            "ToolCallTransform: dropping tool-call body exceeding \(Self.maxBodyBytes)-byte cap without a close tag"
+                        )
+                        bodyBuffer = ""
+                        activeMarker = nil
+                        continue
                     }
                     break
                 }

--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
@@ -112,6 +112,11 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
 
                     try FileManager.default.moveItem(at: tempURL, to: destination)
 
+                    // Harden the at-rest model file on iOS so downloaded weights
+                    // are unreadable until first unlock after reboot. Best-effort:
+                    // never fails the completed download.
+                    DownloadedFileProtection.protect(destination)
+
                     // Verify against a sidecar manifest when one is present next to the
                     // destination file. Missing manifests are silently skipped; verification
                     // failure re-enters the catch block which marks the download failed and

--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
@@ -746,6 +746,9 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
             try DiffusionPackageValidator.writePackageManifest(for: packageModel, files: Array(snapshot.files.keys), in: snapshot.stagingDirectory)
         }
         try FileManager.default.moveItem(at: snapshot.stagingDirectory, to: finalURL)
+        // Harden the at-rest snapshot package on iOS once it reaches its final
+        // location. Best-effort: never fails the completed download.
+        DownloadedFileProtection.protect(finalURL)
         activeDownloads[modelID]?.markCompleted(localURL: finalURL)
         removePendingDownload(id: modelID)
         _ = downloadStateMachine.removeSnapshotDownload(modelID: modelID)

--- a/Sources/ManifoldHuggingFace/DownloadedFileProtection.swift
+++ b/Sources/ManifoldHuggingFace/DownloadedFileProtection.swift
@@ -1,0 +1,41 @@
+#if HuggingFace
+import Foundation
+import ManifoldInference
+
+// MARK: - Downloaded-file Data Protection
+
+/// Applies the iOS Data Protection class to model files once they land in their
+/// final location under Application Support / Models.
+///
+/// Mirrors `ModelContainerFactory.applyProtection()` in
+/// `ManifoldPersistenceSwiftData`: best-effort hardening that keeps downloaded
+/// model weights unreadable until the user first unlocks the device after
+/// reboot, while still allowing background tasks to read them. A missing
+/// protection attribute must never fail or roll back a completed download, so
+/// failures are logged and swallowed — never thrown. No-op on macOS / Mac
+/// Catalyst, where at-rest protection is handled by FileVault.
+enum DownloadedFileProtection {
+
+    /// The Data Protection class applied to downloaded model files.
+    ///
+    /// `.completeUntilFirstUserAuthentication` matches the SwiftData store
+    /// protection in `ModelContainerFactory`: readable while the device is
+    /// unlocked at least once after boot, so background downloads and load
+    /// paths keep working without prompting for the passcode.
+    static func protect(_ url: URL) {
+        #if (os(iOS) || os(tvOS) || os(watchOS)) && !targetEnvironment(macCatalyst)
+        let attributes: [FileAttributeKey: Any] = [
+            .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+        ]
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.setAttributes(attributes, ofItemAtPath: url.path)
+        } catch {
+            Log.download.warning(
+                "Failed to apply file protection to downloaded model at \(url.path, privacy: .private): \(error.localizedDescription)"
+            )
+        }
+        #endif
+    }
+}
+#endif

--- a/Sources/ManifoldMCP/MCPToolExecutor.swift
+++ b/Sources/ManifoldMCP/MCPToolExecutor.swift
@@ -10,6 +10,16 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
     private let lock = NSLock()
     private var requiresApprovalValue: Bool
 
+    /// Default UTF-8 byte ceiling applied to sanitized tool output when no
+    /// ``ToolOutputPolicy`` limit has been pushed in by the owning registry.
+    static let defaultOutputByteLimit = 8_192
+
+    /// UTF-8 byte ceiling for sanitized tool output. Seeded from the owning
+    /// ``ToolRegistry``'s ``ToolOutputPolicy/maxBytes`` at registration time so
+    /// the transport-boundary truncation respects the host's configured policy
+    /// instead of a hardcoded constant. Guarded by `lock`.
+    private var outputByteLimitValue: Int = MCPToolExecutor.defaultOutputByteLimit
+
     public init(definition: ToolDefinition) {
         self.definition = definition
         self.remoteToolName = definition.name
@@ -51,6 +61,24 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Pushes the owning registry's output-size policy into this executor so
+    /// the transport-boundary truncation in ``sanitize(_:limit:)`` matches the
+    /// configured ``ToolOutputPolicy/maxBytes``. A non-positive limit is
+    /// ignored (the executor keeps the 8 KB default) — `0` would otherwise
+    /// erase every tool result before the registry's own policy could act.
+    internal func setOutputByteLimit(_ limit: Int) {
+        guard limit > 0 else { return }
+        lock.lock()
+        outputByteLimitValue = limit
+        lock.unlock()
+    }
+
+    private var outputByteLimit: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return outputByteLimitValue
+    }
+
     public func execute(arguments: JSONSchemaValue) async throws -> ToolResult {
         do {
             try Task.checkCancellation()
@@ -59,7 +87,7 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
             try Task.checkCancellation()
             let parsed = Self.parseResult(response)
             let wrapped = MCPContentSanitizer.wrapForUntrustedSurface(
-                Self.sanitize(parsed.content),
+                sanitize(parsed.content),
                 serverDisplayName: serverDisplayName
             )
             return ToolResult(callId: "", content: wrapped, errorKind: parsed.errorKind)
@@ -68,12 +96,19 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
         } catch let error as MCPError {
             return ToolResult(
                 callId: "",
-                content: Self.sanitize(Self.message(for: error)),
+                content: sanitize(Self.message(for: error)),
                 errorKind: errorKind(for: error)
             )
         } catch {
-            return ToolResult(callId: "", content: Self.sanitize(error.localizedDescription), errorKind: .permanent)
+            return ToolResult(callId: "", content: sanitize(error.localizedDescription), errorKind: .permanent)
         }
+    }
+
+    /// Instance entry point for ``sanitize(_:limit:)`` that applies the
+    /// registry-configured ``outputByteLimit`` and emits a warning when output
+    /// is actually truncated — previously a silent data loss.
+    private func sanitize(_ value: String) -> String {
+        Self.sanitize(value, limit: outputByteLimit, toolName: definition.name)
     }
 
     private static func parseResult(_ value: JSONSchemaValue?) -> (content: String, errorKind: ToolResult.ErrorKind?) {
@@ -150,7 +185,11 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
         }
     }
 
-    private static func sanitize(_ value: String, limit: Int = 8_192) -> String {
+    private static func sanitize(
+        _ value: String,
+        limit: Int = MCPToolExecutor.defaultOutputByteLimit,
+        toolName: String? = nil
+    ) -> String {
         let filtered = value.unicodeScalars.filter { scalar in
             if CharacterSet.controlCharacters.contains(scalar) {
                 return scalar.value == 10 || scalar.value == 13 || scalar.value == 9
@@ -161,9 +200,15 @@ public final class MCPToolExecutor: ToolExecutor, @unchecked Sendable {
         // Compare and truncate by UTF-8 byte count, not grapheme clusters, so
         // multi-byte characters (CJK, emoji) can't be used to smuggle oversized
         // payloads past a grapheme-cluster limit check.
-        if string.utf8.count <= limit {
+        let byteCount = string.utf8.count
+        if byteCount <= limit {
             return string
         }
+        // Truncation is real data loss — surface it rather than silently
+        // dropping the tail. The model only ever sees the truncated prefix.
+        Log.inference.warning(
+            "MCPToolExecutor: truncated tool result for '\(toolName ?? "<unknown>", privacy: .public)' from \(byteCount) to \(limit) bytes"
+        )
         return String(bytes: Array(string.utf8.prefix(limit)), encoding: .utf8) ?? String(string.prefix(limit / 4))
     }
 

--- a/Sources/ManifoldMCP/MCPToolSource.swift
+++ b/Sources/ManifoldMCP/MCPToolSource.swift
@@ -120,7 +120,14 @@ public final class MCPToolSource: @unchecked Sendable {
             }
         }
         let executors = await storage.executors()
+        // Push the registry's configured output-size policy into each executor
+        // so the transport-boundary truncation respects ToolOutputPolicy instead
+        // of a hardcoded 8 KB constant. The registry applies its own oversize
+        // action afterwards; this just stops us silently discarding the tail at
+        // a lower fixed ceiling first.
+        let outputLimit = registry.outputPolicy.maxBytes
         for executor in executors {
+            executor.setOutputByteLimit(outputLimit)
             registry.register(executor)
         }
         let key = ObjectIdentifier(registry)

--- a/Sources/ManifoldMCP/OAuthSecurity.swift
+++ b/Sources/ManifoldMCP/OAuthSecurity.swift
@@ -172,9 +172,16 @@ func mcpBearerRedacted(_ data: Data) -> String {
 func constantTimeEqual(_ a: String, _ b: String) -> Bool {
     let aBytes = Array(a.utf8)
     let bBytes = Array(b.utf8)
-    guard aBytes.count == bBytes.count else { return false }
-    var diff: UInt8 = 0
-    for (x, y) in zip(aBytes, bBytes) {
+    // Fold the length difference into the accumulator instead of returning
+    // early on a count mismatch, so the comparison time does not leak the
+    // length of the shorter string. We iterate over the max length and index
+    // each array modulo its own count (both non-empty after the XOR seed), so a
+    // shorter input still costs the same number of compares.
+    var diff = UInt8(truncatingIfNeeded: aBytes.count ^ bBytes.count)
+    let maxCount = max(aBytes.count, bBytes.count)
+    for i in 0..<maxCount {
+        let x = aBytes.isEmpty ? 0 : aBytes[i % aBytes.count]
+        let y = bBytes.isEmpty ? 0 : bBytes[i % bBytes.count]
         diff |= x ^ y
     }
     return diff == 0

--- a/Tests/ManifoldHuggingFaceTests/DownloadedFileProtectionTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/DownloadedFileProtectionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+#if HuggingFace
+@testable import ManifoldHuggingFace
+
+/// Unit coverage for ``DownloadedFileProtection``.
+///
+/// The kernel Data Protection attribute (`NSFileProtection*`) is an iOS-only
+/// feature; the macOS `swift test` lane exercises the no-op path. The on-disk
+/// assertion that the attribute is actually applied lives in the iOS-Simulator
+/// lane (`scripts/test-ios-simulator.sh`, mirroring
+/// `ModelContainerFileProtectionTests`). Here we pin the contract that matters
+/// on every platform: `protect` is best-effort and must never throw or mutate
+/// the file's contents, so it can be called inline on the download completion
+/// path without risk of failing a finished download.
+final class DownloadedFileProtectionTests: XCTestCase {
+
+    func test_protect_doesNotThrowOrCorruptFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dfp-\(UUID().uuidString).bin")
+        let payload = Data("model-weights".utf8)
+        try payload.write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Best-effort: returns normally on every platform (no-op on macOS).
+        DownloadedFileProtection.protect(tmp)
+
+        XCTAssertEqual(try Data(contentsOf: tmp), payload,
+                       "protect must never alter the file's contents")
+    }
+
+    func test_protect_missingFile_isHarmless() {
+        let absent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dfp-missing-\(UUID().uuidString).bin")
+        // Applying protection to a nonexistent path must be a silent no-op,
+        // never a crash or thrown error.
+        DownloadedFileProtection.protect(absent)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: absent.path))
+    }
+}
+#endif

--- a/Tests/ManifoldInferenceTests/OutputParserSessionTests.swift
+++ b/Tests/ManifoldInferenceTests/OutputParserSessionTests.swift
@@ -247,4 +247,26 @@ final class OutputParserSessionTests: XCTestCase {
         events += mlx.finalize()
         XCTAssertEqual(visible(events), "done<tool_c")
     }
+
+    // MARK: - Body-size cap (DoS guard)
+
+    func test_oversizedToolBody_withoutClose_isDroppedAndParserRecovers() {
+        var transform = ToolCallTransform(markers: [jsonMarker()])
+        // Open a tool block then stream a body far larger than the 256 KB cap
+        // with no matching close tag (a truncated/adversarial stream).
+        var events = transform.process([.token("<tool_call>")])
+        events += transform.process([.token(String(repeating: "x", count: 300 * 1024))])
+
+        // The oversized, unclosed body must be discarded — never handed to
+        // parseBody — and no ToolCall is emitted.
+        XCTAssertTrue(toolCalls(events).isEmpty,
+            "An unbounded unclosed tool body must be dropped, not parsed")
+
+        // After dropping, the parser must be back outside a block: a subsequent
+        // well-formed call is parsed normally rather than being swallowed.
+        var recovery = transform.process([.token("<tool_call>{\"name\":\"f\"}</tool_call>")])
+        recovery += transform.finalize()
+        XCTAssertEqual(toolCalls(recovery).map(\.toolName), ["f"],
+            "Parser must recover and parse a valid call after dropping an oversized body")
+    }
 }

--- a/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
+++ b/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
@@ -777,12 +777,57 @@ final class MCPToolBridgeTests: XCTestCase {
         XCTAssertEqual(registeredNames[0].utf8.count, limit,
                        "tool name at exact byte limit must not be truncated")
     }
+
+    // MARK: - Output truncation respects ToolOutputPolicy
+
+    /// By default (no policy override) the executor truncates oversized tool
+    /// output to the 8 KB transport ceiling.
+    func test_output_truncatedToDefaultLimit_whenNoPolicyOverride() async throws {
+        let big = String(repeating: "a", count: 20_000)
+        let executor = MCPToolExecutor(
+            definition: ToolDefinition(name: "dump", description: "Dump", parameters: .object([:])),
+            serverDisplayName: "Docs",
+            remoteToolName: "dump",
+            requiresApproval: false,
+            callTool: { _, _ in .string(big) }
+        )
+
+        let result = try await executor.execute(arguments: .object([:]))
+        // wrapForUntrustedSurface adds a small envelope, so the sanitized body
+        // is bounded by the default 8 KB ceiling — well under the 20 KB input.
+        XCTAssertLessThan(result.content.utf8.count, 20_000)
+        XCTAssertGreaterThanOrEqual(result.content.utf8.count, MCPToolExecutor.defaultOutputByteLimit - 200)
+    }
+
+    /// When the owning registry configures a larger `ToolOutputPolicy.maxBytes`,
+    /// `register(in:)` pushes that limit into the executor so output that fits
+    /// the configured policy is no longer clipped at the hardcoded 8 KB.
+    func test_output_respectsRegistryPolicyLimit() async throws {
+        let body = String(repeating: "b", count: 16_000) // > 8 KB default, < 64 KB policy
+        let source = makeSource(
+            serverID: UUID(),
+            approvalPolicy: .perCall,
+            toolNames: ["dump"],
+            callTool: { _, _ in .string(body) }
+        )
+        let registry = ToolRegistry()
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: 65_536, onOversize: .allow)
+        await source.register(in: registry)
+
+        let executor = try XCTUnwrap(registry.executor(for: "dump") as? MCPToolExecutor)
+        let result = try await executor.execute(arguments: .object([:]))
+        // Sanitize no longer clips at 8 KB — the full 16 KB body survives the
+        // transport boundary because the policy limit (64 KB) was plumbed in.
+        XCTAssertGreaterThan(result.content.utf8.count, 15_000,
+                             "executor must honour the registry's configured output limit, not the 8 KB default")
+    }
 }
 
 private func makeSource(
     serverID: UUID,
     approvalPolicy: MCPApprovalPolicy,
-    toolNames: [String]
+    toolNames: [String],
+    callTool: (@Sendable (_ toolName: String, _ arguments: JSONSchemaValue) async throws -> JSONSchemaValue?)? = nil
 ) -> MCPToolSource {
     MCPToolSource(
         serverID: serverID,
@@ -796,7 +841,7 @@ private func makeSource(
                 "tools": .array(toolNames.map { .object(["name": .string($0), "inputSchema": .object([:])]) }),
             ])
         },
-        callTool: { _, _ in nil }
+        callTool: callTool ?? { _, _ in nil }
     )
 }
 


### PR DESCRIPTION
Bundle of small, independent security-hardening fixes. Each is self-contained; no feature changes.

## Checklist

- [x] **SHA-pin all GitHub Actions + regression guard.** Every third-party action across `.github/workflows/*.yml` is now pinned to a 40-char commit SHA with a `# vX.Y.Z` comment (`actions/checkout`, `actions/cache`, `actions/upload-artifact`, `github/codeql-action/*`, `actions/deploy-pages`, `actions/dependency-review-action`, `actions/attest-build-provenance`, `actions/upload-pages-artifact`) — matching the existing Trufflehog pin style. A mutable tag can be silently retargeted at a malicious commit; a SHA cannot. Added an `action-pin-audit` step to the `lint` job that greps all workflows and fails CI on any `uses:` ref that is not a 40-hex SHA (local `./` refs exempt). The `lint` push `paths:` filter already includes `.github/workflows/**`, so the guard validates itself. Dependabot already tracks the `github-actions` ecosystem to keep the pins bumped weekly.
- [x] **File protection on downloaded model files (iOS).** New `DownloadedFileProtection.protect(_:)` applies `URLFileProtection.completeUntilFirstUserAuthentication` to the final model file/package once it lands in Application Support/Models, mirroring `ModelContainerFactory.applyProtection()`. Wired into both the single-file and snapshot-package completion paths in `BackgroundDownloadManager`. Best-effort: logs a warning on failure, never throws, never blocks a finished download. No-op on macOS / Mac Catalyst.
- [x] **MCP tool-result truncation respects `ToolOutputPolicy`.** `MCPToolExecutor` previously truncated all tool output at a hardcoded 8 KB ceiling. It now seeds its transport-boundary limit from the owning registry's `ToolOutputPolicy.maxBytes` at `register(in:)` time (default 8 KB when no policy is set) and emits a `Log.inference.warning` when truncation actually drops data — previously silent data loss.
- [x] **Bound tool-call parser body size.** `ToolCallTransform` now caps the buffered tool-call body at 256 KB. An unclosed/runaway body (truncated or adversarial stream) is dropped with a warning and the parser recovers, instead of buffering the rest of the stream unboundedly and handing it to `parseBody`.
- [x] **Constant-time compare length leak (OAuthSecurity).** `constantTimeEqual` no longer returns early on a count mismatch — the length difference is folded into the diff accumulator and the comparison iterates over the max length, so timing no longer leaks the shorter string's length. (Cosmetic given high-entropy state params, but a clean change.)

## Tests
- `MCPToolBridgeTests`: default 8 KB clip + registry-policy-limit honoured (sabotage-verified — disabling the policy push clips a 16 KB body at 8253 bytes).
- `OutputParserSessionTests`: oversized unclosed body dropped + parser recovers (sabotage-verified — raising the cap leaves the parser stuck in-block).
- `DownloadedFileProtectionTests`: `protect` is non-throwing and content-preserving on every platform (the on-disk iOS attribute assertion belongs in the iOS-Simulator lane, `scripts/test-ios-simulator.sh`).

## Gate
- Trait-combo build sweep (`MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz`): green.
- `scripts/test.sh --profile local`: 4911 passed. One failure — `MockBackendLifecycleTests.test_backToBackMakeStream_clearsTaskBetweenRuns`, a pre-existing timing flake in a mock-backend lifecycle test unrelated to this diff (no MCP/Llama/Contract/HuggingFace/workflow touch); passes 5/5 in isolation on re-run.
- `actionlint` clean on all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)