### PR TITLE
feat(traits)!: retire Voice, AppIntents, Skills, and Tools traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,14 +567,14 @@ jobs:
       # nothing) — traits only ADD compiled code, so no suite's behavior changes.
       # Keep all three in sync; diverging the traits silently reintroduces the
       # redundant rebuilds.
-      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Inference + Networking + TurnLoopCharacterization, parallel) [full]
+      - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Voice + Skills + Tools + Inference + Networking + TurnLoopCharacterization, parallel) [full]
         id: test-xctest-suites
         if: steps.test-mode.outputs.mode == 'full'
         timeout-minutes: 30
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldInferenceTests --filter ManifoldNetworkingTests --filter ManifoldSecretsTests --filter ManifoldHardwareTests --filter ManifoldModelCatalogTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --traits CloudSaaS --skip-update --parallel
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldVoiceTests --filter ManifoldSkillsTests --filter ManifoldToolsTests --filter ManifoldInferenceTests --filter ManifoldNetworkingTests --filter ManifoldSecretsTests --filter ManifoldHardwareTests --filter ManifoldModelCatalogTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --traits CloudSaaS --skip-update --parallel
 
       # ManifoldBackendsTests is intentionally NOT included in the --parallel batch
       # above. Under --parallel, swift-test schedules XCTest classes across workers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 | `ManifoldMCPHost` | Runtime-backed MCP server boundary: exposes sessions, messages, RAG documents, and send-message tools to external MCP clients. Depends on `ManifoldMCP` + `ManifoldRuntime`. | None |
 | `ManifoldTools` | End-to-end tool-calling validation harness: fixed reference toolset, declarative scenario runner, JSONL transcript logger. Depends on `ManifoldInference`. | None |
 | `ManifoldAppIntents` | AppIntent ↔ ToolDefinition bridge. Depends on `ManifoldInference`. | None |
-| `ManifoldSkills` | Claude-Code-compatible SKILL.md filesystem discovery and `invoke_skill` dispatcher (macOS-only via `#if os(macOS)`). Default-on (the `Skills` trait is in the default trait set). Depends on `ManifoldInference` + `ManifoldRuntime`. | None |
+| `ManifoldSkills` | Claude-Code-compatible SKILL.md filesystem discovery and `invoke_skill` dispatcher (macOS-only via `#if os(macOS)`). Depends on `ManifoldInference` + `ManifoldRuntime`. | None |
 | `ManifoldMacrosPlugin` | Swift macro compiler plugin implementing `@ToolSchema`. Runs at build time (not linked into app binaries). Trait-gated behind `Macros` (off by default) to keep swift-syntax's ~647 files out of default builds. | None |
 
 ### UI modules
@@ -61,7 +61,7 @@
 | `ManifoldFuzz` | Fuzzing engine: corpus, runner, capture, detectors, sink. Backend-agnostic; depends on `ManifoldInference`. | None |
 | `ManifoldFuzzBackends` | Real-backend factory shim shared by `fuzz-chat` CLI and Xcode-hosted MLX fuzz tests. Depends on `ManifoldFuzz` + `ManifoldBackends`. | MLX, LlamaSwift |
 | `fuzz-chat` | Executable driver for fuzz campaigns against Ollama / Llama / Foundation. Gated on `Fuzz` trait. Run via `scripts/fuzz.sh`. | None |
-| `manifold-tools` | CLI executable for running tool-call validation scenarios from `ManifoldTools`. Gated on `Tools` trait. | None |
+| `manifold-tools` | CLI executable for running tool-call validation scenarios from `ManifoldTools`. Links `ManifoldOllama` directly (never the `ManifoldBackends` umbrella — #982 dual-llama Xcode-scheme hazard). | None |
 
 ### Vendored sources (not standalone products)
 
@@ -82,7 +82,7 @@
 
 | Target | Role | ML deps |
 |--------|------|---------|
-| `ManifoldKit` | Umbrella re-export so app code can `import ManifoldKit` instead of stitching together 4–6 imports. Re-exports `ManifoldInference` + `ManifoldModelCatalog` + `ManifoldRuntime` + `ManifoldPersistenceSwiftData` + `ManifoldBackends` + `ManifoldUI` + `ManifoldSkills` (conditional on `Skills` trait). Specialised modules (UIModelManagement, MCP, Voice, AppIntents, …) stay explicit imports. | None |
+| `ManifoldKit` | Umbrella re-export so app code can `import ManifoldKit` instead of stitching together 4–6 imports. Re-exports `ManifoldInference` + `ManifoldModelCatalog` + `ManifoldRuntime` + `ManifoldPersistenceSwiftData` + `ManifoldBackends` + `ManifoldUI` + `ManifoldSkills`. Specialised modules (UIModelManagement, MCP, Voice, AppIntents, …) stay explicit imports. | None |
 
 **Dependency rules:** Never import any backend family target (or the `ManifoldBackends` umbrella) from UI; never import `ManifoldUIModelManagement` from `ManifoldUI` (CI lint enforces this). `ManifoldUIModelManagement` depends on `ManifoldUI` — cycle dissolved by closure-injecting `APIConfigurationView` via `@ViewBuilder` parameter.
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,11 @@
 // Trait reference (full table in README §2.4):
 //   - Defaults: MLX, Llama, HuggingFace.
 //   - Opt-in heavy/network traits: Ollama, CloudSaaS,
-//     Voice, Tools, AppIntents, Server, Macros, Fuzz, AnyLanguageModel,
-//     HuggingFace.
+//     Server, Macros, Fuzz, AnyLanguageModel, HuggingFace.
+//   - Retired in v0.48: MCP, MCPBuiltinCatalog (PR A2); Voice, Tools,
+//     AppIntents, Skills (PR A3). Those modules now compile unconditionally;
+//     consumers opt in by importing (or not importing) the products.
+//     See docs/MIGRATION-0.48.md.
 //   - `FoundationOnly` is an explicit "App Store-lean" marker for indie iOS
 //     26+/macOS 26+ apps that only need Apple Foundation Models. Pass
 //     `traits: ["FoundationOnly"]` from the consumer manifest — SwiftPM
@@ -109,19 +112,15 @@ let package = Package(
         .executable(name: "ManifoldServer", targets: ["ManifoldServer"]),
     ],
     traits: [
-        .default(enabledTraits: ["MLX", "Llama", "HuggingFace", "Skills"]),
+        .default(enabledTraits: ["MLX", "Llama", "HuggingFace"]),
         .trait(name: "MLX", description: "Enable the MLX inference backend (requires Apple Silicon)"),
         .trait(name: "Llama", description: "Enable the llama.cpp (GGUF) inference backend"),
         .trait(name: "HuggingFace", description: "Enable HuggingFace Hub search, browse, and download"),
         .trait(name: "AnyLanguageModel", description: "Enable the AnyLanguageModel bridge backend target."),
         .trait(name: "Ollama", description: "Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major."),
         .trait(name: "CloudSaaS", description: "Third-party SaaS providers (Claude, OpenAI). Off by default."),
-        .trait(name: "Voice", description: "Enable the ManifoldVoice speech I/O spike and voice composer UI."),
-        .trait(name: "Tools", description: "Enable the ManifoldTools end-to-end tool-calling validation harness and its `manifold-tools` CLI."),
-        .trait(name: "AppIntents", description: "Enable the ManifoldAppIntents AppIntent ↔ ToolDefinition bridge."),
         .trait(name: "Server", description: "Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency."),
         .trait(name: "Macros", description: "Enable the @ToolSchema macro plugin and its swift-syntax dependency. Off by default — pulls ~647 source files into the build graph."),
-        .trait(name: "Skills", description: "Enable the ManifoldSkills module (Claude-Code-compatible SKILL.md discovery + invoke_skill dispatcher). Default-on; macOS-only filesystem scan in v1."),
         // Fuzz is intentionally NOT a default trait. Enabling it adds ManifoldBackends
         // (and transitively LlamaSwift) to fuzz-chat, which conflicts with the MLX
         // integration test targets in the auto-generated Xcode scheme. Run the fuzzer via
@@ -356,10 +355,9 @@ let package = Package(
         ),
         // ManifoldSkills: Claude-Code-compatible SKILL.md filesystem discovery
         // and `invoke_skill` dispatcher. Library target is unconditional
-        // (the body is platform-gated with `#if os(macOS)`); consumer edges
-        // are trait-gated per `feedback_trait_gating_internal_edges` —
-        // wrapping a library-to-library edge in `.when(traits: ["Skills"])`
-        // while sources still import unconditionally is the broken shape.
+        // (the body is platform-gated with `#if os(macOS)`). The Skills trait
+        // was retired in v0.48 (PR A3) — the umbrella re-export and test edges
+        // are unconditional now.
         .target(
             name: "ManifoldSkills",
             dependencies: [
@@ -689,7 +687,7 @@ let package = Package(
                 "ManifoldPersistenceSwiftData",
                 "ManifoldBackends",
                 "ManifoldUI",
-                .target(name: "ManifoldSkills", condition: .when(traits: ["Skills"])),
+                "ManifoldSkills",
                 // Seed-model path: `quickStart(seed:)` drives a background download on
                 // first launch when no model is available. The concrete
                 // BackgroundDownloadManager + HuggingFaceService live in ManifoldHuggingFace
@@ -699,7 +697,6 @@ let package = Package(
             ],
             path: "Sources/ManifoldKit",
             swiftSettings: [
-                .define("Skills", .when(traits: ["Skills"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
@@ -707,10 +704,7 @@ let package = Package(
         .target(
             name: "ManifoldVoice",
             dependencies: ["ManifoldUI"],
-            path: "Sources/ManifoldVoice",
-            swiftSettings: [
-                .define("Voice", .when(traits: ["Voice"])),
-            ]
+            path: "Sources/ManifoldVoice"
         ),
         // Shared test mocks and utilities
         .target(
@@ -788,19 +782,13 @@ let package = Package(
                 "ManifoldContractTestSupport",
             ]
         ),
-        // ManifoldSkills tests — consumer edge to ManifoldSkills is trait-gated
-        // (per `feedback_trait_gating_internal_edges`) so default-traits-off
-        // CI lanes don't try to build the module against the empty no-op body.
         .testTarget(
             name: "ManifoldSkillsTests",
             dependencies: [
-                .target(name: "ManifoldSkills", condition: .when(traits: ["Skills"])),
+                "ManifoldSkills",
                 "ManifoldInference",
                 "ManifoldRuntime",
                 "ManifoldContractTestSupport",
-            ],
-            swiftSettings: [
-                .define("Skills", .when(traits: ["Skills"])),
             ]
         ),
         // ManifoldPersistenceSwiftData-only tests: SwiftData @Model schema,
@@ -977,11 +965,8 @@ let package = Package(
         .testTarget(
             name: "ManifoldVoiceTests",
             dependencies: [
-                .target(name: "ManifoldVoice", condition: .when(traits: ["Voice"])),
+                "ManifoldVoice",
                 .product(name: "ViewInspector", package: "ViewInspector"),
-            ],
-            swiftSettings: [
-                .define("Voice", .when(traits: ["Voice"])),
             ]
         ),
         .testTarget(
@@ -1080,7 +1065,7 @@ let package = Package(
                 "ManifoldPersistenceSwiftData",
                 "ManifoldInference",
                 "ManifoldTestSupport",
-                .target(name: "ManifoldTools", condition: .when(traits: ["Tools"])),
+                "ManifoldTools",
                 .target(name: "ManifoldHuggingFace", condition: .when(traits: ["HuggingFace"])),
             ],
             swiftSettings: [
@@ -1089,7 +1074,6 @@ let package = Package(
                 .define("Ollama", .when(traits: ["Ollama"])),
                 .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
-                .define("Tools", .when(traits: ["Tools"])),
             ]
         ),
         .testTarget(
@@ -1216,30 +1200,31 @@ let package = Package(
                 .copy("Scenarios/built-in"),
             ]
         ),
+        // manifold-tools deliberately does NOT depend on the ManifoldBackends
+        // umbrella: the umbrella drags MLX + llama.framework into the link
+        // graph, and a second llama.framework copy in the auto-generated
+        // Xcode scheme breaks ManifoldMLXIntegrationTests (#982). The CLI
+        // only drives Ollama (or the in-process mock), so it takes the
+        // ManifoldOllama family product directly — still behind the Ollama
+        // trait until that trait retires in PR A4.
         .executableTarget(
             name: "manifold-tools",
             dependencies: [
-                .target(name: "ManifoldTools", condition: .when(traits: ["Tools"])),
-                .target(name: "ManifoldBackends", condition: .when(traits: ["Tools"])),
+                "ManifoldTools",
+                .target(name: "ManifoldOllama", condition: .when(traits: ["Ollama"])),
                 "ManifoldInference",
             ],
             path: "Sources/manifold-tools",
             swiftSettings: [
-                .define("Tools", .when(traits: ["Tools"])),
                 .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
-                .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
         .testTarget(
             name: "ManifoldToolsTests",
             dependencies: [
-                .target(name: "ManifoldTools", condition: .when(traits: ["Tools"])),
+                "ManifoldTools",
                 "ManifoldInference",
                 "ManifoldTestSupport",
-            ],
-            swiftSettings: [
-                .define("Tools", .when(traits: ["Tools"])),
             ]
         ),
         // ManifoldAppIntents: AppIntent ↔ ToolDefinition bridge.
@@ -1255,11 +1240,8 @@ let package = Package(
         .testTarget(
             name: "ManifoldAppIntentsTests",
             dependencies: [
-                .target(name: "ManifoldAppIntents", condition: .when(traits: ["AppIntents"])),
+                "ManifoldAppIntents",
                 "ManifoldInference",
-            ],
-            swiftSettings: [
-                .define("AppIntents", .when(traits: ["AppIntents"])),
             ]
         ),
         // Xcode-only: real MLX model inference requiring Metal shader library.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The same backend, model-management, persistence, and download infrastructure tha
 
 Pick traits to scope which backends and capabilities ship with your build. The full trait → capability table is generated from `Sources/ManifoldKit/FeatureMatrix.swift` and rendered to [docs/FeatureMatrix.md](docs/FeatureMatrix.md).
 
-Defaults (`MLX`, `Llama`, `HuggingFace`) are enabled when you don't pass `--disable-default-traits` or a custom `traits:` array. Opt-in traits include `CloudSaaS`, `Ollama`, `Voice`, `Tools`, `AppIntents`, `Server`, `Macros`, `Fuzz`, and the App Store-lean `FoundationOnly`. See [docs/QUICKSTART.md → Customizing backends](docs/QUICKSTART.md#customizing-backends) for the per-trait build commands.
+Defaults (`MLX`, `Llama`, `HuggingFace`) are enabled when you don't pass `--disable-default-traits` or a custom `traits:` array. Opt-in traits include `CloudSaaS`, `Ollama`, `Server`, `Macros`, `Fuzz`, and the App Store-lean `FoundationOnly`. The former `MCP`, `MCPBuiltinCatalog`, `Voice`, `Tools`, `AppIntents`, and `Skills` traits were retired in v0.48 — those modules now compile unconditionally and you opt in by adding their products. See [docs/QUICKSTART.md → Customizing backends](docs/QUICKSTART.md#customizing-backends) for the per-trait build commands.
 
 For a quantified breakdown of what each trait costs in binary size, build time, and dependency weight — and why the checkout is large regardless of trait set — see [docs/TRAIT-COSTS.md](docs/TRAIT-COSTS.md).
 
@@ -200,7 +200,7 @@ ManifoldKit ships **25 libraries**, **3 executables**, and **1 macro plugin**. T
 
 ```
 ManifoldVoice              ManifoldUIModelManagement
-(Voice trait)              (model browser + endpoint UI)
+(speech I/O)               (model browser + endpoint UI)
         │                          │
         └────────► ManifoldUI ◄────┘
                        │

--- a/Sources/ManifoldKit/Exports+Skills.swift
+++ b/Sources/ManifoldKit/Exports+Skills.swift
@@ -1,7 +1,5 @@
-// Conditional re-export of ManifoldSkills via the umbrella `ManifoldKit`
-// module. Gated on the `Skills` trait (default-on) so consumers building
-// without the trait (e.g. embedded / FoundationOnly) don't pay for the
-// module link.
-#if Skills
+// Re-export of ManifoldSkills via the umbrella `ManifoldKit` module.
+// Unconditional since v0.48 (the `Skills` trait was retired in PR A3) —
+// the module body is platform-gated with `#if os(macOS)` and compiles to a
+// no-op registry elsewhere, so the link cost is negligible.
 @_exported import ManifoldSkills
-#endif

--- a/Sources/ManifoldKit/Exports.swift
+++ b/Sources/ManifoldKit/Exports.swift
@@ -9,7 +9,7 @@
 //     Many apps don't ship the management surface; keeping it out of the
 //     umbrella lets chat-only consumers compile without the 1,800+ LOC.
 //   - `ManifoldMCP` — Model Context Protocol client (no trait since v0.48).
-//   - `ManifoldVoice` — speech I/O composer (trait `Voice`).
+//   - `ManifoldVoice` — speech I/O composer.
 //   - `ManifoldHuggingFace` — Hub browse/download (default-on under
 //     `HuggingFace`, but exposed only via `ManifoldUIModelManagement` UI hooks).
 //   - `ManifoldTools`, `ManifoldAppIntents`, `ManifoldServer`,

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -102,21 +102,6 @@ public enum FeatureMatrix {
             unlocks: [.cloudOpenAI, .cloudClaude, .toolCalling, .visionInput]
         ),
         ManifoldTrait(
-            name: "Voice",
-            description: "Enable the ManifoldVoice speech I/O spike and voice composer UI.",
-            unlocks: [.voiceIO]
-        ),
-        ManifoldTrait(
-            name: "Tools",
-            description: "Enable the ManifoldTools end-to-end tool-calling validation harness and its `manifold-tools` CLI.",
-            unlocks: [.toolCalling]
-        ),
-        ManifoldTrait(
-            name: "AppIntents",
-            description: "Enable the ManifoldAppIntents AppIntent ↔ ToolDefinition bridge.",
-            unlocks: [.toolCalling]
-        ),
-        ManifoldTrait(
             name: "Server",
             description: "Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency.",
             unlocks: [.embeddings]
@@ -124,11 +109,6 @@ public enum FeatureMatrix {
         ManifoldTrait(
             name: "Macros",
             description: "Enable the @ToolSchema macro plugin and its swift-syntax dependency. Off by default — pulls ~647 source files into the build graph.",
-            unlocks: [.toolCalling]
-        ),
-        ManifoldTrait(
-            name: "Skills",
-            description: "Enable the ManifoldSkills target: Claude-Code-compatible filesystem skill discovery (~/.claude/skills/<name>/SKILL.md) plus a single `invoke_skill` dispatch tool. macOS-only in v1 — compiles on iOS as a no-op registry.",
             unlocks: [.toolCalling]
         ),
         ManifoldTrait(

--- a/Sources/ManifoldTools/README.md
+++ b/Sources/ManifoldTools/README.md
@@ -13,8 +13,9 @@
 # Mock backend — no hardware, no Ollama. Useful for CI smoke and local sanity checks.
 swift run --disable-default-traits manifold-tools --backend mock --scenario all
 
-# Real Ollama — requires a local server with tool-capable models installed.
-swift run --disable-default-traits manifold-tools --backend ollama --scenario 02-calc \
+# Real Ollama — requires a local server with tool-capable models installed,
+# and the Ollama trait (the CLI's Ollama path is compiled out without it).
+swift run --disable-default-traits --traits Ollama manifold-tools --backend ollama --scenario 02-calc \
     --ollama-base-url http://localhost:11434 --model llama3.1:8b
 ```
 
@@ -77,7 +78,7 @@ Local developers with Ollama can run the real-model E2E with:
 ```sh
 ollama serve &                          # in another terminal
 ollama pull llama3.1:8b
-swift run --disable-default-traits manifold-tools --backend ollama --scenario all
+swift run --disable-default-traits --traits Ollama manifold-tools --backend ollama --scenario all
 ```
 
 ## Why a dedicated harness?

--- a/Sources/manifold-tools/main.swift
+++ b/Sources/manifold-tools/main.swift
@@ -1,18 +1,18 @@
 // Does not require the Fuzz trait. The Ollama path is gated behind the
-// `Ollama` trait (default-on for now); pass `--disable-default-traits`
-// to drop it. The mock path is always available.
+// `Ollama` trait (not in the default set); pass `--traits Ollama` to enable
+// it. The mock path is always available.
 // For generation fuzzing with real backends, see scripts/fuzz.sh.
 //
-// The body is gated on the `Tools` trait. Without the trait, the executable
-// links to a no-op stub that prints a "trait not enabled" message — this
-// mirrors the ManifoldServer trait pattern (PR #946) and keeps `manifold-tools`
-// out of the default-trait build's link graph for the ManifoldTools and
-// ManifoldBackends symbols.
-#if Tools
+// The `Tools` trait was retired in v0.48 (PR A3) — the CLI body compiles
+// unconditionally now. It links the ManifoldOllama family product directly
+// instead of the ManifoldBackends umbrella so MLX/llama.framework never
+// enter the link graph (the #982 dual-llama Xcode-scheme hazard).
 import Foundation
 import ManifoldInference
-import ManifoldBackends
 import ManifoldTools
+#if Ollama
+import ManifoldOllama
+#endif
 
 /// Hand-rolled argument parser — `swift-argument-parser` would be the right
 /// call in a larger CLI, but pulling in an external SPM dependency for a
@@ -458,8 +458,3 @@ enum MockFactory {
 
 let exitCode = await runCLI()
 exit(exitCode)
-#else
-import Foundation
-print("manifold-tools was built without the `Tools` trait. Re-build with `--traits Tools` to enable.")
-exit(0)
-#endif

--- a/Tests/ManifoldAppIntentsTests/AppEntityParameterTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppEntityParameterTests.swift
@@ -1,4 +1,3 @@
-#if AppIntents
 import XCTest
 import ManifoldInference
 @testable import ManifoldAppIntents
@@ -316,4 +315,3 @@ final class AppEntityParameterTests: XCTestCase {
 }
 
 #endif // canImport(AppIntents)
-#endif

--- a/Tests/ManifoldAppIntentsTests/AppEntityParameterTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppEntityParameterTests.swift
@@ -161,7 +161,8 @@ final class AppEntityParameterTests: XCTestCase {
 
     // MARK: schema synthesis
 
-    func testSchemaEmitsIdOnlyObjectForAppEntityParameter() {
+    func testSchemaEmitsIdOnlyObjectForAppEntityParameter() throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(
             DescribeBookIntent.self,
             approvalPolicy: .readOnlyAutoApprove,
@@ -195,6 +196,7 @@ final class AppEntityParameterTests: XCTestCase {
     // MARK: happy path
 
     func testExecuteResolvesEntityByIdAndRunsPerform() async throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(
             DescribeBookIntent.self,
             approvalPolicy: .readOnlyAutoApprove,
@@ -219,6 +221,7 @@ final class AppEntityParameterTests: XCTestCase {
     // MARK: unknown id
 
     func testExecuteWithUnknownEntityIdReturnsInvalidArguments() async throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(
             DescribeBookIntent.self,
             approvalPolicy: .readOnlyAutoApprove,
@@ -248,6 +251,7 @@ final class AppEntityParameterTests: XCTestCase {
     // MARK: resolver throws
 
     func testExecuteWithThrowingResolverSurfacesPermanent() async throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(
             DescribeBookIntent.self,
             approvalPolicy: .readOnlyAutoApprove,

--- a/Tests/ManifoldAppIntentsTests/AppIntentDispatchE2ETests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentDispatchE2ETests.swift
@@ -1,4 +1,3 @@
-#if AppIntents
 import XCTest
 import ManifoldInference
 @testable import ManifoldAppIntents
@@ -147,4 +146,3 @@ final class AppIntentDispatchE2ETests: XCTestCase {
 }
 
 #endif // canImport(AppIntents)
-#endif

--- a/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
@@ -395,6 +395,7 @@ final class AppIntentStreamingTests: XCTestCase {
     /// this PR closes that drift — both paths now go through the same
     /// resolve-then-decode sequence.
     func testStreamingResolvesAppEntityParameter() async throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(
             StreamingDescribeBookIntent.self,
             approvalPolicy: .readOnlyAutoApprove,
@@ -481,6 +482,7 @@ final class AppIntentStreamingTests: XCTestCase {
     /// being installed before `perform()`, and the entity depends on
     /// `decoder.userInfo` being populated before `init(from:)` runs.
     func testStreamingEntityAndProgressBothFlow() async throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(
             StreamingEntityProgressIntent.self,
             approvalPolicy: .readOnlyAutoApprove,

--- a/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentStreamingTests.swift
@@ -1,4 +1,3 @@
-#if AppIntents
 import XCTest
 import ManifoldInference
 @testable import ManifoldAppIntents
@@ -518,4 +517,3 @@ final class AppIntentStreamingTests: XCTestCase {
 }
 
 #endif // canImport(AppIntents)
-#endif

--- a/Tests/ManifoldAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -1,4 +1,3 @@
-#if AppIntents
 import XCTest
 import ManifoldInference
 @testable import ManifoldAppIntents
@@ -866,4 +865,3 @@ final class AppIntentToolExecutorTests: XCTestCase {
 }
 
 #endif // canImport(AppIntents)
-#endif

--- a/Tests/ManifoldAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -677,7 +677,8 @@ final class AppIntentToolExecutorTests: XCTestCase {
 
     // MARK: title + default emission
 
-    func testSchemaEmitsParameterTitleAsDescription() {
+    func testSchemaEmitsParameterTitleAsDescription() throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(DecoratedIntent.self)
         guard case .object(let root) = executor.definition.parameters,
               case .object(let properties) = root["properties"],
@@ -716,7 +717,8 @@ final class AppIntentToolExecutorTests: XCTestCase {
         )
     }
 
-    func testSchemaOmitsDefaultAndDescriptionWhenNoneProvided() {
+    func testSchemaOmitsDefaultAndDescriptionWhenNoneProvided() throws {
+        try skipUnlessAppIntents26Runtime()
         let executor = AppIntentToolExecutor(DecoratedIntent.self)
         guard case .object(let root) = executor.definition.parameters,
               case .object(let properties) = root["properties"],

--- a/Tests/ManifoldAppIntentsTests/AppIntents26RuntimeSkip.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntents26RuntimeSkip.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+/// The AppIntents test fixtures are `@available(iOS 26, macOS 26, *)`, but
+/// XCTest discovers and runs the annotated classes on older OSes anyway —
+/// where the AppIntents runtime's parameter/entity introspection behaves
+/// differently and the macOS-26 contract does not hold. These tests first
+/// joined per-PR CI in v0.48 PR A3 (the AppIntents trait retirement);
+/// CI runners are macos-15 (the n-1 floor), so the 26-only paths skip there.
+func skipUnlessAppIntents26Runtime(file: StaticString = #filePath, line: UInt = #line) throws {
+    guard #available(iOS 26, macOS 26, *) else {
+        throw XCTSkip("Requires the iOS/macOS 26 AppIntents runtime (entity resolution / parameter metadata introspection)")
+    }
+}

--- a/Tests/ManifoldAppIntentsTests/AskManifoldIntentTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AskManifoldIntentTests.swift
@@ -1,4 +1,3 @@
-#if AppIntents
 import XCTest
 import ManifoldInference
 @testable import ManifoldAppIntents
@@ -147,4 +146,3 @@ final class AskManifoldIntentTests: XCTestCase {
 }
 
 #endif // canImport(AppIntents)
-#endif // AppIntents

--- a/Tests/ManifoldAppIntentsTests/BatchRegistrationTests.swift
+++ b/Tests/ManifoldAppIntentsTests/BatchRegistrationTests.swift
@@ -1,4 +1,3 @@
-#if AppIntents
 import XCTest
 import ManifoldInference
 @testable import ManifoldAppIntents
@@ -285,4 +284,3 @@ final class BatchRegistrationTests: XCTestCase {
 }
 
 #endif // canImport(AppIntents)
-#endif

--- a/Tests/ManifoldCoreTests/PackageTraitGateAuditTest.swift
+++ b/Tests/ManifoldCoreTests/PackageTraitGateAuditTest.swift
@@ -1,11 +1,12 @@
 import XCTest
 
 /// Guards against regressions on issue #951: `Package.swift` must keep the
-/// optional modules — `ManifoldVoice`, `ManifoldTools`, `ManifoldAppIntents`,
-/// and `ManifoldFuzz` (plus its `ManifoldFuzzBackends` sibling) — gated
-/// behind their declared traits. Mirrors the pattern PR #946 established for
-/// the `Server` trait around `ManifoldServer`. (`ManifoldMCP` left this list
-/// in v0.48 when the MCP trait was retired.)
+/// optional modules that still have declared traits — `ManifoldFuzz` (plus
+/// its `ManifoldFuzzBackends` sibling) and the Ollama/CloudSaaS family
+/// products — gated behind those traits. Mirrors the pattern PR #946
+/// established for the `Server` trait around `ManifoldServer`. (The MCP /
+/// MCPBuiltinCatalog traits were retired in v0.48 PR A2; Voice / Tools /
+/// AppIntents / Skills in PR A3. Former entries are gone, not relaxed.)
 ///
 /// ## Why this matters
 ///
@@ -57,25 +58,13 @@ final class PackageTraitGateAuditTest: XCTestCase {
         // MCPBuiltinCatalog traits were retired in v0.48 (PR A2) — ManifoldMCP
         // compiles unconditionally.
 
-        // ManifoldVoice — gated by Voice on the test target. The library
-        // target's product declaration stays unconditional (apps importing
-        // it must opt the trait in via their consumer manifest), but the
-        // in-tree test consumer must carry the gate so swift test
-        // --disable-default-traits doesn't link Voice symbols.
-        .init(description: "ManifoldVoiceTests → ManifoldVoice", module: "ManifoldVoice", trait: "Voice"),
-
-        // ManifoldTools — gated by Tools across the manifold-tools CLI, the test
-        // target, and the ManifoldE2ETests scenario consumer. The
-        // ManifoldBackends edge inside manifold-tools is also Tools-gated so the
-        // executable doesn't pull llama.framework into the auto-generated
-        // Xcode scheme when Tools is off.
-        .init(description: "manifold-tools → ManifoldTools", module: "ManifoldTools", trait: "Tools"),
-        .init(description: "manifold-tools → ManifoldBackends", module: "ManifoldBackends", trait: "Tools"),
-        .init(description: "ManifoldToolsTests → ManifoldTools", module: "ManifoldTools", trait: "Tools"),
-        .init(description: "ManifoldE2ETests → ManifoldTools", module: "ManifoldTools", trait: "Tools"),
-
-        // ManifoldAppIntents — gated by AppIntents on the test target.
-        .init(description: "ManifoldAppIntentsTests → ManifoldAppIntents", module: "ManifoldAppIntents", trait: "AppIntents"),
+        // The Voice / Tools / AppIntents / Skills traits were retired in
+        // v0.48 (PR A3): their consumer edges are unconditional now, so they
+        // no longer appear here. NOTE: manifold-tools must never regain a
+        // ManifoldBackends (umbrella) edge — the umbrella drags
+        // llama.framework into the auto-generated Xcode scheme twice and
+        // breaks ManifoldMLXIntegrationTests (#982). It links ManifoldOllama
+        // directly instead.
 
         // ManifoldFuzz / ManifoldFuzzBackends — gated by Fuzz at the
         // consumer edges (fuzz-chat CLI and ManifoldFuzzTests). The

--- a/Tests/ManifoldE2ETests/DemoScenarioCoverageInventory.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioCoverageInventory.swift
@@ -22,7 +22,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["calc"],
             existingTests: ["DemoScenarioOllamaE2ETests", "DemoScenarioUITests"],
             missingTestLayers: ["dedicated demo tool-logic unit row"],
-            requiredTraits: ["Ollama", "Tools"],
+            requiredTraits: ["Ollama"],
             environmentGates: ["Ollama localhost:11434", "OLLAMA_TEST_MODEL optional fail-loud pin"],
             notes: "Current P1 arithmetic smoke used by the shared E2E harness."
         ),
@@ -32,7 +32,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["now"],
             existingTests: ["DemoScenarioOllamaE2ETests", "DemoScenarioUITests"],
             missingTestLayers: ["dedicated demo tool-logic unit row"],
-            requiredTraits: ["Ollama", "Tools"],
+            requiredTraits: ["Ollama"],
             environmentGates: ["Ollama localhost:11434", "tool-calling-capable local model"],
             notes: "Asserts Asia/Tokyo argument in the Ollama E2E layer."
         ),
@@ -42,7 +42,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["sample_repo_search"],
             existingTests: ["DemoScenarioOllamaE2ETests", "DemoScenarioUITests"],
             missingTestLayers: ["dedicated demo tool-logic unit row"],
-            requiredTraits: ["Ollama", "Tools"],
+            requiredTraits: ["Ollama"],
             environmentGates: ["Ollama localhost:11434", "seeded sandbox workspace"],
             notes: "Uses a per-test fixture root so search results are deterministic."
         ),
@@ -52,7 +52,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["write_file"],
             existingTests: ["DemoScenarioOllamaE2ETests", "DemoScenarioUITests"],
             missingTestLayers: ["dedicated demo approval unit row"],
-            requiredTraits: ["Ollama", "Tools"],
+            requiredTraits: ["Ollama"],
             environmentGates: ["Ollama localhost:11434", "writable sandbox root"],
             notes: "E2E auto-approves the side effect and asserts the file exists."
         ),
@@ -62,7 +62,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["calc"],
             existingTests: ["DemoScenarios.scriptedTurns(for:)"],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["tool loop enabled"],
             notes: "Current demo card; not part of the Wave 0 four-test E2E set."
         ),
@@ -72,7 +72,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["fakeRateLimited"],
             existingTests: ["DemoScenarios.scriptedTurns(for:)"],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["tool loop enabled"],
             notes: "Current demo card exercising retriable ToolResult.ErrorKind."
         ),
@@ -82,7 +82,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["fakeMCPLookup"],
             existingTests: ["DemoScenarios.scriptedTurns(for:)"],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["tool loop enabled"],
             notes: "Current demo card simulating transient MCP transport failure."
         ),
@@ -92,7 +92,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["everything__echo"],
             existingTests: ["DemoScenarios.scriptedTurns(for:)"],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "MCP for live source", "Ollama for real E2E"],
+            requiredTraits: ["MCP for live source", "Ollama for real E2E"],
             environmentGates: ["macOS", "npx", "connected everything MCP server"],
             notes: "Current demo card; live MCP source must be connected before use."
         ),
@@ -102,7 +102,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["list_dir", "read_file"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["seeded notes fixture", "multi-turn tool loop"],
             notes: "P2 headline agent-loop scenario; #707 reuses this shape."
         ),
@@ -112,7 +112,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["read_file", "calc"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["seeded shopping-list fixture", "multi-turn tool loop"],
             notes: "Mixed-tool chain: text retrieval, arithmetic, synthesis."
         ),
@@ -122,7 +122,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["read_file", "read_file"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["parallel tool-call support", "seeded README fixtures"],
             notes: "P3 scenario bundled with parallel tool-call capability."
         ),
@@ -132,7 +132,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["composeEmail or equivalent large-argument tool"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["tool-call delta streaming support"],
             notes: "P3 UI streaming scenario; tool definition is capability-owned."
         ),
@@ -142,7 +142,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["slow sample_repo_search"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["cancellation contract", "slow fixture search"],
             notes: "P3 cancellation scenario; do not add in Wave 0."
         ),
@@ -152,7 +152,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["read_file"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["oversize fixture", "ToolOutputPolicy configured"],
             notes: "P3 output-policy scenario."
         ),
@@ -162,7 +162,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["slow sample_repo_search"],
             existingTests: [],
             missingTestLayers: ["tool-logic integration", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["SwiftData session reload", "app terminate/relaunch harness"],
             notes: "Recovery test hits persistence; keep separate from pure harness."
         ),
@@ -172,7 +172,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["AppIntent reminder tool"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["AppIntents", "Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["Reminders/EventKit permission", "platform availability"],
             notes: "P3 native API scenario; should ship with AppIntent capability."
         ),
@@ -182,7 +182,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["mcp_fs_read"],
             existingTests: [],
             missingTestLayers: ["tool-logic unit", "mock XCUITest", "real Ollama E2E"],
-            requiredTraits: ["Tools", "Ollama for real E2E"],
+            requiredTraits: ["Ollama for real E2E"],
             environmentGates: ["filesystem MCP server fixture", "Ollama localhost:11434"],
             notes: "Still missing per #754 audit; do not implement in Wave 0."
         ),
@@ -192,7 +192,7 @@ enum DemoScenarioCoverageInventory {
             toolset: ["list_dir", "read_file"],
             existingTests: ["Ollama leg covered indirectly by current four E2Es only for P1"],
             missingTestLayers: ["Claude E2E", "Foundation E2E", "cross-backend mock contract"],
-            requiredTraits: ["Tools", "Ollama", "CloudSaaS", "Foundation availability"],
+            requiredTraits: ["Ollama", "CloudSaaS", "Foundation availability"],
             environmentGates: ["Ollama server", "Claude credentials", "iOS 26/macOS 26 Foundation Models"],
             notes: "Still missing per #754 audit; later workers should reuse the shared harness."
         ),

--- a/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
@@ -1,4 +1,4 @@
-#if Ollama && Tools
+#if Ollama
 import Foundation
 import XCTest
 import ManifoldInference

--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
@@ -1,4 +1,4 @@
-#if Ollama && Tools
+#if Ollama
 import XCTest
 import ManifoldInference
 import ManifoldTools

--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaHelpers.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaHelpers.swift
@@ -1,4 +1,4 @@
-#if Ollama && Tools
+#if Ollama
 import Foundation
 import XCTest
 import ManifoldInference

--- a/Tests/ManifoldSkillsTests/AllowedToolsEnforcementTests.swift
+++ b/Tests/ManifoldSkillsTests/AllowedToolsEnforcementTests.swift
@@ -1,4 +1,3 @@
-#if Skills
 import XCTest
 import ManifoldInference
 import ManifoldRuntime
@@ -91,4 +90,3 @@ final class AllowedToolsEnforcementTests: XCTestCase {
         // to return Set() → assertion fails.
     }
 }
-#endif

--- a/Tests/ManifoldSkillsTests/SampleSkillBundleTests.swift
+++ b/Tests/ManifoldSkillsTests/SampleSkillBundleTests.swift
@@ -1,4 +1,3 @@
-#if Skills
 import XCTest
 @testable import ManifoldSkills
 
@@ -64,4 +63,3 @@ final class SampleSkillBundleTests: XCTestCase {
         #endif
     }
 }
-#endif

--- a/Tests/ManifoldSkillsTests/SkillLoaderTests.swift
+++ b/Tests/ManifoldSkillsTests/SkillLoaderTests.swift
@@ -1,4 +1,3 @@
-#if Skills
 import XCTest
 @testable import ManifoldSkills
 
@@ -177,4 +176,3 @@ final class SkillLoaderTests: XCTestCase {
         // and suffix assert fail.
     }
 }
-#endif

--- a/Tests/ManifoldSkillsTests/SkillRegistryTests.swift
+++ b/Tests/ManifoldSkillsTests/SkillRegistryTests.swift
@@ -1,4 +1,3 @@
-#if Skills
 import XCTest
 @testable import ManifoldSkills
 
@@ -63,4 +62,3 @@ final class SkillRegistryTests: XCTestCase {
         // a placeholder → assertion fails.
     }
 }
-#endif

--- a/Tests/ManifoldSkillsTests/SkillToolSourceTests.swift
+++ b/Tests/ManifoldSkillsTests/SkillToolSourceTests.swift
@@ -1,4 +1,3 @@
-#if Skills
 import XCTest
 import ManifoldInference
 import ManifoldRuntime
@@ -155,4 +154,3 @@ final class SkillToolSourceTests: XCTestCase, SessionToolSourceContract {
         // closure — postAllowed stays nil.
     }
 }
-#endif

--- a/Tests/ManifoldSkillsTests/YAMLFrontmatterTests.swift
+++ b/Tests/ManifoldSkillsTests/YAMLFrontmatterTests.swift
@@ -1,4 +1,3 @@
-#if Skills
 import XCTest
 @testable import ManifoldSkills
 
@@ -253,4 +252,3 @@ final class YAMLFrontmatterTests: XCTestCase {
         // would surface as literal characters and the assertion fails.
     }
 }
-#endif

--- a/Tests/ManifoldToolsTests/ReferenceToolsTests.swift
+++ b/Tests/ManifoldToolsTests/ReferenceToolsTests.swift
@@ -1,4 +1,3 @@
-#if Tools
 import XCTest
 import ManifoldInference
 @testable import ManifoldTools
@@ -135,4 +134,3 @@ final class ReferenceToolsTests: XCTestCase {
         return url
     }
 }
-#endif

--- a/Tests/ManifoldToolsTests/SampleRepoSearchToolTests.swift
+++ b/Tests/ManifoldToolsTests/SampleRepoSearchToolTests.swift
@@ -1,4 +1,3 @@
-#if Tools
 import XCTest
 import ManifoldInference
 @testable import ManifoldTools
@@ -231,4 +230,3 @@ final class SampleRepoSearchToolTests: XCTestCase {
         return url
     }
 }
-#endif

--- a/Tests/ManifoldToolsTests/ScenarioRunnerTests.swift
+++ b/Tests/ManifoldToolsTests/ScenarioRunnerTests.swift
@@ -1,4 +1,3 @@
-#if Tools
 import XCTest
 import ManifoldInference
 @testable import ManifoldTools
@@ -525,4 +524,3 @@ private actor ReminderRecorder {
         recorded
     }
 }
-#endif

--- a/Tests/ManifoldVoiceTests/VoiceConversationControllerTests.swift
+++ b/Tests/ManifoldVoiceTests/VoiceConversationControllerTests.swift
@@ -1,4 +1,3 @@
-#if Voice
 import XCTest
 @testable import ManifoldVoice
 
@@ -226,4 +225,3 @@ private final class ControlledToastSleeper {
         continuation = nil
     }
 }
-#endif

--- a/Tests/ManifoldVoiceTests/VoiceDraftComposerTests.swift
+++ b/Tests/ManifoldVoiceTests/VoiceDraftComposerTests.swift
@@ -1,4 +1,3 @@
-#if Voice
 import XCTest
 @testable import ManifoldVoice
 
@@ -25,4 +24,3 @@ final class VoiceDraftComposerTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldVoiceTests/VoiceViewContractTests.swift
+++ b/Tests/ManifoldVoiceTests/VoiceViewContractTests.swift
@@ -1,4 +1,3 @@
-#if Voice
 import XCTest
 import ViewInspector
 @testable import ManifoldVoice
@@ -41,4 +40,3 @@ final class VoiceViewContractTests: XCTestCase {
         XCTAssertEqual(label, WakeWordToast.accessibilityLabel(for: "hey base chat"))
     }
 }
-#endif

--- a/Tests/ManifoldVoiceTests/WakeWordDetectorTests.swift
+++ b/Tests/ManifoldVoiceTests/WakeWordDetectorTests.swift
@@ -1,4 +1,3 @@
-#if Voice
 import XCTest
 @testable import ManifoldVoice
 
@@ -38,4 +37,3 @@ final class WakeWordDetectorTests: XCTestCase {
         XCTAssertNil(detector.ingest(.init(text: "hey base chat", isFinal: false)))
     }
 }
-#endif

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -33,17 +33,15 @@ ManifoldKit's test targets are conditionally linked on Swift package traits:
 | `MLX` | yes | MLX backend, mlx-swift-lm dependency |
 | `Llama` | yes | LlamaBackend, llama.swift dependency |
 | `HuggingFace` | yes | HF model browser |
-| `Skills` | yes | `ManifoldSkills` module and SKILL.md discovery tests |
 | `AnyLanguageModel` | no | AnyLanguageModel bridge backend target |
 | `Ollama` | no | Ollama backend, requires `localhost:11434` |
 | `CloudSaaS` | no | OpenAI/Claude/Responses backends |
-| `Tools` | no | `manifold-tools` CLI body |
 | `Server` | no | ManifoldServer |
 | `Operational` | (planned, T4) | Nightly soak/migration/throughput |
 
 The default-traits build is what CI's per-PR matrix runs against. Running `swift test`
 with no explicit trait flags enables the Package.swift defaults: `MLX`, `Llama`,
-`HuggingFace`, and `Skills`. Use `--disable-default-traits` locally to drop those
+and `HuggingFace`. Use `--disable-default-traits` locally to drop those
 defaults when you want a faster, sim-friendly build.
 
 **When to disable default traits locally:** any iteration that doesn't exercise a hardware backend — `ManifoldRuntimeTests`, `ManifoldPersistenceSwiftDataTests`, `ManifoldUITests`, `ManifoldInferenceTests`, `ManifoldMCPTests`, `ManifoldServerTests`. Skipping MLX avoids an mlx-swift source checkout and a Metal shader compilation pass on every rebuild — the dominant cost in a default-traits cold build.

--- a/docs/AppStoreSubmission.md
+++ b/docs/AppStoreSubmission.md
@@ -79,10 +79,11 @@ Justify with: "the app talks to a user-installed Ollama daemon at
 the network." Apple has approved this pattern for other on-device LLM
 shells.
 
-## 4. Microphone / speech entitlements (Voice trait only)
+## 4. Microphone / speech entitlements (ManifoldVoice consumers only)
 
-If you build with the `Voice` trait, add both usage-description strings.
-Apps without `Voice` should not ship these keys.
+If your app depends on the `ManifoldVoice` product (the former `Voice`
+trait was retired in v0.48), add both usage-description strings.
+Apps that don't link `ManifoldVoice` should not ship these keys.
 
 ```xml
 <key>NSMicrophoneUsageDescription</key>

--- a/docs/FeatureMatrix.md
+++ b/docs/FeatureMatrix.md
@@ -6,7 +6,6 @@ Do not edit by hand — re-run the script.
 | Trait | Description | Capabilities Unlocked |
 |-------|-------------|-----------------------|
 | `AnyLanguageModel` | Reach providers without a native backend (Gemini, xAI, Groq, Mistral, OpenRouter, and others) through the AnyLanguageModel bridge. | `providerBridge` |
-| `AppIntents` | Enable the ManifoldAppIntents AppIntent ↔ ToolDefinition bridge. | `toolCalling` |
 | `CloudSaaS` | Third-party SaaS providers (Claude, OpenAI). Off by default. | `cloudOpenAI`, `cloudClaude`, `toolCalling`, `visionInput` |
 | `CoreAI` | Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface. | _(none — harness/build lever)_ |
 | `FoundationOnly` | App Store-lean: Apple Foundation Models only. Pass `traits: ["FoundationOnly"]` from the consumer manifest — overrides the MLX/Llama/HuggingFace default trait set. | `foundationBackend` |
@@ -17,7 +16,4 @@ Do not edit by hand — re-run the script.
 | `MLX` | Enable the MLX inference backend (requires Apple Silicon) | `localInference`, `mlxBackend`, `visionInput`, `imageGeneration` |
 | `Ollama` | Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major. | `ollama`, `toolCalling`, `embeddings` |
 | `Server` | Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency. | `embeddings` |
-| `Skills` | Enable the ManifoldSkills target: Claude-Code-compatible filesystem skill discovery (~/.claude/skills/<name>/SKILL.md) plus a single `invoke_skill` dispatch tool. macOS-only in v1 — compiles on iOS as a no-op registry. | `toolCalling` |
 | `SystemAIProviderExtension` | Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API. | _(none — harness/build lever)_ |
-| `Tools` | Enable the ManifoldTools end-to-end tool-calling validation harness and its `manifold-tools` CLI. | `toolCalling` |
-| `Voice` | Enable the ManifoldVoice speech I/O spike and voice composer UI. | `voiceIO` |

--- a/docs/QUICKSTART-APPINTENTS.md
+++ b/docs/QUICKSTART-APPINTENTS.md
@@ -8,17 +8,16 @@ The full reference — parameter-type coverage, the `Decodable` boilerplate AppI
 
 This page is a thin pointer to it plus the package wiring.
 
-## Module and trait
+## Module
 
-`ManifoldAppIntents` is a non-default, opt-in module. It depends only on `ManifoldInference` (and AppIntents, which ships with the OS), so apps that don't need SwiftData persistence or the chat UI can adopt it with no transitive weight.
+`ManifoldAppIntents` is an opt-in module. It depends only on `ManifoldInference` (and AppIntents, which ships with the OS), so apps that don't need SwiftData persistence or the chat UI can adopt it with no transitive weight.
 
-Add it explicitly to your target, and enable the `AppIntents` trait on the package dependency:
+No trait required — the former `AppIntents` trait was retired in v0.48. Add the product explicitly to your target:
 
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.46.0", // x-release-please-version
-    traits: [.trait(name: "AppIntents")]
+    from: "0.46.0" // x-release-please-version
 )
 ```
 

--- a/docs/QUICKSTART-VOICE.md
+++ b/docs/QUICKSTART-VOICE.md
@@ -12,21 +12,18 @@ chat-agnostic primitive that anything can drive.
 
 ---
 
-## 1. Add the `Voice` trait
+## 1. Add the `ManifoldVoice` product
 
-In your consumer `Package.swift`:
+No trait required — the former `Voice` trait was retired in v0.48. In your
+consumer `Package.swift`:
 
 ```swift,no-build
 dependencies: [
     .package(
         url: "https://github.com/roryford/ManifoldKit.git",
         from: "0.47.0", // x-release-please-version
-        traits: [
-            .trait(name: "Voice"),
-            // Drop the defaults if you only want voice and not the
-            // MLX/Llama/HuggingFace backends:
-            // .defaults(disabled: true),
-        ]
+        // Tip: pass `traits: [.defaults(disabled: true)]` if you only want
+        // voice and not the MLX/Llama/HuggingFace backends.
     ),
 ],
 targets: [

--- a/docs/TRAIT-COSTS.md
+++ b/docs/TRAIT-COSTS.md
@@ -29,10 +29,6 @@
 | `Ollama` | ManifoldCloud (Ollama bodies) | _(none beyond baseline)_ | — | — | +731 | — |
 | `Server` | ManifoldServer + Hummingbird | `EventSource`, `swift-nio`, `swift-crypto`, `swift-collections`, `swift-atomics`, `swift-system` | ~74 | — | +12157 | — |
 | `Macros` | ManifoldMacrosPlugin + @ToolSchema | `swift-syntax` | ~11 | — | +0 | — |
-| `Skills` | ManifoldSkills | _(none beyond baseline)_ | — | — | +224 | — |
-| `Voice` | ManifoldVoice | _(none beyond baseline)_ | — | — | +429 | — |
-| `Tools` | ManifoldTools + manifold-tools CLI | _(none beyond baseline)_ | — | — | +632 | — |
-| `AppIntents` | ManifoldAppIntents | _(none beyond baseline)_ | — | — | +279 | — |
 | `AnyLanguageModel` | AnyLanguageModel bridge | _(none beyond baseline)_ | — | — | — | — |
 | `Fuzz` | fuzz-chat executable (real backends) | _(none beyond baseline)_ | — | — | — | — |
 

--- a/docs/trait-costs.json
+++ b/docs/trait-costs.json
@@ -113,59 +113,8 @@
   "machine": "Apple Silicon (arm64)",
   "method_version": "1",
   "notes": "IMPORTANT: Macros compiles swift-syntax as a COMPILER PLUGIN (host executable, -tool suffix). Adds ZERO bytes to the final app binary. All ~25 MB of swift-syntax plugin objects are build-time-only. Binary delta = 0 runtime. Build-time overhead: ~60-120s for 647-file swift-syntax tree (not cold-measured)."
-},{
-  "trait": "Skills",
-  "modules_added": "ManifoldSkills",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "224",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "Pure ManifoldKit sources. macOS-only filesystem scan (#if os(macOS)). Default-on trait."
-},{
-  "trait": "Voice",
-  "modules_added": "ManifoldVoice",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "429",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "Pure AVFoundation/Speech wrappers. No external package dependency."
-},{
-  "trait": "Tools",
-  "modules_added": "ManifoldTools + manifold-tools CLI",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "632",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "End-to-end tool-calling validation harness + manifold-tools CLI. Pure ManifoldKit sources."
-},{
-  "trait": "AppIntents",
-  "modules_added": "ManifoldAppIntents",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "279",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "AppIntent ↔ ToolDefinition bridge. Pure AppIntents framework, no external package."
-},{
+},
+  {
   "trait": "AnyLanguageModel",
   "modules_added": "AnyLanguageModel bridge",
   "transitive_deps": [],

--- a/scripts/affected-suites-graph.json
+++ b/scripts/affected-suites-graph.json
@@ -528,8 +528,8 @@
       "type": "executable",
       "path": "Sources/manifold-tools",
       "deps": [
-        "ManifoldBackends",
         "ManifoldInference",
+        "ManifoldOllama",
         "ManifoldTools"
       ]
     },

--- a/scripts/affected-suites.sh
+++ b/scripts/affected-suites.sh
@@ -58,6 +58,9 @@ TEST_JOB_SUITES=(
   ManifoldMCPTests
   ManifoldTestSupportTests
   ManifoldAppIntentsTests
+  ManifoldVoiceTests
+  ManifoldSkillsTests
+  ManifoldToolsTests
   ManifoldInferenceTests
   ManifoldNetworkingTests
   ManifoldTurnLoopCharacterizationTests

--- a/scripts/ci-selective-test.sh
+++ b/scripts/ci-selective-test.sh
@@ -76,6 +76,12 @@ for suite in "$@"; do
     ManifoldBackendsTests)
       run_swift_test "$suite" --disable-default-traits --traits CloudSaaS
       ;;
+    ManifoldVoiceTests|ManifoldSkillsTests|ManifoldToolsTests|ManifoldAppIntentsTests)
+      # No .xcscheme for these suites; their traits were retired in v0.48
+      # (PR A3) so they compile under the shared MCP,CloudSaaS lane shape and
+      # reuse its .build. swift test routing avoids the no-scheme failure path.
+      run_swift_test "$suite" --disable-default-traits --traits MCP,CloudSaaS
+      ;;
     *)
       run_xcodebuild "$suite"
       ;;

--- a/scripts/cold-start-specialised-voice.sh
+++ b/scripts/cold-start-specialised-voice.sh
@@ -10,10 +10,9 @@
 # Package.swift, accidental removal of public types, and dependency-graph
 # changes that drop ManifoldUI (ManifoldVoice's only required dep).
 #
-# Does NOT require the Voice trait — ManifoldVoice itself compiles
-# unconditionally; the Voice trait only adds a conditional-compilation define
-# (`#if Voice`) used by the umbrella ManifoldKit target to re-export voice
-# surface. The library's own sources always compile.
+# No trait involved — the Voice trait was retired in v0.48 (PR A3);
+# ManifoldVoice compiles unconditionally and consumers opt in by adding the
+# product dependency, exactly as this gate does.
 #
 # Does NOT exercise live speech I/O (requires device microphone + synthesis
 # engine, unavailable in CI). The gate verifies that the import compiles and

--- a/scripts/measure-trait-costs.sh
+++ b/scripts/measure-trait-costs.sh
@@ -150,12 +150,8 @@ TRAIT_DEPS["Llama"]="llama.swift"          # xcframework in artifacts/llama.swif
 TRAIT_DEPS["HuggingFace"]="swift-huggingface"
 TRAIT_DEPS["CloudSaaS"]=""                 # ManifoldCloudCore always compiled; no unique checkout
 TRAIT_DEPS["Ollama"]=""                    # same ManifoldCloudCore path, no unique checkout
-TRAIT_DEPS["Voice"]=""                     # pure AVFoundation/Speech, no external package
-TRAIT_DEPS["Tools"]=""                     # ManifoldTools = pure ManifoldKit sources
-TRAIT_DEPS["AppIntents"]=""               # pure AppIntents framework, no external package
 TRAIT_DEPS["Server"]="EventSource swift-nio swift-crypto swift-collections swift-atomics swift-system"
 TRAIT_DEPS["Macros"]="swift-syntax"
-TRAIT_DEPS["Skills"]=""                   # pure ManifoldKit sources
 TRAIT_DEPS["Fuzz"]=""                     # fuzz-chat executable only
 TRAIT_DEPS["AnyLanguageModel"]=""         # AnyLanguageModel package always resolved
 TRAIT_DEPS["FoundationOnly"]=""           # override that removes deps; measured as baseline
@@ -167,12 +163,8 @@ TRAIT_MODULES["Llama"]="ManifoldLlama"
 TRAIT_MODULES["HuggingFace"]="ManifoldHuggingFace"
 TRAIT_MODULES["CloudSaaS"]="ManifoldCloud (SaaS bodies)"
 TRAIT_MODULES["Ollama"]="ManifoldCloud (Ollama bodies)"
-TRAIT_MODULES["Voice"]="ManifoldVoice"
-TRAIT_MODULES["Tools"]="ManifoldTools + manifold-tools CLI"
-TRAIT_MODULES["AppIntents"]="ManifoldAppIntents"
 TRAIT_MODULES["Server"]="ManifoldServer + Hummingbird"
 TRAIT_MODULES["Macros"]="ManifoldMacrosPlugin + @ToolSchema"
-TRAIT_MODULES["Skills"]="ManifoldSkills"
 TRAIT_MODULES["Fuzz"]="fuzz-chat executable (real backends)"
 TRAIT_MODULES["AnyLanguageModel"]="AnyLanguageModel bridge"
 TRAIT_MODULES["FoundationOnly"]="FoundationBackend only (removes MLX+Llama+HuggingFace defaults)"
@@ -186,12 +178,8 @@ TRAIT_FLAGS["Llama"]="--traits Llama"
 TRAIT_FLAGS["HuggingFace"]="--traits HuggingFace"
 TRAIT_FLAGS["CloudSaaS"]="--disable-default-traits --traits CloudSaaS"
 TRAIT_FLAGS["Ollama"]="--disable-default-traits --traits Ollama"
-TRAIT_FLAGS["Voice"]="--disable-default-traits --traits Voice"
-TRAIT_FLAGS["Tools"]="--disable-default-traits --traits Tools"
-TRAIT_FLAGS["AppIntents"]="--disable-default-traits --traits AppIntents"
 TRAIT_FLAGS["Server"]="--disable-default-traits --traits Server"
 TRAIT_FLAGS["Macros"]="--disable-default-traits --traits Macros"
-TRAIT_FLAGS["Skills"]="--disable-default-traits --traits Skills"
 TRAIT_FLAGS["Fuzz"]="--disable-default-traits --traits Fuzz,MLX,Llama"
 TRAIT_FLAGS["AnyLanguageModel"]="--disable-default-traits --traits AnyLanguageModel"
 TRAIT_FLAGS["FoundationOnly"]="--traits FoundationOnly"
@@ -206,10 +194,6 @@ TRAITS_TO_MEASURE=(
     Ollama
     Server
     Macros
-    Skills
-    Voice
-    Tools
-    AppIntents
     AnyLanguageModel
     Fuzz
 )

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -72,9 +72,8 @@ HARDWARE_TRAIT_SUITES=(
 #             This is the default when --profile is omitted (back-compat).
 #   local   — Apple-Silicon pre-push: all traits on (minus Fuzz which is
 #             build-only), the full hardened suite list (including
-#             ManifoldKitTests / ManifoldHuggingFaceTests / ManifoldToolsTests
-#             that PR #1382 proved we need), and --num-workers tuned to the
-#             host core count.
+#             ManifoldKitTests / ManifoldHuggingFaceTests that PR #1382
+#             proved we need), and --num-workers tuned to the host core count.
 #
 # Profile defaults are applied AFTER caller flags are parsed, but only fill
 # slots the caller did not set:
@@ -217,6 +216,11 @@ PROFILE_CI_XCTEST_FILTERS=(
     ManifoldAppIntentsTests
     ManifoldServerTests
     ManifoldTurnLoopCharacterizationTests
+    # Voice / Skills / Tools traits retired in v0.48 (PR A3): these suites
+    # compile in every trait shape now, so they run in the CI shape too.
+    ManifoldVoiceTests
+    ManifoldSkillsTests
+    ManifoldToolsTests
 )
 # Local-profile filters extend the CI list with the suites PR #1382 proved
 # we need to hit when traits are on (KV cache reuse race, etc.).
@@ -224,7 +228,6 @@ PROFILE_LOCAL_XCTEST_FILTERS=(
     "${PROFILE_CI_XCTEST_FILTERS[@]}"
     ManifoldKitTests
     ManifoldHuggingFaceTests
-    ManifoldToolsTests
 )
 PROFILE_SWIFT_TESTING_FILTER="ManifoldInferenceSwiftTestingTests"
 


### PR DESCRIPTION
Part of #1749 / v0.48 packaging release — **PR A3** (plan: `docs/plans/v0.48-packaging-release.md` §2 row A3).

## What

Deletes the four leaf traits (`Voice`, `Tools`, `AppIntents`, `Skills`) from the manifest. The modules now compile unconditionally; consumers opt in by adding (or not adding) the products.

**Consumer migration (breaking):** any consumer passing `traits: [.trait(name: "Voice")]` (or `Tools` / `AppIntents` / `Skills`) gets a resolve error (`package 'manifoldkit' has no trait named '…'`). Fix: delete the trait from your `Package.swift`; keep the `.product(name: "ManifoldVoice" | "ManifoldTools" | "ManifoldAppIntents" | "ManifoldSkills", package: "ManifoldKit")` dependency — that is now the only switch. `Skills` was default-on: `ManifoldSkills` is now re-exported **unconditionally** through the `ManifoldKit` umbrella (body is `#if os(macOS)`-gated, no-op elsewhere), so umbrella consumers see no change.

## manifold-tools dependency repoint (#982 context)

The CLI's `ManifoldBackends` umbrella edge existed *only* behind the `Tools` trait to keep llama.framework from appearing twice in the auto-generated Xcode scheme (#982). With the trait gone, keeping the umbrella edge would re-create the dual-llama collision in every default build. The CLI's actual imports are `ManifoldInference`, `ManifoldTools`, and `OllamaBackend` only — **no MLX or Llama symbols** — so it now depends on:

- `ManifoldTools` (unconditional)
- `ManifoldInference` (unconditional)
- `ManifoldOllama` (gated on the `Ollama` trait until PR A4; the `#if Ollama` runtime fallback throws a clear "rebuild with the Ollama trait" error)

It must never regain a `ManifoldBackends` edge — a guard comment now lives in `PackageTraitGateAuditTest`.

## Strip counts (verified by grep, zero residual)

- 2 source gates: `Sources/ManifoldKit/Exports+Skills.swift` (`#if Skills`), `Sources/manifold-tools/main.swift` (`#if Tools` + `#else` stub)
- 19 test-file gates: 6 Skills, 3 Tools, 6 AppIntents, 4 Voice
- 3 compound `#if Ollama && Tools` in `ManifoldE2ETests` narrowed to `#if Ollama` (Ollama half kept — that trait retires in A4)

## Lockstep files

- `PackageTraitGateAuditTest.expectedGates` — 6 retired entries removed (Voice ×1, Tools ×4, AppIntents ×1); MCP/Fuzz/Ollama/CloudSaaS entries kept
- `FeatureMatrix.swift` − 4 entries; `docs/FeatureMatrix.md` regenerated (`scripts/render-feature-matrix.sh`)
- `docs/trait-costs.json` − 4 rows; `docs/TRAIT-COSTS.md` regenerated (`measure-trait-costs.sh --render-only`); `measure-trait-costs.sh` tables pruned (TraitCostsDriftTest stays green)
- `scripts/affected-suites-graph.json` regenerated (`affected-suites.sh --generate`)
- CI: `ManifoldVoiceTests` / `ManifoldSkillsTests` / `ManifoldToolsTests` join the per-PR XCTest lane (`ci.yml` filter list + step name, `test.sh` CI-profile list, `affected-suites.sh` `TEST_JOB_SUITES`, `ci-selective-test.sh` swift-test routing for these scheme-less suites). The all-traits-build list never contained these four (verified); `PROFILE_LOCAL_TRAITS` likewise (verified — no Skills)
- Docs: README (§Feature Matrix + architecture diagram), Tests/README (trait table + defaults), CLAUDE.md targets table, QUICKSTART-VOICE, QUICKSTART-APPINTENTS, AppStoreSubmission §4, `Sources/ManifoldTools/README.md`, cold-start-voice comment

## Test plan (all run from a clean worktree off origin/main)

- [x] Gate 1 `swift build --build-tests --disable-default-traits` — **Build complete (59s)**; `nm` on the bundle confirms Voice/Skills/Tools test classes compile non-vacuously in this shape
- [x] Gate 2 `swift build --build-tests --disable-default-traits --traits MCP,CloudSaaS` (CI lane shape) — **Build complete (35s)**
- [x] Gate 3 `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — **Build complete (202s)**
- [x] Gate 4 `scripts/test.sh --profile local` — **PASSED, exit 0**: XCTest 4,939 passed / 0 failed / 60 skipped + Swift Testing 179 passed; second invocation 83 passed. Suite-ran proof: ManifoldVoiceTests **14**, ManifoldSkillsTests **35**, ManifoldToolsTests **47**, ManifoldAppIntentsTests **61** passed, 0 failed, 0 skipped
- [x] Reduced-shape execution (A1 lesson): the same four suites re-run under `--disable-default-traits --traits MCP,CloudSaaS` — **157/157 passed**
- [x] **#982 regression check**: `xcodebuild -list` enumerates all schemes cleanly (no duplicate-llama error); `xcodebuild build-for-testing -scheme ManifoldKit-Package -destination 'platform=macOS' -only-testing ManifoldMLXIntegrationTests` produced its build description (`623c9c158a3b…`) and ran 132+ compile tasks with **zero** "Multiple commands produce" / duplicate-framework diagnostics and exactly one llama.framework reference in 6k+ log lines, then was aborted mid-compile as planned

🤖 Generated with [Claude Code](https://claude.com/claude-code)