### PR TITLE
feat: publish backend seam and registrar-injectable quickStart

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -80,3 +80,4 @@ API breakage: var InferenceBackend.capabilities has been removed
 API breakage: var InferenceBackend.isGenerating has been removed
 API breakage: var InferenceBackend.isModelLoaded has been removed
 API breakage: var InferenceBackend.manifest has been removed
+API breakage: constructor ChatViewModel.init(inferenceService:deviceCapability:modelStorage:memoryPressure:toolApprovalGate:userDefaults:conversationRuntime:) is now with @_spi

--- a/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
+++ b/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
@@ -10,31 +10,50 @@ import ManifoldInference
 public enum DefaultBackends {
 
     // MARK: - Static Capability Queries
+    //
+    // Disposition (v0.48 packaging release, #1749): these statics describe
+    // *this binary's compile-time contents*. Once backends can be registered
+    // at runtime from companion packages (`quickStart(backends:)`), a
+    // compile-time answer to "can I load this model?" is wrong — only the
+    // build-introspection queries (`compiledBackends` / `buildProfile` /
+    // `enabledTraits`) keep a meaningful compile-time semantic, and they are
+    // documented as such. The load-capability queries are deprecated in favor
+    // of the live registration state on `InferenceService`.
 
     /// The build/trait contract compiled into the current binary.
+    ///
+    /// Compile-time by definition — answers "what is in *this build*", not
+    /// "what can the assembled service load". Backends registered at runtime
+    /// from companion packages (#1749) are invisible here; use
+    /// ``ManifoldInference/InferenceService/registeredBackendSnapshot()`` for
+    /// load decisions.
     public static var compiledBackends: CompiledBackends { .current }
 
-    /// The current binary's runtime-visible build profile.
+    /// The current binary's compile-time build profile.
+    ///
+    /// Compile-time by definition — see ``compiledBackends``.
     public static var buildProfile: BackendBuildProfile { compiledBackends.buildProfile }
 
     /// The inference traits compiled into the current binary.
+    ///
+    /// Compile-time by definition — see ``compiledBackends``.
     public static var enabledTraits: Set<BackendBuildTrait> { compiledBackends.traits }
 
     /// The local model types supported by this build, without requiring
     /// an `InferenceService` instance.
-    ///
-    /// Useful for static checks before service construction (e.g., in unit tests
-    /// or feature-flag evaluation at app startup).
+    @available(*, deprecated, message: "Compile-time reflection cannot see backends registered at runtime (quickStart(backends:), #1749). Use InferenceService.registeredBackendSnapshot().localModelTypes.")
     public static var supportedModelTypes: Set<ModelType> {
         compiledBackends.localModelTypes
     }
 
     /// Returns `true` if this build includes a backend for the given local model type.
+    @available(*, deprecated, message: "Compile-time reflection cannot see backends registered at runtime (quickStart(backends:), #1749). Use InferenceService.compatibility(for:).isSupported.")
     public static func canLoad(modelType: ModelType) -> Bool {
         compiledBackends.compatibility(for: modelType).isSupported
     }
 
     /// Returns `true` if this build includes a backend for the given API provider.
+    @available(*, deprecated, message: "Compile-time reflection cannot see backends registered at runtime (quickStart(backends:), #1749). Use InferenceService.compatibility(for:).isSupported.")
     public static func canLoad(provider: APIProvider) -> Bool {
         compiledBackends.compatibility(for: provider).isSupported
     }
@@ -87,6 +106,11 @@ public enum DefaultBackends {
     /// `CloudBackends`, which calls `PinnedSessionDelegate.loadDefaultPins()`
     /// and must run before any URLSession factory. Local backends are
     /// independent.
+    ///
+    /// This is the *compiled-in* set only. Backends from companion packages
+    /// (#1749) are not listed here — pass their registrars to
+    /// ``ManifoldKit/ManifoldKit/quickStart(backends:configuration:seed:)``
+    /// or call `register(with:)` on them directly after this fold.
     @MainActor
     public static let registrars: [any BackendRegistrar.Type] = [
         CloudBackends.self,
@@ -103,9 +127,11 @@ public enum DefaultBackends {
     /// nothing — the returned count lets the caller fail fast on an empty,
     /// never-generating service instead of launching a dead app (the footgun
     /// audit's class D — "silent degradation where a fail-fast boundary check
-    /// belongs"). ``ManifoldKit/ManifoldKit/quickStart(configuration:)`` does
-    /// exactly this; hosts driving ``ManifoldBootstrap`` directly should check
-    /// the result too.
+    /// belongs"). Note a bare count is a weak signal once cloud registrars
+    /// register unconditionally: prefer inspecting
+    /// ``ManifoldInference/InferenceService/registeredBackendSnapshot()``
+    /// (`supportsLocalInference` / `cloudProviders`) as
+    /// ``ManifoldKit/ManifoldKit/quickStart(configuration:)`` now does.
     @MainActor
     @discardableResult
     public static func register(with service: InferenceService) -> Int {

--- a/Sources/ManifoldContract/HeuristicTokenizer.swift
+++ b/Sources/ManifoldContract/HeuristicTokenizer.swift
@@ -4,10 +4,14 @@ import Foundation
 ///
 /// This matches the heuristic already used by ``ContextWindowManager`` and is suitable
 /// as a fallback when no model-specific tokenizer is available.
-package struct HeuristicTokenizer: TokenizerProvider {
-    package init() {}
+// @_spi(BackendInternals): published for the backend family packages
+// (manifold-mlx / manifold-llama, #1749). `LlamaBackend` falls back to the
+// chars/4 heuristic when no vocabulary is loaded; keeping the heuristic in
+// one place requires a cross-package (but non-API) symbol.
+@_spi(BackendInternals) public struct HeuristicTokenizer: TokenizerProvider {
+    public init() {}
 
-    package func tokenCount(_ text: String) -> Int {
+    public func tokenCount(_ text: String) -> Int {
         Self.tokenCount(text)
     }
 
@@ -15,7 +19,7 @@ package struct HeuristicTokenizer: TokenizerProvider {
     /// instance (e.g. `LlamaBackend.tokenCount(_:)` fallback when no
     /// vocabulary is loaded). Keeps the `chars / 4` heuristic in one place
     /// across `ManifoldInference` and `ManifoldBackends`.
-    package static func tokenCount(_ text: String) -> Int {
+    public static func tokenCount(_ text: String) -> Int {
         max(1, text.count / 4)
     }
 }

--- a/Sources/ManifoldHardware/MemoryPressureHandler.swift
+++ b/Sources/ManifoldHardware/MemoryPressureHandler.swift
@@ -26,13 +26,17 @@ public enum MemoryPressureLevel: String, Sendable {
 /// immediately when pressure is detected, rather than waiting for the next run-loop
 /// cycle. The callback fires from an arbitrary thread; callers must not perform
 /// blocking work inside it.
+// @_spi(BackendInternals): published for the backend family packages
+// (manifold-mlx / manifold-llama, #1749). `LlamaBackend` registers a
+// synchronous pressure callback to abort the decode loop before the OS
+// escalates; cross-package that requires a public (but non-API) symbol.
 @Observable
-package final class MemoryPressureHandler: @unchecked Sendable {
+@_spi(BackendInternals) public final class MemoryPressureHandler: @unchecked Sendable {
 
     // MARK: - Published State
 
     /// The current memory pressure level reported by the OS.
-    package var pressureLevel: MemoryPressureLevel = .nominal
+    public var pressureLevel: MemoryPressureLevel = .nominal
 
     // MARK: - Private State
 
@@ -54,7 +58,7 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     /// The label is injected rather than read from `ManifoldConfiguration` so that
     /// `ManifoldHardware` remains a zero-dependency module. `InferenceService`
     /// passes `ManifoldConfiguration.shared.memoryPressureQueueLabel` at call-site.
-    package init(queueLabel: String = "com.manifoldkit.memory-pressure") {
+    public init(queueLabel: String = "com.manifoldkit.memory-pressure") {
         self.queue = DispatchQueue(label: queueLabel, qos: .utility)
     }
 
@@ -67,7 +71,7 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     /// Begins listening for memory pressure notifications from the OS.
     ///
     /// Safe to call multiple times -- subsequent calls are no-ops while monitoring is active.
-    package func startMonitoring() {
+    public func startMonitoring() {
         guard source == nil else { return }
 
         let newSource = DispatchSource.makeMemoryPressureSource(
@@ -116,7 +120,7 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     /// Stops listening for memory pressure notifications.
     ///
     /// Safe to call multiple times -- subsequent calls are no-ops if not monitoring.
-    package func stopMonitoring() {
+    public func stopMonitoring() {
         source?.cancel()
         source = nil
     }
@@ -135,7 +139,7 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     ///     registering type and use `removeCallback(for:)` in that type's `deinit`.
     ///   - callback: A `@Sendable` closure that receives the new pressure level.
     ///     Must not perform blocking work — it runs on a utility GCD queue.
-    package func addPressureCallback(
+    public func addPressureCallback(
         for owner: AnyObject,
         _ callback: @escaping @Sendable (MemoryPressureLevel) -> Void
     ) {
@@ -147,7 +151,7 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     /// Removes the callback previously registered for `owner`.
     ///
     /// Safe to call from `deinit` — no-op if no callback was registered.
-    package func removeCallback(for owner: AnyObject) {
+    public func removeCallback(for owner: AnyObject) {
         callbackLock.lock()
         defer { callbackLock.unlock() }
         _callbacks.removeValue(forKey: ObjectIdentifier(owner))
@@ -161,7 +165,7 @@ package final class MemoryPressureHandler: @unchecked Sendable {
     /// real OS `DispatchSource` firing. Takes a snapshot under the lock so callbacks
     /// run outside the critical section, allowing re-entrant `addPressureCallback` /
     /// `removeCallback` calls from within a callback.
-    package func fireCallbacks(level: MemoryPressureLevel) {
+    public func fireCallbacks(level: MemoryPressureLevel) {
         // Take a snapshot under the lock so callbacks run outside it.
         callbackLock.lock()
         let snapshot = _callbacks.values.map { $0 }

--- a/Sources/ManifoldInference/Services/ContextWindowManager.swift
+++ b/Sources/ManifoldInference/Services/ContextWindowManager.swift
@@ -1,4 +1,7 @@
 import Foundation
+// HeuristicTokenizer is @_spi(BackendInternals) — part of the published
+// backend seam (#1749); in-package consumers import the SPI explicitly.
+@_spi(BackendInternals) import ManifoldContract
 
 /// Manages context window budgeting and message trimming.
 ///

--- a/Sources/ManifoldInference/Services/PromptAssembler.swift
+++ b/Sources/ManifoldInference/Services/PromptAssembler.swift
@@ -1,4 +1,7 @@
 import Foundation
+// HeuristicTokenizer is @_spi(BackendInternals) — part of the published
+// backend seam (#1749); in-package consumers import the SPI explicitly.
+@_spi(BackendInternals) import ManifoldContract
 
 /// Assembles prompt slots and conversation history into a context-budgeted prompt.
 ///

--- a/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
+++ b/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
@@ -65,10 +65,14 @@ struct MyChatApp: App {
 > `ManifoldUIModelManagement` module) bound to `showModelManagement`, or seed a
 > model at launch.
 
-> Warning: **The trait cliff.** With no backend trait enabled (`MLX`, `Llama`,
-> `CloudSaaS`, `Ollama`, …), `quickStart()` compiles but throws
-> ``ManifoldKitError`` `.noBackendsRegistered` at runtime — there is nothing to
-> generate with. Enable at least one backend trait for your target.
+> Warning: **The no-backend cliff.** With no backend registered — no backend
+> trait enabled (`MLX`, `Llama`, `CloudSaaS`, `Ollama`, …) and no registrar
+> passed via `quickStart(backends:)` — `quickStart()` compiles but throws
+> ``ManifoldKitError`` `.noBackendsRegistered` at runtime: there is nothing to
+> generate with. Enable a backend trait, or inject a backend package's
+> registrar (e.g. `quickStart(backends: [LlamaBackends.self])`). A cloud-only
+> registration with no configured endpoint launches but logs an actionable
+> warning instead of throwing.
 
 ### The guided path
 

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -44,10 +44,11 @@ import ManifoldHuggingFace
 // (`--disable-default-traits`) any of the four non-Foundation backends could
 // be present or absent — we can only fire a *partial* hint here.
 //
-// The authoritative runtime diagnostic is `ManifoldKitError.noBackendsRegistered`,
-// whose `errorDescription` already names the exact fix:
-//   "quickStart() needs at least one backend trait enabled
-//    (MLX, Llama, CloudSaaS, Ollama, or Foundation on iOS 26 / macOS 26+)."
+// The authoritative runtime diagnostics are `ManifoldKitError.noBackendsRegistered`
+// (nothing registered at all) and the cloud-only-without-endpoint warning from
+// `backendAvailabilityDiagnostic(snapshot:configuredEndpointCount:)` — both
+// derived from live registration state, so they see companion-package
+// registrars injected via `quickStart(backends:)`.
 #if !MLX && !Llama && !CloudSaaS && !Ollama && !canImport(FoundationModels)
 // No locally-resolvable backend traits are compiled in AND FoundationModels is
 // not importable on this toolchain. quickStart() will throw
@@ -119,10 +120,13 @@ public enum ManifoldKit {
     /// download the model registry is refreshed and the selection policy picks
     /// the new model automatically — the chat is live.
     ///
-    /// The download is **skipped silently** when any of the following is true:
+    /// The download is **skipped** (with a log entry, never an error) when any
+    /// of the following is true:
     /// - A model is already available (Foundation or local disk).
-    /// - The `HuggingFace` SwiftPM trait is absent.
-    /// - No local backend (`Llama`, `MLX`) is compiled in.
+    /// - The `HuggingFace` SwiftPM trait is absent (no download machinery).
+    /// - No *registered* backend can load the seed's model type — checked
+    ///   against the live ``InferenceService`` registration state, so backends
+    ///   injected via ``quickStart(backends:configuration:seed:)`` count.
     /// - A network error occurs (the app launches with the empty state instead).
     ///
     /// ### Trait requirements
@@ -160,6 +164,50 @@ public enum ManifoldKit {
         )
     }
 
+    /// Bootstraps a working chat runtime with additional, caller-supplied
+    /// backend registrars.
+    ///
+    /// This is the migration path for backends that live outside this package
+    /// (the `manifold-mlx` / `manifold-llama` companion packages, #1749).
+    /// The compiled-in defaults (``DefaultBackends/registrars``) are registered
+    /// first, then every entry in `backends` — **before** the model registry
+    /// refresh, the optional starter-model seed, and the model-selection
+    /// policy run. Registering a backend only after `quickStart` returns is
+    /// too late for all three of those steps: the seed would skip ("no backend
+    /// can load .gguf"), and the selection policy would refuse to pick an
+    /// on-disk model it believes nothing can load.
+    ///
+    /// ```swift
+    /// import ManifoldKit
+    /// import ManifoldMLX   // from the manifold-mlx companion package
+    ///
+    /// let kit = try await ManifoldKit.quickStart(backends: [MLXBackends.self])
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - backends: Registrars to fold into the service after the compiled-in
+    ///     defaults. Order follows array order; registering the same family
+    ///     twice is harmless (last registration wins per model type).
+    ///   - configuration: Framework configuration. Defaults to
+    ///     ``ManifoldInference/ManifoldConfiguration/default``.
+    ///   - seed: Optional starter-model seed, as in
+    ///     ``quickStart(configuration:seed:)``. The seed sees the injected
+    ///     backends: a GGUF seed downloads when any registered backend —
+    ///     compiled-in or injected — can load `.gguf`.
+    /// - Returns: A ``QuickStartResult`` as in ``quickStart(configuration:)``.
+    public static func quickStart(
+        backends: [any BackendRegistrar.Type],
+        configuration: ManifoldConfiguration = .default,
+        seed: QuickStartSeed? = nil
+    ) async throws -> QuickStartResult {
+        try await _quickStart(
+            configuration: configuration,
+            backends: backends,
+            seed: seed,
+            makeModelContainer: { try ModelContainerFactory.makeContainer() }
+        )
+    }
+
     /// Internal seam used by tests to inject a custom (or throwing) model
     /// container factory and an optional selection policy. Production callers
     /// go through ``quickStart(configuration:)`` or ``quickStart(configuration:seed:)``.
@@ -172,15 +220,25 @@ public enum ManifoldKit {
     ///   - makeModelContainer: Factory closure that produces the SwiftData container.
     ///   - downloadManagerOverride: Injectable download manager for tests. When
     ///     nil and `#if HuggingFace`, a `BackgroundDownloadManager` is created.
+    ///   - foundationAvailableOverride: Test seam for the seed path's "is a
+    ///     zero-cost Foundation model available?" probe, which otherwise
+    ///     depends on the host's Apple Intelligence state. Nil uses the live
+    ///     probe.
+    ///   - storageServiceOverride: Test seam for the seed path's "is a model
+    ///     already on disk?" probe, which otherwise scans the host's real
+    ///     models directory. Nil uses the default service.
     ///   - selectionPolicy: An optional closure that receives the populated
     ///     `ModelRegistry` and returns the `ModelInfo` to select, or `nil` to
     ///     leave no model selected. When `nil` (the default), the built-in
     ///     Foundation-first → first-local → labeled-empty-state policy runs.
     static func _quickStart(
         configuration: ManifoldConfiguration,
+        backends: [any BackendRegistrar.Type] = [],
         seed: QuickStartSeed? = nil,
         makeModelContainer: @MainActor @escaping () throws -> ModelContainer,
         downloadManagerOverride: (any BackgroundDownloadManaging)? = nil,
+        foundationAvailableOverride: Bool? = nil,
+        storageServiceOverride: ModelStorageService? = nil,
         selectionPolicy: (@MainActor (ModelRegistry) async -> ModelInfo?)? = nil
     ) async throws -> QuickStartResult {
         do {
@@ -199,14 +257,50 @@ public enum ManifoldKit {
 
             let bootstrap = try await task.value
 
-            // Fail fast when the build compiled in zero backends for the active
-            // trait / OS combination. Without this the app launches fully wired
-            // — persistence, session list, composer enabled — then throws on the
-            // first turn with a confusing "No model loaded". Surfacing it here,
-            // at the assembly boundary, names the actual cause (missing traits).
-            let registeredBackends = DefaultBackends.register(with: bootstrap.inferenceService)
-            guard registeredBackends > 0 else {
+            // Register the compiled-in defaults first, then any caller-supplied
+            // registrars (companion packages, #1749). Both must run before the
+            // registry refresh, the starter seed, and the selection policy —
+            // all three consult the live registration state below.
+            DefaultBackends.register(with: bootstrap.inferenceService)
+            for registrar in backends {
+                registrar.register(with: bootstrap.inferenceService)
+            }
+
+            // Fail fast / warn loudly when the assembled service can never
+            // generate. Without this the app launches fully wired —
+            // persistence, session list, composer enabled — then throws on the
+            // first turn with a confusing "No model loaded". The check is
+            // runtime-registration-based (not trait-based): once cloud
+            // registrars register unconditionally, "some backend registered"
+            // stops implying "local inference works", so the cloud-only case
+            // additionally checks for a configured endpoint.
+            let snapshot = bootstrap.inferenceService.registeredBackendSnapshot()
+            let configuredEndpointCount: Int
+            if snapshot.supportsLocalInference {
+                // Endpoints are irrelevant to the diagnostic when local
+                // inference is available — skip the fetch.
+                configuredEndpointCount = 0
+            } else {
+                do {
+                    configuredEndpointCount = try await bootstrap.endpointStore.fetchEndpoints().count
+                } catch {
+                    Log.quickStart.warning("quickStart: endpoint fetch failed during backend-availability check: \(error, privacy: .public)")
+                    configuredEndpointCount = 0
+                }
+            }
+            switch backendAvailabilityDiagnostic(
+                snapshot: snapshot,
+                configuredEndpointCount: configuredEndpointCount
+            ) {
+            case .noBackends:
                 throw ManifoldKitError.noBackendsRegistered
+            case .cloudOnlyWithoutEndpoint(let message):
+                // Warn rather than throw: endpoints are commonly configured
+                // *after* quickStart() returns (settings UI, first-run flow),
+                // so a cloud-only service is degraded, not necessarily dead.
+                Log.quickStart.warning("\(message, privacy: .public)")
+            case nil:
+                break
             }
 
             let viewModel = ChatViewModel(
@@ -281,18 +375,32 @@ public enum ManifoldKit {
                 // Foundation check: if the Foundation backend is already
                 // available there is a zero-cost model — skip the download so
                 // we never fetch ~400 MB unnecessarily.
+                // `foundationAvailableOverride` is a test seam: the live
+                // probe depends on the host's Apple Intelligence state, which
+                // would make seed-path tests skip on capable machines.
                 var foundationAvailable = false
                 #if canImport(FoundationModels)
                 if #available(iOS 26, macOS 26, *) {
                     foundationAvailable = FoundationBackend.isAvailable
                 }
                 #endif
+                if let foundationAvailableOverride {
+                    foundationAvailable = foundationAvailableOverride
+                }
 
-                if !foundationAvailable {
+                // Runtime backend gate: the seed must be loadable by a backend
+                // that is actually *registered* — compiled-in or injected via
+                // `backends:`. A compile-time trait check here would silently
+                // no-op the GGUF starter seed for consumers whose Llama-capable
+                // backend arrives from a companion package at runtime (#1749).
+                let seedCompatibility = bootstrap.inferenceService.compatibility(for: seed.modelType)
+                if !foundationAvailable && !seedCompatibility.isSupported {
+                    Log.quickStart.info("quickStart(seed:): no registered backend can load \(String(describing: seed.modelType), privacy: .public) models — seed skipped. Register a compatible backend (e.g. quickStart(backends: [LlamaBackends.self]) with the manifold-llama companion package) to enable the starter download.")
+                } else if !foundationAvailable {
                     #if HuggingFace
                     let dm: any BackgroundDownloadManaging = downloadManagerOverride
                         ?? BackgroundDownloadManager()
-                    let storageService = ModelStorageService()
+                    let storageService = storageServiceOverride ?? ModelStorageService()
                     _ = await _performSeedDownload(
                         seed: seed,
                         storageService: storageService,
@@ -303,7 +411,7 @@ public enum ManifoldKit {
                     // If a downloadManagerOverride was supplied (test injection),
                     // still honour it so tests work without the real HF trait.
                     if let dm = downloadManagerOverride {
-                        let storageService = ModelStorageService()
+                        let storageService = storageServiceOverride ?? ModelStorageService()
                         _ = await _performSeedDownload(
                             seed: seed,
                             storageService: storageService,
@@ -350,17 +458,67 @@ public enum ManifoldKit {
         }
     }
 
+    // MARK: - Backend availability diagnostic
+
+    /// The actionable diagnostics ``quickStart(configuration:)`` derives from
+    /// the live registration state. Internal and pure so tests can pin the
+    /// decision table without driving a full bootstrap.
+    enum BackendAvailabilityDiagnostic: Equatable {
+        /// Nothing is registered at all — the service can never generate.
+        /// `quickStart` throws ``ManifoldKitError/noBackendsRegistered``.
+        case noBackends
+        /// Cloud providers are registered but no local backend is, and no
+        /// endpoint has been configured — the service is degraded until the
+        /// host configures one. `quickStart` logs the associated message.
+        case cloudOnlyWithoutEndpoint(message: String)
+    }
+
+    /// Decides which (if any) backend-availability diagnostic applies.
+    ///
+    /// Runtime-registration-based on purpose: compile-time trait checks cannot
+    /// see backends registered by companion packages via
+    /// ``quickStart(backends:configuration:seed:)``, and once cloud registrars
+    /// register unconditionally a bare "count > 0" check goes permanently
+    /// quiet for the local-inference failure mode.
+    static func backendAvailabilityDiagnostic(
+        snapshot: EnabledBackends,
+        configuredEndpointCount: Int
+    ) -> BackendAvailabilityDiagnostic? {
+        if snapshot.isEmpty {
+            return .noBackends
+        }
+        if !snapshot.supportsLocalInference && configuredEndpointCount == 0 {
+            return .cloudOnlyWithoutEndpoint(message: """
+                quickStart: no local inference backend is registered and no cloud \
+                endpoint is configured — the chat surface will launch but cannot \
+                generate. To enable local inference, add a backend package \
+                (manifold-llama for GGUF, manifold-mlx for MLX) and pass its \
+                registrar: ManifoldKit.quickStart(backends: [LlamaBackends.self]). \
+                To use a cloud provider instead, insert an APIEndpointRecord via \
+                bootstrap.endpointStore and select it before the first send.
+                """)
+        }
+        return nil
+    }
+
     // MARK: - Built-in selection policy
 
     /// The default backend-selection policy applied by `quickStart()`.
     ///
     /// Priority order:
     /// 1. Foundation model — selected when running on iOS 26+ / macOS 26+ and
-    ///    the Foundation backend is compiled in and available at runtime.
-    /// 2. First local model — the first entry in `availableModels` (populated
-    ///    by `refresh()`), which skips cloud/endpoint-configured backends that
-    ///    have no `ModelInfo` representation in the registry.
+    ///    a Foundation-capable backend is *registered* and available at runtime.
+    /// 2. First **loadable** local model — the first entry in `availableModels`
+    ///    (populated by `refresh()`) whose ``ModelType`` has a registered
+    ///    backend. On-disk files with no registered backend are skipped: a
+    ///    GGUF on disk with no Llama-capable backend would otherwise be
+    ///    "selected", compile clean, and fail confusingly on the first send.
     /// 3. Nil — no model is pre-selected; the UI must prompt the user to add one.
+    ///
+    /// All compatibility checks go through ``ModelRegistry/compatibility(for:)``
+    /// (live registration state) rather than compile-time trait reflection, so
+    /// backends injected via ``quickStart(backends:configuration:seed:)`` are
+    /// honoured.
     @MainActor
     static func defaultSelectionPolicy(_ registry: ModelRegistry) async -> ModelInfo? {
         // Foundation-first: on Apple-Intelligence-capable devices the built-in
@@ -368,18 +526,25 @@ public enum ManifoldKit {
         // disk space, no endpoint configuration required.
         #if canImport(FoundationModels)
         if #available(iOS 26, macOS 26, *) {
-            if DefaultBackends.canLoad(modelType: .foundation),
+            if registry.compatibility(for: .foundation).isSupported,
                let provider = registry.foundationModelProvider, provider() {
                 return .builtInFoundation
             }
         }
         #endif
 
-        // Fall back to the first local model discovered on disk. All ModelType
-        // cases (.gguf, .mlx, .foundation) represent local backends — there is
-        // no "remote" ModelType in the registry (cloud backends are addressed
-        // through APIEndpointRecord + APIProvider, not ModelInfo).
-        return registry.availableModels.first
+        // Fall back to the first local model discovered on disk *that some
+        // registered backend can load*. All ModelType cases (.gguf, .mlx,
+        // .foundation) represent local backends — there is no "remote"
+        // ModelType in the registry (cloud backends are addressed through
+        // APIEndpointRecord + APIProvider, not ModelInfo).
+        for model in registry.availableModels {
+            if registry.compatibility(for: model.modelType).isSupported {
+                return model
+            }
+            Log.quickStart.info("quickStart: skipping \(model.fileName, privacy: .public) — no registered backend can load \(String(describing: model.modelType), privacy: .public) models. Add the matching backend package (manifold-llama for GGUF, manifold-mlx for MLX) and pass its registrar to quickStart(backends:).")
+        }
+        return nil
     }
 }
 

--- a/Sources/ManifoldKit/QuickStartSeed.swift
+++ b/Sources/ManifoldKit/QuickStartSeed.swift
@@ -10,10 +10,11 @@
 //   - The new surface is a second overload: quickStart(seed:), where `seed` is
 //     a QuickStartSeed value. The caller specifies which model to seed and an
 //     optional progress closure; ManifoldKit handles the rest.
-//   - Trait contract: seeding requires HuggingFace + at least one local backend
-//     (Llama or MLX). When those traits are absent the seed parameter is a
-//     no-op: quickStart(seed:) behaves exactly like quickStart() and the host
-//     receives a clear thrown error if it calls seedIfNeeded() directly.
+//   - Gating contract: seeding requires the HuggingFace trait (download
+//     machinery, compile-time) + a registered backend that can load the seed's
+//     model type (checked at runtime against InferenceService, so companion
+//     registrars passed to quickStart(backends:) count). When either is
+//     missing the seed parameter is a logged no-op.
 //
 // The implementation uses `BackgroundDownloadManaging` (protocol in
 // ManifoldModelCatalog) so the concrete BackgroundDownloadManager (ManifoldHuggingFace,
@@ -32,22 +33,24 @@ import ManifoldInference
 /// small model **before** the selection policy runs — so on first launch the
 /// composer is live and generating, not stuck at "No model loaded".
 ///
-/// ### Trait requirements
+/// ### Requirements
 ///
-/// Seeding requires the `HuggingFace` SwiftPM trait (default-on) **and** at
-/// least one local backend trait (`Llama` or `MLX`). When the `HuggingFace`
-/// trait is absent the seed is silently skipped (no download, no error) because
-/// there is no download machinery available. When `HuggingFace` is compiled in
-/// but no local backend is present the download would succeed but no backend
-/// could load the file — in that case the download is also skipped.
+/// Seeding requires the `HuggingFace` SwiftPM trait (default-on) for the
+/// download machinery, **and** a *registered* backend capable of loading the
+/// seed's model type. The backend check is made against the live
+/// ``ManifoldInference/InferenceService`` registration state — not compile-time
+/// traits — so a Llama-capable backend injected at runtime via
+/// ``ManifoldKit/ManifoldKit/quickStart(backends:configuration:seed:)``
+/// (e.g. from the manifold-llama companion package) enables the GGUF seed.
 ///
 /// ### Skip conditions
 ///
-/// The seed is skipped automatically when any of the following is true:
+/// The seed is skipped automatically (logged, never thrown) when any of the
+/// following is true:
 /// - A model is already selectable (Foundation available, or a local model on
 ///   disk). Never downloads redundantly.
-/// - `HuggingFace` trait is absent.
-/// - No local backend trait (`Llama`, `MLX`) is compiled in.
+/// - `HuggingFace` trait is absent (no download machinery).
+/// - No registered backend can load the seed's model type.
 /// - The device has no internet connectivity (the error is silently swallowed so
 ///   the app still launches with the "No model" empty state rather than crashing).
 ///

--- a/Sources/ManifoldLlama/LlamaBackend.swift
+++ b/Sources/ManifoldLlama/LlamaBackend.swift
@@ -4,6 +4,11 @@ import LlamaSwift
 import os
 import Synchronization
 import ManifoldInference
+// BackendInternals SPI: MemoryPressureHandler (ManifoldHardware) and
+// HeuristicTokenizer (ManifoldContract) are part of the frozen backend seam
+// published for the companion family packages (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldContract
 
 /// llama.cpp inference backend for GGUF-format models.
 ///

--- a/Sources/ManifoldModelCatalog/ManifoldKitError.swift
+++ b/Sources/ManifoldModelCatalog/ManifoldKitError.swift
@@ -45,8 +45,8 @@ public enum ManifoldKitError: Error, Sendable, LocalizedError, Equatable {
     /// is a short, PII-free description of where decoding failed (e.g.
     /// `"missing field: choices"`).
     case decodingFailure(String)
-    /// No inference backend was compiled into the binary for the active trait /
-    /// OS combination, so the assembled service can never generate. Raised at
+    /// No inference backend is registered (compiled-in, injected, or
+    /// OS-provided), so the assembled service can never generate. Raised at
     /// the assembly boundary (``ManifoldKit/ManifoldKit/quickStart(configuration:)``)
     /// as a fail-fast diagnostic rather than letting the app launch dead and
     /// throw on the first turn.
@@ -85,7 +85,7 @@ public enum ManifoldKitError: Error, Sendable, LocalizedError, Equatable {
         case .decodingFailure(let detail):
             return "Couldn't read the server response: \(detail)"
         case .noBackendsRegistered:
-            return "No inference backends are compiled into this build. quickStart() needs at least one backend trait enabled (MLX, Llama, CloudSaaS, Ollama, or Foundation). Check the package traits / build settings."
+            return "No inference backends are registered. Add a local backend package and pass its registrar to quickStart(backends:) — manifold-llama (GGUF) or manifold-mlx (MLX) — or enable a backend trait in this build (MLX, Llama, CloudSaaS, Ollama), or run on iOS 26 / macOS 26+ for the built-in Foundation Models backend."
         case .unknown(let underlyingDescription):
             if underlyingDescription.isEmpty {
                 return "An unexpected error occurred."

--- a/Sources/ManifoldRuntime/Services/ContextBudgetPlanner.swift
+++ b/Sources/ManifoldRuntime/Services/ContextBudgetPlanner.swift
@@ -1,4 +1,7 @@
 import Foundation
+// HeuristicTokenizer is @_spi(BackendInternals) — part of the published
+// backend seam (#1749); in-package consumers import the SPI explicitly.
+@_spi(BackendInternals) import ManifoldContract
 import ManifoldInference
 
 /// An entry in a ``ContextBudgetPlanner``.

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+MemoryPressure.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+MemoryPressure.swift
@@ -1,6 +1,8 @@
 import Foundation
 import ManifoldRuntime
 import ManifoldInference
+// MemoryPressureHandler is @_spi(BackendInternals) — published backend seam (#1749).
+@_spi(BackendInternals) import ManifoldHardware
 
 // MARK: - ChatViewModel + Memory Pressure
 

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -2,6 +2,11 @@ import Foundation
 import Observation
 import ManifoldRuntime
 import ManifoldInference
+// BackendInternals SPI: MemoryPressureHandler / HeuristicTokenizer moved from
+// `package` to `@_spi(BackendInternals) public` for the companion-package
+// split (#1749); in-package consumers import the SPI explicitly.
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldContract
 
 /// Central view model for the chat interface.
 ///
@@ -810,7 +815,10 @@ public final class ChatViewModel {
         )
     }
 
-    package init(
+    // @_spi(BackendInternals): the injected MemoryPressureHandler is itself
+    // SPI (backend seam published for the companion split, #1749), and a
+    // non-SPI `package` signature may not reference an SPI type.
+    @_spi(BackendInternals) public init(
         inferenceService: InferenceService = InferenceService(),
         deviceCapability: DeviceCapabilityService = DeviceCapabilityService(),
         modelStorage: ModelStorageService = ModelStorageService(),

--- a/Tests/ManifoldBackendsTests/DefaultBackendsCapabilityTests.swift
+++ b/Tests/ManifoldBackendsTests/DefaultBackendsCapabilityTests.swift
@@ -13,6 +13,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
 
     // MARK: - Static supportedModelTypes
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_supportedModelTypes_isSubsetOfAllModelTypes() {
         // Every value in supportedModelTypes must be a valid ModelType.
         // This catches accidental duplicates or phantom values.
@@ -22,6 +25,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
                       "supportedModelTypes contains unexpected values: \(supported.subtracting(valid))")
     }
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_canLoad_modelType_matchesSupportedModelTypes() {
         // canLoad(modelType:) must agree with supportedModelTypes.
         for type_ in [ModelType.gguf, .mlx, .foundation] {
@@ -31,6 +37,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         }
     }
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_canLoad_provider_matchesCompiledContract() {
         let compiled = DefaultBackends.compiledBackends
         for provider in APIProvider.allCases {
@@ -43,6 +52,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         }
     }
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_compiledBackends_passthroughsMatchStaticQueries() {
         XCTAssertEqual(DefaultBackends.buildProfile, DefaultBackends.compiledBackends.buildProfile)
         XCTAssertEqual(DefaultBackends.enabledTraits, DefaultBackends.compiledBackends.traits)
@@ -64,6 +76,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         }
     }
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_register_declaresLocalModelTypesConsistentlyWithStaticQuery() {
         let service = InferenceService()
         DefaultBackends.register(with: service)
@@ -75,6 +90,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         }
     }
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_register_doesNotDeclareUnsupportedModelTypes() {
         let service = InferenceService()
         DefaultBackends.register(with: service)
@@ -102,6 +120,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         }
     }
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_register_snapshotLocalTypesMatchStaticQuery() {
         let service = InferenceService()
         DefaultBackends.register(with: service)
@@ -113,6 +134,9 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
 
     // MARK: - FrameworkCapabilityService integration
 
+    // Exercises APIs deprecated in B2 (#1749) — annotation silences the
+    // in-repo deprecation warning while pinning behavior until A4/C2.
+    @available(*, deprecated)
     func test_frameworkCapabilityService_afterRegisterAndRefresh_matchesStaticQuery() {
         let service = InferenceService()
         DefaultBackends.register(with: service)

--- a/Tests/ManifoldBackendsTests/LlamaBackendMemoryPressureTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaBackendMemoryPressureTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
 
 // MARK: - Thread-safe counter for @Sendable callback closures
 

--- a/Tests/ManifoldBackendsTests/LlamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/LlamaBackendTests.swift
@@ -7,6 +7,8 @@ import ManifoldInference
 import ManifoldTestSupport
 import ManifoldBackends
 @_spi(Testing) import ManifoldLlama
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 /// Tests for LlamaBackend state, capabilities, and error handling.
 ///

--- a/Tests/ManifoldBackendsTests/MLXMemoryPressureMissingTests.swift
+++ b/Tests/ManifoldBackendsTests/MLXMemoryPressureMissingTests.swift
@@ -2,6 +2,8 @@
 import XCTest
 @_spi(Testing) import ManifoldMLX
 import ManifoldBackends
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
 
 /// Code-level regression guard for the MLX/Llama memory-pressure-handler
 /// asymmetry called out by audit claim #1's neighbour finding:

--- a/Tests/ManifoldE2ETests/ContextOverflowE2ETests.swift
+++ b/Tests/ManifoldE2ETests/ContextOverflowE2ETests.swift
@@ -3,6 +3,8 @@ import Foundation
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 /// E2E tests for context overflow behaviour.
 ///

--- a/Tests/ManifoldE2ETests/MemoryPressureUnloadE2ETests.swift
+++ b/Tests/ManifoldE2ETests/MemoryPressureUnloadE2ETests.swift
@@ -5,6 +5,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// E2E test for the memory pressure -> model unload pipeline.
 ///

--- a/Tests/ManifoldHardwareTests/MemoryPressureEventTests.swift
+++ b/Tests/ManifoldHardwareTests/MemoryPressureEventTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import ManifoldHardware
 import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
 
 /// Tests for the MemoryPressureEvent stream on InferenceService.
 ///

--- a/Tests/ManifoldHardwareTests/MemoryPressureHandlerTests.swift
+++ b/Tests/ManifoldHardwareTests/MemoryPressureHandlerTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 @testable import ManifoldHardware
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
 
 final class MemoryPressureHandlerTests: XCTestCase {
 

--- a/Tests/ManifoldInferenceSwiftTestingTests/HeuristicTokenizerTests.swift
+++ b/Tests/ManifoldInferenceSwiftTestingTests/HeuristicTokenizerTests.swift
@@ -1,5 +1,7 @@
 import Testing
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 @Suite("HeuristicTokenizer")
 struct HeuristicTokenizerTests {

--- a/Tests/ManifoldInferenceTests/CachingTokenizerTests.swift
+++ b/Tests/ManifoldInferenceTests/CachingTokenizerTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import ManifoldInference
 @testable import ManifoldContract  // #1719: streaming/tokenizer seams moved to Contract
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 // MARK: - Test double
 

--- a/Tests/ManifoldInferenceTests/HotPathPerformanceTests.swift
+++ b/Tests/ManifoldInferenceTests/HotPathPerformanceTests.swift
@@ -2,6 +2,8 @@ import XCTest
 import ManifoldTestSupport
 @testable import ManifoldInference
 @testable import ManifoldContract  // #1719: streaming/tokenizer seams moved to Contract
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 final class HotPathPerformanceTests: XCTestCase {
 

--- a/Tests/ManifoldInferenceTests/PromptAssemblerUtilizationTests.swift
+++ b/Tests/ManifoldInferenceTests/PromptAssemblerUtilizationTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 /// Coverage for ``AssembledPrompt/contextUtilization`` — the fraction of the
 /// context window consumed by a prompt assembly pass.

--- a/Tests/ManifoldInferenceTests/TokenizationPerformanceTests.swift
+++ b/Tests/ManifoldInferenceTests/TokenizationPerformanceTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import ManifoldInference
 @testable import ManifoldContract  // #1719: streaming/tokenizer seams moved to Contract
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 final class TokenizationPerformanceTests: XCTestCase {
 

--- a/Tests/ManifoldKitTests/QuickStartBackendsTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartBackendsTests.swift
@@ -1,0 +1,319 @@
+// QuickStartBackendsTests.swift
+//
+// Exercises the v0.48 consumer-path APIs (#1749):
+//   - `quickStart(backends:)` registrar injection, and its ordering contract
+//     (injected registrars are visible to the seed and the selection policy).
+//   - Runtime gating of the starter seed (no compile-time trait reflection).
+//   - The selection policy's compatibility filter (on-disk models with no
+//     registered backend must not be auto-selected).
+//   - The backend-availability diagnostic decision table (fail-fast guard +
+//     cloud-only-without-endpoint warning).
+//
+// These are integration tests: they drive the real `_quickStart` assembly
+// against in-memory SwiftData containers, with `MockInferenceBackend`
+// (ManifoldTestSupport) standing in for a runtime-registered family backend —
+// exactly the shape a manifold-llama / manifold-mlx companion registrar has.
+
+import XCTest
+import Foundation
+import SwiftData
+import ManifoldInference
+import ManifoldPersistenceSwiftData
+import ManifoldTestSupport
+@testable import ManifoldKit
+
+// MARK: - Mock companion registrar
+
+/// Stand-in for a companion package's registrar (e.g. `LlamaBackends` from
+/// manifold-llama): registers a GGUF-capable backend with the service. The
+/// shape mirrors the real family registrars — factory + declareSupport.
+enum MockGGUFBackends: BackendRegistrar {
+    @MainActor
+    static func register(with service: InferenceService) {
+        service.registerBackendFactory { modelType in
+            modelType == .gguf ? MockInferenceBackend() : nil
+        }
+        service.declareSupport(for: .gguf)
+    }
+}
+
+@MainActor
+final class QuickStartBackendsTests: XCTestCase {
+
+    private var tempDir: URL = URL(fileURLWithPath: "/tmp")
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quickStartBackends-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        tempDir = dir
+    }
+
+    override func tearDownWithError() throws {
+        do {
+            try FileManager.default.removeItem(at: tempDir)
+        } catch {
+            // Best-effort cleanup of a per-test scratch dir; nothing to assert.
+        }
+        try super.tearDownWithError()
+    }
+
+    /// Returns true when the *compiled-in* default registrars already provide
+    /// a GGUF backend (Llama-trait builds). Negative gating cases are not
+    /// arrangeable in those builds because `_quickStart` always folds the
+    /// defaults first — skip honestly instead of asserting a vacuous pass.
+    private var buildHasCompiledInGGUFBackend: Bool {
+        let probe = InferenceService()
+        DefaultBackends.register(with: probe)
+        return probe.registeredBackendSnapshot().supportsGGUF
+    }
+
+    private func makeGGUFModelInfo(name: String = "test.gguf") -> ModelInfo {
+        ModelInfo(
+            id: UUID(),
+            name: "Test GGUF",
+            fileName: name,
+            url: tempDir.appendingPathComponent(name),
+            fileSize: 500_000,
+            modelType: .gguf
+        )
+    }
+
+    // MARK: - quickStart(backends:) ordering
+
+    /// The whole point of registrar injection: backends passed to
+    /// `quickStart(backends:)` must be registered *before* the selection
+    /// policy runs, so the policy's compatibility queries see them.
+    /// (Registering after quickStart returns is too late — review blocker.)
+    func test_quickStartBackends_injectedRegistrarVisibleAtSelectionPolicyTime() async throws {
+        // Recorded inside the policy closure, i.e. at the exact pipeline stage
+        // whose ordering this test pins.
+        var ggufSupportedAtPolicyTime: Bool?
+
+        _ = try await ManifoldKit._quickStart(
+            configuration: .default,
+            backends: [MockGGUFBackends.self],
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { registry in
+                ggufSupportedAtPolicyTime = registry.compatibility(for: .gguf).isSupported
+                return nil
+            }
+        )
+
+        XCTAssertEqual(ggufSupportedAtPolicyTime, true,
+            "A registrar injected via quickStart(backends:) must be registered before the selection policy runs (#1749)")
+    }
+
+    /// End-to-end: with an injected GGUF backend, the *default* policy selects
+    /// an on-disk GGUF model — the post-split consumer happy path.
+    func test_quickStartBackends_defaultPolicy_selectsModelLoadableByInjectedBackend() async throws {
+        let localModel = makeGGUFModelInfo()
+
+        let result = try await ManifoldKit._quickStart(
+            configuration: .default,
+            backends: [MockGGUFBackends.self],
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { registry in
+                // Deterministic regardless of test-host OS / Apple Intelligence.
+                registry.foundationModelProvider = { false }
+                registry.availableModels = [localModel]
+                return await ManifoldKit.defaultSelectionPolicy(registry)
+            }
+        )
+
+        XCTAssertEqual(result.viewModel.modelRegistry.selectedModel?.id, localModel.id,
+            "Default policy must select a model loadable by a runtime-injected backend")
+    }
+
+    // MARK: - Seed runtime gating
+
+    /// The GGUF starter seed must run when a GGUF-capable backend is
+    /// registered at runtime via `quickStart(backends:)` — the compile-time
+    /// trait check it replaced could never see this case.
+    func test_seed_runs_whenGGUFBackendInjectedAtRuntime() async throws {
+        let manager = MockDownloadManager()
+        // Pre-seed a completed DownloadState so the poll loop exits
+        // immediately — reaching startDownload at all is the property under
+        // test. (startDownloadError can't be used here: the mock throws
+        // before recording into startedModels.)
+        let seed = QuickStartSeed.recommendedSmallModel()
+        let model = DownloadableModel(
+            repoID: seed.repoID,
+            fileName: seed.fileName,
+            displayName: seed.displayName,
+            modelType: seed.modelType,
+            sizeBytes: seed.sizeBytes
+        )
+        let completedState = DownloadState(model: model)
+        completedState.markCompleted(localURL: tempDir.appendingPathComponent(seed.fileName))
+        manager.activeDownloads[model.id] = completedState
+
+        _ = try await ManifoldKit._quickStart(
+            configuration: .default,
+            backends: [MockGGUFBackends.self],
+            seed: seed,
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            downloadManagerOverride: manager,
+            foundationAvailableOverride: false,
+            // Isolated empty scratch dir: the "model already on disk" skip
+            // gate must not fire from ambient models on the test host.
+            storageServiceOverride: ModelStorageService(
+                baseDirectory: tempDir,
+                includeUserDocumentsFallback: false
+            ),
+            selectionPolicy: { _ in nil }
+        )
+
+        XCTAssertFalse(manager.startedModels.isEmpty,
+            "Seed must attempt the download when a runtime-injected backend can load .gguf (#1735 re-based on runtime registration)")
+    }
+
+    /// Without any GGUF-capable backend registered, the seed must skip —
+    /// downloading ~400 MB nothing can load is the silent-failure trap this
+    /// gate exists to close.
+    func test_seed_skips_whenNoRegisteredBackendCanLoadGGUF() async throws {
+        try XCTSkipIf(buildHasCompiledInGGUFBackend,
+            "Compiled-in GGUF backend present (Llama trait) — the no-GGUF-backend case is not arrangeable in this build")
+
+        let manager = MockDownloadManager()
+
+        _ = try await ManifoldKit._quickStart(
+            configuration: .default,
+            seed: .recommendedSmallModel(),
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            downloadManagerOverride: manager,
+            foundationAvailableOverride: false,
+            storageServiceOverride: ModelStorageService(
+                baseDirectory: tempDir,
+                includeUserDocumentsFallback: false
+            ),
+            selectionPolicy: { _ in nil }
+        )
+
+        XCTAssertTrue(manager.startedModels.isEmpty,
+            "Seed must skip when no registered backend can load .gguf — a download nothing can load is dead weight")
+    }
+
+    // MARK: - Selection compatibility filter
+
+    /// An on-disk model whose type has NO registered backend must not be
+    /// auto-selected: the model would appear selected, the app would compile
+    /// and launch clean, and the first send would fail with a confusing load
+    /// error (worst silent break of the companion split).
+    func test_defaultPolicy_skipsModel_withNoRegisteredBackend() async throws {
+        // Fresh service with nothing registered — deterministic in every
+        // trait combination, unlike driving _quickStart (which always folds
+        // the compiled-in defaults).
+        let service = InferenceService()
+        let registry = ModelRegistry(
+            inferenceService: service,
+            modelStorage: ModelStorageService(
+                baseDirectory: tempDir,
+                includeUserDocumentsFallback: false
+            )
+        )
+        registry.foundationModelProvider = { false }
+        registry.availableModels = [makeGGUFModelInfo()]
+
+        let chosen = await ManifoldKit.defaultSelectionPolicy(registry)
+
+        XCTAssertNil(chosen,
+            "defaultSelectionPolicy must not auto-select a model no registered backend can load")
+    }
+
+    /// Counterpart: the same registry picks the model once a capable backend
+    /// registers — proving the nil above comes from the compatibility filter,
+    /// not from some other property of the setup.
+    func test_defaultPolicy_selectsModel_onceBackendRegisters() async throws {
+        let service = InferenceService()
+        let registry = ModelRegistry(
+            inferenceService: service,
+            modelStorage: ModelStorageService(
+                baseDirectory: tempDir,
+                includeUserDocumentsFallback: false
+            )
+        )
+        registry.foundationModelProvider = { false }
+        let model = makeGGUFModelInfo()
+        registry.availableModels = [model]
+
+        MockGGUFBackends.register(with: service)
+        let chosen = await ManifoldKit.defaultSelectionPolicy(registry)
+
+        XCTAssertEqual(chosen?.id, model.id,
+            "defaultSelectionPolicy must select the model once a capable backend is registered")
+    }
+
+    // MARK: - Backend-availability diagnostic
+
+    /// Decision table for the runtime guard that replaced the trait-based
+    /// "registered count > 0" check. Pure-function tests so every case is
+    /// reachable in every build (driving _quickStart can't produce an empty
+    /// snapshot in Foundation-capable builds).
+    func test_backendAvailabilityDiagnostic_decisionTable() {
+        // Nothing registered at all → fail fast.
+        XCTAssertEqual(
+            ManifoldKit.backendAvailabilityDiagnostic(
+                snapshot: EnabledBackends(),
+                configuredEndpointCount: 0
+            ),
+            .noBackends,
+            "Empty registration must keep the noBackendsRegistered fail-fast reachable"
+        )
+
+        // Cloud-only, no endpoint configured → actionable warning.
+        let cloudOnly = EnabledBackends(localModelTypes: [], cloudProviders: [.ollama])
+        let diagnostic = ManifoldKit.backendAvailabilityDiagnostic(
+            snapshot: cloudOnly,
+            configuredEndpointCount: 0
+        )
+        guard case .cloudOnlyWithoutEndpoint(let message) = diagnostic else {
+            XCTFail("Cloud-only + zero endpoints must produce the cloudOnlyWithoutEndpoint warning, got \(String(describing: diagnostic))")
+            return
+        }
+        // The message must name the companion packages and both remediation
+        // paths — that wording is the deliverable (plan §8 risk 2).
+        XCTAssertTrue(message.contains("manifold-llama"), "Warning must name manifold-llama")
+        XCTAssertTrue(message.contains("manifold-mlx"), "Warning must name manifold-mlx")
+        XCTAssertTrue(message.contains("quickStart(backends:"), "Warning must point at the registrar-injection API")
+        XCTAssertTrue(message.contains("APIEndpointRecord"), "Warning must point at the cloud-endpoint remediation")
+
+        // Cloud-only with a configured endpoint → healthy, no diagnostic.
+        XCTAssertNil(
+            ManifoldKit.backendAvailabilityDiagnostic(
+                snapshot: cloudOnly,
+                configuredEndpointCount: 1
+            ),
+            "A configured endpoint makes a cloud-only service usable — no diagnostic"
+        )
+
+        // Any local backend → healthy regardless of endpoints.
+        XCTAssertNil(
+            ManifoldKit.backendAvailabilityDiagnostic(
+                snapshot: EnabledBackends(localModelTypes: [.gguf], cloudProviders: []),
+                configuredEndpointCount: 0
+            ),
+            "Local inference available — no diagnostic"
+        )
+    }
+
+    /// The guard stays wired through the real assembly path: an injected
+    /// local backend must produce a successful, fully-wired launch (and the
+    /// healthy path must not throw noBackendsRegistered).
+    func test_quickStartBackends_injectedLocalBackend_launchesClean() async throws {
+        let result = try await ManifoldKit._quickStart(
+            configuration: .default,
+            backends: [MockGGUFBackends.self],
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { _ in nil }
+        )
+
+        XCTAssertNotNil(result.viewModel.activeSession,
+            "quickStart(backends:) must produce a usable chat surface")
+        XCTAssertTrue(
+            result.bootstrap.inferenceService.registeredBackendSnapshot().supportsGGUF,
+            "Injected registrar's support must be visible on the bootstrap's service after quickStart returns"
+        )
+    }
+}

--- a/Tests/ManifoldKitTests/QuickStartSeedTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartSeedTests.swift
@@ -260,6 +260,10 @@ final class QuickStartSeedTests: XCTestCase {
 
         let result = try await ManifoldKit._quickStart(
             configuration: .default,
+            // The seed gate is runtime-registration-based (#1749): inject a
+            // GGUF-capable registrar so the download path is reachable under
+            // --disable-default-traits builds too.
+            backends: [MockGGUFBackends.self],
             seed: seed,
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
             downloadManagerOverride: manager,
@@ -304,6 +308,8 @@ final class QuickStartSeedTests: XCTestCase {
         // a Foundation model that would otherwise win the selection race).
         let result = try await ManifoldKit._quickStart(
             configuration: .default,
+            // See above: keep the download path reachable in trait-less builds.
+            backends: [MockGGUFBackends.self],
             seed: seed,
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
             downloadManagerOverride: manager,

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -277,7 +277,7 @@ final class QuickStartTests: XCTestCase {
 
     /// When the built-in policy is in effect (selectionPolicy: nil) and
     /// `availableModels` contains a local model but no Foundation model is
-    /// available, the first local model must be selected.
+    /// available, the first *loadable* local model must be selected.
     ///
     /// We exercise this via a custom policy that:
     /// 1. Clears `foundationModelProvider` to ensure the Foundation-first branch
@@ -285,6 +285,11 @@ final class QuickStartTests: XCTestCase {
     ///    available and would win the priority race).
     /// 2. Seeds `availableModels` with the local model.
     /// 3. Delegates to `defaultSelectionPolicy` to exercise its logic directly.
+    ///
+    /// A GGUF-capable mock registrar is injected via `backends:` because the
+    /// default policy now refuses to select models no registered backend can
+    /// load (#1749) — under `--disable-default-traits` there is no compiled-in
+    /// GGUF backend.
     func test_quickStart_defaultPolicy_selectsFirstLocalModel_whenAvailable() async throws {
         let localModel = ModelInfo(
             id: UUID(),
@@ -297,6 +302,7 @@ final class QuickStartTests: XCTestCase {
 
         let result = try await ManifoldKit._quickStart(
             configuration: .default,
+            backends: [MockGGUFBackends.self],
             makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
             selectionPolicy: { registry in
                 // Suppress Foundation availability so we reach the "first local

--- a/Tests/ManifoldRuntimeTests/ContextBudgetPlannerTests.swift
+++ b/Tests/ManifoldRuntimeTests/ContextBudgetPlannerTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import ManifoldRuntime
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 /// Tests for ``ContextBudgetPlanner`` and the backward-compatible
 /// ``PromptContextPipeline/assemble(messageCount:)`` path.

--- a/Tests/ManifoldUIModelManagementTests/ModelManagementSheetLogicTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/ModelManagementSheetLogicTests.swift
@@ -1,6 +1,9 @@
 @preconcurrency import XCTest
 #if canImport(AppKit)
 import AppKit
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 #endif
 import SwiftUI
 @testable import ManifoldUI

--- a/Tests/ManifoldUIModelManagementTests/TestChatViewModelFactory.swift
+++ b/Tests/ManifoldUIModelManagementTests/TestChatViewModelFactory.swift
@@ -7,6 +7,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Mirror of `Tests/ManifoldUITests/TestChatViewModelFactory.swift`.
 ///

--- a/Tests/ManifoldUITests/BackendActivityPhaseTests.swift
+++ b/Tests/ManifoldUITests/BackendActivityPhaseTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 @MainActor
 final class BackendActivityPhaseTests: XCTestCase {

--- a/Tests/ManifoldUITests/ChatViewModelCacheLifecycleTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelCacheLifecycleTests.swift
@@ -6,6 +6,9 @@ import ManifoldPersistenceSwiftData
 @testable import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Tests that `ChatViewModel`'s per-message token count cache is invalidated at
 /// the correct moments so stale counts from a previous tokenizer (or previous

--- a/Tests/ManifoldUITests/ChatViewModelLoadPlanWiringTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelLoadPlanWiringTests.swift
@@ -1,6 +1,9 @@
 @preconcurrency import XCTest
 @testable import ManifoldUI
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 private let oneGB: UInt64 = 1_024 * 1_024 * 1_024
 

--- a/Tests/ManifoldUITests/ChatViewModelLoopDetectionTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelLoopDetectionTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 @MainActor
 final class ChatViewModelLoopDetectionTests: XCTestCase {

--- a/Tests/ManifoldUITests/ChatViewModelRuntimeAdapterTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelRuntimeAdapterTests.swift
@@ -5,6 +5,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 // MARK: - ChatViewModel ↔ ConversationRuntime adapter tests
 //

--- a/Tests/ManifoldUITests/ChatViewModelStagedAttachmentsTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelStagedAttachmentsTests.swift
@@ -3,6 +3,9 @@ import Foundation
 @testable import ManifoldUI
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Coverage for the public staged-attachment API on `ChatViewModel` introduced
 /// in issue #1302. Verifies that consumers building custom composers reach the

--- a/Tests/ManifoldUITests/ChatViewModelSystemPromptContextTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelSystemPromptContextTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 @MainActor
 final class ChatViewModelSystemPromptContextTests: XCTestCase {

--- a/Tests/ManifoldUITests/ContextEstimationIntegrationTests.swift
+++ b/Tests/ManifoldUITests/ContextEstimationIntegrationTests.swift
@@ -6,6 +6,8 @@ import ManifoldPersistenceSwiftData
 @testable import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 /// Integration tests for context estimation using REAL HeuristicTokenizer and
 /// ContextWindowManager with no mocks on the computation path.

--- a/Tests/ManifoldUITests/ContextEstimatorTests.swift
+++ b/Tests/ManifoldUITests/ContextEstimatorTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import ManifoldUI
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldContract
 
 /// Unit tests for the pure `ContextEstimator` struct extracted from
 /// `ChatViewModel.updateContextEstimate()`. No ChatViewModel, no persistence.

--- a/Tests/ManifoldUITests/GenerationExtensionTests.swift
+++ b/Tests/ManifoldUITests/GenerationExtensionTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 // MARK: - Tests
 

--- a/Tests/ManifoldUITests/LoadDispatchCoordinationTests.swift
+++ b/Tests/ManifoldUITests/LoadDispatchCoordinationTests.swift
@@ -3,6 +3,9 @@
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 @MainActor
 final class LoadDispatchCoordinationTests: XCTestCase {

--- a/Tests/ManifoldUITests/MemoryAndConcurrencyTests.swift
+++ b/Tests/ManifoldUITests/MemoryAndConcurrencyTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Tests for memory pressure transitions and concurrency edge cases in ChatViewModel.
 @MainActor

--- a/Tests/ManifoldUITests/MultiThinkingBlockTests.swift
+++ b/Tests/ManifoldUITests/MultiThinkingBlockTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Tests for #482 / #604: two ``GenerationEvent/thinkingCompleted`` events
 /// on a single assistant turn must produce two distinct ``MessagePart/thinking``

--- a/Tests/ManifoldUITests/TestChatViewModelFactory.swift
+++ b/Tests/ManifoldUITests/TestChatViewModelFactory.swift
@@ -6,6 +6,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Shared `ChatViewModel` test factory. Replaces ~10 copies of the same
 /// `private func makeViewModel(...)` / `private func makeViewModelWithMock(...)`

--- a/Tests/ManifoldUITests/ThinkingStreamingTests.swift
+++ b/Tests/ManifoldUITests/ThinkingStreamingTests.swift
@@ -4,6 +4,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 /// Asserts the live-streaming behavior introduced for issue #481: the
 /// reasoning block must mutate multiple times during the streaming phase

--- a/Tests/ManifoldUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/ManifoldUITests/ViewModelEdgeCaseTests.swift
@@ -5,6 +5,9 @@ import ManifoldRuntime
 import ManifoldPersistenceSwiftData
 @testable import ManifoldInference
 import ManifoldTestSupport
+// BackendInternals SPI: seam published for the companion split (#1749).
+@_spi(BackendInternals) import ManifoldHardware
+@_spi(BackendInternals) import ManifoldUI
 
 @MainActor
 final class ViewModelEdgeCaseTests: XCTestCase {


### PR DESCRIPTION
## Summary

PR B2 of the v0.48 packaging release (plan: `docs/plans/v0.48-packaging-release.md` §3 B2). Publishes the undeclared backend seam the family backends compile against, adds registrar injection to `quickStart`, and re-bases every consumer-facing capability check on **runtime registration state** instead of compile-time trait reflection — closing the four silent-failure traps named in plan §8 risk 2.

## 1. `@_spi(BackendInternals)` seam publication (freeze surface for B3)

Full sweep of every `package`-visibility declaration in ManifoldContract / ManifoldInference / ManifoldHardware / ManifoldModelCatalog (grep by **symbol name**, not import statements — symbols leak transitively through the `@_exported` chains), checked against `Sources/ManifoldMLX` + `Sources/ManifoldLlama` usage:

| `package` symbol (owning target) | Family usage | Disposition |
|---|---|---|
| `MemoryPressureHandler` (ManifoldHardware) | `LlamaBackend.swift:200` (+ `startMonitoring`/`stopMonitoring`/`addPressureCallback`/`removeCallback`) | **Promoted** → `@_spi(BackendInternals) public` |
| `HeuristicTokenizer` (ManifoldContract) | `LlamaBackend.swift` `tokenCount` fallback (×2) | **Promoted** → `@_spi(BackendInternals) public` |
| `StreamingArgumentAccumulator`, `SSEStreamParser`, `SSEEventIDTracker` (Contract) | none | stays `package` |
| `encodeJSONSchemaToFoundation`, `CachingTokenizer`, `ToolSpillReaper.setDefaultDirectoryOverride`, `InferenceService.unloadModel(reason:)/setPreToolUseHook/notifyPressureLevel` (Inference) | none | stays `package` |
| `MemoryPressureBroadcaster`, `AppleSiliconBandwidth`, `QuantizationBits`, `CompiledBackends.buildProfile(for:)`, `PromptTemplateDetector`, `FileNameError`, `GenerationCapabilityRequirement.sortKey`, `GGUFMetadata(+Reader)`, `GGUFReaderError`, `GGUFKVCacheParameters/Estimator` (Hardware) | none | stays `package` |
| `ModelStorageService.init(baseDirectory:…)`, `APIEndpointRecord.validate()` (ModelCatalog) | none | stays `package` |

Knock-on: `ChatViewModel`'s `package init(… memoryPressure:)` (ManifoldUI) became `@_spi(BackendInternals) public init` — a non-SPI `package` signature may not reference an SPI type. **B3 note:** the frozen `@_spi(BackendInternals)` surface is `MemoryPressureHandler` + `MemoryPressureLevel` interplay (level enum was already public), `HeuristicTokenizer`, and that `ChatViewModel` init.

In-package consumers (5 source files, ~22 test files) gained a mechanical `@_spi(BackendInternals) import` line — those edits are deletions-grade mechanical and verified by the build gate, which is why the file count exceeds the 40-file guidance.

## 2. `quickStart(backends:)` — API shape

```swift
let kit = try await ManifoldKit.quickStart(backends: [MLXBackends.self])
```

Chosen shape: a **new overload with `backends:` as a required, first, unlabeled-default-free parameter** — `quickStart(backends:configuration:seed:)` — rather than (a) adding a defaulted param to the existing overloads (changes the mangled signatures of the two shipped `quickStart` functions → API-break-gate noise, and a defaulted `backends:` on both would make bare `quickStart()` ambiguous) or (b) a `registrars` property on `ManifoldConfiguration` (config is a `Sendable` value type in ManifoldInference; registrar metatypes are `@MainActor`-registered assembly-time concerns, and the plan's §7 decision 2 already resolved to `quickStart(backends:)`). The existing two overloads are byte-compatible; the new one matches the plan §4 migration snippet exactly.

Ordering contract (the whole point): injected registrars are registered immediately after `DefaultBackends.register(with:)` and **before** the availability guard, the starter seed (#1735), `ModelRegistry.refresh()`, and the selection policy.

## 3. Runtime-registration re-basing (the four silent-failure traps)

| Trap | Fix |
|---|---|
| (a) `noBackendsRegistered` guard goes dead once cloud registers unconditionally | Replaced `register() count > 0` with a pure decision function `backendAvailabilityDiagnostic(snapshot:configuredEndpointCount:)`: empty snapshot → **throw** `noBackendsRegistered` (kept reachable); cloud-only + zero configured endpoints → **actionable `Log.warning`** naming manifold-llama / manifold-mlx, `quickStart(backends:)`, and the `APIEndpointRecord` path (warn not throw: endpoints are legitimately configured after `quickStart` returns). Error string rewritten to name the companion packages. |
| (b) `QuickStartSeed` skip conditions were compile-time | Seed now gates on `inferenceService.compatibility(for: seed.modelType)` — live registration, so runtime-injected Llama-capable backends enable the GGUF seed; skip is a `Log.info` with remediation, never silent-silent. `#if HuggingFace` remains only for the download *machinery* (genuinely compile-time). |
| (c) incompatible on-disk models auto-selected | `defaultSelectionPolicy` now filters through `ModelRegistry.compatibility(for:)` (→ `InferenceService.compatibility(for:)`): first **loadable** local model wins; skipped files are logged with the companion-package pointer. Foundation-first branch re-based from `DefaultBackends.canLoad` to the same runtime query. |
| (d) `DefaultBackends` statics | Disposition table below. |

### `DefaultBackends` per-symbol disposition

| Symbol | Disposition | Rationale |
|---|---|---|
| `compiledBackends` | **Keep, compile-time (documented)** | Inherently "what is in this build"; redesign of `CompiledBackends` itself is PR A4's scope |
| `buildProfile` | **Keep, compile-time (documented)** | Build introspection (FIPS/build-modes evidence) |
| `enabledTraits` | **Keep, compile-time (documented)** | Build introspection; trait set dies at C2 anyway |
| `supportedModelTypes` | **Deprecated** → `InferenceService.registeredBackendSnapshot().localModelTypes` | Consumers use it to decide loadability — must reflect runtime |
| `canLoad(modelType:)` | **Deprecated** → `InferenceService.compatibility(for:).isSupported` | same |
| `canLoad(provider:)` | **Deprecated** → `InferenceService.compatibility(for:).isSupported` | same |
| `registrars` | **Keep** | The compiled-in default fold; doc now points companion users at `quickStart(backends:)` |
| `register(with:)` | **Keep** | Still the assembly entry point; doc warns the bare count is a weak signal and points at the snapshot |

`CompiledBackends` / `APIProvider.availableInBuild` deliberately untouched (A4 scope).

## 4. Tests (`Tests/ManifoldKitTests/QuickStartBackendsTests.swift`, + updates)

- **Ordering**: injected registrar's `.gguf` support visible inside the selection-policy closure; end-to-end default-policy selection of a model only the injected backend can load.
- **Seed runtime gating**: seed downloads with an injected GGUF registrar (new `foundationAvailableOverride` / `storageServiceOverride` test seams keep this deterministic on Apple-Intelligence/dev hosts); skips with none (honest `XCTSkipIf` when the build compiles a real Llama backend in).
- **Selection filter**: on-disk GGUF + empty `InferenceService` → not selected; same registry selects it once a backend registers.
- **Guard**: full decision-table test for `backendAvailabilityDiagnostic`, including the required wording (manifold-llama, manifold-mlx, `quickStart(backends:`, `APIEndpointRecord`).

**Sabotage evidence** (break → observe failure → restore), 3 of the 4:
1. Inverted the seed compatibility gate → `test_seed_runs_whenGGUFBackendInjectedAtRuntime` and `test_seed_skips_whenNoRegisteredBackendCanLoadGGUF` both failed.
2. Removed the selection compatibility filter → `test_defaultPolicy_skipsModel_withNoRegisteredBackend` failed (`XCTAssertNil` got the incompatible model).
3. Made the empty-snapshot branch return nil → `test_backendAvailabilityDiagnostic_decisionTable` failed ("fail-fast must stay reachable").

## Gates

1. `swift build --build-tests --disable-default-traits` — clean
2. `swift build --build-tests --disable-default-traits --traits MCP,CloudSaaS` — clean
3. `swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,MCP,MCPBuiltinCatalog,HuggingFace,Fuzz` — clean
4. `scripts/test.sh --profile local` — **PASSED** — XCTest 5,029 run / 0 failed (61 skips: hardware/env gates), Swift Testing 83/83, exit 0

Zero manifest footprint (no Package.swift / trait edits; Package.resolved untouched).

## Findings for A4 / B3

- **A4**: `CompiledBackendsTests` & `TraitAwareServerBackendProvider` consume `DefaultBackends.compiledBackends`; `DefaultBackendsCapabilityTests` methods that pin the now-deprecated statics carry `@available(*, deprecated)` annotations — A4's runtime-capability redesign should rewrite or retire those tests. `OllamaBackend.init(urlSession:)` carries a #714 deprecation message that still tells users to "add the `Ollama` trait" — needs the A5 string sweep.
- **B3**: freeze surface = the two promoted `@_spi(BackendInternals)` types + the `ChatViewModel` SPI init above, in addition to the public `BackendRegistrar` / `registerBackendFactory` / `declareSupport(for:)` / `EnabledBackends` / `ModelCompatibilityResult` set this PR's APIs lean on.

Part of #1749 / v0.48 packaging release — PR B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
