### PR TITLE
fix(ManifoldMLX): load diffusion model from its actual directory

### DIFF
--- a/Sources/ManifoldMLX/MLXDiffusionBackend.swift
+++ b/Sources/ManifoldMLX/MLXDiffusionBackend.swift
@@ -42,13 +42,15 @@ public enum MLXDiffusionError: Error, LocalizedError {
 ///
 /// Other layouts throw ``MLXDiffusionError/unsupportedModelLayout``.
 ///
-/// ## Hub directory convention
+/// ## Directory convention
 ///
-/// `HuggingFaceService.downloadDiffusionModel` writes snapshots into Hub's
-/// `<root>/models/<org>/<name>` layout (e.g.
-/// `<root>/models/stabilityai/sdxl-turbo/unet/...`). `loadModel(from:)`
-/// derives the Hub `downloadBase` by walking three components up from the
-/// supplied `url` — no bridging symlink is required.
+/// `loadModel(from:)` loads weights directly from the directory it is given —
+/// the `directoryURL` carried by `ImageModelInfo`. That directory holds the
+/// diffusers submodules (`unet/`, `vae/`, `scheduler/`, …) at its top level and
+/// may be either a flat install (`.../<org>__<name>/`) or a Hub leaf
+/// (`.../models/<org>/<name>/`). Files are resolved relative to that directory
+/// via `StableDiffusionConfiguration.resolvingFiles(in:)`, so no particular Hub
+/// `downloadBase` shape — and no bridging symlink — is required.
 ///
 /// ## Concurrency
 ///
@@ -96,19 +98,21 @@ public final class MLXDiffusionBackend: ImageGenerationBackend, @unchecked Senda
             throw MLXDiffusionError.insufficientMemory(plan.reasons)
         }
 
-        // `url` is the Hub leaf (`.../models/<org>/<name>`). Walk three
-        // components up — `<name>`, `<org>`, `models` — to recover the
-        // `downloadBase` Hub uses to resolve `localRepoLocation`. The
-        // download path already produces this layout (see
-        // `DiffusionDownload.hubLeafDirectory(in:repoID:)`), which is
-        // why no symlink bridge is needed.
-        let hubBase = url
-            .deletingLastPathComponent() // drop <name>
-            .deletingLastPathComponent() // drop <org>
-            .deletingLastPathComponent() // drop "models"
-
-        let hub = HubApi(downloadBase: hubBase, useOfflineMode: true)
-        guard let generator = try preset.textToImageGenerator(
+        // `url` is the actual model directory handed to us by the storage
+        // layer — `ImageGenerationService` passes `ImageModelInfo.directoryURL`.
+        // That directory can be either a Hub leaf (`.../models/<org>/<name>`)
+        // or a flat install (`.../<org>__<name>/`); both carry the diffusers
+        // submodules (`unet/`, `vae/`, `scheduler/`, …) directly inside it.
+        //
+        // Resolve weights relative to `url` itself rather than reconstructing a
+        // Hub `downloadBase` by walking three components up and assuming a
+        // `models/<org>/<name>` shape — that assumption breaks for flat installs
+        // (walking up lands at `~/Library/Application Support`, where Hub then
+        // looks for a non-existent `models/<org>/<name>` tree). An offline
+        // `HubApi` is still supplied so nothing attempts a network fetch; its
+        // `localRepoLocation` is overridden by `resolvingFiles(in:)`.
+        let hub = HubApi(useOfflineMode: true)
+        guard let generator = try preset.resolvingFiles(in: url).textToImageGenerator(
             hub: hub, configuration: .init(quantize: true)
         ) else {
             throw MLXDiffusionError.unsupportedModelLayout(url)

--- a/Sources/StableDiffusion/Load.swift
+++ b/Sources/StableDiffusion/Load.swift
@@ -118,6 +118,23 @@ public struct StableDiffusionConfiguration: Sendable {
         @Sendable (HubApi, StableDiffusionConfiguration, LoadConfiguration) throws ->
             StableDiffusion
 
+    /// When set, weight/config files are resolved directly under this directory
+    /// instead of `HubApi.localRepoLocation(repo)`. This lets a caller point the
+    /// generator at an arbitrary on-disk model directory whose layout does not
+    /// match Hub's `<downloadBase>/models/<org>/<name>` convention (e.g. a flat
+    /// `.../<org>__<name>/` install). When `nil`, resolution falls back to the
+    /// Hub layout, preserving the original `download(hub:)` + `localRepoLocation`
+    /// behaviour.
+    var localDirectory: URL? = nil
+
+    /// Returns a copy of this configuration whose files resolve directly under
+    /// `directory` rather than via `HubApi.localRepoLocation`. See ``localDirectory``.
+    public func resolvingFiles(in directory: URL) -> StableDiffusionConfiguration {
+        var copy = self
+        copy.localDirectory = directory
+        return copy
+    }
+
     public func download(
         hub: HubApi = HubApi(), progressHandler: @escaping (Progress) -> Void = { _ in }
     ) async throws {
@@ -379,8 +396,9 @@ func loadWeights(
 func resolve(hub: HubApi, configuration: StableDiffusionConfiguration, key: FileKey) -> URL {
     precondition(
         configuration.files[key] != nil, "configuration \(configuration.id) missing key: \(key)")
-    let repo = Hub.Repo(id: configuration.id)
-    let directory = hub.localRepoLocation(repo)
+    // Prefer an explicit on-disk directory when supplied (flat `<org>__<name>`
+    // installs); otherwise fall back to Hub's `<downloadBase>/models/<org>/<name>`.
+    let directory = configuration.localDirectory ?? hub.localRepoLocation(Hub.Repo(id: configuration.id))
     return directory.appending(component: configuration.files[key]!)
 }
 


### PR DESCRIPTION
## Problem

`MLXDiffusionBackend.loadModel(from:)` could not load an installed diffusion
model, throwing because it couldn't find `scheduler/scheduler_config.json`.

The backend assumed the URL it was given was a HuggingFace **Hub leaf** of the
form `<downloadBase>/models/<org>/<name>`. It reconstructed a Hub `downloadBase`
by walking three path components up (`<name>`, `<org>`, `models`), built
`HubApi(downloadBase:)`, and relied on Hub's `localRepoLocation(repo)` (==
`<downloadBase>/models/<org>/<name>`) to resolve each weight file.

But the model on disk is stored **flat** under the app-scoped models directory:

```
<App Support>/<bundleId>/ImageModels/stabilityai__sdxl-turbo/
  model_index.json  scheduler/  unet/  vae/  text_encoder/  text_encoder_2/  ...
```

There is no `models/<org>/<name>` subtree inside it.
`ImageGenerationService.loadModel` passes that flat `directoryURL` straight to
the backend, so walking three components up landed at `<App Support>`, and Hub
then looked for a non-existent
`<App Support>/models/stabilityai/sdxl-turbo/scheduler/scheduler_config.json` —
hence the failure. (This is an internal MK inconsistency: the backend's Hub-leaf
path assumption did not match the flat layout the install actually has.)

## Fix

Resolve weights relative to the directory the backend is **actually given**,
instead of reconstructing a Hub path:

- The vendored `StableDiffusionConfiguration` gains an optional `localDirectory`
  (set via the new `resolvingFiles(in:)`). When present,
  `resolve(hub:configuration:key:)` joins files directly under that directory
  rather than `HubApi.localRepoLocation`.
- `MLXDiffusionBackend.loadModel(from:)` passes the model URL through
  `resolvingFiles(in:)` and supplies a plain offline `HubApi`. The fragile
  "walk three up + `HubApi(downloadBase:)`" scheme is removed.

This loads the model from both a flat `<org>__<name>` install **and** a Hub
`models/<org>/<name>` leaf, with **no bridging symlink**. When `localDirectory`
is nil the original `download(hub:)` + `localRepoLocation` path is untouched, so
the existing Hub-layout download flow is preserved.

## Tests

- ManifoldKit unit tests (default traits): `MLXDiffusionBackendTests` (9),
  `DiffusionDownloadTests` (6), `ModelStorageServiceTests` (24) — all pass; the
  Hub-layout download path is not regressed.
- LocalImage real-model E2E (`LocalImageRealModelE2ETests`, real SDXL-Turbo
  weights, no symlink): `testSDXLTurboGeneratesPixel` (1024²) and
  `testSDXLTurboPortraitProducesTallerImage` (768×1024) both **pass**.

## Context

This unblocks LocalImage's real-model image generation — those existing
LocalImage E2E tests fail without this fix. The bug was surfaced by LocalImage
PR #1 (the aspect-ratio / seed-lock feature), whose portrait path exercises the
real on-device load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)