### PR TITLE
fix: close connect-time DNS-rebinding TOCTOU in cloud transport

### DIFF
--- a/Sources/ManifoldCloud/OllamaModelListService.swift
+++ b/Sources/ManifoldCloud/OllamaModelListService.swift
@@ -72,7 +72,10 @@ public final class OllamaModelListService: Sendable {
         var request = URLRequest(url: tagsURL)
         request.httpMethod = "GET"
 
-        let (data, response) = try await urlSession.data(for: request)
+        // Connect-time IP pinning closes the DNS-rebinding TOCTOU the pre-flight
+        // `DNSRebindingGuard.validate(url:)` above cannot — it checks the address
+        // URLSession actually connected to (see ConnectAddressPinningDelegate).
+        let (data, response) = try await ConnectAddressPinningDelegate.pinnedData(for: request, on: urlSession)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw CloudBackendError.networkError(

--- a/Sources/ManifoldCloud/OllamaModelProbe.swift
+++ b/Sources/ManifoldCloud/OllamaModelProbe.swift
@@ -2,6 +2,7 @@
 import Foundation
 import os
 import ManifoldInference
+import ManifoldCloudCore
 
 /// Decoded subset of Ollama's `/api/show` response we actually consume.
 struct OllamaShowProbe {
@@ -42,7 +43,10 @@ enum OllamaModelProbe {
 
         let (data, response): (Data, URLResponse)
         do {
-            (data, response) = try await urlSession.data(for: request)
+            // Connect-time IP pinning: a probe that rebinds to a private address
+            // is cancelled and surfaced as a throw here, degrading to non-thinking
+            // (the safe direction) rather than reaching an internal host.
+            (data, response) = try await ConnectAddressPinningDelegate.pinnedData(for: request, on: urlSession)
         } catch {
             Log.network.info("OllamaBackend /api/show probe failed (\(error.localizedDescription, privacy: .public)) — treating \(modelName, privacy: .public) as non-thinking")
             return .empty

--- a/Sources/ManifoldCloud/WebSearch/DefaultWebSearchRuntime.swift
+++ b/Sources/ManifoldCloud/WebSearch/DefaultWebSearchRuntime.swift
@@ -61,7 +61,7 @@ public final class DefaultWebSearchRuntime: WebSearchRuntime {
             "max_tokens": 1000
         ])
 
-        let (responseData, response) = try await urlSession.data(for: request)
+        let (responseData, response) = try await ConnectAddressPinningDelegate.pinnedData(for: request, on: urlSession)
         let httpStatus = (response as? HTTPURLResponse)?.statusCode
         guard httpStatus == 200 else {
             throw WebSearchRuntimeError.httpFailure(status: httpStatus)

--- a/Sources/ManifoldCloudCore/ConnectAddressPinningDelegate.swift
+++ b/Sources/ManifoldCloudCore/ConnectAddressPinningDelegate.swift
@@ -1,0 +1,122 @@
+import Foundation
+import ManifoldInference
+
+/// Per-task `URLSessionTaskDelegate` that closes the connect-time half of the
+/// DNS-rebinding TOCTOU on the cloud transport path.
+///
+/// ## The residual window `DNSRebindingGuard` cannot close
+///
+/// ``DNSRebindingGuard/validate(url:)`` resolves the endpoint hostname with its
+/// own `getaddrinfo` query *before* the request and fails closed on a private
+/// address. But `URLSession.bytes(for:)` / `data(for:)` re-resolve the hostname
+/// at connect time with a **separate** query. An attacker controlling DNS can
+/// return a public IP to the guard's pre-flight query (so the check passes) and a
+/// private IP — loopback, RFC1918, `169.254.169.254` (cloud IMDS), link-local,
+/// IPv4-mapped, NAT64, etc. — to URLSession's actual connection, reaching internal
+/// services. The pre-resolution guard never sees the address URLSession truly used.
+///
+/// This delegate closes that window by inspecting the address URLSession
+/// *actually* connected to (`URLSessionTaskTransactionMetrics.remoteAddress`,
+/// per redirect hop) once the connection's metrics are collected, classifying it
+/// with ``PrivateIPClassifier``, and cancelling the task plus recording a
+/// blocked-connection URL on violation. The transport reads ``blockedConnectedURL``
+/// after the request returns (or after the stream errors) and surfaces
+/// ``CloudBackendError/blockedAddress(_:)``.
+///
+/// Localhost literals (`localhost`, `127.0.0.1`, `::1`) bypass the check — these
+/// are explicitly configured local servers (Ollama, LM Studio), mirroring the
+/// bypass in ``DNSRebindingGuard`` and ``PrivateIPClassifier/isLocalhostURL(_:)``.
+///
+/// ## Defense-in-depth, not a replacement
+///
+/// This composes with — and does not replace — the pre-resolution
+/// ``DNSRebindingGuard`` (which catches the "guard saw a private IP" half of the
+/// window and fails closed before any bytes are sent) and the session-level
+/// ``RedirectGuardDelegate`` (hop cap, scheme-downgrade reject, redirect-target IP
+/// filter, cross-origin credential strip). All three fire on the cloud session task.
+///
+/// - Note: This intentionally parallels `ManifoldMCP`'s `MCPRedirectCapDelegate`
+///   connect-time pinning (PR #1748). ManifoldMCP depends on `ManifoldInference`,
+///   not `ManifoldCloudCore`, and the reverse edge is likewise forbidden by the
+///   module dependency rules, so the small delegate logic is mirrored cloud-side
+///   rather than shared as a single type. The IP-classification logic itself
+///   (`PrivateIPClassifier`) *is* shared across both stacks.
+public final class ConnectAddressPinningDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+
+    /// Lock guarding `_blockedConnectedURL`. URLSession delivers
+    /// `didFinishCollecting` on an arbitrary background queue, so the violation
+    /// flag must be written under a lock and read back on the caller's actor.
+    private let lock = NSLock()
+    private var _blockedConnectedURL: URL?
+
+    /// The URL whose connection resolved to a blocked (private/reserved) address,
+    /// or `nil` if every connected address was acceptable. Read by the transport
+    /// after the request completes to decide whether to throw
+    /// ``CloudBackendError/blockedAddress(_:)``.
+    var blockedConnectedURL: URL? {
+        lock.withLock { _blockedConnectedURL }
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        // Inspect every transaction (the original request plus any redirect hops):
+        // each carries the address URLSession actually connected to. If any one is
+        // private/reserved, the connection touched an internal host — block it.
+        for transaction in metrics.transactionMetrics {
+            guard let requestURL = transaction.request.url,
+                  let remote = transaction.remoteAddress,
+                  let category = Self.classifyConnectedAddress(remote, for: requestURL) else {
+                continue
+            }
+            Log.network.error(
+                "Cloud transport: blocked connection — \(requestURL.host ?? "?", privacy: .public) connected to \(remote, privacy: .public) (\(category.description, privacy: .public)). DNS rebinding TOCTOU."
+            )
+            lock.withLock {
+                if _blockedConnectedURL == nil { _blockedConnectedURL = requestURL }
+            }
+            // Cancel so no further bytes flow over the offending connection — a
+            // long-lived SSE stream that rebinds mid-handshake is torn down here.
+            task.cancel()
+            return
+        }
+    }
+
+    /// Classifies the address URLSession connected to, returning the blocked
+    /// category or `nil` when the address is public (or the request targets an
+    /// explicitly configured localhost server, which always bypasses).
+    ///
+    /// `remoteAddress` from `URLSessionTaskTransactionMetrics` is a bare numeric
+    /// host (no port), but may carry an IPv6 zone identifier (`fe80::1%en0`);
+    /// ``PrivateIPClassifier`` strips the zone, so we pass it through unchanged.
+    static func classifyConnectedAddress(_ remoteAddress: String, for url: URL) -> BlockedAddressCategory? {
+        if PrivateIPClassifier.isLocalhostURL(url) { return nil }
+        return PrivateIPClassifier.classifyIPLiteral(remoteAddress)
+    }
+
+    /// Performs `session.data(for:)` with connect-time IP pinning attached, then
+    /// throws ``CloudBackendError/blockedAddress(_:)`` if URLSession connected to a
+    /// private/reserved address (DNS rebinding) before returning the response body.
+    ///
+    /// `data(for:)` returns only after the task completes, by which point the
+    /// connection's metrics report the address URLSession actually connected to —
+    /// so a single post-call check covers the whole request. Non-streaming cloud
+    /// callers (Ollama model-list / probe, web search) use this instead of calling
+    /// `data(for:)` directly so they get the same connect-time guarantee the SSE
+    /// path has, without each call site re-implementing the check.
+    public static func pinnedData(
+        for request: URLRequest,
+        on session: URLSession
+    ) async throws -> (Data, URLResponse) {
+        let connectionGuard = ConnectAddressPinningDelegate()
+        let (data, response) = try await session.data(for: request, delegate: connectionGuard)
+        if let blocked = connectionGuard.blockedConnectedURL {
+            throw CloudBackendError.blockedAddress(
+                "Connection to \(blocked.host ?? "endpoint") resolved to a private/reserved address (DNS rebinding) — blocked"
+            )
+        }
+        return (data, response)
+    }
+}

--- a/Sources/ManifoldCloudCore/SSEGenerationSupport.swift
+++ b/Sources/ManifoldCloudCore/SSEGenerationSupport.swift
@@ -19,3 +19,19 @@ final class WeakBox<T: AnyObject>: @unchecked Sendable {
     weak var value: T?
     init(_ value: T?) { self.value = value }
 }
+
+/// Sendable wrapper for a strong, lock-guarded reference to a non-Sendable class.
+///
+/// Used to hand the successful connection's `ConnectAddressPinningDelegate` from
+/// the retry closure (which runs off the runner's task) back to the `run` catch
+/// path so a mid-stream DNS-rebinding cancellation can be distinguished from a
+/// user cancellation. The reference must be *strong* — a weak box could drop the
+/// delegate before the catch path reads its violation flag.
+final class StrongBox<T: AnyObject>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: T?
+    var value: T? {
+        get { lock.withLock { _value } }
+        set { lock.withLock { _value = newValue } }
+    }
+}

--- a/Sources/ManifoldCloudCore/SSEGenerationTaskRunner.swift
+++ b/Sources/ManifoldCloudCore/SSEGenerationTaskRunner.swift
@@ -56,10 +56,12 @@ struct SSEGenerationTaskRunner {
         defer { context.finishGeneration() }
 
         var streamError: Error?
+        let connectionGuardBox = StrongBox<ConnectAddressPinningDelegate>()
         do {
             try await context.validateEndpoint()
 
-            let bytes = try await openConnection(streamBox: streamBox)
+            let (bytes, connectionGuard) = try await openConnection(streamBox: streamBox)
+            connectionGuardBox.value = connectionGuard
 
             await MainActor.run { streamBox.value?.setPhase(.streaming) }
             try await context.streamParser(bytes, continuation)
@@ -68,7 +70,18 @@ struct SSEGenerationTaskRunner {
             continuation.finish()
         } catch {
             streamError = error
-            if error is CancellationError || Task.isCancelled {
+            // A connection that rebinds to a private address mid-stream is
+            // cancelled by the guard's metrics hook; surface it as a blocked
+            // address rather than a silent finish.
+            if let blocked = connectionGuardBox.value?.blockedConnectedURL {
+                let blockError = CloudBackendError.blockedAddress(
+                    "Connection to \(blocked.host ?? "endpoint") rebound to a private/reserved address mid-stream — blocked"
+                )
+                streamError = blockError
+                Log.network.error("\(context.currentBackendName()) stream blocked: DNS rebinding to private address mid-stream")
+                await MainActor.run { streamBox.value?.setPhase(.failed(blockError.localizedDescription)) }
+                continuation.finish(throwing: blockError)
+            } else if error is CancellationError || Task.isCancelled {
                 continuation.finish()
             } else {
                 Log.network.error("\(context.currentBackendName()) stream error: \(error.localizedDescription, privacy: .private)")
@@ -91,10 +104,10 @@ struct SSEGenerationTaskRunner {
 
     private func openConnection(
         streamBox: WeakBox<GenerationStream>
-    ) async throws -> URLSession.AsyncBytes {
+    ) async throws -> (URLSession.AsyncBytes, ConnectAddressPinningDelegate) {
         let retryCounter = SendableCounter()
 
-        let (bytes, _) = try await withRetry(
+        let (bytes, _, connectionGuard) = try await withRetry(
             strategy: context.retryStrategy,
             sleeper: context.retrySleeper ?? { try await Task.sleep(for: $0) }
         ) {
@@ -109,7 +122,28 @@ struct SSEGenerationTaskRunner {
             if let lastID = context.eventIDTracker.lastEventID {
                 attemptRequest.setValue(lastID, forHTTPHeaderField: "Last-Event-ID")
             }
-            let (bytes, response) = try await context.session.bytes(for: attemptRequest)
+
+            // Connect-time IP pinning closes the DNS-rebinding TOCTOU that the
+            // pre-flight `DNSRebindingGuard` (run in `context.validateEndpoint()`)
+            // cannot: it inspects the address URLSession actually connected to.
+            // A per-task delegate fires `didFinishCollecting` alongside the
+            // session-level composite delegate without displacing it.
+            let connectionGuard = ConnectAddressPinningDelegate()
+            let (bytes, response) = try await context.session.bytes(
+                for: attemptRequest,
+                delegate: connectionGuard
+            )
+
+            // If the connection's metrics already report a private/reserved remote
+            // address by the time the response headers arrive, block before
+            // consuming any stream bytes. The guard also cancels the task on
+            // violation, so a poisoned long-lived SSE connection is torn down and
+            // surfaces as a stream error in the parser below.
+            if let blocked = connectionGuard.blockedConnectedURL {
+                throw CloudBackendError.blockedAddress(
+                    "Connection to \(blocked.host ?? "endpoint") resolved to a private/reserved address (DNS rebinding) — blocked"
+                )
+            }
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 // Carry the rim's `serverError(statusCode: 0, ...)`
@@ -124,9 +158,9 @@ struct SSEGenerationTaskRunner {
             }
 
             try await context.statusValidator(httpResponse, bytes)
-            return (bytes, httpResponse)
+            return (bytes, httpResponse, connectionGuard)
         }
 
-        return bytes
+        return (bytes, connectionGuard)
     }
 }

--- a/Tests/ManifoldBackendsTests/ConnectAddressPinningDelegateTests.swift
+++ b/Tests/ManifoldBackendsTests/ConnectAddressPinningDelegateTests.swift
@@ -1,0 +1,118 @@
+#if Ollama || CloudSaaS
+import XCTest
+@testable import ManifoldCloudCore
+import ManifoldInference
+
+/// Connect-time DNS-rebinding TOCTOU — cloud transport stack.
+///
+/// `DNSRebindingGuard.validate(url:)` resolves the endpoint hostname with its own
+/// `getaddrinfo` query *before* the request and fails closed on a private address.
+/// But `URLSession.bytes(for:)` / `data(for:)` re-resolve the hostname with a
+/// *separate* query at connect time. An attacker controlling DNS returns a public
+/// IP to the guard's pre-flight query (so the check passes) and a private IP to
+/// URLSession's query — reaching internal hosts despite the pre-flight check.
+///
+/// These tests exercise the connect-time pin in ``ConnectAddressPinningDelegate``,
+/// which inspects the address URLSession *actually* connected to
+/// (`URLSessionTaskTransactionMetrics.remoteAddress`) and blocks it if private.
+/// `URLSessionTaskMetrics` has no public initializer, so we drive the decision
+/// point — `classifyConnectedAddress(_:for:)` — directly. That function is the
+/// sole gate between an observed connected address and the
+/// `CloudBackendError.blockedAddress` the transport throws.
+///
+/// This is the cloud-side sibling of `MCPConnectedAddressGuardTests` (PR #1748).
+final class ConnectAddressPinningDelegateTests: XCTestCase {
+
+    // MARK: - The TOCTOU is closed: guard saw public, connection went private
+
+    func test_connectionToPrivateAddress_isBlocked_evenWhenHostIsPublicName() {
+        // Pre-flight resolved `api.example.com` to a public IP (the attacker's
+        // first answer); URLSession then connected to a private/reserved address.
+        // The connect-time pin must classify that as a block.
+        let publicHostURL = URL(string: "https://api.example.com/v1/chat/completions")!
+
+        let blockedAddresses = [
+            "169.254.169.254",  // link-local / cloud IMDS
+            "127.0.0.1",        // loopback
+            "10.0.0.5",         // RFC1918
+            "192.168.1.20",     // RFC1918
+            "172.16.4.4",       // RFC1918
+            "100.64.0.1",       // carrier-grade NAT / cloud-internal
+            "::1",              // IPv6 loopback
+            "fd00::1",          // IPv6 unique-local
+            "fe80::1",          // IPv6 link-local
+            "::ffff:127.0.0.1", // IPv4-mapped loopback
+            "64:ff9b::a00:5"    // NAT64-embedded RFC1918
+        ]
+
+        for address in blockedAddresses {
+            let category = ConnectAddressPinningDelegate.classifyConnectedAddress(address, for: publicHostURL)
+            XCTAssertNotNil(
+                category,
+                "Connection to \(address) for a public hostname must be blocked (DNS rebinding TOCTOU)"
+            )
+        }
+    }
+
+    // MARK: - Legitimate public connections still pass
+
+    func test_connectionToPublicAddress_isAllowed() {
+        let url = URL(string: "https://api.openai.com/v1/chat/completions")!
+        // 93.184.216.34 is example.com's public IP — must not be blocked.
+        XCTAssertNil(
+            ConnectAddressPinningDelegate.classifyConnectedAddress("93.184.216.34", for: url),
+            "A public connected address must not be blocked"
+        )
+    }
+
+    // MARK: - Explicit localhost servers bypass the pin (Ollama, LM Studio)
+
+    func test_explicitLocalhostURL_bypassesConnectedAddressPin() {
+        // An explicitly configured local server (http://127.0.0.1 — e.g. Ollama)
+        // connecting to 127.0.0.1 is legitimate — the pin must not block it. This
+        // mirrors the isLocalhostURL bypass in DNSRebindingGuard.
+        let localhostURL = URL(string: "http://127.0.0.1:11434/api/tags")!
+        XCTAssertNil(
+            ConnectAddressPinningDelegate.classifyConnectedAddress("127.0.0.1", for: localhostURL),
+            "Explicitly configured localhost server must bypass the connected-address pin"
+        )
+
+        let localhostNameURL = URL(string: "http://localhost:11434/api/tags")!
+        XCTAssertNil(
+            ConnectAddressPinningDelegate.classifyConnectedAddress("127.0.0.1", for: localhostNameURL),
+            "localhost name must bypass the connected-address pin"
+        )
+
+        let ipv6LoopbackURL = URL(string: "http://[::1]:11434/api/tags")!
+        XCTAssertNil(
+            ConnectAddressPinningDelegate.classifyConnectedAddress("::1", for: ipv6LoopbackURL),
+            "Explicitly configured ::1 server must bypass the connected-address pin"
+        )
+    }
+
+    // MARK: - Non-localhost host connecting to loopback is still an attack
+
+    func test_publicHostConnectingToLoopback_isBlocked() {
+        // A remote domain that connects to 127.0.0.1 is a rebinding attack even
+        // though 127.0.0.1 is loopback — only an *explicitly configured* localhost
+        // URL bypasses, not any connection that happens to land on loopback.
+        let url = URL(string: "https://totally-legit.example.com/v1/chat/completions")!
+        XCTAssertNotNil(
+            ConnectAddressPinningDelegate.classifyConnectedAddress("127.0.0.1", for: url),
+            "A public hostname connecting to loopback must be blocked (rebinding attack)"
+        )
+    }
+
+    // MARK: - IPv6 zone identifier on the connected address is handled
+
+    func test_connectedAddressWithIPv6ZoneID_isClassified() {
+        // remoteAddress can carry a zone identifier (fe80::1%en0). PrivateIPClassifier
+        // strips the zone, so a zoned link-local address must still classify as blocked.
+        let url = URL(string: "https://api.example.com/v1/chat/completions")!
+        XCTAssertNotNil(
+            ConnectAddressPinningDelegate.classifyConnectedAddress("fe80::1%en0", for: url),
+            "A zoned IPv6 link-local connected address must be blocked"
+        )
+    }
+}
+#endif

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -84,7 +84,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
     /// usage is approved. These do legitimate network I/O — cloud backends,
     /// the model-download manager, test infra.
     ///
-    /// **Cap: 48 entries.** Adding to this list weakens Rule 1; require
+    /// **Cap: 49 entries.** Adding to this list weakens Rule 1; require
     /// reviewer sign-off and prefer to route new network code through
     /// `URLSessionProvider` (which is itself in this allowlist).
     private static let networkIOAllowlist: Set<String> = [
@@ -109,6 +109,11 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         "ManifoldCloudCore/URLSessionProvider.swift",
         "ManifoldCloudCore/PinnedSessionDelegate.swift",
         "ManifoldCloudCore/DNSRebindingGuard.swift",
+        // Connect-time IP pinning (DNS-rebinding TOCTOU, sibling of MCP PR #1748):
+        // wraps session.data(for:delegate:) with a URLSessionTaskDelegate that
+        // inspects URLSessionTaskTransactionMetrics.remoteAddress. A genuine
+        // network boundary — references URLSession/URLRequest by design.
+        "ManifoldCloudCore/ConnectAddressPinningDelegate.swift",
         // Phase 2/A + 2/B/i — FramedTransport protocol + concrete impls.
         // All three consume `URLSession.AsyncBytes` from `SSECloudBackend`;
         // they do not construct sessions of their own. No new network
@@ -354,7 +359,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         Self.assertNoOffenders(offenders)
 
         XCTAssertLessThanOrEqual(
-            Self.networkIOAllowlist.count, 48,
+            Self.networkIOAllowlist.count, 49,
             "networkIOAllowlist exceeds cap. Each new entry weakens the rule — re-architect rather than expand the list."
         )
     }


### PR DESCRIPTION
## The residual TOCTOU

`ManifoldCloudCore/DNSRebindingGuard` resolves the endpoint hostname with its own `getaddrinfo` query *before* each request and **fails closed** on a private/reserved address. But `URLSession.bytes(for:)` / `data(for:)` re-resolve the hostname at connect time with a **separate** query. An attacker controlling DNS can return:

- a **public IP** to the guard's pre-flight query → the check passes, and
- a **private IP** (loopback, RFC1918, `169.254.169.254` cloud IMDS, link-local, IPv4-mapped, NAT64, …) to URLSession's actual connection → reaching internal services.

The pre-resolution guard never observes the address URLSession truly connected to. That connect-time window is what this PR closes.

## The fix — connect-time IP pinning

New `ConnectAddressPinningDelegate` (a per-task `URLSessionTaskDelegate`) implements `urlSession(_:task:didFinishCollecting:)`, reads `URLSessionTaskTransactionMetrics.remoteAddress` (the address actually connected to, per redirect hop), classifies it with the shared `PrivateIPClassifier`, and on a private/reserved hit **cancels the task** and records a blocked-connection URL. The transport then surfaces `CloudBackendError.blockedAddress`.

Wired into the cloud request paths:
- **SSE generation** (`SSEGenerationTaskRunner`): per-attempt delegate on `bytes(for:delegate:)`, checked post-connection and again on mid-stream cancellation (a rebind mid-stream is surfaced as a block, not a silent finish).
- **Non-streaming** Ollama model-list, `/api/show` probe, and web-search paths route through `ConnectAddressPinningDelegate.pinnedData(for:on:)`.

Localhost-configured endpoints (Ollama, LM Studio: `localhost`/`127.0.0.1`/`::1`) bypass the pin, mirroring the `isLocalhostURL` bypass in `DNSRebindingGuard`.

## Composition — defense-in-depth, not replacement

The pre-resolution `DNSRebindingGuard` is **untouched**. It still catches the "guard saw a private IP" half of the window and fails closed before any bytes are sent. The session-level `RedirectGuardDelegate` (hop cap, scheme-downgrade reject, redirect-target IP filter, cross-origin credential strip) is also unchanged. The new connect-time pin closes the remaining half: guard's query returned public, URLSession's separate query returned private.

## Sibling MCP fix

This mirrors the connect-time pinning shipped for MCP in **#1748** (`MCPRedirectCapDelegate`). `ManifoldMCP` depends on `ManifoldInference`, not `ManifoldCloudCore`, and the reverse edge is forbidden by the module dependency rules, so the small delegate logic is duplicated cloud-side (with a comment noting the intentional parallel) while the IP-classification logic (`PrivateIPClassifier`) is shared across both stacks.

## Proving test

`ConnectAddressPinningDelegateTests` drives the `classifyConnectedAddress(_:for:)` decision point directly (`URLSessionTaskMetrics` has no public initializer). It proves a request whose hostname would pass the pre-flight guard with a public IP but **connects to a private IP** is blocked — across loopback, RFC1918, link-local/IMDS, CGNAT, IPv6 ULA/link-local, IPv4-mapped, and NAT64 — while public addresses and explicitly-configured localhost servers pass. Sabotage-verified: neutering the classifier fails the block assertions. `TrafficBoundaryAuditTest` allowlists the new network boundary (cap 48→49).

## Gate

`scripts/test.sh --profile local` green (5001 XCTest + Swift Testing, 0 failures). Trait-combo `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)