### PR TITLE
docs: fix inaccuracies, broken links, and stale references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@ shorter, recipe-shaped surface for *consumers*.
 ManifoldKit is a Swift package. Install via SwiftPM:
 
 ```swift
-.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.36.0")
+.package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.46.0")
 ```
 
 > **Pre-1.0.** Minor versions can introduce breaking changes. For production,
-> pin to a specific tag (`exact: "0.36.0"`) and read [CHANGELOG.md](CHANGELOG.md)
+> pin to a specific tag (`exact: "0.46.0"`) and read [CHANGELOG.md](CHANGELOG.md)
 > before bumping. The `0.x` line stabilises pieces incrementally; `1.0.0` will
 > be the freeze point.
 
@@ -189,7 +189,7 @@ print(reply.content)
 ```
 
 For scripted drivers / integration tests, `sendMessage(_:)` returns the
-completed `ChatMessageRecord`. Polling `vm.lastTurnState` after the awaited call
+completed `ChatMessage`. Polling `vm.lastTurnState` after the awaited call
 inspects the same outcome:
 
 ```swift
@@ -245,11 +245,11 @@ There are three message-shaped types. Pick the right one:
 
 | Type | Module | When to use |
 |------|--------|-------------|
-| `ChatMessageRecord` | `ManifoldInference` | Transport / app code. The shape `sendMessage(_:)` returns. |
-| `ChatMessage` (`@Model`) | `ManifoldPersistenceSwiftData` | SwiftData row — owned by the persistence layer. |
+| `ChatMessage` (struct) | `ManifoldInference` | Transport / app code. The shape `sendMessage(_:)` returns. (`ChatMessageRecord` is a deprecated alias for this type.) |
+| `ChatMessage` (`@Model`) | `ManifoldPersistenceSwiftData` | SwiftData row — owned by the persistence layer. Disambiguate with the full schema path when both are in scope. |
 | `StructuredMessage` | `ManifoldInference` | Cloud-wire payload assembled by `InferenceService`. Internal — backends consume it. |
 
-App code reads and writes `ChatMessageRecord`. The persistence and wire types
+App code reads and writes `ChatMessage` (the struct). The persistence and wire types
 are managed by ManifoldKit.
 
 ## Tool calling
@@ -277,7 +277,7 @@ on every consumer:
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.36.0",
+    from: "0.46.0",
     traits: [.trait(name: "Macros")]
 )
 ```
@@ -355,7 +355,7 @@ Cloud backends require **`--traits CloudSaaS`** (default-off):
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.36.0",
+    from: "0.46.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,11 @@ suite fails CI if any of them is violated.
    in transitively.
 
 4. **`ConversationRuntime` is the single turn loop.** Every user-facing chat
-   action — `send`, `regenerate`, `edit`, `cancel`, `branch` — routes through
-   `ConversationRuntime`. There is no alternative path. New features that
-   touch turn flow extend `ConversationRuntime`; they must not call
-   `InferenceService` directly from the UI layer.
+   action — send, regenerate, edit, cancel, branch — routes through
+   `ConversationRuntime` via `processTurn(TurnInput(...))`. There is no
+   alternative path. New features that touch turn flow extend
+   `ConversationRuntime`; they must not call `InferenceService` directly from
+   the UI layer.
 
 If a PR genuinely needs to cross one of these boundaries, the fix is almost
 always to promote a protocol downward (into `ManifoldInference`) or extract a

--- a/Example/README.md
+++ b/Example/README.md
@@ -53,8 +53,9 @@ More examples ship alongside new features — see each example's README for deta
 
 ## Customization
 
-To add your own backends, import `ManifoldBackends` and call:
+To add your own backends, import `ManifoldBackends` and call `register` with the `InferenceService` from your bootstrap result:
 
 ```swift
-DefaultBackends.register(with: chatViewModel.inferenceService)
+let result = try await ManifoldKit.quickStart()
+DefaultBackends.register(with: result.bootstrap.inferenceService)
 ```

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Full runnable: [`Example/Examples/MinimalExample`](Example/Examples/MinimalExamp
 
 **n-1 OS reach, WWDC-ready.** ManifoldKit serves iOS 18 / macOS 15 — the installed base that Apple Foundation Models (OS-26-only, AI-hardware-gated, 4096-token cap, single fixed model) can't reach — and wraps Foundation Models as just one more backend instead of competing with it. Trait gating means one codebase yields either a ~5 MB `FoundationOnly` App Store build or the full local + cloud + RAG + voice + image-gen stack. Pre-wired stub traits (`SystemAIProviderExtension`, `CoreAI`) mean whatever Apple ships next September is one more backend, not a migration. See [CLAUDE.md → Platform policy](CLAUDE.md#platform-policy).
 
-**Reliability and security as product.** TLS pinning, SSRF and DNS-rebind guards, a throwing Keychain, a documented [threat model](docs/THREAT_MODEL.md), a fuzz harness, 5,700+ tests, capability-routed structured output, human-in-the-loop tool approval (`ToolApprovalGate`), and cost/metrics observability ship in the box. These are the things that go wrong between the demo and App Store review — see [docs/RELIABILITY.md](docs/RELIABILITY.md) for the implementation-backed guarantees.
+**Reliability and security as product.** TLS pinning, SSRF and DNS-rebind guards, a throwing Keychain, a documented [threat model](docs/THREAT_MODEL.md), a fuzz harness, 6,500+ tests, capability-routed structured output, human-in-the-loop tool approval (`ToolApprovalGate`), and cost/metrics observability ship in the box. These are the things that go wrong between the demo and App Store review — see [docs/RELIABILITY.md](docs/RELIABILITY.md) for the implementation-backed guarantees.
 
-ManifoldKit is **decomposable, not monolithic**: 14 trait-gated modules. Take just the engine ([CLI / server path](docs/QUICKSTART-CLI.md)), just the UI (bring-your-own-runtime), or the whole stack — the umbrella is a convenience, not a requirement.
+ManifoldKit is **decomposable, not monolithic**: 25 libraries across a layered module graph. Take just the engine ([CLI / server path](docs/QUICKSTART-CLI.md)), just the UI (bring-your-own-runtime), or the whole stack — the umbrella is a convenience, not a requirement.
 
 ## What's already in the box
 
@@ -196,7 +196,7 @@ Start with [`Example/Examples/MinimalExample`](Example/Examples/MinimalExample) 
 
 ## Architecture
 
-ManifoldKit ships **14 libraries**, **2 executables**, and **1 macro plugin**. The core runtime stack is six libraries; the rest are optional sibling modules and test-only targets gated behind SwiftPM traits.
+ManifoldKit ships **25 libraries**, **3 executables**, and **1 macro plugin**. The core runtime stack is six libraries; the rest are optional sibling modules and test-only targets gated behind SwiftPM traits.
 
 ```
 ManifoldVoice              ManifoldUIModelManagement
@@ -225,7 +225,7 @@ ManifoldVoice              ManifoldUIModelManagement
 
 ### Turn-loop orchestration
 
-`ConversationRuntime` (`Sources/ManifoldRuntime/Services/ConversationRuntime.swift`) is the **single turn loop** for chat. It owns `send`, `regenerate`, `edit`, `cancel`, and `branch` — there is no alternative path. Host apps get a configured runtime from `ManifoldBootstrap` (exposed as `bootstrap.conversationRuntime`) and forward user actions to it. See [CONTRIBUTING.md → Architecture invariants](CONTRIBUTING.md#architecture-invariants) for the full list of dependency rules the lint enforces.
+`ConversationRuntime` (`Sources/ManifoldRuntime/Services/ConversationRuntime.swift`) is the **single turn loop** for chat. It owns all turn-flow operations — send, regenerate, edit, cancel, and branch — dispatched through `processTurn(TurnInput(...))` with the corresponding `TurnKind` case. There is no alternative path. Host apps get a configured runtime from `ManifoldBootstrap` (exposed as `bootstrap.conversationRuntime`) and forward user actions to it. See [CONTRIBUTING.md → Architecture invariants](CONTRIBUTING.md#architecture-invariants) for the full list of dependency rules the lint enforces.
 
 ## Supported Model Types
 
@@ -255,7 +255,7 @@ Discovery additionally surfaces any `.gguf` files (or MLX model directories) in 
 | `SessionManagerViewModel` | Chat session CRUD and selection. |
 | `ModelManagementViewModel` | HuggingFace search, downloads, local model management (`ManifoldUIModelManagement`). |
 | `InferenceService` | Backend orchestrator — selects and delegates to the right backend. |
-| `ConversationRuntime` | Single turn loop for send/regenerate/edit/cancel/branch with `ConversationEvent` hooks. |
+| `ConversationRuntime` | Single turn loop — all turn-flow operations dispatched via `processTurn(TurnInput(...))` with `ConversationEvent` hooks. |
 | `ChatView` | Main chat interface with message list and input bar. |
 | `SessionListView` | Sidebar session list with rename/delete. |
 | `ModelManagementSheet` | Combined model browser + storage management. |

--- a/Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md
+++ b/Sources/ManifoldAppIntents/ManifoldAppIntents.docc/ManifoldAppIntents.md
@@ -40,7 +40,7 @@ registry.register(AppIntentToolExecutor(AskManifoldDemoIntent.self))
 inferenceService.toolRegistry = registry
 ```
 
-The model now sees `ask_base_chat_demo_intent` in its tool list and can
+The model now sees `ask_manifold_demo_intent` in its tool list and can
 invoke it whenever the conversation calls for it.
 
 `AppIntentToolExecutor` requires per-call approval by default. For explicitly

--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -19,8 +19,10 @@ layers:
 - `ManifoldRuntime` adds persistence-agnostic ports and use cases.
 - `ManifoldPersistenceSwiftData` adds the shipped SwiftData schema and
   ``ManifoldBootstrap`` entry point.
-- `ManifoldBackends` adds the concrete MLX, llama.cpp, Foundation, and cloud
-  backends, depending on `ManifoldInference` directly so it stays free of
+- `ManifoldBackends` re-exports the concrete MLX, llama.cpp, Foundation, and
+  cloud backends. The MLX and llama.cpp families depend on `ManifoldInference`
+  directly; the Foundation and cloud families were repointed to `ManifoldContract`
+  (the thin protocol kernel) in v0.40+ so they stay free of engine internals and
   SwiftData.
 
 Apps that bring their own persistence and UI can depend on this target alone

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
@@ -6,7 +6,7 @@ ManifoldKit's shipped SwiftData adapter — concrete schema, container factory, 
 
 `ManifoldPersistenceSwiftData` is the default storage tier for ManifoldKit. It provides:
 
-- **`@Model` types** — `ChatSession`, `ChatMessage`, `APIEndpoint`, `SamplerPreset`, `Agent`, and the versioned schemas in `Schema/` (currently `ManifoldSchemaV9`) plus the matching `ManifoldMigrationPlan`.
+- **`@Model` types** — `ChatSession`, `ChatMessage`, `APIEndpoint`, `SamplerPreset`, `PersistedAgent`, and the versioned schemas in `Schema/` (currently `ManifoldSchemaV9`) plus the matching `ManifoldMigrationPlan`.
 - **Adapter conformances** — `SwiftDataPersistenceProvider` implements both ``MessageStore`` and ``SessionStore``; `SwiftDataEndpointStore`, `SwiftDataSamplerPresetStore`, `SwiftDataBenchmarkCache`, `SwiftDataUsageStore`, and `SwiftDataDocumentStore` cover the remaining ports.
 - **``ModelContainerFactory``** — builds per-app on-disk or in-memory `ModelContainer`s, applies the configured `NSFileProtection` class on iOS, and prevents two ManifoldKit apps on the same machine from sharing a SwiftData store.
 - **``ManifoldBootstrap``** — the one-call entry point that installs ``ManifoldConfiguration/shared``, builds the inference service, container, persistence adapters, and a pre-wired ``ConversationRuntime`` in a fixed safe order.

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/ManifoldRuntime.md
@@ -25,13 +25,13 @@ Import `ManifoldRuntime` directly when:
 
 ## When not to use this module
 
-- **You only need to call a backend.** ``InferenceService``, ``Backend``, and ``GenerationConfig`` live in `ManifoldInference`. The runtime adds session, persistence, and hooks on top — if you have none of those, skip the runtime and drive the backend directly.
+- **You only need to call a backend.** ``InferenceService``, ``InferenceBackend``, and ``GenerationConfig`` live in `ManifoldInference`. The runtime adds session, persistence, and hooks on top — if you have none of those, skip the runtime and drive the backend directly.
 - **You are happy with the shipped SwiftUI chat shell.** ``ChatView`` and ``ChatViewModel`` already configure a ``ConversationRuntime`` for you via ``ManifoldBootstrap``; you only need to touch this module if you are driving the runtime yourself.
 - **You want a backend.** Backend family targets do not import `ManifoldRuntime`. Importing this module from inside a backend creates a layering cycle.
 
 ## Beyond chat
 
-`ConversationRuntime` is named for its most common use case but is best understood as a **session-scoped turn-loop shell**: it persists writes, assembles context, calls a ``Backend``, streams events, and tears down on cancel. Anything that fits that shape — interactive agents, classification pipelines that need to record prompts, voice-driven flows, image-generation runs (see ``ImageGenerationRuntime``) — can sit on top of these ports without dragging in `ChatView`. The "chat" word in the surface area names is historical; the orchestration shell is general.
+`ConversationRuntime` is named for its most common use case but is best understood as a **session-scoped turn-loop shell**: it persists writes, assembles context, calls an ``InferenceBackend``, streams events, and tears down on cancel. Anything that fits that shape — interactive agents, classification pipelines that need to record prompts, voice-driven flows, image-generation runs (see ``ImageGenerationRuntime``) — can sit on top of these ports without dragging in `ChatView`. The "chat" word in the surface area names is historical; the orchestration shell is general.
 
 Sibling runtime ports cover non-text surfaces: ``ImageGenerationRuntime`` and ``VideoGenerationRuntime`` insert a placeholder message and drive a progress event stream, while ``WebSearchRuntime`` is request/response — it returns search-result text so a tool can hand it straight back to the model. All three are abstractions here in `ManifoldRuntime`; their concrete network-touching implementations live above the UI layer (e.g. `DefaultWebSearchRuntime` in `ManifoldCloud`), keeping `ManifoldUI` free of backend-family and `URLSession` imports.
 

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -51,7 +51,7 @@ in the source tree.
 
 ### 1. Certificate pinning (`PinnedSessionDelegate`)
 
-- **File:** `Sources/ManifoldBackends/PinnedSessionDelegate.swift`
+- **File:** `Sources/ManifoldCloudCore/PinnedSessionDelegate.swift`
 - **Primitive:** `CC_SHA256` (CommonCrypto) over the server leaf certificate's
   SPKI (Subject Public Key Info).
 - **Purpose:** TLS pinning. Each new connection's leaf-cert SPKI is hashed and
@@ -65,7 +65,7 @@ in the source tree.
 
 ### 2. Keychain (`KeychainService`)
 
-- **File:** `Sources/ManifoldInference/Services/KeychainService.swift`
+- **File:** `Sources/ManifoldSecrets/KeychainService.swift`
 - **Primitive:** `SecItemAdd`, `SecItemUpdate`, `SecItemCopyMatching`,
   `SecItemDelete` (Security.framework) with class
   `kSecClassGenericPassword` and accessibility
@@ -78,7 +78,7 @@ in the source tree.
 
 ### 3. UUID v5 generation (`UUID+v5`)
 
-- **File:** `Sources/ManifoldInference/Utilities/UUID+v5.swift`
+- **File:** `Sources/ManifoldModelCatalog/UUID+v5.swift`
 - **Primitive:** `Insecure.SHA1` (CryptoKit).
 - **Purpose:** Deterministic name-based UUIDs per RFC 4122 §4.3 (used to derive
   stable identifiers from string names — for fixtures, deduplication, etc.).
@@ -292,9 +292,9 @@ Use this when responding to a procurement security review:
   <https://support.apple.com/guide/security/welcome/web>
 - RFC 7636 (PKCE): <https://datatracker.ietf.org/doc/html/rfc7636>
 - RFC 4122 §4.3 (UUID v5): <https://datatracker.ietf.org/doc/html/rfc4122#section-4.3>
-- ManifoldKit Security Model DocC article: see [`SecurityModel.md`][secmodel]
+- ManifoldKit Threat Model: [`docs/THREAT_MODEL.md`](THREAT_MODEL.md)
 - ManifoldKit Security Policy: [`.github/SECURITY.md`](../.github/SECURITY.md)
-- ManifoldKit Threat Model (when published): `THREAT_MODEL.md` — tracked under #736.
+- ManifoldKit Threat Model: [`THREAT_MODEL.md`](THREAT_MODEL.md).
 
 ---
 
@@ -304,4 +304,4 @@ release that touches `Sources/**/*.swift` files importing `CryptoKit`,
 `CommonCrypto`, or `Security`.*
 
 [cmvp]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search
-[secmodel]: ../Sources/ManifoldCore/ManifoldCore.docc/Articles/SecurityModel.md
+[secmodel]: THREAT_MODEL.md

--- a/docs/LAUNCH-BRIEF.md
+++ b/docs/LAUNCH-BRIEF.md
@@ -70,7 +70,7 @@ corners, like a layer cake viewed from the side. Top to bottom:
 
 - **Band 1 — UI** (top): label `SwiftUI` · chips: `ChatView` · `SessionListView` · `ModelManagementSheet` · `thinking-block UI` · `RAG citations`.
 - **Band 2 — Runtime**: label `ConversationRuntime` · chips: `turn loop (send / regenerate / edit / cancel / branch)` · `tool-approval gating` · `metrics + cost`.
-- **Band 3 — Persistence**: label `SwiftData` · chips: `MessageStore` · `SessionStore` · `EndpointStore` · `migrations V3→V5`.
+- **Band 3 — Persistence**: label `SwiftData` · chips: `MessageStore` · `SessionStore` · `EndpointStore` · `versioned schema migrations`.
 - **Band 4 — Backends** (bottom): label `Inference` · chips: `MLX` · `llama.cpp` · `Foundation Models` · `OpenAI` · `Anthropic` · `Ollama` · `AnyLanguageModel bridge`.
 
 **The "owned" treatment:** all four bands are saturated/filled in ManifoldKit's
@@ -215,7 +215,7 @@ persistence + multi-backend inference into one drop-in chat product.**
    can't reach, wraps FM as just one backend, and ships either a ~5 MB
    `FoundationOnly` build or the whole stack.
 4. **Reliability & security as a product.** TLS pinning, SSRF/DNS guards,
-   throwing Keychain, a published threat model, a fuzz harness, 5,700+ tests,
+   throwing Keychain, a published threat model, a fuzz harness, 6,500+ tests,
    capability-routed structured output, and tool-approval gating.
 
 ### Drop it in
@@ -265,7 +265,7 @@ Anthropic, Ollama — one `GenerationStream` protocol, identical features.
 **3/**
 WWDC 2026 next week? Whatever on-device model Apple ships = one more backend,
 not a rewrite (the stub traits are already in Package.swift). Plus it serves iOS
-18 / macOS 15 that Foundation Models can't. Pre-1.0, MIT, 5,700+ tests.
+18 / macOS 15 that Foundation Models can't. Pre-1.0, MIT, 6,500+ tests.
 → github.com/roryford/ManifoldKit
 
 ---

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -122,7 +122,7 @@ different binary footprints — a manifest choice, not a fork.
 The things that go wrong between the demo and App Store review are first-class:
 TLS certificate pinning (fail-closed on known cloud APIs), SSRF and DNS-rebind
 guards, a throwing Keychain surface, a published `THREAT_MODEL.md`, a fuzz
-harness, and **5,700+ tests**. Capability-routed structured output,
+harness, and **6,500+ tests**. Capability-routed structured output,
 human-in-the-loop tool approval, and cost/metrics observability are built in,
 not bolted on.
 

--- a/docs/QUICKSTART-APPINTENTS.md
+++ b/docs/QUICKSTART-APPINTENTS.md
@@ -17,7 +17,7 @@ Add it explicitly to your target, and enable the `AppIntents` trait on the packa
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.43.0", // x-release-please-version
+    from: "0.46.0", // x-release-please-version
     traits: [.trait(name: "AppIntents")]
 )
 ```

--- a/docs/QUICKSTART-RAG.md
+++ b/docs/QUICKSTART-RAG.md
@@ -50,7 +50,7 @@ the `Llama` trait (the on-device `LlamaEmbeddingBackend` lives in
 dependencies: [
     .package(
         url: "https://github.com/roryford/ManifoldKit.git",
-        from: "0.44.0" // x-release-please-version
+        from: "0.46.0" // x-release-please-version
     ),
 ],
 targets: [

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -10,9 +10,7 @@ The format is deliberate: every "X is enforced by Y" claim links to the actual f
 workflow. Every "X is not mitigated" row names the tracking issue (or explains why an
 item is permanently out of scope).
 
-For a higher-level narrative — and the corresponding DocC API surface — see the
-[Security Model](../Sources/ManifoldCore/ManifoldCore.docc/Articles/SecurityModel.md)
-article.
+For a higher-level narrative, see [SECURITY.md](../SECURITY.md).
 
 ## Audience and scope
 
@@ -136,8 +134,8 @@ considered hostile on the far side and what ManifoldKit validates as data crosse
 - **Not mitigated:** semantic prompt injection. **ManifoldKit does not solve
   prompt injection.** System prompts are not a security boundary; tool calls and
   retrieved content are untrusted from the model's perspective. See the
-  [Security Model](../Sources/ManifoldCore/ManifoldCore.docc/Articles/SecurityModel.md#prompt-injection-explicit-disclaimer)
-  article for guidance.
+  [Threats considered — User content ↔ model](#b4-user-content--model)
+  section above for the explicit disclaimer.
 
 ### B5. UI / framework ↔ host application
 
@@ -319,8 +317,7 @@ Each item is either deferred to a tracked issue or explicitly out of scope.
 
 - [SECURITY.md](../SECURITY.md) — disclosure policy, supported versions, build-mode
   guarantees.
-- [Security Model](../Sources/ManifoldCore/ManifoldCore.docc/Articles/SecurityModel.md)
-  — DocC article covering in-source mitigations at API granularity.
+- [`docs/FIPS.md`](FIPS.md) — cryptographic primitive inventory and FIPS posture.
 - [`TrafficBoundaryAuditTest`](../Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift)
   — the source-grep audit referenced throughout.
 - [`DenyAllURLProtocol`](../Sources/ManifoldTestSupport/DenyAllURLProtocol.swift)


### PR DESCRIPTION
## Summary

5-worker parallel audit of all 100+ markdown files — root docs, quickstarts, technical docs, and DocC articles. Fixes are targeted surgical edits only.

**Root & quickstart docs**
- `README.md`: `ConversationRuntime` API updated to `processTurn(TurnInput(...))` (old per-operation methods removed), library/executable counts corrected (14→25 / 2→3), test count updated (5,700→6,500+)
- `AGENTS.md`: 4 stale version pins bumped (0.36→0.46), `ChatMessageRecord` → `ChatMessage` in type description
- `CONTRIBUTING.md`: architecture invariant updated to current `processTurn` API
- `docs/QUICKSTART-APPINTENTS.md`, `QUICKSTART-RAG.md`: stale version pins bumped

**Technical docs**
- `docs/FIPS.md`: 5 stale file paths fixed (`PinnedSessionDelegate` → ManifoldCloudCore, `KeychainService` → ManifoldSecrets, `UUID+v5` → ManifoldModelCatalog); broken ManifoldCore DocC link removed
- `docs/THREAT_MODEL.md`: broken ManifoldCore intro link removed, dead anchor fixed, added FIPS.md cross-ref
- `docs/POSITIONING.md` + `LAUNCH-BRIEF.md`: test count updated to 6,500+; stale V3→V5 schema migration claim removed
- `Example/README.md`: `chatViewModel.inferenceService` (internal) → `result.bootstrap.inferenceService` (public)

**DocC articles**
- `ManifoldRuntime.docc`: `Backend` → `InferenceBackend` symbol links (no public type named `Backend`)
- `ManifoldInference.docc`: architecture description updated to reflect ManifoldContract dependency split (Foundation + Cloud now target ManifoldContract, not ManifoldInference)
- `ManifoldPersistenceSwiftData.docc`: `Agent` → `PersistedAgent` in @Model type list
- `ManifoldAppIntents.docc`: `ask_base_chat_demo_intent` → `ask_manifold_demo_intent` (stale BaseChatKit-era name)

## Test plan

- [ ] CI passes (docs-only change — readme-snippets + lint jobs are the relevant gates)
- [ ] No files outside the 14 changed files were touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)