### PR TITLE
chore: fix all owned-code warnings (deprecated APIs, Sendable, unused vars)

### DIFF
--- a/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
+++ b/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
@@ -46,16 +46,24 @@ public enum DefaultBackends {
     /// without instantiating hardware-dependent backends.
     static func backendTypeName(for modelType: ModelType) -> String? {
         switch modelType {
-        #if Llama
-        case .gguf:       return "LlamaBackend"
-        #endif
-        #if MLX
-        case .mlx:        return "MLXBackend"
-        #endif
-        #if canImport(FoundationModels)
-        case .foundation: return "FoundationBackend"
-        #endif
-        default:          return nil
+        case .gguf:
+            #if Llama
+            return "LlamaBackend"
+            #else
+            return nil
+            #endif
+        case .mlx:
+            #if MLX
+            return "MLXBackend"
+            #else
+            return nil
+            #endif
+        case .foundation:
+            #if canImport(FoundationModels)
+            return "FoundationBackend"
+            #else
+            return nil
+            #endif
         }
     }
 

--- a/Sources/ManifoldHardware/GGUFSignedManifest.swift
+++ b/Sources/ManifoldHardware/GGUFSignedManifest.swift
@@ -133,6 +133,7 @@ public struct GGUFSignedManifestVerifier: Sendable {
         }
     }
 
+    @discardableResult
     private func requireAcceptedSignature(for manifest: GGUFSignedManifest) throws -> GGUFSignedManifest.Signature {
         guard let signature = manifest.signature else {
             throw GGUFSignedManifestVerificationError.unsignedManifest

--- a/Sources/ManifoldHardware/MemoryPressureBroadcaster.swift
+++ b/Sources/ManifoldHardware/MemoryPressureBroadcaster.swift
@@ -44,7 +44,7 @@ package final class MemoryPressureBroadcaster: @unchecked Sendable {
             }
             continuation.onTermination = { [weak self] _ in
                 self?.lock.withLock { continuations in
-                    continuations.removeValue(forKey: key)
+                    _ = continuations.removeValue(forKey: key)
                 }
             }
         }

--- a/Sources/ManifoldHardware/StructuredOutputStrategy.swift
+++ b/Sources/ManifoldHardware/StructuredOutputStrategy.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// Backend-specific mechanism used to request structured model output.
-public enum StructuredOutputStrategy: Sendable, Equatable {
+// `any Decodable.Type` is a metatype — safely shareable across concurrency
+// boundaries since metatypes carry no mutable instance state.
+public enum StructuredOutputStrategy: @unchecked Sendable, Equatable {
     /// GBNF grammar string for sampler-level constrained decoding.
     case gbnf(String)
     /// Foundation guided-generation target type.
@@ -28,7 +30,7 @@ public enum StructuredOutputStrategy: Sendable, Equatable {
 }
 
 /// Payload a caller wants a backend to produce in structured form.
-public struct StructuredOutputTarget: Sendable, Equatable {
+public struct StructuredOutputTarget: @unchecked Sendable, Equatable {
     public var gbnfGrammar: String?
     public var guidedType: (any Decodable.Type)?
     public var jsonSchema: String?

--- a/Sources/ManifoldInference/Networking/CompositeURLSessionDelegate.swift
+++ b/Sources/ManifoldInference/Networking/CompositeURLSessionDelegate.swift
@@ -85,7 +85,7 @@ extension CompositeURLSessionDelegate: URLSessionDelegate {
     public func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
         // The pinning delegate (when present) owns the response — its
         // `urlSession(_:didReceive:completionHandler:)` is required to call
@@ -228,7 +228,7 @@ extension CompositeURLSessionDelegate: URLSessionDataDelegate {
         _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
     ) {
         if let dataDelegate {
             dataDelegate.urlSession?(

--- a/Sources/ManifoldLlama/LlamaModelLoader.swift
+++ b/Sources/ManifoldLlama/LlamaModelLoader.swift
@@ -294,7 +294,7 @@ final class LlamaModelLoader: @unchecked Sendable {
             llama_model_meta_val_str(model, key, ptr.baseAddress, ptr.count)
         }
         guard written > 0 else { return nil }
-        return String(cString: buffer)
+        return buffer.withUnsafeBytes { ptr in String(decoding: ptr.prefix(Int(written)), as: UTF8.self) }
     }
 
     /// Reads `general.architecture` from the loaded GGUF model's metadata.
@@ -313,7 +313,7 @@ final class LlamaModelLoader: @unchecked Sendable {
             llama_model_meta_val_str(model, key, ptr.baseAddress, ptr.count)
         }
         guard written > 0 else { return nil }
-        return String(cString: buffer)
+        return buffer.withUnsafeBytes { ptr in String(decoding: ptr.prefix(Int(written)), as: UTF8.self) }
     }
 }
 #endif

--- a/Sources/ManifoldLlama/LlamaTokenization.swift
+++ b/Sources/ManifoldLlama/LlamaTokenization.swift
@@ -44,12 +44,10 @@ enum LlamaTokenization {
         }
 
         // Try to form a valid UTF-8 string
-        invalidUTF8Buffer.append(0) // null-terminate
-        if let str = String(validatingUTF8: invalidUTF8Buffer) {
+        if let str = String(validating: invalidUTF8Buffer.map { UInt8(bitPattern: $0) }, as: UTF8.self) {
             invalidUTF8Buffer.removeAll()
             return str.isEmpty ? nil : str
         }
-        invalidUTF8Buffer.removeLast() // remove null terminator, keep accumulating
         return nil
     }
 }

--- a/Sources/ManifoldMLX/Diffusion/Flux/FluxDiffusionBackend.swift
+++ b/Sources/ManifoldMLX/Diffusion/Flux/FluxDiffusionBackend.swift
@@ -175,7 +175,7 @@ public final class FluxDiffusionBackend: ImageGenerationBackend, @unchecked Send
             return had
         }
         if wasLoaded {
-            MLX.GPU.set(cacheLimit: 0)
+            MLX.Memory.cacheLimit = 0
         }
     }
 

--- a/Sources/ManifoldMLX/MLXDiffusionBackend.swift
+++ b/Sources/ManifoldMLX/MLXDiffusionBackend.swift
@@ -179,7 +179,7 @@ public final class MLXDiffusionBackend: ImageGenerationBackend, @unchecked Senda
                     // This prevents UNet activations and VAE activations from
                     // competing for GPU memory simultaneously.
                     let decode = generator.detachedDecoder()
-                    MLX.GPU.set(cacheLimit: 0)
+                    MLX.Memory.cacheLimit = 0
 
                     let decoded = decode(finalLatent)
                     // decode() returns float32 in [0, 1]; Image expects uint8 [0, 255].
@@ -225,7 +225,7 @@ public final class MLXDiffusionBackend: ImageGenerationBackend, @unchecked Senda
         // MLX.GPU.set(cacheLimit:) before any MLX work triggers Metal
         // initialisation and crashes in test environments.
         if wasLoaded {
-            MLX.GPU.set(cacheLimit: 0)
+            MLX.Memory.cacheLimit = 0
         }
     }
 

--- a/Sources/ManifoldModelCatalog/UUID+v5.swift
+++ b/Sources/ManifoldModelCatalog/UUID+v5.swift
@@ -17,7 +17,7 @@ extension UUID {
         let hash = Array(sha1.finalize())
 
         // Set version (4 bits) to 0101 (v5) and variant (2 bits) to 10.
-        var uuid = (
+        let uuid = (
             hash[0], hash[1], hash[2], hash[3],
             hash[4], hash[5],
             (hash[6] & 0x0F) | 0x50,  // version 5

--- a/Sources/ManifoldNetworking/NetworkActivityTrackingDelegate.swift
+++ b/Sources/ManifoldNetworking/NetworkActivityTrackingDelegate.swift
@@ -52,7 +52,7 @@ package final class NetworkActivityTrackingDelegate: NSObject, URLSessionDataDel
         _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        completionHandler: @escaping @Sendable (URLSession.ResponseDisposition) -> Void
     ) {
         ensureBegin(for: dataTask)
         if let downstream {

--- a/Sources/ManifoldTestSupport/ConversationRuntimeScenario.swift
+++ b/Sources/ManifoldTestSupport/ConversationRuntimeScenario.swift
@@ -236,9 +236,8 @@ enum ConversationRuntimeScenarioRunner {
         runtime: ConversationRuntime,
         drivingAction: () async throws -> ConversationStreamHandle
     ) async -> ConversationRuntimeScenarioResult.StepResult {
-        let handle: ConversationStreamHandle
         do {
-            handle = try await drivingAction()
+            _ = try await drivingAction()
         } catch let caught {
             return ConversationRuntimeScenarioResult.StepResult(
                 action: step.action,


### PR DESCRIPTION
## Summary

- **Deprecated string/memory APIs** — `String(cString:)` and `String(validatingUTF8:)` replaced with `withUnsafeBytes`+`String(decoding:as:)`/`String(validating:as:)` in `LlamaModelLoader` and `LlamaTokenization`; `MLX.GPU.set(cacheLimit:)` replaced with `MLX.Memory.cacheLimit =` in `FluxDiffusionBackend` and `MLXDiffusionBackend`
- **Sendable warnings** — `completionHandler` params annotated `@Sendable` in `CompositeURLSessionDelegate` and `NetworkActivityTrackingDelegate`; `StructuredOutputStrategy`/`StructuredOutputTarget` marked `@unchecked Sendable` (metatypes carry no mutable state)
- **Unreachable default** — `DefaultBackends.backendTypeName(for:)` switch restructured to exhaustive per-case `#if` blocks
- **Unused results / trivial** — `@discardableResult` on `GGUFSignedManifest.requireAcceptedSignature`; `_ =` on `withLock` in `MemoryPressureBroadcaster`; dropped unused `handle` binding in `ConversationRuntimeScenario`; removed spurious `await` in `InternalMCPTransport.readOutputLoop`; `var → let` for uuid tuple in `UUID+v5`

Vendored sources (`StableDiffusion/`, `FluxSwift/`) are intentionally left untouched.

## Test plan

- [x] `scripts/test.sh --profile ci --skip-update` — 83/83 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)