### PR TITLE
refactor(ManifoldRuntime): extract TurnCompressionCoordinator and thin turn flows

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -15,8 +15,11 @@ package struct ConversationTurnExecutor: Sendable {
     private let events: TurnEventEmitter
     private let emptyResponseObserver: (@Sendable (ConversationRuntime.EmptyResponseDiagnostic) -> Void)?
     private let generationHooks: [any GenerationHook]
-    private let compressionPolicy: (any CompressionPolicy)?
-    private let preTurnCompressionPolicy: (any PreTurnCompressionPolicy)?
+    /// Pre-turn / post-turn compress-and-replace seam. Owns both compression
+    /// policies and the shared summarisation generate closure. See
+    /// ``TurnCompressionCoordinator`` for the ordering contract the
+    /// characterization goldens pin.
+    private let compression: TurnCompressionCoordinator
     private let hookTimeout: Duration
     private let historyShaper: (any HistoryShaper)?
     private let historyAssembler: HistoryAssembler
@@ -66,11 +69,17 @@ package struct ConversationTurnExecutor: Sendable {
         self.ragService = ragService
         self.usageStore = usageStore
         self.registry = registry
-        self.events = TurnEventEmitter(emit)
+        let events = TurnEventEmitter(emit)
+        self.events = events
         self.emptyResponseObserver = emptyResponseObserver
         self.generationHooks = generationHooks
-        self.compressionPolicy = compressionPolicy
-        self.preTurnCompressionPolicy = preTurnCompressionPolicy
+        self.compression = TurnCompressionCoordinator(
+            persistence: persistence,
+            inferenceService: inferenceService,
+            events: events,
+            preTurnPolicy: preTurnCompressionPolicy,
+            postTurnPolicy: compressionPolicy
+        )
         self.hookTimeout = hookTimeout
         self.historyShaper = historyShaper
         self.historyAssembler = HistoryAssembler(providers: historyProviders)
@@ -127,67 +136,11 @@ package struct ConversationTurnExecutor: Sendable {
         // Pre-turn compression: runs before the user message is appended so
         // the just-submitted action always falls outside the compressed
         // segment. Only runs for `.send` turns (not regenerate / edit / branch).
-        // Failures throw to the caller — unlike post-turn compression which
-        // logs and continues, pre-turn failure aborts the turn because the
-        // host's ordering invariant depends on compression completing first.
+        // Failures throw to the caller — see ``TurnCompressionCoordinator``.
         //
-        // userMessage is created AFTER this block so its timestamp naturally
+        // userMessage is created AFTER this call so its timestamp naturally
         // follows the compression summary records in store sort order.
-        if let preTurnPolicy = preTurnCompressionPolicy {
-            let existingHistory: [ChatMessage]
-            do {
-                existingHistory = try await persistence.fetchMessages(sessionID: sessionID)
-            } catch {
-                throw ConversationError.persistence(error)
-            }
-            let lastPromptTokens = existingHistory.last(where: { $0.role == .assistant })?.promptTokens
-            if preTurnPolicy.shouldCompressBeforeTurn(
-                messageCount: existingHistory.count,
-                lastPromptTokens: lastPromptTokens
-            ) {
-                let generate = makeCompressionGenerateClosure()
-                let compressed: [ChatMessage]
-                do {
-                    compressed = try await preTurnPolicy.compressBeforeTurn(
-                        history: existingHistory,
-                        sessionID: sessionID,
-                        generate: generate
-                    )
-                } catch {
-                    throw ConversationError.preTurnCompressionFailed(error)
-                }
-                guard !compressed.isEmpty else {
-                    throw ConversationError.preTurnCompressionFailed(
-                        PreTurnCompressionEmptyResultError()
-                    )
-                }
-                // "Before" bracket for the `.historyCompressed` "after" signal.
-                // The removed set is computed from the policy's replacement
-                // output (records present before but absent from `compressed`)
-                // so the IDs are accurate rather than a placeholder — emitting
-                // it here, after `compressBeforeTurn` resolves but before the
-                // store mutation, keeps it ordered ahead of `.historyCompressed`
-                // without fabricating which records will actually be dropped.
-                let retainedIDs = Set(compressed.map(\.id))
-                let removedIDs = existingHistory.compactMap {
-                    retainedIDs.contains($0.id) ? nil : $0.id
-                }
-                emit(.compressionTriggered(removed: removedIDs, reason: .contextWindowExceeded))
-                do {
-                    try await persistence.deleteMessages(for: sessionID)
-                    for message in compressed {
-                        try await persistence.insertMessage(message)
-                    }
-                } catch {
-                    throw ConversationError.persistence(error)
-                }
-                emit(.historyCompressed(sessionID: sessionID, insertedRecords: compressed))
-                await preTurnPolicy.postCompressBeforeTurn(
-                    sessionID: sessionID,
-                    insertedRecords: compressed
-                )
-            }
-        }
+        try await compression.compressBeforeTurnIfNeeded(sessionID: sessionID)
 
         let userMessage = ChatMessage(
             role: .user,
@@ -210,36 +163,16 @@ package struct ConversationTurnExecutor: Sendable {
 
         // Launch the streaming work through the runtime-owned task registry
         // so cancellation and completion bookkeeping have one owner.
-        await taskRegistry.launch(handle: handle) { [self] in
-            // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
-            for hook in generationHooks {
-                await hook.willBeginTurn(sessionID: sessionID)
-            }
-            let preparedHistory: PreparedTurnHistory
-            do {
-                preparedHistory = try await fetchAndPrepareTurnHistory(
-                    sessionID: sessionID,
-                    turnKind: .send(text: text, attachments: attachments),
-                    userPrompt: text
-                )
-            } catch {
-                await failPreparedTurn(
-                    error,
-                    sessionID: sessionID,
-                    handle: handle,
-                    outcomeCompletion: outcomeCompletion
-                )
-                return
-            }
-            await runGenerationTurn(
-                sessionID: sessionID,
-                userPrompt: text,
-                preparedHistory: preparedHistory,
-                config: config,
-                handle: handle,
-                outcomeCompletion: outcomeCompletion
-            )
-        }
+        await launchGenerationTask(
+            sessionID: sessionID,
+            turnKind: .send(text: text, attachments: attachments),
+            userPrompt: text,
+            config: config,
+            handle: handle,
+            taskRegistry: taskRegistry,
+            firesPreTurnHooks: true,
+            outcomeCompletion: outcomeCompletion
+        )
 
         return handle
     }
@@ -275,36 +208,16 @@ package struct ConversationTurnExecutor: Sendable {
         }
         emit(.messageRemoved(messageID: lastAssistant.id))
 
-        await taskRegistry.launch(handle: handle) { [self] in
-            // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
-            for hook in generationHooks {
-                await hook.willBeginTurn(sessionID: sessionID)
-            }
-            let preparedHistory: PreparedTurnHistory
-            do {
-                preparedHistory = try await fetchAndPrepareTurnHistory(
-                    sessionID: sessionID,
-                    turnKind: .regenerate,
-                    userPrompt: nil
-                )
-            } catch {
-                await failPreparedTurn(
-                    error,
-                    sessionID: sessionID,
-                    handle: handle,
-                    outcomeCompletion: outcomeCompletion
-                )
-                return
-            }
-            await runGenerationTurn(
-                sessionID: sessionID,
-                userPrompt: nil,
-                preparedHistory: preparedHistory,
-                config: config,
-                handle: handle,
-                outcomeCompletion: outcomeCompletion
-            )
-        }
+        await launchGenerationTask(
+            sessionID: sessionID,
+            turnKind: .regenerate,
+            userPrompt: nil,
+            config: config,
+            handle: handle,
+            taskRegistry: taskRegistry,
+            firesPreTurnHooks: true,
+            outcomeCompletion: outcomeCompletion
+        )
 
         return handle
     }
@@ -364,36 +277,16 @@ package struct ConversationTurnExecutor: Sendable {
         }
 
         let handle = ConversationStreamHandle()
-        await taskRegistry.launch(handle: handle) { [self] in
-            // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
-            for hook in generationHooks {
-                await hook.willBeginTurn(sessionID: sessionID)
-            }
-            let preparedHistory: PreparedTurnHistory
-            do {
-                preparedHistory = try await fetchAndPrepareTurnHistory(
-                    sessionID: sessionID,
-                    turnKind: .edit(messageID: messageID, text: text),
-                    userPrompt: nil
-                )
-            } catch {
-                await failPreparedTurn(
-                    error,
-                    sessionID: sessionID,
-                    handle: handle,
-                    outcomeCompletion: outcomeCompletion
-                )
-                return
-            }
-            await runGenerationTurn(
-                sessionID: sessionID,
-                userPrompt: nil,
-                preparedHistory: preparedHistory,
-                config: config,
-                handle: handle,
-                outcomeCompletion: outcomeCompletion
-            )
-        }
+        await launchGenerationTask(
+            sessionID: sessionID,
+            turnKind: .edit(messageID: messageID, text: text),
+            userPrompt: nil,
+            config: config,
+            handle: handle,
+            taskRegistry: taskRegistry,
+            firesPreTurnHooks: true,
+            outcomeCompletion: outcomeCompletion
+        )
         return handle
     }
 
@@ -486,38 +379,73 @@ package struct ConversationTurnExecutor: Sendable {
             thinkingStreamingBatchCharacterLimit: 128,
             loopDetectionEnabled: true
         )
+        // Branch historically does NOT fire `willBeginTurn` pre-turn hooks —
+        // the legacy BranchInput path never did. Preserved as-is.
+        await launchGenerationTask(
+            sessionID: newSessionID,
+            turnKind: .branch(
+                messageID: branchMessageID,
+                newSessionID: newSessionID,
+                newSessionTitle: newSessionTitle,
+                generateAfter: generateAfter
+            ),
+            userPrompt: nil,
+            config: branchConfig,
+            handle: handle,
+            taskRegistry: taskRegistry,
+            firesPreTurnHooks: false,
+            outcomeCompletion: outcomeCompletion
+        )
+        return handle
+    }
+
+    /// Shared launch shape for all four turn flows: pre-turn hook fan-out,
+    /// history fetch/shape/assemble, then the generation inner loop — all on
+    /// the runtime-owned task registry so cancellation and completion
+    /// bookkeeping have one owner. `firesPreTurnHooks` is `false` only for
+    /// the branch flow (legacy parity: BranchInput never fired them).
+    private func launchGenerationTask(
+        sessionID: UUID,
+        turnKind: TurnKind,
+        userPrompt: String?,
+        config: TurnConfig,
+        handle: ConversationStreamHandle,
+        taskRegistry: ConversationTurnTaskRegistry,
+        firesPreTurnHooks: Bool,
+        outcomeCompletion: ConversationTurnOutcomeCompletion?
+    ) async {
         await taskRegistry.launch(handle: handle) { [self] in
+            if firesPreTurnHooks {
+                // Fire pre-turn hooks so consumers can cancel in-flight work from prior turns.
+                for hook in generationHooks {
+                    await hook.willBeginTurn(sessionID: sessionID)
+                }
+            }
             let preparedHistory: PreparedTurnHistory
             do {
                 preparedHistory = try await fetchAndPrepareTurnHistory(
-                    sessionID: newSessionID,
-                    turnKind: .branch(
-                        messageID: branchMessageID,
-                        newSessionID: newSessionID,
-                        newSessionTitle: newSessionTitle,
-                        generateAfter: generateAfter
-                    ),
-                    userPrompt: nil
+                    sessionID: sessionID,
+                    turnKind: turnKind,
+                    userPrompt: userPrompt
                 )
             } catch {
                 await failPreparedTurn(
                     error,
-                    sessionID: newSessionID,
+                    sessionID: sessionID,
                     handle: handle,
                     outcomeCompletion: outcomeCompletion
                 )
                 return
             }
             await runGenerationTurn(
-                sessionID: newSessionID,
-                userPrompt: nil,
+                sessionID: sessionID,
+                userPrompt: userPrompt,
                 preparedHistory: preparedHistory,
-                config: branchConfig,
+                config: config,
                 handle: handle,
                 outcomeCompletion: outcomeCompletion
             )
         }
-        return handle
     }
 
     // MARK: Shared generation inner loop
@@ -1205,83 +1133,15 @@ package struct ConversationTurnExecutor: Sendable {
             }
         }
 
-        // Compression check: ask the policy whether the context is full enough
-        // to warrant compression. Skipped when no token usage is available
-        // (policy can't make a meaningful decision without promptTokens) or
-        // when the backend doesn't report a context size (contextSize == 0).
-        if let compressionPolicy, let promptTokens = usage?.promptTokens {
-            let contextSize = await readContextWindowSize()
-            let contextUtilization = contextSize > 0 ? Double(promptTokens) / Double(contextSize) : 0
-            if contextSize > 0 && compressionPolicy.shouldCompress(promptTokens: promptTokens, contextSize: contextSize, contextUtilization: contextUtilization) {
-                let history: [ChatMessage]
-                do {
-                    history = try await persistence.fetchMessages(sessionID: sessionID)
-                } catch {
-                    Log.inference.warning("CompressionPolicy: fetchMessages failed, skipping compression: \(error.localizedDescription, privacy: .public)")
-                    return
-                }
-
-                let generate = makeCompressionGenerateClosure()
-
-                // preCompact hook: v1 is observational. The plan's hook
-                // contract documents that preCompact CANNOT block compression
-                // (there's no mutation channel for the history shape); a
-                // hook that returns block:true logs a warning but compression
-                // still runs. Emit `.hookFired(event: "preCompact", ...)`
-                // regardless so observability stays consistent.
-                if let turnHookRegistry {
-                    let input = HookInput(
-                        event: .preCompact,
-                        sessionID: sessionID,
-                        toolName: nil,
-                        toolArguments: nil
-                    )
-                    let output = await turnHookRegistry.run(input)
-                    emit(.hookFired(event: "preCompact", sessionID: sessionID))
-                    if output.block {
-                        Log.inference.warning(
-                            "preCompact hook returned block:true — block is not honoured for compaction in v1; ignoring and proceeding with compression."
-                        )
-                    }
-                }
-
-                do {
-                    let compressed = try await compressionPolicy.compress(
-                        history: history,
-                        sessionID: sessionID,
-                        generate: generate
-                    )
-                    // Guard against an empty result — deleting all messages
-                    // without re-inserting anything would silently wipe the
-                    // conversation. Treat this as a policy error; preserve the
-                    // existing history rather than destroying it.
-                    guard !compressed.isEmpty else {
-                        Log.inference.warning(
-                            "CompressionPolicy.compress returned empty history (sessionID=\(sessionID, privacy: .private)); skipping replacement to preserve existing messages"
-                        )
-                        return
-                    }
-                    // "Before" bracket for `.historyCompressed`. Removed IDs are
-                    // derived from the policy's replacement set (records present
-                    // in `history` but absent from `compressed`) so the event
-                    // carries the real dropped records, emitted ahead of the
-                    // store mutation and the "after" `.historyCompressed`.
-                    let retainedIDs = Set(compressed.map(\.id))
-                    let removedIDs = history.compactMap {
-                        retainedIDs.contains($0.id) ? nil : $0.id
-                    }
-                    emit(.compressionTriggered(removed: removedIDs, reason: .contextWindowExceeded))
-                    try await persistence.deleteMessages(for: sessionID)
-                    for message in compressed {
-                        try await persistence.insertMessage(message)
-                    }
-                    emit(.historyCompressed(sessionID: sessionID, insertedRecords: compressed))
-                    await compressionPolicy.postCompress(sessionID: sessionID, insertedRecords: compressed)
-                } catch {
-                    Log.inference.warning("CompressionPolicy.compress failed (sessionID=\(sessionID, privacy: .private)): \(error.localizedDescription, privacy: .public)")
-                }
-            }
-        }
+        // Post-turn compression: runs after the terminal `streamFinished` /
+        // `afterGeneration`, including the preCompact hook (observational in
+        // v1 — block:true is ignored). Failures log and continue; the
+        // generation has already succeeded. See ``TurnCompressionCoordinator``.
+        await compression.compressAfterTurnIfNeeded(
+            sessionID: sessionID,
+            promptTokens: usage?.promptTokens,
+            hookRegistry: turnHookRegistry
+        )
     }
 
 
@@ -1320,12 +1180,6 @@ package struct ConversationTurnExecutor: Sendable {
     private enum TurnPreparationFailure: Error {
         case persistence(any Error)
         case contextAssembly(any Error)
-    }
-
-    private struct PreTurnCompressionEmptyResultError: LocalizedError, Sendable {
-        var errorDescription: String? {
-            "Pre-turn compression returned an empty history."
-        }
     }
 
     private enum HistoryShaperValidationError: LocalizedError, Sendable {
@@ -1485,38 +1339,6 @@ package struct ConversationTurnExecutor: Sendable {
         }
     }
 
-    /// Returns a `@Sendable` closure that drives a background inference call
-    /// for summarisation. Used by both pre-turn and post-turn compression paths.
-    private func makeCompressionGenerateClosure() -> @Sendable ([ChatMessage]) async throws -> String {
-        let inferenceService = self.inferenceService
-        return { messages in
-            let structured = messages
-                .filter { $0.kind.isWireVisible }
-                .map { record -> StructuredMessage in
-                    let role = record.kind.backendRole ?? record.role
-                    return StructuredMessage(role: role.rawValue, parts: record.contentParts)
-                }
-            let (token, compressStream) = try await inferenceService.enqueueAsync(
-                structuredMessages: structured,
-                priority: .background
-            )
-            var result = ""
-            var consumer = GenerationStreamConsumer(loopDetectionEnabled: false)
-            do {
-                for try await event in compressStream.events {
-                    try Task.checkCancellation()
-                    if case .appendText(let chunk) = consumer.handle(event) {
-                        result += chunk
-                    }
-                }
-            } catch {
-                await inferenceService.cancelAsync(token)
-                throw error
-            }
-            return result
-        }
-    }
-
     private func makeTurnContext(
         sessionID: UUID,
         history: [ChatMessage],
@@ -1542,13 +1364,6 @@ package struct ConversationTurnExecutor: Sendable {
             .joined(separator: " ")
             .lowercased()
         return joined.isEmpty ? nil : joined
-    }
-
-    /// Reads the backend's context window size from the main actor.
-    /// Returns 0 when unavailable — callers treat 0 as "skip compression".
-    @MainActor
-    private func readContextWindowSize() async -> Int {
-        inferenceService.capabilities?.contextWindowSize ?? 0
     }
 
     @MainActor

--- a/Sources/ManifoldRuntime/Services/TurnCompressionCoordinator.swift
+++ b/Sources/ManifoldRuntime/Services/TurnCompressionCoordinator.swift
@@ -1,0 +1,250 @@
+import Foundation
+import ManifoldInference
+
+/// Per-turn compression coordination seam, extracted from
+/// ``ConversationTurnExecutor`` (#1725, step P3a). Owns the two
+/// compress-and-replace sequences plus the shared background-summarisation
+/// generate closure both paths drive:
+///
+/// - **Pre-turn** — ``compressBeforeTurnIfNeeded(sessionID:)`` runs at the top
+///   of the send flow, BEFORE the user message is inserted, so the
+///   just-submitted action always falls outside the compressed segment.
+///   Failures throw to the caller: the host's ordering invariant depends on
+///   compression completing first, so a pre-turn failure aborts the turn.
+/// - **Post-turn** — ``compressAfterTurnIfNeeded(sessionID:promptTokens:hookRegistry:)``
+///   runs after the turn's terminal `streamFinished`, at the very end of the
+///   generation path. Failures log and continue — the generation has already
+///   succeeded and must not be retroactively failed by a compression error.
+///
+/// Both paths preserve the event bracket the characterization goldens pin:
+/// `.compressionTriggered` (emitted after the policy resolves but before the
+/// store mutation, carrying the real removed-record IDs) followed by
+/// `.historyCompressed` (after the replacement insert).
+///
+/// The post-turn path also owns the **preCompact** hook call. v1 contract:
+/// the hook is observational — a `block: true` result logs a warning but does
+/// NOT prevent compression (there is no mutation channel for the history
+/// shape). Do not "fix" this without a major-version contract change.
+///
+/// Sendability discipline (invariant 5): this holds the ``TurnEventEmitter``
+/// — a bare `@Sendable (ConversationEvent) -> Void` sink — never a
+/// `@MainActor`-capturing wrapper. The only main-actor state read is the
+/// explicit `@MainActor` ``readContextWindowSize()`` hop.
+struct TurnCompressionCoordinator: Sendable {
+    private let persistence: ConversationPersistencePort
+    private let inferenceService: InferenceService
+    private let events: TurnEventEmitter
+    private let preTurnPolicy: (any PreTurnCompressionPolicy)?
+    private let postTurnPolicy: (any CompressionPolicy)?
+
+    init(
+        persistence: ConversationPersistencePort,
+        inferenceService: InferenceService,
+        events: TurnEventEmitter,
+        preTurnPolicy: (any PreTurnCompressionPolicy)?,
+        postTurnPolicy: (any CompressionPolicy)?
+    ) {
+        self.persistence = persistence
+        self.inferenceService = inferenceService
+        self.events = events
+        self.preTurnPolicy = preTurnPolicy
+        self.postTurnPolicy = postTurnPolicy
+    }
+
+    struct PreTurnCompressionEmptyResultError: LocalizedError, Sendable {
+        var errorDescription: String? {
+            "Pre-turn compression returned an empty history."
+        }
+    }
+
+    // MARK: Pre-turn
+
+    /// Pre-turn compression: runs before the user message is appended so
+    /// the just-submitted action always falls outside the compressed
+    /// segment. Only runs for `.send` turns (not regenerate / edit / branch).
+    /// Failures throw to the caller — unlike post-turn compression which
+    /// logs and continues, pre-turn failure aborts the turn because the
+    /// host's ordering invariant depends on compression completing first.
+    func compressBeforeTurnIfNeeded(sessionID: UUID) async throws {
+        guard let preTurnPolicy else { return }
+        let existingHistory: [ChatMessage]
+        do {
+            existingHistory = try await persistence.fetchMessages(sessionID: sessionID)
+        } catch {
+            throw ConversationError.persistence(error)
+        }
+        let lastPromptTokens = existingHistory.last(where: { $0.role == .assistant })?.promptTokens
+        guard preTurnPolicy.shouldCompressBeforeTurn(
+            messageCount: existingHistory.count,
+            lastPromptTokens: lastPromptTokens
+        ) else { return }
+
+        let generate = makeCompressionGenerateClosure()
+        let compressed: [ChatMessage]
+        do {
+            compressed = try await preTurnPolicy.compressBeforeTurn(
+                history: existingHistory,
+                sessionID: sessionID,
+                generate: generate
+            )
+        } catch {
+            throw ConversationError.preTurnCompressionFailed(error)
+        }
+        guard !compressed.isEmpty else {
+            throw ConversationError.preTurnCompressionFailed(
+                PreTurnCompressionEmptyResultError()
+            )
+        }
+        // "Before" bracket for the `.historyCompressed` "after" signal.
+        // The removed set is computed from the policy's replacement
+        // output (records present before but absent from `compressed`)
+        // so the IDs are accurate rather than a placeholder — emitting
+        // it here, after `compressBeforeTurn` resolves but before the
+        // store mutation, keeps it ordered ahead of `.historyCompressed`
+        // without fabricating which records will actually be dropped.
+        let retainedIDs = Set(compressed.map(\.id))
+        let removedIDs = existingHistory.compactMap {
+            retainedIDs.contains($0.id) ? nil : $0.id
+        }
+        events.emit(.compressionTriggered(removed: removedIDs, reason: .contextWindowExceeded))
+        do {
+            try await persistence.deleteMessages(for: sessionID)
+            for message in compressed {
+                try await persistence.insertMessage(message)
+            }
+        } catch {
+            throw ConversationError.persistence(error)
+        }
+        events.emit(.historyCompressed(sessionID: sessionID, insertedRecords: compressed))
+        await preTurnPolicy.postCompressBeforeTurn(
+            sessionID: sessionID,
+            insertedRecords: compressed
+        )
+    }
+
+    // MARK: Post-turn
+
+    /// Compression check: ask the policy whether the context is full enough
+    /// to warrant compression. Skipped when no token usage is available
+    /// (policy can't make a meaningful decision without promptTokens) or
+    /// when the backend doesn't report a context size (contextSize == 0).
+    func compressAfterTurnIfNeeded(
+        sessionID: UUID,
+        promptTokens: Int?,
+        hookRegistry: HookRegistry?
+    ) async {
+        guard let postTurnPolicy, let promptTokens else { return }
+        let contextSize = await readContextWindowSize()
+        let contextUtilization = contextSize > 0 ? Double(promptTokens) / Double(contextSize) : 0
+        guard contextSize > 0 && postTurnPolicy.shouldCompress(promptTokens: promptTokens, contextSize: contextSize, contextUtilization: contextUtilization) else { return }
+
+        let history: [ChatMessage]
+        do {
+            history = try await persistence.fetchMessages(sessionID: sessionID)
+        } catch {
+            Log.inference.warning("CompressionPolicy: fetchMessages failed, skipping compression: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let generate = makeCompressionGenerateClosure()
+
+        // preCompact hook: v1 is observational. The plan's hook
+        // contract documents that preCompact CANNOT block compression
+        // (there's no mutation channel for the history shape); a
+        // hook that returns block:true logs a warning but compression
+        // still runs. Emit `.hookFired(event: "preCompact", ...)`
+        // regardless so observability stays consistent.
+        if let hookRegistry {
+            let input = HookInput(
+                event: .preCompact,
+                sessionID: sessionID,
+                toolName: nil,
+                toolArguments: nil
+            )
+            let output = await hookRegistry.run(input)
+            events.emit(.hookFired(event: "preCompact", sessionID: sessionID))
+            if output.block {
+                Log.inference.warning(
+                    "preCompact hook returned block:true — block is not honoured for compaction in v1; ignoring and proceeding with compression."
+                )
+            }
+        }
+
+        do {
+            let compressed = try await postTurnPolicy.compress(
+                history: history,
+                sessionID: sessionID,
+                generate: generate
+            )
+            // Guard against an empty result — deleting all messages
+            // without re-inserting anything would silently wipe the
+            // conversation. Treat this as a policy error; preserve the
+            // existing history rather than destroying it.
+            guard !compressed.isEmpty else {
+                Log.inference.warning(
+                    "CompressionPolicy.compress returned empty history (sessionID=\(sessionID, privacy: .private)); skipping replacement to preserve existing messages"
+                )
+                return
+            }
+            // "Before" bracket for `.historyCompressed`. Removed IDs are
+            // derived from the policy's replacement set (records present
+            // in `history` but absent from `compressed`) so the event
+            // carries the real dropped records, emitted ahead of the
+            // store mutation and the "after" `.historyCompressed`.
+            let retainedIDs = Set(compressed.map(\.id))
+            let removedIDs = history.compactMap {
+                retainedIDs.contains($0.id) ? nil : $0.id
+            }
+            events.emit(.compressionTriggered(removed: removedIDs, reason: .contextWindowExceeded))
+            try await persistence.deleteMessages(for: sessionID)
+            for message in compressed {
+                try await persistence.insertMessage(message)
+            }
+            events.emit(.historyCompressed(sessionID: sessionID, insertedRecords: compressed))
+            await postTurnPolicy.postCompress(sessionID: sessionID, insertedRecords: compressed)
+        } catch {
+            Log.inference.warning("CompressionPolicy.compress failed (sessionID=\(sessionID, privacy: .private)): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: Shared generate closure
+
+    /// Returns a `@Sendable` closure that drives a background inference call
+    /// for summarisation. Used by both pre-turn and post-turn compression paths.
+    private func makeCompressionGenerateClosure() -> @Sendable ([ChatMessage]) async throws -> String {
+        let inferenceService = self.inferenceService
+        return { messages in
+            let structured = messages
+                .filter { $0.kind.isWireVisible }
+                .map { record -> StructuredMessage in
+                    let role = record.kind.backendRole ?? record.role
+                    return StructuredMessage(role: role.rawValue, parts: record.contentParts)
+                }
+            let (token, compressStream) = try await inferenceService.enqueueAsync(
+                structuredMessages: structured,
+                priority: .background
+            )
+            var result = ""
+            var consumer = GenerationStreamConsumer(loopDetectionEnabled: false)
+            do {
+                for try await event in compressStream.events {
+                    try Task.checkCancellation()
+                    if case .appendText(let chunk) = consumer.handle(event) {
+                        result += chunk
+                    }
+                }
+            } catch {
+                await inferenceService.cancelAsync(token)
+                throw error
+            }
+            return result
+        }
+    }
+
+    /// Reads the backend's context window size from the main actor.
+    /// Returns 0 when unavailable — callers treat 0 as "skip compression".
+    @MainActor
+    private func readContextWindowSize() async -> Int {
+        inferenceService.capabilities?.contextWindowSize ?? 0
+    }
+}

--- a/Sources/ManifoldTestSupport/MockInferenceBackend.swift
+++ b/Sources/ManifoldTestSupport/MockInferenceBackend.swift
@@ -8,7 +8,58 @@ import ManifoldInference
 public final class MockInferenceBackend: InferenceBackend, ConversationHistoryReceiver, StructuredHistoryReceiver, @unchecked Sendable {
     public var isModelLoaded: Bool = false
     public var isGenerating: Bool = false
-    public var capabilities: BackendCapabilities
+
+    /// Enqueue-throw hook (#1606 error path).
+    ///
+    /// `InferenceService.enqueue` never calls into the backend synchronously
+    /// — the only backend read on the enqueue path is `capabilities`, whose
+    /// tool-calling gate rejects tool-carrying requests up front
+    /// (`supportsToolCalling == false` → enqueue throws before any stream or
+    /// token exists). When this flag is `true`, the ``capabilities`` getter
+    /// reports `supportsToolCalling == false` regardless of the configured
+    /// value, so the next tool-carrying enqueue throws synchronously — AFTER
+    /// the runtime has advertised and registered session tool executors.
+    ///
+    /// Use to exercise the register-then-enqueue-fails cleanup path
+    /// (``SessionToolDispatchBinder``'s error-path unregister). Requests
+    /// without tools are unaffected.
+    public var rejectToolCarryingEnqueues: Bool = false
+
+    /// Backing store for ``capabilities``; the getter rewrites
+    /// `supportsToolCalling` when ``rejectToolCarryingEnqueues`` is set.
+    private var storedCapabilities: BackendCapabilities
+
+    public var capabilities: BackendCapabilities {
+        get {
+            guard rejectToolCarryingEnqueues else { return storedCapabilities }
+            let caps = storedCapabilities
+            return BackendCapabilities(
+                supportedParameters: caps.supportedParameters,
+                maxContextTokens: caps.maxContextTokens,
+                requiresPromptTemplate: caps.requiresPromptTemplate,
+                supportsSystemPrompt: caps.supportsSystemPrompt,
+                supportsToolCalling: false,
+                supportsStructuredOutput: caps.supportsStructuredOutput,
+                supportsNativeJSONMode: caps.supportsNativeJSONMode,
+                cancellationStyle: caps.cancellationStyle,
+                supportsTokenCounting: caps.supportsTokenCounting,
+                memoryStrategy: caps.memoryStrategy,
+                maxOutputTokens: caps.maxOutputTokens,
+                supportsStreaming: caps.supportsStreaming,
+                isRemote: caps.isRemote,
+                supportsKVCachePersistence: caps.supportsKVCachePersistence,
+                supportsGrammarConstrainedSampling: caps.supportsGrammarConstrainedSampling,
+                supportsThinking: caps.supportsThinking,
+                supportsVision: caps.supportsVision,
+                streamsToolCallArguments: caps.streamsToolCallArguments,
+                supportsParallelToolCalls: caps.supportsParallelToolCalls,
+                supportsGuidedStructuredOutput: caps.supportsGuidedStructuredOutput,
+                sharesMLXProcessResources: caps.sharesMLXProcessResources,
+                maxAdvertisedToolCount: caps.maxAdvertisedToolCount
+            )
+        }
+        set { storedCapabilities = newValue }
+    }
 
     // Configurable behavior
     public var tokensToYield: [String] = ["Hello", " world"]
@@ -153,7 +204,7 @@ public final class MockInferenceBackend: InferenceBackend, ConversationHistoryRe
         cancellationStyle: .cooperative,
         supportsTokenCounting: false
     )) {
-        self.capabilities = capabilities
+        self.storedCapabilities = capabilities
     }
 
     public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {

--- a/Tests/ManifoldTurnLoopCharacterizationTests/SessionToolSourceDispatchTest.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/SessionToolSourceDispatchTest.swift
@@ -172,4 +172,55 @@ final class SessionToolSourceDispatchTest: XCTestCase {
             "session-scoped executor must be unregistered when the turn ends; a leak would bind later turns to a stale session"
         )
     }
+
+    /// Register-then-enqueue-fails (#1725 step C): when `enqueueAsync` throws
+    /// AFTER the session tool executors were registered (#1606 ordering puts
+    /// registration strictly before enqueue), the error-path unregister in
+    /// the turn loop must still run — otherwise the failed turn leaks a
+    /// session-scoped executor into the shared registry.
+    ///
+    /// The failure is driven by ``MockInferenceBackend/rejectToolCarryingEnqueues``:
+    /// the queue's capability gate reads `backend.capabilities` at enqueue
+    /// time and rejects tool-carrying requests synchronously, before any
+    /// stream exists — so no stream-drain cleanup path can mask a missing
+    /// enqueue-failure unregister.
+    func test_sessionToolExecutor_unregisteredWhenEnqueueThrows() async throws {
+        let stack = try InMemoryPersistenceHarness.make()
+        let session = ManifoldInference.ChatSession(id: UUID(), title: "enqueue-fail")
+        try await stack.provider.insertSession(session)
+
+        let backend = Self.toolCapableBackend()
+        backend.rejectToolCarryingEnqueues = true
+
+        let registry = ToolRegistry()
+        let service = InferenceService(backend: backend, name: "DispatchMock", toolRegistry: registry)
+        // sessionStore wired so the executor fetches a real session record —
+        // registration only happens with a non-nil record, and the unregister
+        // assertion below would be vacuous without it.
+        let runtime = ConversationRuntime(
+            messageStore: stack.provider,
+            sessionStore: stack.provider,
+            inferenceService: service
+        )
+        await runtime.updateSessionToolSources([StubGenerateImageToolSource()])
+
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: session.id, kind: .send(text: "should fail at enqueue"))
+        )
+        let outcome = await handle?.outcome
+
+        // The turn must have failed at enqueue (capability gate), proving the
+        // failure happened on the enqueue path — i.e. after register, before
+        // any stream existed — rather than the turn quietly succeeding.
+        guard case .inference = outcome?.error else {
+            XCTFail("expected an enqueue-time inference failure, got \(String(describing: outcome?.error))")
+            return
+        }
+
+        let leaked = service.toolRegistry?.contains(name: StubGenerateImageToolSource.toolName) ?? false
+        XCTAssertFalse(
+            leaked,
+            "enqueue failure must still unregister the session tool executors registered before enqueueAsync (#1606 error path)"
+        )
+    }
 }


### PR DESCRIPTION
Closes #1725. Final P2c sub-phase: extracts the compression coordination out of `ConversationTurnExecutor` and thins the four entry flows. Behavior-preserving — proven against the characterization goldens.

## What changed
- **New `TurnCompressionCoordinator`** (`Sources/ManifoldRuntime/Services/`, ~250 L) — lifts the pre-turn and post-turn compress-and-replace sequences plus the shared `makeCompressionGenerateClosure` out of the executor. Takes the event sink as a bare `@Sendable (ConversationEvent) -> Void` via `TurnEventEmitter`; the only main-actor read (`contextWindowSize`) stays behind an explicit `@MainActor readContextWindowSize()` hop.
- **Executor thinned** (~290 L net) — the four flows (send/regenerate/edit/branch) unify behind a single `launchGenerationTask` helper. New `firesPreTurnHooks` knob: `true` for send/regenerate/edit, `false` for branch (preserves the documented legacy hook-suppression for branch).
- **Step C — enqueue-failure coverage** — `MockInferenceBackend` gains an opt-in `rejectToolCarryingEnqueues` hook (default off, backward-compatible); new `test_sessionToolExecutor_unregisteredWhenEnqueueThrows` pins the `SessionToolDispatchBinder` error-path unregister (register-then-enqueue-fails → executors unregistered + `.inference` error surfaced).

Step A (grow compression goldens) was already delivered on `main` via #1732 — the three `CompressionGoldenTests` (postTurn / preTurn / preCompact-observational) are the safety net this extraction is proven against.

## Verification
- Full local gate (`scripts/test.sh --profile local`): **5011 tests, 0 failures, PASSED.**
- Characterization goldens diff **clean** (all 11, incl. the 3 compression goldens) — a golden test fails on any snapshot diff, so clean passes prove behavior preservation.
- Sabotage checks were applied per extracted seam during development and removed before commit.

## Invariants (#1721) — all preserved
1. `sessionRecord` stays a function-local re-pinned `var`; coordinator touches no session record, returns void. ✅
2. #965 switch-cancel-resend `discardRequests(notMatching:)` ordering untouched. ✅
3. #1606 register-before-enqueue ordering intact across all flows (shared `runGenerationTurn`). ✅
4. KV-cache / backend-state reads not reordered around the stream-consume boundary. ✅
5. `@Sendable` event sinks never capture `@MainActor` state; single read behind a `@MainActor` hop. ✅
6. preCompact `block:true` stays observational (ignored). ✅
7. Per-turn token-usage pinning preserved (turn-local `let` feeds the post-turn decision). ✅

## Persona review (3 parallel reviewers on the diff)
- **Concurrency:** SHIP — invariants 1/4/5 preserved, sound `Sendable` conformance, no `Task.detached`/`@unchecked Sendable`/`try?` issues.
- **Turn-loop correctness:** SHIP — pre/post-turn orderings and invariants 2/3/6/7 preserved with line-level evidence; four-flow compression parity confirmed.
- **Test coverage:** SHIP — enqueue-fail test is non-vacuous (verified against the real catch path); mock hook backward-compatible.

**Coverage note (from review, non-blocking):** the post-turn compression goldens exercise `.send` only; regenerate/edit/branch rely on `launchGenerationTask` structural parity (they route through the same `runGenerationTurn`). Low residual risk; flagged here for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
