### PR TITLE
feat(traits)!: retire MCP and MCPBuiltinCatalog traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,8 +469,9 @@ jobs:
       # - Run `swift test --filter ManifoldBackendsTests --traits MLX,Llama` on
       #   Apple Silicon for MLX/llama.cpp paths.
       # - Run `swift test --filter ManifoldE2ETests` on physical hardware.
-      # - --traits MCP compiles the offline ManifoldMCPTests target; RUN_MCP_E2E
-      #   stays unset here, so per-PR CI never requires external MCP servers.
+      # - ManifoldMCPTests compiles unconditionally (MCP trait retired in
+      #   v0.48); RUN_MCP_E2E stays unset here, so per-PR CI never requires
+      #   external MCP servers.
       # - MCP E2E stays out of per-PR CI; nightly-slow-tests runs the
       #   RUN_MCP_E2E-gated streamable-HTTP smoke with a narrow filter so
       #   npx/network-backed subprocess tests remain local-only.
@@ -487,7 +488,6 @@ jobs:
       # When Tier 0 returns a bounded affected-suite list (pull_request only),
       # route each suite to the fastest correct test path via ci-selective-test.sh:
       #   - Suite has an xcscheme AND is not trait-gated → xcodebuild (subgraph compile)
-      #   - ManifoldMCPTests → swift test --traits MCP (no xcodebuild trait activation)
       #   - ManifoldBackendsTests → serial swift test (hardware dep in subgraph)
       # Saves ~127s full-bundle compile by compiling only the affected subgraph(s).
       # When Tier 0 returns FULL (hub-module change, push to main) or NONE (no
@@ -507,14 +507,14 @@ jobs:
           [[ "$affected" == "FULL" || "$affected" == "NONE" || -z "$affected" ]] \
             && emit_full "affected=${affected:-unset} (NONE falls back to full as conservative measure)"
           # Count suites that require a full swift-test bundle compile (can't use xcodebuild):
-          # ManifoldMCPTests (MCP trait not in defaults) and ManifoldBackendsTests
-          # (ManifoldMLX/ManifoldLlama in subgraph → Metal shaders with xcodebuild defaults).
+          # ManifoldBackendsTests (ManifoldMLX/ManifoldLlama in subgraph → Metal shaders
+          # with xcodebuild defaults).
           # Running 2+ such suites separately compiles the full bundle twice, which is always
           # slower than one full run. Also fall back if total suite count is large (≥8)
           # to avoid excessive sequential xcodebuild overhead outweighing the compile savings.
           swift_test_count=0
           for s in $affected; do
-            case "$s" in ManifoldMCPTests|ManifoldBackendsTests) ((swift_test_count++)) ;; esac
+            case "$s" in ManifoldBackendsTests) ((swift_test_count++)) ;; esac
           done
           total_count=$(printf '%s\n' $affected | wc -w | tr -d ' ')
           [[ $swift_test_count -ge 2 ]] \
@@ -557,14 +557,14 @@ jobs:
       # the design rationale.
       #
       # All three test invocations below pass the SAME trait set
-      # (`MCP,CloudSaaS`). `swift test --filter` always builds the whole test
+      # (`CloudSaaS`). `swift test --filter` always builds the whole test
       # tree (the filter only gates execution), so a different trait set per
       # invocation means a different conditional-compilation config and forces a
       # full recompile each time — measured ~63s rebuilt on the Swift Testing
       # step alone (CI log, run 26705440802). Using one superset trait set lets
       # steps 2–3 reuse step 1's `.build` and drop to test-execution-only. The
-      # set is a superset (step 1 needs MCP, step 3 needs CloudSaaS, step 2 needs
-      # neither) — traits only ADD compiled code, so no suite's behavior changes.
+      # set is a superset (step 3 needs CloudSaaS, steps 1–2 need
+      # nothing) — traits only ADD compiled code, so no suite's behavior changes.
       # Keep all three in sync; diverging the traits silently reintroduces the
       # redundant rebuilds.
       - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Inference + Networking + TurnLoopCharacterization, parallel) [full]
@@ -574,7 +574,7 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --filter ManifoldNetworkingTests --filter ManifoldSecretsTests --filter ManifoldHardwareTests --filter ManifoldModelCatalogTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --traits MCP,CloudSaaS --skip-update --parallel
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --filter ManifoldNetworkingTests --filter ManifoldSecretsTests --filter ManifoldHardwareTests --filter ManifoldModelCatalogTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --traits CloudSaaS --skip-update --parallel
 
       # ManifoldBackendsTests is intentionally NOT included in the --parallel batch
       # above. Under --parallel, swift-test schedules XCTest classes across workers
@@ -593,7 +593,7 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-backends.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldBackendsTests --disable-default-traits --traits MCP,CloudSaaS --skip-update
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldBackendsTests --disable-default-traits --traits CloudSaaS --skip-update
 
       # `if: (success() || failure())` so a failing XCTest step still surfaces
       # Swift Testing failures in the same run — otherwise breakage in both
@@ -606,7 +606,7 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-swift-testing.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --traits MCP,CloudSaaS --skip-update
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --traits CloudSaaS --skip-update
 
       # Coverage thresholds run nightly in nightly-slow-tests.yml — they were
       # moved out of per-main-push CI to reclaim ~130s of wall (~22 billed
@@ -834,8 +834,8 @@ jobs:
 
       # Specialised: ManifoldMCP — links ManifoldMCP as a standalone product
       # dependency and verifies that MCPServerDescriptor, MCPTransportKind, and
-      # MCPToolSource are reachable from outside the package. MCP trait is not
-      # required (trait only gates the ManifoldMCPTests dependency edge).
+      # MCPToolSource are reachable from outside the package. ManifoldMCP
+      # compiles unconditionally (MCP trait retired in v0.48).
       - name: Cold-start specialised — ManifoldMCP
         if: success() || failure()
         timeout-minutes: 10
@@ -1001,4 +1001,4 @@ jobs:
         timeout-minutes: 25
         run: |
           swift build --build-tests \
-            --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz
+            --traits MLX,Llama,Ollama,CloudSaaS,HuggingFace,Fuzz

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           RUN_MCP_E2E: "1"
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-mcp-e2e-smoke.log
-        run: scripts/test.sh --filter "ManifoldMCPE2ESmokeTests" --disable-default-traits --traits MCP --skip-update --min-passed 1
+        run: scripts/test.sh --filter "ManifoldMCPE2ESmokeTests" --disable-default-traits --skip-update --min-passed 1
 
       - name: Test — Operational tier (soak + migration)
         id: test-operational
@@ -124,7 +124,6 @@ jobs:
             --filter ManifoldInferenceTests \
             --filter ManifoldMCPTests \
             --disable-default-traits \
-            --traits MCP \
             --enable-code-coverage \
             --skip-update
           scripts/check-coverage.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Specialised modules stay opt-in and are imported by name when you need them:
 | `ManifoldUIModelManagement` | `ModelManagementSheet`, `APIConfigurationView`, model browser/download UI. Not in the umbrella because chat-only consumers can ship without 1,800+ LOC of management surface. |
 | `ManifoldHuggingFace` *(optional, `HuggingFace` trait, default-on)* | Hub search, browse, background downloads. |
 | `ManifoldVoice` *(optional, `Voice` trait)* | Speech I/O composer accessory. |
-| `ManifoldMCP` *(optional, `MCP` trait)* | Model Context Protocol client + tool bridge. |
+| `ManifoldMCP` *(optional)* | Model Context Protocol client + tool bridge. Compiles unconditionally (no trait since v0.48). |
 | `ManifoldAppIntents` *(optional, `AppIntents` trait)* | AppIntent ↔ ToolDefinition bridge. |
 
 Contributors changing ManifoldKit internals can still import the individual products
@@ -407,8 +407,6 @@ that bite consumers:
 - **`CloudSaaS` (default-off)** — required for OpenAI / Claude. Off in regulated
   builds.
 - **`Ollama` (default-off)** — required for `OllamaBackend`. Self-hosted only.
-- **`MCPBuiltinCatalog` (default-off)** — required for the built-in MCP catalog
-  (`notion`, `linear`, `github` descriptors).
 - **`Voice` (default-off)** — required for `ManifoldVoice` speech I/O.
 
 When you `--disable-default-traits`, you must explicitly add the ones you want

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@
 
 | Target | Role | ML deps |
 |--------|------|---------|
-| `ManifoldMCP` | Model Context Protocol client surface, descriptors, transports, OAuth, tool bridge (`MCPClient`, `MCPToolSource`). Always compiles; the `MCP` trait gates test edges and the `MCPBuiltinCatalog` define only — the module itself is unconditional. Depends on `ManifoldInference`. | None |
+| `ManifoldMCP` | Model Context Protocol client surface, descriptors, transports, OAuth, tool bridge (`MCPClient`, `MCPToolSource`). Compiles unconditionally — the `MCP` and `MCPBuiltinCatalog` traits were retired in v0.48 (catalog descriptors included). Depends on `ManifoldInference`. | None |
 | `ManifoldMCPHost` | Runtime-backed MCP server boundary: exposes sessions, messages, RAG documents, and send-message tools to external MCP clients. Depends on `ManifoldMCP` + `ManifoldRuntime`. | None |
 | `ManifoldTools` | End-to-end tool-calling validation harness: fixed reference toolset, declarative scenario runner, JSONL transcript logger. Depends on `ManifoldInference`. | None |
 | `ManifoldAppIntents` | AppIntent ↔ ToolDefinition bridge. Depends on `ManifoldInference`. | None |
@@ -88,19 +88,19 @@
 
 **Backend family deps (post-P2a #1719, post-v0.48 A1):** `ManifoldMLX` and `ManifoldLlama` depend on `ManifoldInference` (real engine use: `extension InferenceService`, `ToolRegistry`, `BackendRegistrar`). `ManifoldFoundation`, `ManifoldOllama`, and `ManifoldCloudSaaS` compile against `ManifoldContract` (+ `ManifoldCloudCore` for the two cloud families) without touching the engine directly. The `ManifoldCloud` shim depends on `ManifoldCloudCore`, `ManifoldRuntime` (for `DefaultWebSearchRuntime`'s `WebSearchRuntime` port conformance — un-gated library→library edge; see Package.swift comment), and trait-gated edges to the two cloud families. `ManifoldMCP` depends on `ManifoldInference` (uses `ToolExecutor`, `ToolRegistry`). The consumer→family edge is trait-gated: `MLX` for `ManifoldMLX`, `Llama` for `ManifoldLlama`, `Ollama` for `ManifoldOllama`, `CloudSaaS` for `ManifoldCloudSaaS` (and `CloudSaaS || Ollama` for the `ManifoldCloud` shim); `ManifoldCloudCore` and `ManifoldFoundation` are always linked.
 
-The umbrella `ManifoldBackends` re-exports each family conditionally so `import ManifoldBackends` keeps working in any trait combination. `MCPCatalog` descriptors are trait-gated behind `MCPBuiltinCatalog`; the `ManifoldMCP` module itself is unconditional (the `MCP` trait only gates test edges and the built-in catalog define).
+The umbrella `ManifoldBackends` re-exports each family conditionally so `import ManifoldBackends` keeps working in any trait combination. `ManifoldMCP` (including the `MCPCatalog` descriptors) compiles unconditionally — the `MCP` and `MCPBuiltinCatalog` traits were retired in v0.48.
 
 ## Running tests
 
 Use `scripts/test.sh` — it runs configured suites and prints an honest summary. Key flags:
 - `--disable-default-traits` — excludes MLX/Llama/hardware-gated tests (required for CI)
 - `--skip-update` — skips per-invocation git-remote contact (drop only if you edited Package.swift)
-- `--traits MLX,Llama,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace` — for full-traits builds
+- `--traits MLX,Llama,Ollama,CloudSaaS,HuggingFace` — for full-traits builds
 
 **Special cases:**
 - MLX integration tests require Xcode (Metal shaders): `scripts/test-mlx-integration.sh`
 - Swift Testing must run in a separate process from XCTest (mixing causes libmalloc SIGABRT — see #681)
-- MCP E2E: `RUN_MCP_E2E=1 swift test --traits MCP --filter ManifoldMCPE2ESmokeTests` — `MCP` isn't in the default trait set (defaults are MLX/Llama/HuggingFace), so the trait flag is required or the filter matches zero compiled tests and the build emits `error: fatalError`. Filter to the streamable suite; `EverythingServerSmokeTests` has hung 28+ min in past runs.
+- MCP E2E: `RUN_MCP_E2E=1 swift test --filter ManifoldMCPE2ESmokeTests` — MCP test targets compile unconditionally (MCP trait retired in v0.48); the `RUN_MCP_E2E=1` env var still gates execution. Filter to the streamable suite; `EverythingServerSmokeTests` has hung 28+ min in past runs.
 - Ollama E2E requires Ollama at localhost:11434 and `--traits Ollama` (dropped from defaults in v2.0)
 - Llama: in-process runs are safe — `LlamaBackendProcessLifecycle` latches `llama_backend_init` exactly once per process (was a per-class isolation script pre-#1319)
 - `ManifoldE2ETests`: bare form `swift test --filter ManifoldE2ETests --disable-default-traits` runs the full suite; for narrower targeting anchor the regex (`--filter 'ManifoldE2ETests\.'` then test name). Bare-vs-anchored behavior shifted in swift-test post-v2.
@@ -192,7 +192,7 @@ When Apple ships a new major OS each September, bump both minimums and remove `#
 scripts/test.sh --profile local
 ```
 
-Runs all-traits XCTest + Swift Testing on the full trait surface (`MLX,Llama,MCP,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace,Macros`). This catches the trait-combo bugs CI cannot see (see PR #1382 for the canonical example: a KV cache reuse race that only fails under `--traits MLX,Llama`). Two-invocation shape is preserved internally (XCTest filters, then `ManifoldInferenceSwiftTestingTests` in a separate process — mixing the two runners in one process triggers libmalloc SIGABRT, #681). The profile deliberately does NOT pass `--parallel` or `--num-workers`: explicit parallelism can surface process-global state races in `BackendContractChecks` when backend test classes interleave (fixed for claim-methods in #1601, but implicit scheduling matches historical behavior — keep it).
+Runs all-traits XCTest + Swift Testing on the full trait surface (`MLX,Llama,Ollama,CloudSaaS,HuggingFace,Macros`). This catches the trait-combo bugs CI cannot see (see PR #1382 for the canonical example: a KV cache reuse race that only fails under `--traits MLX,Llama`). Two-invocation shape is preserved internally (XCTest filters, then `ManifoldInferenceSwiftTestingTests` in a separate process — mixing the two runners in one process triggers libmalloc SIGABRT, #681). The profile deliberately does NOT pass `--parallel` or `--num-workers`: explicit parallelism can surface process-global state races in `BackendContractChecks` when backend test classes interleave (fixed for claim-methods in #1601, but implicit scheduling matches historical behavior — keep it).
 
 **Pre-push (CI repro — only when chasing a CI failure):**
 
@@ -208,7 +208,7 @@ Both profiles respect explicit caller flags: `scripts/test.sh --profile local --
 
 **Trait-combo sweep** (whenever modifying a switched enum, a `GenerationEvent` / `GenerationConfig` / `BackendCapabilities`-shaped type, or any trait-gated source file):
 ```bash
-swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz
+swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,HuggingFace,Fuzz
 ```
 Default-trait builds won't catch CloudSaaS- or Ollama-gated switch exhaustiveness. The all-traits-on `--build-tests` is the cheapest single check.
 

--- a/Example/Advanced.xcodeproj/project.pbxproj
+++ b/Example/Advanced.xcodeproj/project.pbxproj
@@ -909,7 +909,6 @@
 				MLX,
 				Llama,
 				HuggingFace,
-				MCPBuiltinCatalog,
 			);
 		};
 /* End XCLocalSwiftPackageReference section */

--- a/Example/Advanced/MCP/DemoMCPCoordinator.swift
+++ b/Example/Advanced/MCP/DemoMCPCoordinator.swift
@@ -37,11 +37,12 @@ final class DemoMCPCoordinator {
         self.isFoundationModelsActive = isFoundationModelsActive
 
         // Catalog composition rationale (PR #921 / `feat/demo-mcp-server`):
-        // - The MCPBuiltinCatalog trait is enabled in the demo's pbxproj so
-        //   `MCPCatalog.all` (Notion / Linear / GitHub) is non-empty out of
-        //   the box. These OAuth-gated entries are useful for users who have
-        //   accounts with those providers, but they aren't a no-config happy
-        //   path for someone just kicking the tyres.
+        // - `MCPCatalog.all` (Notion / Linear / GitHub) compiles
+        //   unconditionally (the MCPBuiltinCatalog trait was retired in
+        //   v0.48), so the catalog is non-empty out of the box. These
+        //   OAuth-gated entries are useful for users who have accounts with
+        //   those providers, but they aren't a no-config happy path for
+        //   someone just kicking the tyres.
         // - To give every macOS user a working tap-to-connect server with
         //   zero credentials, we prepend a stdio descriptor that launches
         //   `@modelcontextprotocol/server-everything` via `npx`. The server
@@ -53,13 +54,11 @@ final class DemoMCPCoordinator {
         #if os(macOS) && !targetEnvironment(macCatalyst)
         assembled.append(Self.demoEchoDescriptor)
         #endif
-        #if MCPBuiltinCatalog
         assembled.append(contentsOf: MCPCatalog.all)
-        #endif
         self.catalog = assembled
 
         if assembled.isEmpty {
-            self.catalogHelpText = "No services configured. Enable the MCPBuiltinCatalog trait or run on macOS to see the demo Echo server."
+            self.catalogHelpText = "No services configured."
         } else {
             self.catalogHelpText = "Tap Connect on a service to start its session."
         }

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 
 // Trait reference (full table in README §2.4):
 //   - Defaults: MLX, Llama, HuggingFace.
-//   - Opt-in heavy/network traits: Ollama, CloudSaaS, MCP, MCPBuiltinCatalog,
+//   - Opt-in heavy/network traits: Ollama, CloudSaaS,
 //     Voice, Tools, AppIntents, Server, Macros, Fuzz, AnyLanguageModel,
 //     HuggingFace.
 //   - `FoundationOnly` is an explicit "App Store-lean" marker for indie iOS
@@ -116,8 +116,6 @@ let package = Package(
         .trait(name: "AnyLanguageModel", description: "Enable the AnyLanguageModel bridge backend target."),
         .trait(name: "Ollama", description: "Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major."),
         .trait(name: "CloudSaaS", description: "Third-party SaaS providers (Claude, OpenAI). Off by default."),
-        .trait(name: "MCP", description: "Enable the ManifoldMCP module and MCP client surface."),
-        .trait(name: "MCPBuiltinCatalog", description: "Enable ManifoldMCP's built-in catalog descriptors."),
         .trait(name: "Voice", description: "Enable the ManifoldVoice speech I/O spike and voice composer UI."),
         .trait(name: "Tools", description: "Enable the ManifoldTools end-to-end tool-calling validation harness and its `manifold-tools` CLI."),
         .trait(name: "AppIntents", description: "Enable the ManifoldAppIntents AppIntent ↔ ToolDefinition bridge."),
@@ -331,10 +329,7 @@ let package = Package(
         .target(
             name: "ManifoldMCP",
             dependencies: ["ManifoldInference"],
-            path: "Sources/ManifoldMCP",
-            swiftSettings: [
-                .define("MCPBuiltinCatalog", .when(traits: ["MCPBuiltinCatalog"])),
-            ]
+            path: "Sources/ManifoldMCP"
         ),
         // ManifoldMCPHost: runtime-backed MCP server boundary. Exposes
         // sessions, messages, RAG documents, and send-message tools to external
@@ -908,26 +903,20 @@ let package = Package(
         .testTarget(
             name: "ManifoldMCPTests",
             dependencies: [
-                .target(name: "ManifoldMCP", condition: .when(traits: ["MCP"])),
-                .target(name: "ManifoldMCPHost", condition: .when(traits: ["MCP"])),
+                "ManifoldMCP",
+                "ManifoldMCPHost",
                 "ManifoldInference",
                 "ManifoldRuntime",
                 "ManifoldTestSupport",
             ],
-            resources: [.copy("Fixtures")],
-            swiftSettings: [
-                .define("MCP", .when(traits: ["MCP"])),
-            ]
+            resources: [.copy("Fixtures")]
         ),
         .testTarget(
             name: "ManifoldMCPE2ETests",
             dependencies: [
-                .target(name: "ManifoldMCP", condition: .when(traits: ["MCP"])),
+                "ManifoldMCP",
                 "ManifoldInference",
                 "ManifoldTestSupport",
-            ],
-            swiftSettings: [
-                .define("MCP", .when(traits: ["MCP"])),
             ]
         ),
         // Umbrella test target — covers every family target via per-trait

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The same backend, model-management, persistence, and download infrastructure tha
 
 Pick traits to scope which backends and capabilities ship with your build. The full trait → capability table is generated from `Sources/ManifoldKit/FeatureMatrix.swift` and rendered to [docs/FeatureMatrix.md](docs/FeatureMatrix.md).
 
-Defaults (`MLX`, `Llama`, `HuggingFace`) are enabled when you don't pass `--disable-default-traits` or a custom `traits:` array. Opt-in traits include `CloudSaaS`, `Ollama`, `MCP`, `Voice`, `Tools`, `AppIntents`, `Server`, `Macros`, `Fuzz`, and the App Store-lean `FoundationOnly`. See [docs/QUICKSTART.md → Customizing backends](docs/QUICKSTART.md#customizing-backends) for the per-trait build commands.
+Defaults (`MLX`, `Llama`, `HuggingFace`) are enabled when you don't pass `--disable-default-traits` or a custom `traits:` array. Opt-in traits include `CloudSaaS`, `Ollama`, `Voice`, `Tools`, `AppIntents`, `Server`, `Macros`, `Fuzz`, and the App Store-lean `FoundationOnly`. See [docs/QUICKSTART.md → Customizing backends](docs/QUICKSTART.md#customizing-backends) for the per-trait build commands.
 
 For a quantified breakdown of what each trait costs in binary size, build time, and dependency weight — and why the checkout is large regardless of trait set — see [docs/TRAIT-COSTS.md](docs/TRAIT-COSTS.md).
 

--- a/Sources/ManifoldKit/Exports.swift
+++ b/Sources/ManifoldKit/Exports.swift
@@ -8,7 +8,7 @@
 //   - `ManifoldUIModelManagement` — model browser/download/API editor UI.
 //     Many apps don't ship the management surface; keeping it out of the
 //     umbrella lets chat-only consumers compile without the 1,800+ LOC.
-//   - `ManifoldMCP` — Model Context Protocol client (trait `MCP`).
+//   - `ManifoldMCP` — Model Context Protocol client (no trait since v0.48).
 //   - `ManifoldVoice` — speech I/O composer (trait `Voice`).
 //   - `ManifoldHuggingFace` — Hub browse/download (default-on under
 //     `HuggingFace`, but exposed only via `ManifoldUIModelManagement` UI hooks).

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -31,6 +31,10 @@ public enum ManifoldCapability: String, CaseIterable, Sendable {
     case toolCalling
     case visionInput
     case voiceIO
+    // mcpClient/mcpHost are no longer unlocked by any trait — ManifoldMCP and
+    // ManifoldMCPHost compile unconditionally as of v0.48 (MCP +
+    // MCPBuiltinCatalog traits retired). Cases stay: removing public enum
+    // cases is a separate API break with no consumer benefit.
     case mcpClient
     case mcpHost
     case ragKnowledgeBase
@@ -96,16 +100,6 @@ public enum FeatureMatrix {
             name: "CloudSaaS",
             description: "Third-party SaaS providers (Claude, OpenAI). Off by default.",
             unlocks: [.cloudOpenAI, .cloudClaude, .toolCalling, .visionInput]
-        ),
-        ManifoldTrait(
-            name: "MCP",
-            description: "Enable the ManifoldMCP module and MCP client surface.",
-            unlocks: [.mcpClient, .mcpHost]
-        ),
-        ManifoldTrait(
-            name: "MCPBuiltinCatalog",
-            description: "Enable ManifoldMCP's built-in catalog descriptors.",
-            unlocks: [.mcpClient]
         ),
         ManifoldTrait(
             name: "Voice",

--- a/Sources/ManifoldMCP/MCPCatalog.swift
+++ b/Sources/ManifoldMCP/MCPCatalog.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ManifoldInference
 
-#if MCPBuiltinCatalog
 
 // MARK: - Static server spec
 
@@ -200,4 +199,3 @@ public enum MCPCatalog {
         return url
     }
 }
-#endif

--- a/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPCatalogBuiltin.md
+++ b/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPCatalogBuiltin.md
@@ -1,12 +1,6 @@
 # Built-in MCP Catalog
 
-`MCPCatalog` is compiled only when the `MCPBuiltinCatalog` trait is enabled.
-
-## Trait
-
-```bash
-swift test --filter ManifoldMCPTests --disable-default-traits --traits MCPBuiltinCatalog
-```
+`MCPCatalog` compiles unconditionally — the `MCPBuiltinCatalog` trait was retired in v0.48, so the built-in descriptors are always available wherever `ManifoldMCP` is.
 
 ## Purpose
 

--- a/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md
+++ b/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPGettingStarted.md
@@ -4,14 +4,13 @@ Define one or more MCP server descriptors, then connect them through ``MCPClient
 
 For a shortest-path setup, see <doc:MCPQuickStart>.
 
-> Important: Enable the `MCP` trait in your package dependency before importing
-> `ManifoldMCP`.
+> Note: No trait is required — the `MCP` trait was retired in v0.48. Add the
+> `ManifoldMCP` product to your target's dependencies and import it.
 >
 > ```swift
 > .package(
 >     url: "https://github.com/roryford/ManifoldKit.git",
->     from: "0.36.0",
->     traits: [.trait(name: "MCP")]
+>     from: "0.48.0"
 > )
 > ```
 

--- a/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPQuickStart.md
+++ b/Sources/ManifoldMCP/ManifoldMCP.docc/Articles/MCPQuickStart.md
@@ -53,9 +53,7 @@ try await source.refreshTools()
 
 ## Built-in templates
 
-> **Trait requirement:** Built-in catalog entries (`MCPCatalog.notion`, `.linear`, `.github`) require the `MCPBuiltinCatalog` trait. In your `Package.swift` dependency: `.product(name: "ManifoldMCP", package: "ManifoldKit", condition: .when(traits: ["MCPBuiltinCatalog"]))`. Or enable globally: `.trait(name: "MCPBuiltinCatalog")`.
-
-When `MCPBuiltinCatalog` is enabled, start from ``MCPCatalog``:
+Built-in catalog entries (`MCPCatalog.notion`, `.linear`, `.github`) are always available — the `MCPBuiltinCatalog` trait was retired in v0.48. Start from ``MCPCatalog``:
 
 ```swift,no-build
 var notion = MCPCatalog.notion

--- a/Sources/ManifoldMCP/ManifoldMCP.docc/ManifoldMCP.md
+++ b/Sources/ManifoldMCP/ManifoldMCP.docc/ManifoldMCP.md
@@ -8,7 +8,7 @@ Model Context Protocol (MCP) client primitives for ManifoldKit.
 
 - transport/auth/capability types (`MCPServerDescriptor`, `MCPTransportKind`, `MCPAuthorizationDescriptor`)
 - connection + source lifecycle (`MCPClient`, `MCPToolSource`)
-- catalog presets (`MCPCatalog`, gated by `MCPBuiltinCatalog`)
+- catalog presets (`MCPCatalog`)
 
 Use this module to model and audit tool boundaries before wiring concrete transport internals.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -98,14 +98,14 @@ swift test --filter ManifoldBackendsTests --traits MLX,Llama
 # Additional headless E2E coverage (mock backends; no special hardware)
 swift test --filter ManifoldE2ETests --disable-default-traits
 
-# MCP built-in catalog descriptors (trait-gated metadata tests)
-scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --traits MCP,MCPBuiltinCatalog --skip-update
+# MCP unit tests (incl. built-in catalog descriptors — compile unconditionally)
+scripts/test.sh --filter ManifoldMCPTests --disable-default-traits --skip-update
 
 # MCP end-to-end smoke tests are explicit opt-in only.
 # Nightly runs the streamable-HTTP smoke; keep the filter narrow so the
 # npx/network-backed EverythingServerSmokeTests suite does not run by default.
 RUN_MCP_E2E=1 scripts/test.sh --filter ManifoldMCPE2ESmokeTests \
-  --disable-default-traits --traits MCP --skip-update --min-passed 1
+  --disable-default-traits --skip-update --min-passed 1
 
 # Full subprocess E2E, local only: requires npx on PATH and network access to
 # download @modelcontextprotocol/server-everything.

--- a/Tests/ManifoldCoreTests/PackageTraitGateAuditTest.swift
+++ b/Tests/ManifoldCoreTests/PackageTraitGateAuditTest.swift
@@ -1,10 +1,11 @@
 import XCTest
 
 /// Guards against regressions on issue #951: `Package.swift` must keep the
-/// five optional modules — `ManifoldMCP`, `ManifoldVoice`, `ManifoldTools`,
-/// `ManifoldAppIntents`, and `ManifoldFuzz` (plus its `ManifoldFuzzBackends`
-/// sibling) — gated behind their declared traits. Mirrors the pattern PR #946
-/// established for the `Server` trait around `ManifoldServer`.
+/// optional modules — `ManifoldVoice`, `ManifoldTools`, `ManifoldAppIntents`,
+/// and `ManifoldFuzz` (plus its `ManifoldFuzzBackends` sibling) — gated
+/// behind their declared traits. Mirrors the pattern PR #946 established for
+/// the `Server` trait around `ManifoldServer`. (`ManifoldMCP` left this list
+/// in v0.48 when the MCP trait was retired.)
 ///
 /// ## Why this matters
 ///
@@ -52,9 +53,9 @@ final class PackageTraitGateAuditTest: XCTestCase {
     }
 
     private static let expectedGates: [ExpectedGate] = [
-        // ManifoldMCP — gated by MCP across both test consumers.
-        .init(description: "ManifoldMCPTests → ManifoldMCP", module: "ManifoldMCP", trait: "MCP"),
-        .init(description: "ManifoldMCPE2ETests → ManifoldMCP", module: "ManifoldMCP", trait: "MCP"),
+        // ManifoldMCP edges are no longer listed here: the MCP and
+        // MCPBuiltinCatalog traits were retired in v0.48 (PR A2) — ManifoldMCP
+        // compiles unconditionally.
 
         // ManifoldVoice — gated by Voice on the test target. The library
         // target's product declaration stays unconditional (apps importing
@@ -106,7 +107,7 @@ final class PackageTraitGateAuditTest: XCTestCase {
 
         var violations: [String] = []
         for gate in Self.expectedGates {
-            // Sample shape (whitespace-loose): `.target(name: "ManifoldMCP", condition: .when(traits: ["MCP"]))`.
+            // Sample shape (whitespace-loose): `.target(name: "ManifoldVoice", condition: .when(traits: ["Voice"]))`.
             // We accept either single or double quotes and any reasonable
             // whitespace inside the `traits: [...]` array; the trait name
             // must appear inside that array literal on a line that also

--- a/Tests/ManifoldE2ETests/DemoScenarioCoverageInventory.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioCoverageInventory.swift
@@ -182,7 +182,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["mcp_fs_read"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["MCP", "Tools", "Ollama for real E2E"],
+            requiredTraits: ["Tools", "Ollama for real E2E"],
             environmentGates: ["filesystem MCP server fixture", "Ollama localhost:11434"],
             notes: "Still missing per #754 audit; do not implement in Wave 0."
         ),

--- a/Tests/ManifoldMCPE2ETests/EverythingServerSmokeTests.swift
+++ b/Tests/ManifoldMCPE2ETests/EverythingServerSmokeTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 #if os(macOS) && !targetEnvironment(macCatalyst)
 import Foundation
 import XCTest
@@ -110,5 +109,4 @@ final class EverythingServerSmokeTests: XCTestCase {
             || FileManager.default.fileExists(atPath: "/opt/homebrew/bin/npx")
     }
 }
-#endif
 #endif

--- a/Tests/ManifoldMCPE2ETests/ManifoldMCPE2EPlaceholderTests.swift
+++ b/Tests/ManifoldMCPE2ETests/ManifoldMCPE2EPlaceholderTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -88,4 +87,3 @@ final class ManifoldMCPE2ESmokeTests: XCTestCase {
         XCTAssertEqual(firstToolName, "ping")
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/AuthMCPOAuthAuthorizationTests.swift
+++ b/Tests/ManifoldMCPTests/AuthMCPOAuthAuthorizationTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -1573,4 +1572,3 @@ private func XCTAssertThrowsErrorAsync<T>(
         handler(error)
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/ChaosMCPTransportTests.swift
+++ b/Tests/ManifoldMCPTests/ChaosMCPTransportTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import XCTest
 @testable import ManifoldMCP
 
@@ -208,4 +207,3 @@ final class ChaosMCPTransportTests: XCTestCase {
     }
 }
 
-#endif

--- a/Tests/ManifoldMCPTests/Contracts/MCPToolSourceContractTests.swift
+++ b/Tests/ManifoldMCPTests/Contracts/MCPToolSourceContractTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import XCTest
 import ManifoldInference
 @testable import ManifoldMCP
@@ -111,4 +110,3 @@ final class MCPToolSourceContractTests: XCTestCase {
         await source.invalidateApprovals(toolName: nil)
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/Helpers/ChaosMCPTransport.swift
+++ b/Tests/ManifoldMCPTests/Helpers/ChaosMCPTransport.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import Synchronization
 @testable import ManifoldMCP
@@ -252,6 +251,4 @@ final class ChaosMCPTransport: MCPTransport, @unchecked Sendable {
         }
     }
 }
-
-#endif
 

--- a/Tests/ManifoldMCPTests/MCPApprovalPersistenceTests.swift
+++ b/Tests/ManifoldMCPTests/MCPApprovalPersistenceTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -98,4 +97,3 @@ final class MCPApprovalPersistenceTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPCatalogTests.swift
+++ b/Tests/ManifoldMCPTests/MCPCatalogTests.swift
@@ -1,9 +1,7 @@
-#if MCP
 import XCTest
 import ManifoldMCP
 
 final class MCPCatalogTests: XCTestCase {
-    #if MCPBuiltinCatalog
     func test_eachCatalogEntryEndpointIsHTTPS() {
         for descriptor in MCPCatalog.all {
             if case .streamableHTTP(let endpoint, _) = descriptor.transport {
@@ -65,6 +63,4 @@ final class MCPCatalogTests: XCTestCase {
             }
         }
     }
-    #endif
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPConnectedAddressGuardTests.swift
+++ b/Tests/ManifoldMCPTests/MCPConnectedAddressGuardTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -92,4 +91,3 @@ final class MCPConnectedAddressGuardTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPContentSanitizerCorpusTests.swift
+++ b/Tests/ManifoldMCPTests/MCPContentSanitizerCorpusTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import XCTest
 @testable import ManifoldMCP
 
@@ -104,4 +103,3 @@ final class MCPContentSanitizerCorpusTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPContentSanitizerTests.swift
+++ b/Tests/ManifoldMCPTests/MCPContentSanitizerTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import XCTest
 @testable import ManifoldMCP
 
@@ -45,4 +44,3 @@ final class MCPContentSanitizerTests: XCTestCase {
         XCTAssertTrue(textResult.contains("trust=\"untrusted\""))
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPErrorMappingTests.swift
+++ b/Tests/ManifoldMCPTests/MCPErrorMappingTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -178,4 +177,3 @@ final class MCPErrorMappingTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPFoundationModelsCompatibilityTests.swift
+++ b/Tests/ManifoldMCPTests/MCPFoundationModelsCompatibilityTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -326,4 +325,3 @@ final class MCPFoundationModelsCompatibilityTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPHardeningTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHardeningTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -1021,4 +1020,3 @@ extension MCPHardeningTests {
         }
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPHostServerTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHostServerTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -500,4 +499,3 @@ private actor LoopbackHostTransport: MCPHostTransport {
         continuation.resume(returning: value)
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPJSONRPCCodecTests.swift
+++ b/Tests/ManifoldMCPTests/MCPJSONRPCCodecTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -42,4 +41,3 @@ final class MCPJSONRPCCodecTests: XCTestCase {
         // Sabotage: removing the JSON nesting-depth counter in MCPJSONRPCCodec.decode() so it never enforces maxJSONNestingDepth would allow the deeply nested payload through without throwing, causing XCTAssertThrowsError to fail
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPOAuthTokenStoreKeychainTests.swift
+++ b/Tests/ManifoldMCPTests/MCPOAuthTokenStoreKeychainTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import XCTest
 import Security
 @testable import ManifoldMCP
@@ -273,4 +272,3 @@ final class MCPOAuthTokenStoreKeychainTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPProviderFixtureContractTests.swift
+++ b/Tests/ManifoldMCPTests/MCPProviderFixtureContractTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -73,7 +72,6 @@ final class MCPProviderFixtureContractTests: XCTestCase {
         }
     }
 
-    #if MCPBuiltinCatalog
     func test_serverFixturesMatchBuiltinCatalogContracts() throws {
         for provider in providers {
             let fixture = try loadServerFixture(provider: provider)
@@ -102,7 +100,6 @@ final class MCPProviderFixtureContractTests: XCTestCase {
             // Sabotage: changing the UUID or endpoint URL in MCPCatalog.github/linear/notion without updating the corresponding server.json fixture would cause the catalog.id or catalog.transport.endpoint equality checks to fail
         }
     }
-    #endif
 
     private func fixtureURL(provider: String, file: String) throws -> URL {
         guard let base = Bundle.module.resourceURL else {
@@ -179,7 +176,6 @@ final class MCPProviderFixtureContractTests: XCTestCase {
         )
     }
 
-    #if MCPBuiltinCatalog
     private func descriptor(for provider: String) -> MCPServerDescriptor {
         switch provider {
         case "github":
@@ -192,7 +188,6 @@ final class MCPProviderFixtureContractTests: XCTestCase {
             fatalError("Unhandled provider: \(provider)")
         }
     }
-    #endif
 
     private func requireJSONObject(data: Data, file: String, provider: String) throws -> [String: Any] {
         let raw = try JSONSerialization.jsonObject(with: data)
@@ -301,4 +296,3 @@ private struct ServerFixture: Decodable {
         }
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPSessionTests.swift
+++ b/Tests/ManifoldMCPTests/MCPSessionTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -370,4 +369,3 @@ private actor MockSessionTransport: MCPTransport {
         sent
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPStdioTransportTests.swift
+++ b/Tests/ManifoldMCPTests/MCPStdioTransportTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Darwin
 import Foundation
 import XCTest
@@ -286,4 +285,3 @@ final class MCPStdioTransportTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPStreamableHTTPIntegrationTests.swift
+++ b/Tests/ManifoldMCPTests/MCPStreamableHTTPIntegrationTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -82,4 +81,3 @@ final class MCPStreamableHTTPIntegrationTests: XCTestCase {
         XCTAssertEqual(firstToolName, "ping")
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPStreamableHTTPTransportTests.swift
+++ b/Tests/ManifoldMCPTests/MCPStreamableHTTPTransportTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -256,4 +255,3 @@ private actor RetryingAuthorization: MCPAuthorization {
         return .retry
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
+++ b/Tests/ManifoldMCPTests/MCPToolBridgeTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -886,4 +885,3 @@ private actor AsyncGate {
         continuation = nil
     }
 }
-#endif

--- a/Tests/ManifoldMCPTests/ManifoldMCPScaffoldTests.swift
+++ b/Tests/ManifoldMCPTests/ManifoldMCPScaffoldTests.swift
@@ -1,4 +1,3 @@
-#if MCP
 import Foundation
 import XCTest
 @testable import ManifoldMCP
@@ -34,7 +33,6 @@ final class ManifoldMCPScaffoldTests: XCTestCase {
         // Sabotage: removing any provider subdirectory (e.g. Fixtures/Providers/github/) or any of the three required JSON files inside it would fail the corresponding FileManager.fileExists XCTAssertTrue
     }
 
-    #if MCPBuiltinCatalog
     func test_builtinCatalogDescriptorsUseHTTPSAndStableIDs() throws {
         let catalog = MCPCatalog.all
         XCTAssertEqual(catalog.count, 3)
@@ -50,6 +48,4 @@ final class ManifoldMCPScaffoldTests: XCTestCase {
             // Sabotage: changing any MCPCatalog descriptor's transport endpoint from https:// to http:// would fail the XCTAssertEqual(endpoint.scheme?.lowercased(), "https") check for that descriptor
         }
     }
-    #endif
 }
-#endif

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -13,7 +13,7 @@ This directory contains the test suites that gate every PR to ManifoldKit. CI ru
 | `ManifoldPersistenceSwiftDataTests` | Real SwiftData stack, schemas, migrations | Integration tier: hits SwiftData. |
 | `ManifoldBackendsTests` | Per-backend behaviour, capability contracts | Trait-gated; many tests skip without the relevant trait. |
 | `ManifoldBackendsTests/Conformance/` | Per-backend conformance suites against the strengthened contract harness | New in T1.1. |
-| `ManifoldMCPTests` | MCP protocol, transports, OAuth, sanitizers | `#if MCP`-gated. |
+| `ManifoldMCPTests` | MCP protocol, transports, OAuth, sanitizers | Compiles unconditionally (MCP trait retired in v0.48). |
 | `ManifoldTestSupportTests` | Sanity tests for `Sources/ManifoldTestSupport/` mocks/fakes | Lightweight. |
 | `ManifoldUITests` | SwiftUI view models, view-tree contracts via ViewInspector | `@MainActor`-isolated. |
 | `ManifoldUIModelManagementTests` | Model browser/download UI | Depends on `ManifoldUIModelManagement`. |
@@ -37,8 +37,6 @@ ManifoldKit's test targets are conditionally linked on Swift package traits:
 | `AnyLanguageModel` | no | AnyLanguageModel bridge backend target |
 | `Ollama` | no | Ollama backend, requires `localhost:11434` |
 | `CloudSaaS` | no | OpenAI/Claude/Responses backends |
-| `MCP` | no | MCP client + transports |
-| `MCPBuiltinCatalog` | no | Bundled MCP server descriptors |
 | `Tools` | no | `manifold-tools` CLI body |
 | `Server` | no | ManifoldServer |
 | `Operational` | (planned, T4) | Nightly soak/migration/throughput |
@@ -193,7 +191,7 @@ This proves the assertion (a) exercises a real production code path, (b) is valu
 ## Special cases
 
 - **MLX integration**: `scripts/test-mlx-integration.sh` — Xcode-only, metallib required. See #986.
-- **MCP E2E**: `RUN_MCP_E2E=1 swift test --traits MCP --filter ManifoldMCPE2ESmokeTests` — gated env var + trait. The `everything-server` smoke has hung in past runs; filter to the streamable subset.
+- **MCP E2E**: `RUN_MCP_E2E=1 swift test --filter ManifoldMCPE2ESmokeTests` — gated by env var (the target compiles unconditionally since the MCP trait was retired in v0.48). The `everything-server` smoke has hung in past runs; filter to the streamable subset.
 - **Ollama**: requires `localhost:11434` and `--traits Ollama`.
 - **Operational tier** (planned): nightly trait `Operational` for soak/migration/throughput/quality baseline.
 
@@ -296,7 +294,7 @@ Cold-start gates scaffold a fresh SwiftPM consumer in a tmpdir, depend on this r
 | Audience | Suite |
 |---|---|
 | Per-PR CI | All default-trait suites (the two-call shape above) |
-| Per-PR CI (matrix) | Per-trait builds for MCP, Ollama, CloudSaaS |
+| Per-PR CI (matrix) | Per-trait builds for Ollama, CloudSaaS |
 | Nightly | `ManifoldE2ETests`, MLX integration, `Operational` (planned T4) |
 | Pre-push (local) | The two-call shape |
 | Hardware-specific | `ManifoldE2ETests/LlamaThinkingE2ETests` etc. — install fixtures via `~/Library/Caches/ManifoldKit/test-models/manifest.json` |

--- a/docs/FeatureMatrix.md
+++ b/docs/FeatureMatrix.md
@@ -14,8 +14,6 @@ Do not edit by hand — re-run the script.
 | `HuggingFace` | Enable HuggingFace Hub search, browse, and download | `modelDownload` |
 | `Llama` | Enable the llama.cpp (GGUF) inference backend | `localInference`, `llamaBackend`, `embeddings` |
 | `Macros` | Enable the @ToolSchema macro plugin and its swift-syntax dependency. Off by default — pulls ~647 source files into the build graph. | `toolCalling` |
-| `MCP` | Enable the ManifoldMCP module and MCP client surface. | `mcpClient`, `mcpHost` |
-| `MCPBuiltinCatalog` | Enable ManifoldMCP's built-in catalog descriptors. | `mcpClient` |
 | `MLX` | Enable the MLX inference backend (requires Apple Silicon) | `localInference`, `mlxBackend`, `visionInput`, `imageGeneration` |
 | `Ollama` | Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major. | `ollama`, `toolCalling`, `embeddings` |
 | `Server` | Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency. | `embeddings` |

--- a/docs/TRAIT-COSTS.md
+++ b/docs/TRAIT-COSTS.md
@@ -27,8 +27,6 @@
 | `HuggingFace` | ManifoldHuggingFace | `swift-huggingface` | ~2 | — | +5026 | — |
 | `CloudSaaS` | ManifoldCloud (SaaS bodies) | _(none beyond baseline)_ | — | — | +731 | — |
 | `Ollama` | ManifoldCloud (Ollama bodies) | _(none beyond baseline)_ | — | — | +731 | — |
-| `MCP` | ManifoldMCP + ManifoldMCPHost | _(none beyond baseline)_ | — | — | +1914 | — |
-| `MCPBuiltinCatalog` | ManifoldMCP built-in catalog | _(none beyond baseline)_ | — | — | +31 | — |
 | `Server` | ManifoldServer + Hummingbird | `EventSource`, `swift-nio`, `swift-crypto`, `swift-collections`, `swift-atomics`, `swift-system` | ~74 | — | +12157 | — |
 | `Macros` | ManifoldMacrosPlugin + @ToolSchema | `swift-syntax` | ~11 | — | +0 | — |
 | `Skills` | ManifoldSkills | _(none beyond baseline)_ | — | — | +224 | — |

--- a/docs/trait-costs.json
+++ b/docs/trait-costs.json
@@ -88,32 +88,6 @@
   "method_version": "1",
   "notes": "Same ManifoldCloud + ManifoldCloudCore modules as CloudSaaS; Ollama HTTP dialect compiled in instead of SaaS endpoints."
 },{
-  "trait": "MCP",
-  "modules_added": "ManifoldMCP + ManifoldMCPHost",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "1914",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "ManifoldMCP=1697 KB + ManifoldMCPHost=217 KB. Pure ManifoldKit sources; no external package."
-},{
-  "trait": "MCPBuiltinCatalog",
-  "modules_added": "ManifoldMCP built-in catalog",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "31",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "Compile-time flag enabling ManifoldMCP's built-in catalog descriptors. Delta above MCP baseline = ~31 KB."
-},{
   "trait": "Server",
   "modules_added": "ManifoldServer + Hummingbird",
   "transitive_deps": ["EventSource", "swift-nio", "swift-crypto", "swift-collections", "swift-atomics", "swift-system"],

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -165,7 +165,7 @@ for i in $SORTED_INDEXES; do
     status="NO DATA"
     printf "  %-36s %10s %9d%% %8s\n" "$module" "--" "$threshold" "$status"
     # No data means the module wasn't in the profdata — treat as warning not failure
-    # (e.g. MCP tests require --traits MCP, which the coverage run may not include)
+    # (e.g. the coverage run's --filter set may not have exercised the module)
     continue
   fi
 

--- a/scripts/ci-selective-test.sh
+++ b/scripts/ci-selective-test.sh
@@ -7,9 +7,6 @@
 # Routing rules:
 #   - Suite has a .xcscheme AND is not trait-gated
 #       → xcodebuild test -scheme (compiles only the subgraph, not the full bundle)
-#   - ManifoldMCPTests
-#       → swift test --traits MCP  (xcodebuild cannot activate non-default traits;
-#         running without MCP silently drops all test sources → 0 compiled tests)
 #   - ManifoldBackendsTests
 #       → swift test --disable-default-traits (has ManifoldMLX/ManifoldLlama in its
 #         dep graph; xcodebuild default traits trigger Metal shader compilation;
@@ -76,11 +73,8 @@ run_swift_test() {
 
 for suite in "$@"; do
   case "$suite" in
-    ManifoldMCPTests)
-      run_swift_test "$suite" --disable-default-traits --traits MCP,CloudSaaS
-      ;;
     ManifoldBackendsTests)
-      run_swift_test "$suite" --disable-default-traits --traits MCP,CloudSaaS
+      run_swift_test "$suite" --disable-default-traits --traits CloudSaaS
       ;;
     *)
       run_xcodebuild "$suite"

--- a/scripts/cold-start-specialised-mcp.sh
+++ b/scripts/cold-start-specialised-mcp.sh
@@ -11,10 +11,8 @@
 # Package.swift, accidental removal of public types, and dependency-graph
 # changes that drop ManifoldInference (ManifoldMCP's only required dep).
 #
-# Does NOT require the MCP trait — ManifoldMCP itself compiles unconditionally;
-# the MCP trait only gates the ManifoldMCPTests → ManifoldMCP dependency edge
-# so the test target can declare the dep conditionally without pulling it
-# into every non-MCP build.
+# No trait flags needed — ManifoldMCP compiles unconditionally (the MCP-related
+# traits were retired in v0.48).
 #
 # Runs in CI on every PR. ~30s on a warm cache.
 

--- a/scripts/measure-trait-costs.sh
+++ b/scripts/measure-trait-costs.sh
@@ -150,8 +150,6 @@ TRAIT_DEPS["Llama"]="llama.swift"          # xcframework in artifacts/llama.swif
 TRAIT_DEPS["HuggingFace"]="swift-huggingface"
 TRAIT_DEPS["CloudSaaS"]=""                 # ManifoldCloudCore always compiled; no unique checkout
 TRAIT_DEPS["Ollama"]=""                    # same ManifoldCloudCore path, no unique checkout
-TRAIT_DEPS["MCP"]=""                       # pure ManifoldKit sources, no external package
-TRAIT_DEPS["MCPBuiltinCatalog"]=""         # compile flag only
 TRAIT_DEPS["Voice"]=""                     # pure AVFoundation/Speech, no external package
 TRAIT_DEPS["Tools"]=""                     # ManifoldTools = pure ManifoldKit sources
 TRAIT_DEPS["AppIntents"]=""               # pure AppIntents framework, no external package
@@ -169,8 +167,6 @@ TRAIT_MODULES["Llama"]="ManifoldLlama"
 TRAIT_MODULES["HuggingFace"]="ManifoldHuggingFace"
 TRAIT_MODULES["CloudSaaS"]="ManifoldCloud (SaaS bodies)"
 TRAIT_MODULES["Ollama"]="ManifoldCloud (Ollama bodies)"
-TRAIT_MODULES["MCP"]="ManifoldMCP + ManifoldMCPHost"
-TRAIT_MODULES["MCPBuiltinCatalog"]="ManifoldMCP built-in catalog"
 TRAIT_MODULES["Voice"]="ManifoldVoice"
 TRAIT_MODULES["Tools"]="ManifoldTools + manifold-tools CLI"
 TRAIT_MODULES["AppIntents"]="ManifoldAppIntents"
@@ -190,8 +186,6 @@ TRAIT_FLAGS["Llama"]="--traits Llama"
 TRAIT_FLAGS["HuggingFace"]="--traits HuggingFace"
 TRAIT_FLAGS["CloudSaaS"]="--disable-default-traits --traits CloudSaaS"
 TRAIT_FLAGS["Ollama"]="--disable-default-traits --traits Ollama"
-TRAIT_FLAGS["MCP"]="--disable-default-traits --traits MCP"
-TRAIT_FLAGS["MCPBuiltinCatalog"]="--disable-default-traits --traits MCP,MCPBuiltinCatalog"
 TRAIT_FLAGS["Voice"]="--disable-default-traits --traits Voice"
 TRAIT_FLAGS["Tools"]="--disable-default-traits --traits Tools"
 TRAIT_FLAGS["AppIntents"]="--disable-default-traits --traits AppIntents"
@@ -210,8 +204,6 @@ TRAITS_TO_MEASURE=(
     HuggingFace
     CloudSaaS
     Ollama
-    MCP
-    MCPBuiltinCatalog
     Server
     Macros
     Skills

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -96,7 +96,6 @@ DISABLE_DEFAULT_TRAITS_PRESENT=0
 NUM_WORKERS_PRESENT=0
 SKIP_UPDATE_PRESENT=0
 MCP_FILTER_REQUESTED=0
-MCP_TRAIT_REQUESTED=0
 TRAITS_ARG_INDEX=-1
 SPIKE_MODULE=""
 while [[ $# -gt 0 ]]; do
@@ -174,18 +173,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --traits)
             traits="${2:?'--traits requires a comma-separated trait list'}"
-            if [[ ",$traits," == *",MCP,"* ]]; then
-                MCP_TRAIT_REQUESTED=1
-            fi
             TRAITS_ARG_INDEX=$((${#SWIFT_ARGS[@]} + 1))
             SWIFT_ARGS+=("$1" "$traits")
             shift 2
             ;;
         --traits=*)
-            traits="${1#--traits=}"
-            if [[ ",$traits," == *",MCP,"* ]]; then
-                MCP_TRAIT_REQUESTED=1
-            fi
             TRAITS_ARG_INDEX=${#SWIFT_ARGS[@]}
             SWIFT_ARGS+=("$1")
             shift
@@ -237,7 +229,7 @@ PROFILE_LOCAL_XCTEST_FILTERS=(
 PROFILE_SWIFT_TESTING_FILTER="ManifoldInferenceSwiftTestingTests"
 
 # Local profile trait set: every trait minus Fuzz (which is build-only).
-PROFILE_LOCAL_TRAITS="MLX,Llama,MCP,MCPBuiltinCatalog,Ollama,CloudSaaS,HuggingFace,Macros"
+PROFILE_LOCAL_TRAITS="MLX,Llama,Ollama,CloudSaaS,HuggingFace,Macros"
 
 if [[ -n "$PROFILE" ]]; then
     case "$PROFILE" in
@@ -382,16 +374,6 @@ if [[ -n "$PROFILE" ]]; then
         RC2=$?
         set -e
         exit $RC2
-    fi
-fi
-
-if [[ $MCP_FILTER_REQUESTED -eq 1 && $MCP_TRAIT_REQUESTED -eq 0 ]]; then
-    # ManifoldMCP test sources are #if MCP-gated; without the trait SwiftPM
-    # builds an empty target and reports a false-green 0-test run.
-    if [[ $TRAITS_ARG_INDEX -ge 0 ]]; then
-        SWIFT_ARGS[$TRAITS_ARG_INDEX]="${SWIFT_ARGS[$TRAITS_ARG_INDEX]},MCP"
-    else
-        SWIFT_ARGS+=("--traits" "MCP")
     fi
 fi
 
@@ -601,7 +583,7 @@ elif [[ $SWIFT_EXIT -ne 0 ]]; then
     echo "  RESULT: FAILED (swift test exit code $SWIFT_EXIT)"
     FINAL_EXIT=$SWIFT_EXIT
 elif [[ $MCP_FILTER_REQUESTED -eq 1 && $mcp_test_events -eq 0 ]]; then
-    echo "  RESULT: TRIPWIRE — MCP filter matched 0 MCP test cases; ensure --traits MCP compiled the target"
+    echo "  RESULT: TRIPWIRE — MCP filter matched 0 MCP test cases (target dropped from the build, or filter typo)"
     FINAL_EXIT=3
 elif [[ $total_passed -eq 0 && $total_skipped -gt 0 && $total_failed -eq 0 && $total_crashed_count -eq 0 ]]; then
     echo "  RESULT: TRIPWIRE — 0 tests passed, $total_skipped skipped (entire suite silently skipped)"


### PR DESCRIPTION
## Summary

Retires the `MCP` and `MCPBuiltinCatalog` SwiftPM traits. `ManifoldMCP`, `ManifoldMCPHost`, and the `MCPCatalog` built-in descriptors (Notion / Linear / GitHub) now compile unconditionally. Per plan decision #5, MCP tests now run on every CI lane.

Part of #1749 / v0.48 packaging release — PR A2 (`docs/plans/v0.48-packaging-release.md` §2 A2).

## ⚠️ Consumer migration (breaking)

SwiftPM **hard-errors on unknown trait names**: if your manifest passes `traits: ["MCP"]` or `traits: ["MCPBuiltinCatalog"]` (or `.trait(name: "MCP")` / a conditional `.product(..., condition: .when(traits: ["MCPBuiltinCatalog"]))`), resolution fails with `package 'manifoldkit' has no trait named 'MCP'`.

**Fix:** remove both trait names from your `traits:` array / dependency conditions. Nothing else changes — MCP is now always available; just `import ManifoldMCP`.

## Lockstep surfaces changed in this PR

- **Package.swift** — trait declarations deleted; `ManifoldMCPTests` / `ManifoldMCPE2ETests` dependency edges and the `MCPCatalog` define made unconditional
- **Sources** — `#if MCPBuiltinCatalog` stripped from `MCPCatalog.swift`
- **Tests** — 24 whole-file `#if MCP` gates + 4 inline `#if MCPBuiltinCatalog` gates stripped across `Tests/ManifoldMCPTests` + `Tests/ManifoldMCPE2ETests`
- **ci.yml** — three test lanes: `--traits MCP,CloudSaaS` → `--traits CloudSaaS` (now :577/:596/:609); `all-traits-build` list → `MLX,Llama,Ollama,CloudSaaS,HuggingFace,Fuzz` (:1004); Tier-2 `ManifoldMCPTests` special-case removed — the suite now routes to its existing xcodebuild scheme
- **ci-selective-test.sh** — MCP routing case deleted; `ManifoldBackendsTests` case drops `MCP` from its trait set
- **nightly-slow-tests.yml** — `--traits MCP` dropped from the MCP E2E smoke (:91) and coverage (:126) steps; `RUN_MCP_E2E=1` execution gating **stays**
- **scripts/test.sh** — MCP trait auto-append plumbing (`MCP_TRAIT_REQUESTED`) removed; `PROFILE_LOCAL_TRAITS` → `MLX,Llama,Ollama,CloudSaaS,HuggingFace,Macros`; the zero-match MCP tripwire is retained (still catches filter typos / dropped targets)
- **measure-trait-costs.sh + docs/trait-costs.json + docs/TRAIT-COSTS.md** — MCP rows removed (script would otherwise hard-error on the dead trait)
- **Audit/matrix** — `PackageTraitGateAuditTest.expectedGates` loses its 2 MCP entries; `FeatureMatrix.swift` loses both trait entries (`mcpClient`/`mcpHost` capability cases stay — removing public enum cases is a separate API break with no consumer benefit); `docs/FeatureMatrix.md` regenerated via `scripts/render-feature-matrix.sh`; `scripts/affected-suites-graph.json` regenerated (no content change — the snapshot doesn't encode trait conditions)
- **Example/Advanced** — `MCPBuiltinCatalog` removed from the pbxproj local-package `traits = (...)` block (would hard-error Xcode resolution); `DemoMCPCoordinator` de-gated
- **Docs** — CLAUDE.md (targets table, MCP E2E instructions, trait-combo sweep, local-profile trait list), AGENTS.md, README.md, TESTING.md, Tests/README.md, ManifoldMCP DocC articles (`MCPGettingStarted`, `MCPQuickStart`, `MCPCatalogBuiltin`, module page)

Sweep check (`grep -rn "MCPBuiltinCatalog|traits MCP|\"MCP\"" .github/ scripts/ Package.swift` over yml/sh/swift): **clean** — only module/product names remain.

## Test plan

- [x] `swift build --build-tests --disable-default-traits` — clean (MCP tests now compile on this lane; the new CI reality)
- [x] `swift build --build-tests --disable-default-traits --traits CloudSaaS` — clean (new ci.yml lane shape)
- [x] `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,HuggingFace,Fuzz` — clean (matches the new `all-traits-build` list exactly)
- [x] `scripts/test.sh --profile local` (with the edited test.sh) — **PASSED**: 4,842 XCTest tests (60 skipped, 0 failures) + 83 Swift Testing tests; **ManifoldMCPTests executed 220 test cases** (zero-match trap verified N>0)

## Notes for PR A4 (Ollama/CloudSaaS retirement — same surfaces)

Post-this-PR line numbers: ci.yml test lanes `--traits CloudSaaS` at :577/:596/:609; `all-traits-build` trait list at :1004; Tier-2 swift_test_count case (now Backends-only) at :536–540; `ci-selective-test.sh` Backends case at :76–78; `test.sh` `PROFILE_LOCAL_TRAITS` at :232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)