### PR TITLE
feat(traits)!: retire Ollama and CloudSaaS traits

### DIFF
--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -15,8 +15,9 @@ name: Build modes + binary symbol audit
 #  - **PR vs schedule matrix split.** On `pull_request`, the matrix runs only
 #    `[saas]`; on `schedule` (and `workflow_dispatch`) it runs all four
 #    `[offline, ollama, saas, full]`. Rationale: `saas` carries a
-#    CloudSaaS-only test step (`ManifoldBackendsTests --traits CloudSaaS`)
-#    that is real signal not covered by ci.yml, so it stays per-PR. `full`
+#    reduced-shape test step (`ManifoldBackendsTests --disable-default-traits`)
+#    that mirrors ci.yml's lane against the SaaS product graph, so it stays
+#    per-PR. `full`
 #    is a release-config + all-traits build that produces a binary symbol
 #    audit; per-PR it cost ~9 min wall-clock (~90 min billed at the 10x
 #    macos-15 multiplier) on every dep-touching PR while catching only
@@ -54,20 +55,25 @@ on:
     branches: [main]
     paths:
       # Package.resolved only (not Package.swift): a dep-version bump can break
-      # trait-gated compilation (#if MLX / #if Llama / #if CloudSaaS), so it
-      # warrants the saas+full build check. Package.swift edits that affect trait
-      # defines always accompany backend source changes (listed below), so
+      # trait-gated compilation (#if MLX / #if Llama), so it warrants the
+      # saas+full build check. Package.swift edits that affect trait defines
+      # always accompany backend source changes (listed below), so
       # Package.swift alone is dropped — non-backend target additions and platform
       # floor bumps don't affect trait-gated builds, and the nightly run catches
       # any gap within 24 hours.
       - "Package.resolved"
-      - "Sources/ManifoldBackends/**"
-      - "Sources/ManifoldServerBackends/**"
+      - "Sources/ManifoldBackendsUmbrella/**"
+      - "Sources/ManifoldCloudCore/**"
+      - "Sources/ManifoldCloud/**"
+      - "Sources/ManifoldOllama/**"
+      - "Sources/ManifoldCloudSaaS/**"
+      - "Sources/ManifoldServer/**"
       - "Sources/ManifoldUI/Views/Settings/**"
       - "Sources/ManifoldUIModelManagement/Views/Settings/**"
-      - "Sources/ManifoldInference/Models/APIProvider.swift"
+      - "Sources/ManifoldHardware/APIProvider.swift"
       - "Sources/manifold-tools/main.swift"
       - ".github/workflows/build-modes.yml"
+      - "scripts/build-modes.sh"
       - "scripts/build-modes.sh"
 
 # Cancel earlier in-flight runs of this workflow on the same ref. Scheduled
@@ -88,8 +94,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # On PRs: only saas. `saas` carries a CloudSaaS-only test slice not
-        # covered by ci.yml, which is the per-PR-relevant signal. `full` and
+        # On PRs: only saas. `saas` carries a SaaS-product test slice,
+        # which is the per-PR-relevant signal. `full` and
         # the offline/ollama legs are audit-only builds; running them per-PR
         # cost ~9 min wall-clock and ~90 min billed time on every dep-touching
         # PR without catching live bugs (#953 Lever A). On schedule/
@@ -119,7 +125,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-${{ matrix.mode }}-
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.3-spm-
 
-      # The saas leg additionally runs the CloudSaaS-only test slice — the
+      # The saas leg additionally runs the backends test slice — the
       # other two legs are build+audit only. Splitting this out keeps the
       # matrix readable and avoids running tests on `full` (already covered
       # by the per-PR ci.yml suite once MLX/Llama traits are present).
@@ -131,9 +137,9 @@ jobs:
       # doesn't always have the new revision pack). The flag is also
       # deprecated in current SwiftPM. Dropping it costs ~1s of `git fetch`
       # and is the documented escape hatch.
-      - name: Test [saas] — ManifoldBackends with CloudSaaS only
+      - name: Test [saas] — ManifoldBackends, reduced shape
         if: matrix.mode == 'saas'
-        run: scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits --traits CloudSaaS
+        run: scripts/test.sh --filter ManifoldBackendsTests --disable-default-traits
 
       - name: Build + audit [${{ matrix.mode }}]
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,17 +556,15 @@ jobs:
       # diagnostic signal about which test stalled. See the script header for
       # the design rationale.
       #
-      # All three test invocations below pass the SAME trait set
-      # (`CloudSaaS`). `swift test --filter` always builds the whole test
-      # tree (the filter only gates execution), so a different trait set per
-      # invocation means a different conditional-compilation config and forces a
-      # full recompile each time — measured ~63s rebuilt on the Swift Testing
-      # step alone (CI log, run 26705440802). Using one superset trait set lets
-      # steps 2–3 reuse step 1's `.build` and drop to test-execution-only. The
-      # set is a superset (step 3 needs CloudSaaS, steps 1–2 need
-      # nothing) — traits only ADD compiled code, so no suite's behavior changes.
-      # Keep all three in sync; diverging the traits silently reintroduces the
-      # redundant rebuilds.
+      # All three test invocations below pass the SAME build shape
+      # (`--disable-default-traits`, no extra traits — the cloud families
+      # compile unconditionally since v0.48 PR A4). `swift test --filter`
+      # always builds the whole test tree (the filter only gates execution),
+      # so a different trait set per invocation means a different
+      # conditional-compilation config and forces a full recompile each time —
+      # measured ~63s rebuilt on the Swift Testing step alone (CI log, run
+      # 26705440802). Keep all three in sync; diverging the traits silently
+      # reintroduces the redundant rebuilds.
       - name: Test — XCTest suites (Core + Runtime + PersistenceSwiftData + UI + UIModelManagement + MCP + TestSupport + AppIntents + Voice + Skills + Tools + Inference + Networking + TurnLoopCharacterization, parallel) [full]
         id: test-xctest-suites
         if: steps.test-mode.outputs.mode == 'full'
@@ -574,7 +572,7 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-xctest-suites.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldVoiceTests --filter ManifoldSkillsTests --filter ManifoldToolsTests --filter ManifoldInferenceTests --filter ManifoldNetworkingTests --filter ManifoldSecretsTests --filter ManifoldHardwareTests --filter ManifoldModelCatalogTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --traits CloudSaaS --skip-update --parallel
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldCoreTests --filter ManifoldRuntimeTests --filter ManifoldPersistenceSwiftDataTests --filter ManifoldUITests --filter ManifoldUIModelManagementTests --filter ManifoldMCPTests --filter ManifoldTestSupportTests --filter ManifoldAppIntentsTests --filter ManifoldVoiceTests --filter ManifoldSkillsTests --filter ManifoldToolsTests --filter ManifoldInferenceTests --filter ManifoldNetworkingTests --filter ManifoldSecretsTests --filter ManifoldHardwareTests --filter ManifoldModelCatalogTests --filter ManifoldTurnLoopCharacterizationTests --disable-default-traits --skip-update --parallel
 
       # ManifoldBackendsTests is intentionally NOT included in the --parallel batch
       # above. Under --parallel, swift-test schedules XCTest classes across workers
@@ -593,7 +591,7 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-backends.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldBackendsTests --disable-default-traits --traits CloudSaaS --skip-update
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldBackendsTests --disable-default-traits --skip-update
 
       # `if: (success() || failure())` so a failing XCTest step still surfaces
       # Swift Testing failures in the same run — otherwise breakage in both
@@ -606,7 +604,7 @@ jobs:
         env:
           MANIFOLD_TEST_OUTPUT_FILE: ${{ github.workspace }}/test-diagnostics/test-inference-swift-testing.log
           STALL_SECONDS: "240"
-        run: scripts/ci-test-with-watchdog.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --traits CloudSaaS --skip-update
+        run: scripts/ci-test-with-watchdog.sh --filter ManifoldInferenceSwiftTestingTests --disable-default-traits --skip-update
 
       # Coverage thresholds run nightly in nightly-slow-tests.yml — they were
       # moved out of per-main-push CI to reclaim ~130s of wall (~22 billed
@@ -948,7 +946,7 @@ jobs:
   # trait-combo breakage is therefore invisible to per-PR CI.  Two canonical
   # failure shapes have already burned CI time:
   #   - #1382: a KV-cache reuse race that only manifests under `--traits MLX,Llama`
-  #   - #1660: a BackendRegistrar break that only manifests under `--traits Ollama`
+  #   - #1660: a BackendRegistrar break that only manifested under `--traits Ollama` (trait retired in v0.48)
   # Both merged green on the `--disable-default-traits` lane and were caught by
   # the nightly all-traits build — *after* landing on main.
   #
@@ -1001,4 +999,4 @@ jobs:
         timeout-minutes: 25
         run: |
           swift build --build-tests \
-            --traits MLX,Llama,Ollama,CloudSaaS,HuggingFace,Fuzz
+            --traits MLX,Llama,HuggingFace,Fuzz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,16 +350,16 @@ await vm.loadCloudEndpoint(endpoint)
 let reply = try await vm.sendMessage("hello")
 ```
 
-Cloud backends require **`--traits CloudSaaS`** (default-off):
+Cloud backends are always compiled in since v0.48 (the `CloudSaaS` /
+`Ollama` traits were retired) — no trait flags needed:
 
 ```swift
 .package(
     url: "https://github.com/roryford/ManifoldKit.git",
-    from: "0.46.0",
+    from: "0.48.0",
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
-        .trait(name: "CloudSaaS"),
     ]
 )
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@
 | `ManifoldMLX` | MLX inference backend, resource arbiter, capability probe, MLX tool dialect, diffusion backends (`MLXDiffusionBackend`, `FluxDiffusionBackend`). Depends on `ManifoldInference`. | MLX |
 | `ManifoldLlama` | llama.cpp (GGUF) inference, generation driver, embedding backend, GGUF tool-call parser. Depends on `ManifoldInference`. | LlamaSwift |
 | `ManifoldFoundation` | Apple Foundation Models bridge — gated by OS availability (`#if canImport(FoundationModels)`, iOS 26 / macOS 26+), no trait. **Repointed to `ManifoldContract` only** (P2a #1719) — no engine-state dependency. | None |
-| `ManifoldOllama` | Ollama (self-hosted / LAN) backend family: `OllamaBackend`, model list/probe services, NDJSON stream extractor, `OllamaBackends` registrar. Compiles unconditionally — the `Ollama` trait gates consumer→`ManifoldOllama` edges, not source compilation. Depends on `ManifoldContract` + `ManifoldCloudCore`. Split out of `ManifoldCloud` in v0.48 (PR A1). | None |
-| `ManifoldCloudSaaS` | SaaS backend family: Anthropic Claude, OpenAI Chat Completions, OpenAI Responses, LM Studio / custom OpenAI-compatible endpoints, `CloudSaaSBackends` registrar. Compiles unconditionally — the `CloudSaaS` trait gates consumer→`ManifoldCloudSaaS` edges. Depends on `ManifoldContract` + `ManifoldCloudCore`. Split out of `ManifoldCloud` in v0.48 (PR A1). | None |
-| `ManifoldCloud` | **Deprecated re-export shim** (v0.48 product split): `@_exported import`s `ManifoldCloudCore` plus `ManifoldOllama` / `ManifoldCloudSaaS` behind their traits so `import ManifoldCloud` keeps compiling for one release. Still hosts `DefaultWebSearchRuntime` — its `ManifoldRuntime` dep is a deliberate library→library edge (`WebSearchRuntime` port conformance); a defending comment in Package.swift explains why it stays un-gated. | None |
+| `ManifoldOllama` | Ollama (self-hosted / LAN) backend family: `OllamaBackend`, model list/probe services, NDJSON stream extractor, `OllamaBackends` registrar. Compiles unconditionally with unconditional consumer edges (the `Ollama` trait was retired in v0.48 PR A4). Depends on `ManifoldContract` + `ManifoldCloudCore`. Split out of `ManifoldCloud` in v0.48 (PR A1). | None |
+| `ManifoldCloudSaaS` | SaaS backend family: Anthropic Claude, OpenAI Chat Completions, OpenAI Responses, LM Studio / custom OpenAI-compatible endpoints, `CloudSaaSBackends` registrar. Compiles unconditionally with unconditional consumer edges (the `CloudSaaS` trait was retired in v0.48 PR A4). Depends on `ManifoldContract` + `ManifoldCloudCore`. Split out of `ManifoldCloud` in v0.48 (PR A1). | None |
+| `ManifoldCloud` | **Deprecated re-export shim** (v0.48 product split): `@_exported import`s `ManifoldCloudCore` plus `ManifoldOllama` / `ManifoldCloudSaaS` (unconditional since PR A4) so `import ManifoldCloud` keeps compiling for one release. Still hosts `DefaultWebSearchRuntime` — its `ManifoldRuntime` dep is a deliberate library→library edge (`WebSearchRuntime` port conformance); a defending comment in Package.swift explains why it stays un-gated. | None |
 | `ManifoldCloudCore` | Shared SSE / TLS-pinning / DNS-rebind / URLSession infrastructure (`SSECloudBackend`, `PinnedSessionDelegate`, `DNSRebindingGuard`, `URLSessionProvider`, `CloudErrorSanitizer`, `ThinkingBlockManager`) plus the provider-agnostic encoding/parsing surface shared by both cloud families (`CloudMessageEncoder`, `CloudPayloadHandler`, `CloudHTTPProviderAdapter`, OpenAI-compatible Chat Completions parsing). Always linked; compiles unconditionally since v0.48 removed its trait gates. Depends on `ManifoldInference`. | None |
 | `ManifoldBackends` | Umbrella re-export shim (`Sources/ManifoldBackendsUmbrella/`). Hosts cross-family glue (`DefaultBackends`, per-family `BackendRegistrar` conformances) and `@_exported import`s the four family targets so existing `import ManifoldBackends` consumers keep compiling. | MLX, LlamaSwift |
 
@@ -86,7 +86,7 @@
 
 **Dependency rules:** Never import any backend family target (or the `ManifoldBackends` umbrella) from UI; never import `ManifoldUIModelManagement` from `ManifoldUI` (CI lint enforces this). `ManifoldUIModelManagement` depends on `ManifoldUI` — cycle dissolved by closure-injecting `APIConfigurationView` via `@ViewBuilder` parameter.
 
-**Backend family deps (post-P2a #1719, post-v0.48 A1):** `ManifoldMLX` and `ManifoldLlama` depend on `ManifoldInference` (real engine use: `extension InferenceService`, `ToolRegistry`, `BackendRegistrar`). `ManifoldFoundation`, `ManifoldOllama`, and `ManifoldCloudSaaS` compile against `ManifoldContract` (+ `ManifoldCloudCore` for the two cloud families) without touching the engine directly. The `ManifoldCloud` shim depends on `ManifoldCloudCore`, `ManifoldRuntime` (for `DefaultWebSearchRuntime`'s `WebSearchRuntime` port conformance — un-gated library→library edge; see Package.swift comment), and trait-gated edges to the two cloud families. `ManifoldMCP` depends on `ManifoldInference` (uses `ToolExecutor`, `ToolRegistry`). The consumer→family edge is trait-gated: `MLX` for `ManifoldMLX`, `Llama` for `ManifoldLlama`, `Ollama` for `ManifoldOllama`, `CloudSaaS` for `ManifoldCloudSaaS` (and `CloudSaaS || Ollama` for the `ManifoldCloud` shim); `ManifoldCloudCore` and `ManifoldFoundation` are always linked.
+**Backend family deps (post-P2a #1719, post-v0.48 A1):** `ManifoldMLX` and `ManifoldLlama` depend on `ManifoldInference` (real engine use: `extension InferenceService`, `ToolRegistry`, `BackendRegistrar`). `ManifoldFoundation`, `ManifoldOllama`, and `ManifoldCloudSaaS` compile against `ManifoldContract` (+ `ManifoldCloudCore` for the two cloud families) without touching the engine directly. The `ManifoldCloud` shim depends on `ManifoldCloudCore`, `ManifoldRuntime` (for `DefaultWebSearchRuntime`'s `WebSearchRuntime` port conformance — un-gated library→library edge; see Package.swift comment), and trait-gated edges to the two cloud families. `ManifoldMCP` depends on `ManifoldInference` (uses `ToolExecutor`, `ToolRegistry`). The consumer→family edge is trait-gated only for the local families: `MLX` for `ManifoldMLX`, `Llama` for `ManifoldLlama`. The cloud edges (`ManifoldOllama`, `ManifoldCloudSaaS`, the `ManifoldCloud` shim) are unconditional since v0.48 PR A4; `ManifoldCloudCore` and `ManifoldFoundation` are always linked.
 
 The umbrella `ManifoldBackends` re-exports each family conditionally so `import ManifoldBackends` keeps working in any trait combination. `ManifoldMCP` (including the `MCPCatalog` descriptors) compiles unconditionally — the `MCP` and `MCPBuiltinCatalog` traits were retired in v0.48.
 
@@ -95,13 +95,13 @@ The umbrella `ManifoldBackends` re-exports each family conditionally so `import 
 Use `scripts/test.sh` — it runs configured suites and prints an honest summary. Key flags:
 - `--disable-default-traits` — excludes MLX/Llama/hardware-gated tests (required for CI)
 - `--skip-update` — skips per-invocation git-remote contact (drop only if you edited Package.swift)
-- `--traits MLX,Llama,Ollama,CloudSaaS,HuggingFace` — for full-traits builds
+- `--traits MLX,Llama,HuggingFace` — for full-traits builds
 
 **Special cases:**
 - MLX integration tests require Xcode (Metal shaders): `scripts/test-mlx-integration.sh`
 - Swift Testing must run in a separate process from XCTest (mixing causes libmalloc SIGABRT — see #681)
 - MCP E2E: `RUN_MCP_E2E=1 swift test --filter ManifoldMCPE2ESmokeTests` — MCP test targets compile unconditionally (MCP trait retired in v0.48); the `RUN_MCP_E2E=1` env var still gates execution. Filter to the streamable suite; `EverythingServerSmokeTests` has hung 28+ min in past runs.
-- Ollama E2E requires Ollama at localhost:11434 and `--traits Ollama` (dropped from defaults in v2.0)
+- Ollama E2E requires Ollama at localhost:11434 (the backend always compiles since v0.48; only the live server is required)
 - Llama: in-process runs are safe — `LlamaBackendProcessLifecycle` latches `llama_backend_init` exactly once per process (was a per-class isolation script pre-#1319)
 - `ManifoldE2ETests`: bare form `swift test --filter ManifoldE2ETests --disable-default-traits` runs the full suite; for narrower targeting anchor the regex (`--filter 'ManifoldE2ETests\.'` then test name). Bare-vs-anchored behavior shifted in swift-test post-v2.
 
@@ -192,7 +192,7 @@ When Apple ships a new major OS each September, bump both minimums and remove `#
 scripts/test.sh --profile local
 ```
 
-Runs all-traits XCTest + Swift Testing on the full trait surface (`MLX,Llama,Ollama,CloudSaaS,HuggingFace,Macros`). This catches the trait-combo bugs CI cannot see (see PR #1382 for the canonical example: a KV cache reuse race that only fails under `--traits MLX,Llama`). Two-invocation shape is preserved internally (XCTest filters, then `ManifoldInferenceSwiftTestingTests` in a separate process — mixing the two runners in one process triggers libmalloc SIGABRT, #681). The profile deliberately does NOT pass `--parallel` or `--num-workers`: explicit parallelism can surface process-global state races in `BackendContractChecks` when backend test classes interleave (fixed for claim-methods in #1601, but implicit scheduling matches historical behavior — keep it).
+Runs all-traits XCTest + Swift Testing on the full trait surface (`MLX,Llama,HuggingFace,Macros`). This catches the trait-combo bugs CI cannot see (see PR #1382 for the canonical example: a KV cache reuse race that only fails under `--traits MLX,Llama`). Two-invocation shape is preserved internally (XCTest filters, then `ManifoldInferenceSwiftTestingTests` in a separate process — mixing the two runners in one process triggers libmalloc SIGABRT, #681). The profile deliberately does NOT pass `--parallel` or `--num-workers`: explicit parallelism can surface process-global state races in `BackendContractChecks` when backend test classes interleave (fixed for claim-methods in #1601, but implicit scheduling matches historical behavior — keep it).
 
 **Pre-push (CI repro — only when chasing a CI failure):**
 
@@ -208,9 +208,9 @@ Both profiles respect explicit caller flags: `scripts/test.sh --profile local --
 
 **Trait-combo sweep** (whenever modifying a switched enum, a `GenerationEvent` / `GenerationConfig` / `BackendCapabilities`-shaped type, or any trait-gated source file):
 ```bash
-swift build --build-tests --traits MLX,Llama,Ollama,CloudSaaS,HuggingFace,Fuzz
+swift build --build-tests --traits MLX,Llama,HuggingFace,Fuzz
 ```
-Default-trait builds won't catch CloudSaaS- or Ollama-gated switch exhaustiveness. The all-traits-on `--build-tests` is the cheapest single check.
+Default-trait builds won't catch MLX/Llama/Fuzz-gated switch exhaustiveness. The all-traits-on `--build-tests` is the cheapest single check.
 
 CI runs on macOS (10× billing). Each failed push wastes ~25 billed minutes. Test locally first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,25 +127,25 @@ and the `withKnownIssue` policy.
 A backend is anything that conforms to `InferenceBackend` and gets registered with
 `InferenceService`.
 
-1. **Pick the right trait** for the file. The four trait gates are:
-   - `MLX` — Apple Silicon MLX backend.
-   - `Llama` — llama.cpp / GGUF.
-   - `Ollama` — self-hosted HTTP (in defaults today; opt-in next major).
-   - `CloudSaaS` — third-party SaaS (Claude, OpenAI). Off by default.
+1. **Pick the right home** for the file. Local backends are trait-gated:
+   - `MLX` — Apple Silicon MLX backend (`Sources/ManifoldMLX`, wrap in `#if MLX`).
+   - `Llama` — llama.cpp / GGUF (`Sources/ManifoldLlama`, wrap in `#if Llama`).
 
-   Wrap the backend file's contents in `#if <Trait>` so it does not compile in
-   modes that exclude it.
+   Cloud backends are **not** trait-gated since v0.48 — they live in
+   `Sources/ManifoldOllama` / `Sources/ManifoldCloudSaaS` (shared HTTP/SSE
+   infra in `Sources/ManifoldCloudCore`) and compile unconditionally;
+   consumers exclude them by not linking the products.
 
 2. **Register via `DefaultBackends.register(with:)`** rather than calling backend
    constructors from app code. The registration helper handles trait gating and
    default-backend wiring; direct constructor calls bypass that and emit
    deprecation warnings.
 
-3. **Update `APIProvider.availableInBuild`** so the UI provider picker doesn't
-   list a backend whose code isn't linked. Match the existing `#if` gating.
+3. **Update `APIProvider.availableInBuild`** (via `BackendDescriptorRegistry`)
+   so the UI provider picker lists the new provider in documented order.
 
-4. **Add tests in `ManifoldBackendsTests`** with the matching `#if <Trait>` so
-   they don't run in trait sets that exclude the backend.
+4. **Add tests in `ManifoldBackendsTests`** — with a matching `#if <Trait>`
+   only for trait-gated local backends; cloud backend tests are unconditional.
 
 5. **HTTP I/O goes through `URLSessionProvider`.** Direct `URLSession.shared` use
    is banned by `TrafficBoundaryAuditTest` Rule 1. If your backend speaks HTTP,
@@ -179,8 +179,9 @@ UI lives in `ManifoldUI` and (for model-management surfaces) `ManifoldUIModelMan
    `ManifoldInference`'s service protocols.
 
 2. **Cloud-config UI** (anything that talks to `APIEndpoint`, lists API providers,
-   or reads/writes Keychain entries) goes behind `#if Ollama || CloudSaaS`. In
-   the offline build mode, the cloud-config UI compiles out entirely.
+   or reads/writes Keychain entries) compiles unconditionally since v0.48. If an
+   affordance should hide for a given deployment, key it on runtime endpoint
+   configuration state — not a compile flag.
 
 3. **Pasteboard writes** must use `localOnly: true` or be added to the
    `privacyAPIAllowlist` with an explicit justification entry. Default

--- a/FUZZING.md
+++ b/FUZZING.md
@@ -37,10 +37,10 @@ The wrapper prints a preflight line showing which backends it found (Llama via `
 Direct invocation works too — the wrapper just adds the preflight and the MLX xcodebuild bridge:
 
 ```bash
-swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat --minutes 5
-swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat --iterations 200 --backend ollama --quiet
-swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat --single --seed 42 --model qwen3.5
-swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat --backend mock --iterations 200 --workers 4 --corpus-subset smoke --quiet
+swift run --traits Fuzz,MLX,Llama fuzz-chat --minutes 5
+swift run --traits Fuzz,MLX,Llama fuzz-chat --iterations 200 --backend ollama --quiet
+swift run --traits Fuzz,MLX,Llama fuzz-chat --single --seed 42 --model qwen3.5
+swift run --traits Fuzz,MLX,Llama fuzz-chat --backend mock --iterations 200 --workers 4 --corpus-subset smoke --quiet
 ```
 
 Common flags:
@@ -120,7 +120,7 @@ cat tmp/fuzz/index.json | jq '.[].model_id' | sort | uniq -c
 `--workers N` runs multiple isolated `fuzz-chat` child processes, then merges their findings into the parent output directory. This is intentionally process-level rather than an in-process `TaskGroup`: each worker owns its backend instance, RNG state, reporter, and `FindingsSink`, avoiding cross-worker interference and backend-specific global state.
 
 ```bash
-swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat \
+swift run --traits Fuzz,MLX,Llama fuzz-chat \
   --backend mock \
   --iterations 200 \
   --workers 4 \

--- a/Package.swift
+++ b/Package.swift
@@ -2,12 +2,11 @@
 
 // Trait reference (full table in README §2.4):
 //   - Defaults: MLX, Llama, HuggingFace.
-//   - Opt-in heavy/network traits: Ollama, CloudSaaS,
-//     Server, Macros, Fuzz, AnyLanguageModel, HuggingFace.
+//   - Opt-in traits: Server, Macros, Fuzz, AnyLanguageModel.
 //   - Retired in v0.48: MCP, MCPBuiltinCatalog (PR A2); Voice, Tools,
-//     AppIntents, Skills (PR A3). Those modules now compile unconditionally;
-//     consumers opt in by importing (or not importing) the products.
-//     See docs/MIGRATION-0.48.md.
+//     AppIntents, Skills (PR A3); Ollama, CloudSaaS (PR A4). Those modules
+//     now compile unconditionally; consumers opt in by importing (or not
+//     importing) the products. See docs/MIGRATION-0.48.md.
 //   - `FoundationOnly` is an explicit "App Store-lean" marker for indie iOS
 //     26+/macOS 26+ apps that only need Apple Foundation Models. Pass
 //     `traits: ["FoundationOnly"]` from the consumer manifest — SwiftPM
@@ -117,8 +116,6 @@ let package = Package(
         .trait(name: "Llama", description: "Enable the llama.cpp (GGUF) inference backend"),
         .trait(name: "HuggingFace", description: "Enable HuggingFace Hub search, browse, and download"),
         .trait(name: "AnyLanguageModel", description: "Enable the AnyLanguageModel bridge backend target."),
-        .trait(name: "Ollama", description: "Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major."),
-        .trait(name: "CloudSaaS", description: "Third-party SaaS providers (Claude, OpenAI). Off by default."),
         .trait(name: "Server", description: "Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency."),
         .trait(name: "Macros", description: "Enable the @ToolSchema macro plugin and its swift-syntax dependency. Off by default — pulls ~647 source files into the build graph."),
         // Fuzz is intentionally NOT a default trait. Enabling it adds ManifoldBackends
@@ -314,8 +311,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("Macros", .when(traits: ["Macros"])),
                 .define("FoundationOnly", .when(traits: ["FoundationOnly"])),
@@ -403,10 +398,11 @@ let package = Package(
         // file `#if`s smeared across the body.
         //
         // Trait-gating rule (per CLAUDE.md): gate the consumer→family edge,
-        // not the family→library edge. `ManifoldCloud → ManifoldCloudCore` is
-        // unconditional (always linked together); `Consumer → ManifoldCloud`
-        // is gated by `CloudSaaS || Ollama` so a `FoundationOnly` build never
-        // pulls Cloud sources at all.
+        // not the family→library edge. Since v0.48 (PR A4) the cloud edges
+        // are unconditional — the Ollama / CloudSaaS traits are retired and
+        // the families always compile. Consumers that don't want SaaS code
+        // in a shipped binary depend on the specific products they need
+        // instead of the umbrella (link-out, not compile-out; docs/FIPS.md).
         //
         // The legacy `ManifoldBackends` target/module is preserved as a thin
         // re-export shim (sources moved to `Sources/ManifoldBackendsUmbrella/`
@@ -523,10 +519,9 @@ let package = Package(
         ),
 
         // ManifoldOllama: the Ollama (self-hosted / LAN) backend family.
-        // Compiles unconditionally — the Ollama trait gates the
-        // consumer→ManifoldOllama edges (umbrella, shim, tests), not source
-        // compilation inside the target. Split out of ManifoldCloud in the
-        // v0.48 packaging release (PR A1).
+        // Compiles unconditionally; all consumer edges are unconditional too
+        // since the Ollama trait retired (PR A4). Split out of ManifoldCloud
+        // in the v0.48 packaging release (PR A1).
         .target(
             name: "ManifoldOllama",
             dependencies: [
@@ -542,9 +537,10 @@ let package = Package(
 
         // ManifoldCloudSaaS: the SaaS backend family (Anthropic Claude,
         // OpenAI Chat Completions, OpenAI Responses, LM Studio / custom
-        // OpenAI-compatible endpoints). Compiles unconditionally — the
-        // CloudSaaS trait gates the consumer→ManifoldCloudSaaS edges. Split
-        // out of ManifoldCloud in the v0.48 packaging release (PR A1).
+        // OpenAI-compatible endpoints). Compiles unconditionally; all
+        // consumer edges are unconditional too since the CloudSaaS trait
+        // retired (PR A4). Split out of ManifoldCloud in the v0.48
+        // packaging release (PR A1).
         .target(
             name: "ManifoldCloudSaaS",
             dependencies: [
@@ -555,8 +551,7 @@ let package = Package(
         ),
 
         // ManifoldCloud: deprecated re-export shim (v0.48 product split).
-        // `@_exported import`s ManifoldOllama / ManifoldCloudSaaS (each
-        // behind its trait, mirroring these gated edges) so existing
+        // `@_exported import`s ManifoldOllama / ManifoldCloudSaaS so existing
         // `import ManifoldCloud` consumers keep compiling for one release.
         // Also still hosts DefaultWebSearchRuntime — the one cloud file that
         // conforms to a ManifoldRuntime port, an edge neither provider
@@ -571,17 +566,10 @@ let package = Package(
                 // trait-gating rule. ManifoldRuntime is SwiftData-free, so this
                 // does not drag SwiftData into the family target.
                 "ManifoldRuntime",
-                .target(name: "ManifoldOllama", condition: .when(traits: ["Ollama"])),
-                .target(name: "ManifoldCloudSaaS", condition: .when(traits: ["CloudSaaS"])),
+                "ManifoldOllama",
+                "ManifoldCloudSaaS",
             ],
-            path: "Sources/ManifoldCloud",
-            swiftSettings: [
-                // The shim is the one target that still needs per-trait
-                // compilation conditions: a per-trait `@_exported import`
-                // inside one file requires `#if`.
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-            ]
+            path: "Sources/ManifoldCloud"
         ),
 
         // ManifoldBackends: the legacy umbrella module, now a thin re-export
@@ -602,21 +590,19 @@ let package = Package(
                 "ManifoldFoundation",
                 .target(name: "ManifoldMLX", condition: .when(traits: ["MLX"])),
                 .target(name: "ManifoldLlama", condition: .when(traits: ["Llama"])),
-                .target(name: "ManifoldCloud", condition: .when(traits: ["CloudSaaS", "Ollama"])),
+                "ManifoldCloud",
                 // Direct edges to the v0.48 family products: CloudBackends
                 // forwards to OllamaBackends / CloudSaaSBackends, and an
                 // explicit `import` requires a declared edge even though the
                 // ManifoldCloud shim re-exports both.
-                .target(name: "ManifoldOllama", condition: .when(traits: ["Ollama"])),
-                .target(name: "ManifoldCloudSaaS", condition: .when(traits: ["CloudSaaS"])),
+                "ManifoldOllama",
+                "ManifoldCloudSaaS",
                 .product(name: "AnyLanguageModel", package: "AnyLanguageModel", condition: .when(traits: ["AnyLanguageModel"])),
             ],
             path: "Sources/ManifoldBackendsUmbrella",
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("FoundationOnly", .when(traits: ["FoundationOnly"])),
                 .define("AnyLanguageModel", .when(traits: ["AnyLanguageModel"])),
@@ -631,8 +617,6 @@ let package = Package(
             ],
             path: "Sources/ManifoldUI",
             swiftSettings: [
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
@@ -653,8 +637,6 @@ let package = Package(
             ],
             path: "Sources/ManifoldUIModelManagement",
             swiftSettings: [
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
@@ -719,8 +701,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
@@ -925,13 +905,13 @@ let package = Package(
                 "ManifoldHardware",
                 .target(name: "ManifoldMLX", condition: .when(traits: ["MLX"])),
                 .target(name: "ManifoldLlama", condition: .when(traits: ["Llama"])),
-                .target(name: "ManifoldCloud", condition: .when(traits: ["CloudSaaS", "Ollama"])),
+                "ManifoldCloud",
                 // Direct edges for `@testable import ManifoldOllama` /
                 // `@testable import ManifoldCloudSaaS` — @testable requires a
                 // direct declared edge; the shim's re-export only carries
                 // public symbols.
-                .target(name: "ManifoldOllama", condition: .when(traits: ["Ollama"])),
-                .target(name: "ManifoldCloudSaaS", condition: .when(traits: ["CloudSaaS"])),
+                "ManifoldOllama",
+                "ManifoldCloudSaaS",
                 "ManifoldUI",
                 "ManifoldRuntime",
                 "ManifoldPersistenceSwiftData",
@@ -944,8 +924,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("FoundationOnly", .when(traits: ["FoundationOnly"])),
                 .define("AnyLanguageModel", .when(traits: ["AnyLanguageModel"])),
@@ -1027,8 +1005,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("Server", .when(traits: ["Server"])),
             ]
@@ -1071,8 +1047,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
@@ -1089,8 +1063,6 @@ let package = Package(
             ],
             exclude: ["__Snapshots__"],
             swiftSettings: [
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),
@@ -1137,8 +1109,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("Fuzz", .when(traits: ["Fuzz"])),
             ]
@@ -1159,8 +1129,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("Fuzz", .when(traits: ["Fuzz"])),
             ]
@@ -1177,8 +1145,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
                 .define("Fuzz", .when(traits: ["Fuzz"])),
             ]
@@ -1205,19 +1171,16 @@ let package = Package(
         // graph, and a second llama.framework copy in the auto-generated
         // Xcode scheme breaks ManifoldMLXIntegrationTests (#982). The CLI
         // only drives Ollama (or the in-process mock), so it takes the
-        // ManifoldOllama family product directly — still behind the Ollama
-        // trait until that trait retires in PR A4.
+        // ManifoldOllama family product directly (unconditional since the
+        // Ollama trait retired in PR A4).
         .executableTarget(
             name: "manifold-tools",
             dependencies: [
                 "ManifoldTools",
-                .target(name: "ManifoldOllama", condition: .when(traits: ["Ollama"])),
+                "ManifoldOllama",
                 "ManifoldInference",
             ],
-            path: "Sources/manifold-tools",
-            swiftSettings: [
-                .define("Ollama", .when(traits: ["Ollama"])),
-            ]
+            path: "Sources/manifold-tools"
         ),
         .testTarget(
             name: "ManifoldToolsTests",
@@ -1260,8 +1223,6 @@ let package = Package(
             swiftSettings: [
                 .define("MLX", .when(traits: ["MLX"])),
                 .define("Llama", .when(traits: ["Llama"])),
-                .define("Ollama", .when(traits: ["Ollama"])),
-                .define("CloudSaaS", .when(traits: ["CloudSaaS"])),
                 .define("HuggingFace", .when(traits: ["HuggingFace"])),
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The same backend, model-management, persistence, and download infrastructure tha
 
 Pick traits to scope which backends and capabilities ship with your build. The full trait → capability table is generated from `Sources/ManifoldKit/FeatureMatrix.swift` and rendered to [docs/FeatureMatrix.md](docs/FeatureMatrix.md).
 
-Defaults (`MLX`, `Llama`, `HuggingFace`) are enabled when you don't pass `--disable-default-traits` or a custom `traits:` array. Opt-in traits include `CloudSaaS`, `Ollama`, `Server`, `Macros`, `Fuzz`, and the App Store-lean `FoundationOnly`. The former `MCP`, `MCPBuiltinCatalog`, `Voice`, `Tools`, `AppIntents`, and `Skills` traits were retired in v0.48 — those modules now compile unconditionally and you opt in by adding their products. See [docs/QUICKSTART.md → Customizing backends](docs/QUICKSTART.md#customizing-backends) for the per-trait build commands.
+Defaults (`MLX`, `Llama`, `HuggingFace`) are enabled when you don't pass `--disable-default-traits` or a custom `traits:` array. Opt-in traits include `Server`, `Macros`, `Fuzz`, and the App Store-lean `FoundationOnly`. The former `MCP`, `MCPBuiltinCatalog`, `Voice`, `Tools`, `AppIntents`, `Skills`, `Ollama`, and `CloudSaaS` traits were retired in v0.48 — those modules (including all cloud backends) now compile unconditionally and you opt in by importing (or, for cloud, simply not linking) their products. See [docs/QUICKSTART.md → Customizing backends](docs/QUICKSTART.md#customizing-backends) for the per-trait build commands.
 
 For a quantified breakdown of what each trait costs in binary size, build time, and dependency weight — and why the checkout is large regardless of trait set — see [docs/TRAIT-COSTS.md](docs/TRAIT-COSTS.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,15 +37,17 @@ guarantee. Consumers in regulated verticals can compile the package in `offline`
 `ollama` mode and have a mechanically-checked guarantee that no SaaS-cloud code is
 linked into the binary.
 
-| Mode      | Default? | Traits enabled                | Backends linked                 |
-|-----------|----------|-------------------------------|---------------------------------|
-| `offline` | **Yes**  | `MLX`, `Llama`                | MLX, llama.cpp, Foundation      |
-| `ollama`  | No       | `MLX`, `Llama`, `Ollama`      | + Ollama HTTP client            |
-| `saas`    | No       | `MLX`, `Llama`, `CloudSaaS`   | + Claude, OpenAI                |
-| `full`    | No       | all of the above              | every backend ManifoldKit ships         |
+Since v0.48 the `Ollama` and `CloudSaaS` traits are retired: cloud sources
+always compile in the package. Excluding cloud code from a shipped binary is a
+**link-out** decision — build/link only the products you need — not a compile
+flag. The build modes map to product graphs (see `scripts/build-modes.sh`):
 
-The default trait set today is `MLX, Llama` (per `Package.swift`), which corresponds
-to the `offline` build profile. `Ollama` and `CloudSaaS` are both opt-in.
+| Mode      | Build invocation                                        | Cloud code linked              |
+|-----------|---------------------------------------------------------|--------------------------------|
+| `offline` | `--disable-default-traits --target ManifoldUI`          | none                           |
+| `ollama`  | `--disable-default-traits --target ManifoldOllama`      | Ollama HTTP client + shared TLS-pinning infra (`ManifoldCloudCore`) |
+| `saas`    | `--disable-default-traits --target ManifoldCloudSaaS`   | Claude, OpenAI + shared infra  |
+| `full`    | plain `swift build` (default traits `MLX,Llama,HuggingFace`) | every backend ManifoldKit ships |
 
 ### Consumer manifest snippets
 
@@ -89,9 +91,10 @@ and the import-graph rule in the same audit):
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
-        .trait(name: "Ollama"),
     ]
 )
+// Cloud backends always compile since v0.48; depend on the ManifoldOllama
+// product (and not ManifoldCloudSaaS) for the ollama-mode link surface.
 ```
 
 Same `offline` guarantees, plus:
@@ -119,9 +122,10 @@ Same `offline` guarantees, plus:
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
-        .trait(name: "CloudSaaS"),
     ]
 )
+// Cloud backends always compile since v0.48; depend on the ManifoldCloudSaaS
+// product for the SaaS link surface.
 ```
 
 `saas` adds Claude and OpenAI backends. Pinning is **on by default** for both
@@ -138,10 +142,9 @@ transport-security boundary.
     traits: [
         .trait(name: "MLX"),
         .trait(name: "Llama"),
-        .trait(name: "Ollama"),
-        .trait(name: "CloudSaaS"),
     ]
 )
+// All cloud backends are compiled in; this is the maximum-surface build.
 ```
 
 `full` is the maximum-surface developer build. Use it for development; pick a
@@ -153,7 +156,7 @@ narrower mode for shipping production binaries.
 |--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | [`TrafficBoundaryAuditTest`](Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift)                                | Rule classes 1–7: `URLSession` import allowlist, C interop / dynamic dispatch ban, hostname literals allowlist, privacy-API allowlist, `Package.swift` hygiene, import-graph layering, trait-name validity. |
 | [`DenyAllURLProtocolTests`](Tests/ManifoldTestSupportTests/DenyAllURLProtocolTests.swift) and [`URLSessionProviderNetworkDisabledTests`](Tests/ManifoldBackendsTests/URLSessionProviderNetworkDisabledTests.swift) | Runtime network isolation: when `networkDisabled` is set, every URL request fails closed.                          |
-| `#if Ollama` / `#if CloudSaaS` conditional compilation in `Sources/ManifoldBackends/`                                    | Trait-gated backend code is not compiled into the binary if the trait is absent.                                    |
+| Per-mode symbol audit in `scripts/build-modes.sh` (nightly, `.github/workflows/build-modes.yml`)                          | Cloud backend code is not *linked* into a product graph that excludes it (link-out claim; the compile-out traits were retired in v0.48). |
 | `--disable-default-traits` swift test invocations in CI (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml))      | At least one CI job exercises the offline trait set on every PR; signature regressions surface as compile errors.   |
 
 There is currently no separate `scripts/build-modes.sh` — that consolidation is tracked

--- a/Sources/ManifoldBackendsUmbrella/CloudBackends.swift
+++ b/Sources/ManifoldBackendsUmbrella/CloudBackends.swift
@@ -1,27 +1,18 @@
 import ManifoldInference
-#if Ollama
 import ManifoldOllama
-#endif
-#if CloudSaaS
 import ManifoldCloudSaaS
-#endif
 
 /// Cross-family forwarding registrar for the cloud backends.
 ///
 /// The real registration glue moved next to the backends in the v0.48
 /// product split (`OllamaBackends` in `ManifoldOllama`, `CloudSaaSBackends`
-/// in `ManifoldCloudSaaS`). This thin forwarder keeps the
-/// `DefaultBackends.registrars` lineup — and the BackendRegistrar contract
-/// that registration is a no-op when every trait this registrar covers is
-/// disabled — unchanged for one release.
+/// in `ManifoldCloudSaaS`); both families compile unconditionally now that
+/// the Ollama / CloudSaaS traits are retired. This thin forwarder keeps the
+/// `DefaultBackends.registrars` lineup unchanged for one release.
 public enum CloudBackends: BackendRegistrar {
     @MainActor
     public static func register(with service: InferenceService) {
-        #if Ollama
         OllamaBackends.register(with: service)
-        #endif
-        #if CloudSaaS
         CloudSaaSBackends.register(with: service)
-        #endif
     }
 }

--- a/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
+++ b/Sources/ManifoldBackendsUmbrella/DefaultBackends.swift
@@ -88,15 +88,10 @@ public enum DefaultBackends {
 
     static func backendTypeName(for provider: APIProvider) -> String? {
         switch provider {
-        #if CloudSaaS
         case .claude:                     return "ClaudeBackend"
         case .openAI, .lmStudio, .custom: return "OpenAIBackend"
         case .openAIResponses:            return "OpenAIResponsesBackend"
-        #endif
-        #if Ollama
         case .ollama:                     return "OllamaBackend"
-        #endif
-        default: return nil
         }
     }
 
@@ -123,12 +118,9 @@ public enum DefaultBackends {
     /// how many backend capabilities (local model types + cloud providers) were
     /// actually wired.
     ///
-    /// Each registrar is trait-gated internally, so a minimal build can register
-    /// nothing — the returned count lets the caller fail fast on an empty,
-    /// never-generating service instead of launching a dead app (the footgun
-    /// audit's class D — "silent degradation where a fail-fast boundary check
-    /// belongs"). Note a bare count is a weak signal once cloud registrars
-    /// register unconditionally: prefer inspecting
+    /// Since v0.48 the cloud registrars register unconditionally (the Ollama
+    /// and CloudSaaS traits are retired), so the count is always non-zero —
+    /// a bare count is a weak signal. Prefer inspecting
     /// ``ManifoldInference/InferenceService/registeredBackendSnapshot()``
     /// (`supportsLocalInference` / `cloudProviders`) as
     /// ``ManifoldKit/ManifoldKit/quickStart(configuration:)`` now does.

--- a/Sources/ManifoldBackendsUmbrella/Exports.swift
+++ b/Sources/ManifoldBackendsUmbrella/Exports.swift
@@ -9,9 +9,10 @@
 //
 // Trait-gating rule (per CLAUDE.md): we gate the consumer→family edge in
 // `Package.swift` (and the `@_exported import` here), not the
-// family→library edge inside the family targets. Family targets always
-// compile when their trait is on; the umbrella stays buildable in any
-// trait combination.
+// family→library edge inside the family targets. Only the MLX / Llama
+// edges remain trait-gated; the cloud edges are unconditional since the
+// Ollama / CloudSaaS traits retired in v0.48 (PR A4). The umbrella stays
+// buildable in any trait combination.
 
 @_exported import ManifoldInference
 @_exported import ManifoldCloudCore
@@ -26,6 +27,4 @@
 
 @_exported import ManifoldFoundation
 
-#if CloudSaaS || Ollama
 @_exported import ManifoldCloud
-#endif

--- a/Sources/ManifoldCloud/Exports.swift
+++ b/Sources/ManifoldCloud/Exports.swift
@@ -10,10 +10,9 @@
 // `ManifoldCloudCore`.
 //
 // `import ManifoldCloud` keeps compiling for one release via these
-// re-exports; new code should import the specific module it needs. The
-// `#if` gates mirror the trait-gated consumer→product edges in
-// Package.swift (this shim is the one place a per-trait `@_exported
-// import` still needs a compilation condition).
+// re-exports; new code should import the specific module it needs. Since
+// v0.48 PR A4 (Ollama/CloudSaaS traits retired) both family re-exports are
+// unconditional — the families always compile.
 //
 // `DefaultWebSearchRuntime` (WebSearch/) still lives here: it conforms to
 // the `WebSearchRuntime` port from ManifoldRuntime, an edge neither
@@ -22,10 +21,6 @@
 
 @_exported import ManifoldCloudCore
 
-#if Ollama
 @_exported import ManifoldOllama
-#endif
 
-#if CloudSaaS
 @_exported import ManifoldCloudSaaS
-#endif

--- a/Sources/ManifoldCloudCore/CloudHTTPProviderAdapter.swift
+++ b/Sources/ManifoldCloudCore/CloudHTTPProviderAdapter.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ManifoldInference
-import ManifoldCloudCore
 
 /// Composition root for cloud HTTP backends.
 ///

--- a/Sources/ManifoldCloudCore/OpenAIChatCompletionsPayloadParsing.swift
+++ b/Sources/ManifoldCloudCore/OpenAIChatCompletionsPayloadParsing.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ManifoldInference
-import ManifoldCloudCore
 
 /// Wire-shape parsing for the OpenAI Chat Completions streaming format.
 ///

--- a/Sources/ManifoldCloudCore/URLSessionProvider.swift
+++ b/Sources/ManifoldCloudCore/URLSessionProvider.swift
@@ -8,14 +8,13 @@ import ManifoldInference
 /// All backends continue to accept a `urlSession:` init parameter for
 /// test injection via `MockURLProtocol`.
 ///
-/// ## Trait gating
+/// ## Availability
 ///
-/// The factories are conditionally compiled:
-/// - ``pinned`` / ``pinned()`` are only available with the `CloudSaaS` trait —
-///   no SaaS backend means no pinning is needed.
-/// - ``unpinned`` / ``unpinned()`` are available whenever `Ollama` or
-///   `CloudSaaS` is enabled — used by Ollama (LAN) and as the LM-Studio /
-///   `.custom` provider session under `CloudSaaS`.
+/// All factories compile unconditionally since v0.48 (the Ollama/CloudSaaS
+/// traits are retired):
+/// - ``pinned`` / ``pinned()`` — used by the SaaS backends (Claude, OpenAI).
+/// - ``unpinned`` / ``unpinned()`` — used by Ollama (LAN) and as the
+///   LM-Studio / `.custom` provider session.
 /// - ``background(identifier:hopCap:additionalDownloadDelegate:)`` is
 ///   always available; it is the seam used by `BackgroundDownloadManager`
 ///   (under the `HuggingFace` trait) and any other long-running

--- a/Sources/ManifoldCloudSaaS/CloudSaaSBackends.swift
+++ b/Sources/ManifoldCloudSaaS/CloudSaaSBackends.swift
@@ -23,12 +23,11 @@ public enum CloudSaaSBackends: BackendRegistrar {
             }
         }
 
-        // Declare support via `availableInBuild` (not unconditionally) to
-        // preserve the pre-split coupling to `CompiledBackends.current`:
-        // in a build whose trait set excludes CloudSaaS, registration stays
-        // a no-op on the declared-support side. The registration-derived
-        // redesign of `CompiledBackends` is deliberately deferred (v0.48
-        // plan, PR A4).
+        // Declare support via `availableInBuild` to stay coupled to
+        // `CompiledBackends.current` — compile-time truth for what is in
+        // this binary. Since v0.48 (traits retired) the SaaS providers are
+        // always compiled in, so this loop always declares them; whether an
+        // endpoint is *configured* is a runtime question the UI answers.
         for provider in APIProvider.availableInBuild where provider != .ollama {
             service.declareSupport(for: provider)
         }

--- a/Sources/ManifoldFuzz/FuzzConfig.swift
+++ b/Sources/ManifoldFuzz/FuzzConfig.swift
@@ -7,7 +7,7 @@ public enum BackendChoice: String, Sendable, CaseIterable {
     case mlx
     case all
     /// OpenAI-Chat-Completions-compatible cloud endpoint (OpenRouter, OpenAI,
-    /// Together, …) driven via `OpenAIBackend`. Gated on the `CloudSaaS` trait.
+    /// Together, …) driven via `OpenAIBackend`.
     case openai
     /// Hardware-free `MockInferenceBackend` path. Used by PR-tier CI.
     case mock

--- a/Sources/ManifoldFuzzBackends/FuzzModelDiscovery.swift
+++ b/Sources/ManifoldFuzzBackends/FuzzModelDiscovery.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if Ollama
 import ManifoldBackends
-#endif
 
 /// Fuzz-local model discovery utilities.
 ///
@@ -11,7 +9,6 @@ enum FuzzModelDiscovery {
 
     // MARK: - Ollama
 
-#if Ollama
     static func listOllamaModels(baseURL: URL) -> [String]? {
         guard let models = fetchOllamaModels(baseURL: baseURL) else { return nil }
         return models.map(\.name)
@@ -49,7 +46,6 @@ enum FuzzModelDiscovery {
         let result = semaphore.wait(timeout: .now() + 5)
         return result == .success ? box.value : nil
     }
-#endif
 
     // MARK: - MLX Models
 

--- a/Sources/ManifoldFuzzBackends/OllamaFuzzFactory.swift
+++ b/Sources/ManifoldFuzzBackends/OllamaFuzzFactory.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import Foundation
 import ManifoldBackends
 import ManifoldFuzz
@@ -133,4 +132,3 @@ public struct OllamaFuzzFactory: FuzzBackendFactory {
         return models.first { $0.lowercased().contains(lowered) }
     }
 }
-#endif

--- a/Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift
+++ b/Sources/ManifoldFuzzBackends/OpenAIFuzzFactory.swift
@@ -1,4 +1,4 @@
-#if CloudSaaS && Fuzz
+#if Fuzz
 import Foundation
 import ManifoldBackends
 import ManifoldFuzz

--- a/Sources/ManifoldHardware/APIProvider.swift
+++ b/Sources/ManifoldHardware/APIProvider.swift
@@ -49,11 +49,11 @@ public enum APIProvider: String, Codable, CaseIterable, Identifiable, Sendable {
 
     /// The providers actually available in this build.
     ///
-    /// Iterates the cases compatible with the `Ollama` and `CloudSaaS` traits.
-    /// Use this when a UI or registration loop should only present providers
-    /// the build can actually instantiate. ``allCases`` stays unconditional —
-    /// it's data, not behaviour, and `ConversationRecords.selectedEndpointID`
-    /// must be able to decode any case regardless of build flavour.
+    /// Since v0.48 the cloud families compile unconditionally, so this is
+    /// every built-in provider (plus registry-registered third parties), in
+    /// documented sort order. Kept as the single registration/UI iteration
+    /// point: whether an endpoint is *configured* for a provider is a
+    /// runtime question, answered by the endpoint store — not this list.
     public static var availableInBuild: [APIProvider] {
         CompiledBackends.current.orderedCloudProviders
     }

--- a/Sources/ManifoldHardware/CompiledBackends.swift
+++ b/Sources/ManifoldHardware/CompiledBackends.swift
@@ -2,6 +2,11 @@ import Foundation
 
 /// Inference traits that materially change which backends a build can expose at
 /// runtime.
+///
+/// `.ollama` and `.cloudSaaS` are retained for Codable stability but are no
+/// longer SwiftPM traits: since v0.48 the cloud families compile
+/// unconditionally, so both members are always present in
+/// ``CompiledBackends/current``.
 public enum BackendBuildTrait: String, CaseIterable, Codable, Hashable, Sendable {
     case mlx = "MLX"
     case llama = "Llama"
@@ -12,9 +17,12 @@ public enum BackendBuildTrait: String, CaseIterable, Codable, Hashable, Sendable
 
 /// The network/profile posture of the current build.
 ///
-/// This maps the trait combinations documented in README / SECURITY into a
-/// runtime-visible contract that host apps can switch over without reproducing
-/// SwiftPM trait logic in their own shims.
+/// Since v0.48 the cloud families compile unconditionally, so
+/// ``CompiledBackends/current`` always reports `.full`. The other cases
+/// remain for hand-constructed ``CompiledBackends`` values (tests,
+/// ManifoldServer's injectable provider) and Codable stability. Excluding
+/// cloud code from a shipped binary is now a *link-time* decision — depend
+/// on the products you want (see docs/FIPS.md) — not a compile flag.
 public enum BackendBuildProfile: String, CaseIterable, Codable, Sendable {
     /// No networked inference backends are compiled in.
     case offline
@@ -135,15 +143,14 @@ public struct CompiledBackends: Sendable, Equatable {
         }
         #endif
 
-        #if Ollama
+        // Cloud families compile unconditionally since v0.48 (the Ollama and
+        // CloudSaaS traits are retired), so they are constant members here.
+        // Whether a cloud endpoint is *usable* is a runtime configuration
+        // question — see APIEndpointStore / the endpoint editors in UIMM.
         traits.insert(.ollama)
         cloudProviders.insert(.ollama)
-        #endif
-
-        #if CloudSaaS
         traits.insert(.cloudSaaS)
         cloudProviders.formUnion([.claude, .openAI, .openAIResponses, .lmStudio, .custom])
-        #endif
 
         return Self(
             buildProfile: buildProfile(for: traits),
@@ -181,10 +188,12 @@ public struct CompiledBackends: Sendable, Equatable {
 
     private func unavailableReason(for provider: APIProvider) -> String {
         switch provider {
+        // Unreachable via `CompiledBackends.current` since v0.48 (cloud is
+        // always compiled in); still reachable for hand-constructed values.
         case .ollama:
-            return "Ollama endpoints require the Ollama trait in this build."
+            return "Ollama support is not included in this CompiledBackends value."
         case .openAI, .openAIResponses, .claude, .lmStudio, .custom:
-            return "Cloud API endpoints require the CloudSaaS trait in this build."
+            return "Cloud API support is not included in this CompiledBackends value."
         }
     }
 }

--- a/Sources/ManifoldKit/FeatureMatrix.swift
+++ b/Sources/ManifoldKit/FeatureMatrix.swift
@@ -4,9 +4,8 @@
 //
 // Why this exists: until now, "which trait do I need for X?" was prose
 // scattered across README §2.4, CONTRIBUTING, and DefaultBackends comments.
-// Drifting prose meant the answer to "do I need `CloudSaaS` or `Ollama` for
-// OpenAI?" required reading three files. This file is the machine-readable
-// matrix; `scripts/render-feature-matrix.sh` renders it to
+// Drifting prose meant the answer to "which trait unlocks X?" required
+// reading three files. This file is the machine-readable matrix; `scripts/render-feature-matrix.sh` renders it to
 // `docs/FeatureMatrix.md`, and `FeatureMatrixTests` asserts every trait in
 // `Package.swift` has an entry here (failing CI when someone adds a trait
 // without updating the matrix).
@@ -19,12 +18,16 @@ import Foundation
 /// A user-facing capability that one or more traits unlock.
 ///
 /// Capabilities are the *outcome* a consumer wants ("I want to call Claude")
-/// rather than the lever they need to flip (the `CloudSaaS` trait).
+/// rather than the lever they need to flip (a SwiftPM trait).
 public enum ManifoldCapability: String, CaseIterable, Sendable {
     case localInference          // run a model on-device
     case mlxBackend
     case llamaBackend
     case foundationBackend
+    // cloudOpenAI/cloudClaude/ollama are no longer unlocked by any trait —
+    // the cloud families compile unconditionally as of v0.48 (Ollama +
+    // CloudSaaS traits retired in PR A4). Cases stay: removing public enum
+    // cases is a separate API break with no consumer benefit.
     case cloudOpenAI
     case cloudClaude
     case ollama
@@ -90,16 +93,6 @@ public enum FeatureMatrix {
             name: "AnyLanguageModel",
             description: "Reach providers without a native backend (Gemini, xAI, Groq, Mistral, OpenRouter, and others) through the AnyLanguageModel bridge.",
             unlocks: [.providerBridge]
-        ),
-        ManifoldTrait(
-            name: "Ollama",
-            description: "Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major.",
-            unlocks: [.ollama, .toolCalling, .embeddings]
-        ),
-        ManifoldTrait(
-            name: "CloudSaaS",
-            description: "Third-party SaaS providers (Claude, OpenAI). Off by default.",
-            unlocks: [.cloudOpenAI, .cloudClaude, .toolCalling, .visionInput]
         ),
         ManifoldTrait(
             name: "Server",

--- a/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
+++ b/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
@@ -109,7 +109,8 @@ install to first token, follow the loose-markdown front door:
 Every engine sits behind one ``InferenceBackend`` protocol; ``DefaultBackends``
 registers the ones compiled in for the active traits. The on-device families are
 re-exported here. Cloud backends (OpenAI, Anthropic, Ollama, LAN) live in
-`ManifoldCloud` and appear once the `CloudSaaS` / `Ollama` traits are enabled.
+`ManifoldOllama` / `ManifoldCloudSaaS` and are always compiled in since v0.48
+(the `CloudSaaS` / `Ollama` traits were retired).
 
 - ``InferenceBackend``
 - ``DefaultBackends``

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -21,43 +21,21 @@ import ManifoldUI
 import ManifoldHuggingFace
 #endif
 
-// MARK: - Compile-time backend diagnostics (Deliverable B)
+// MARK: - Backend availability diagnostics
 //
-// Goal: emit a warning at compile time when no inference backend will be
-// available so `quickStart()` never silently throws `noBackendsRegistered`
-// at launch.
-//
-// Why a full "no backends" warning is NOT safe to emit here
-// ──────────────────────────────────────────────────────────
-// `ManifoldFoundation` / `FoundationBackend` is *unconditionally* linked into
-// the `ManifoldBackends` umbrella — it is NOT behind a SwiftPM trait.
-// Whether the backend fires at runtime depends only on the OS version
-// (`#available(iOS 26, macOS 26, *)`). A consumer building with *zero* traits
-// on a macOS 26 machine still gets a working Foundation backend; emitting
-// `#warning("no backends")` in that case would be a false alarm.
-//
-// We therefore limit the warning to the one subset we CAN detect at compile
-// time without risk of false alarms: builds that explicitly suppress the
-// FoundationOnly trait AND compile in none of the other four backend traits.
-// Under `FoundationOnly` the MLX/Llama/HuggingFace defaults are intentionally
-// absent; the Foundation backend is expected. Under zero traits
-// (`--disable-default-traits`) any of the four non-Foundation backends could
-// be present or absent — we can only fire a *partial* hint here.
+// There is intentionally no compile-time "no backends" `#warning` here (one
+// existed pre-v0.48). Since v0.48 the cloud families (Ollama + SaaS) compile
+// unconditionally, so the "zero backends compiled in" condition the old
+// warning guarded is no longer expressible. Whether a backend can actually
+// *generate* is a runtime question: a cloud backend needs a configured
+// endpoint, FoundationBackend needs iOS 26 / macOS 26+, and local backends
+// need a downloaded model.
 //
 // The authoritative runtime diagnostics are `ManifoldKitError.noBackendsRegistered`
 // (nothing registered at all) and the cloud-only-without-endpoint warning from
 // `backendAvailabilityDiagnostic(snapshot:configuredEndpointCount:)` — both
 // derived from live registration state, so they see companion-package
 // registrars injected via `quickStart(backends:)`.
-#if !MLX && !Llama && !CloudSaaS && !Ollama && !canImport(FoundationModels)
-// No locally-resolvable backend traits are compiled in AND FoundationModels is
-// not importable on this toolchain. quickStart() will throw
-// ManifoldKitError.noBackendsRegistered at launch unless the host device is
-// running iOS 26 / macOS 26+ (where FoundationBackend activates dynamically).
-// Add at least one of: MLX, Llama, CloudSaaS, Ollama to your traits array, or
-// target iOS 26+ / macOS 26+ to rely on the built-in Foundation Models backend.
-#warning("ManifoldKit: no backend traits compiled in and FoundationModels not importable. quickStart() will throw noBackendsRegistered unless the device runs iOS 26 / macOS 26+. Enable MLX, Llama, CloudSaaS, or Ollama, or target iOS 26+ / macOS 26+.")
-#endif
 
 /// The umbrella namespace for ManifoldKit's high-level entry points.
 ///

--- a/Sources/ManifoldModelCatalog/ManifoldKitError.swift
+++ b/Sources/ManifoldModelCatalog/ManifoldKitError.swift
@@ -85,7 +85,7 @@ public enum ManifoldKitError: Error, Sendable, LocalizedError, Equatable {
         case .decodingFailure(let detail):
             return "Couldn't read the server response: \(detail)"
         case .noBackendsRegistered:
-            return "No inference backends are registered. Add a local backend package and pass its registrar to quickStart(backends:) — manifold-llama (GGUF) or manifold-mlx (MLX) — or enable a backend trait in this build (MLX, Llama, CloudSaaS, Ollama), or run on iOS 26 / macOS 26+ for the built-in Foundation Models backend."
+            return "No inference backends are registered. Call DefaultBackends.register(with:) or quickStart() to register the built-in backends (cloud backends are always compiled in since v0.48), pass a companion registrar to quickStart(backends:) — manifold-llama (GGUF) or manifold-mlx (MLX) — or run on iOS 26 / macOS 26+ for the built-in Foundation Models backend."
         case .unknown(let underlyingDescription):
             if underlyingDescription.isEmpty {
                 return "An unexpected error occurred."

--- a/Sources/ManifoldOllama/OllamaBackend.swift
+++ b/Sources/ManifoldOllama/OllamaBackend.swift
@@ -197,7 +197,7 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
     /// ``URLSessionProvider/networkDisabled`` is set, the underlying property
     /// access traps. Use ``makeChecked(urlSession:)`` for a throwing variant
     /// that surfaces the kill-switch as a recoverable error.
-    @available(*, deprecated, message: "OllamaBackend remains available; this is a build-mode migration notice. Before the next major, add the `Ollama` trait to package dependencies or register via DefaultBackends.register(_:); see README 'Build modes' and #714.")
+    @available(*, deprecated, message: "Direct construction bypasses registration. Register via DefaultBackends.register(with:) or quickStart(), or use makeChecked(urlSession:) for kill-switch-safe construction; see docs/MIGRATION-0.48.md.")
     public init(urlSession: URLSession? = nil) {
         // Adapter capabilities mirror what `OllamaBackend.capabilities`
         // resolves before any /api/show probe has run. The dynamic
@@ -321,7 +321,7 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
 
     /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
     /// as ``CloudBackendError/networkDisabled`` instead of trapping.
-    @available(*, deprecated, message: "OllamaBackend remains available; this is a build-mode migration notice. Before the next major, add the `Ollama` trait to package dependencies or register via DefaultBackends.register(_:); see README 'Build modes' and #714.")
+    @available(*, deprecated, message: "Direct construction bypasses registration. Register via DefaultBackends.register(with:) or quickStart(), or use makeChecked(urlSession:) for kill-switch-safe construction; see docs/MIGRATION-0.48.md.")
     public static func makeChecked(urlSession: URLSession? = nil) throws -> OllamaBackend {
         let session: URLSession
         if let urlSession {

--- a/Sources/ManifoldOllama/OllamaBackends.swift
+++ b/Sources/ManifoldOllama/OllamaBackends.swift
@@ -13,12 +13,11 @@ public enum OllamaBackends: BackendRegistrar {
             provider == .ollama ? OllamaBackend(_registrar: ()) : nil
         }
 
-        // Declare support via `availableInBuild` (not unconditionally) to
-        // preserve the pre-split coupling to `CompiledBackends.current`:
-        // in a build whose trait set excludes Ollama, registration stays a
-        // no-op on the declared-support side. The registration-derived
-        // redesign of `CompiledBackends` is deliberately deferred (v0.48
-        // plan, PR A4).
+        // Declare support via `availableInBuild` to stay coupled to
+        // `CompiledBackends.current` — compile-time truth for what is in
+        // this binary. Since v0.48 (traits retired) Ollama is always
+        // compiled in, so this loop always declares `.ollama`; whether an
+        // endpoint is *configured* is a runtime question the UI answers.
         for provider in APIProvider.availableInBuild where provider == .ollama {
             service.declareSupport(for: provider)
         }

--- a/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
+++ b/Sources/ManifoldServer/TraitAwareServerBackendProvider.swift
@@ -69,6 +69,14 @@ internal struct ServerBackendSelection: Equatable, Sendable {
     }
 }
 
+/// Validates the CLI's backend selection against ``CompiledBackends`` and
+/// lazily loads the requested backend.
+///
+/// Naming note (v0.48): "trait-aware" is only literally true for the local
+/// families — MLX and Llama remain SwiftPM traits until the companion-package
+/// split (C-stream). The Ollama / SaaS families compile unconditionally, so
+/// their `CompiledBackends` members are constant `true` and the injected
+/// `compiledBackends` value only restricts them in tests.
 internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
     internal let selection: ServerBackendSelection
     internal let compiledBackends: CompiledBackends
@@ -221,7 +229,6 @@ internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
     }
 
     private func loadOllamaBackend(modelOverride: String?) async throws -> any InferenceBackend {
-        #if Ollama
         let modelName = modelOverride ?? selection.model ?? APIProvider.ollama.defaultModelName
         guard let baseURL = URL(string: selection.ollamaBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             throw ServerError.invalidConfiguration("--ollama-base-url must be a valid URL.")
@@ -230,9 +237,6 @@ internal actor TraitAwareServerBackendProvider: ServerBackendProvider {
         backend.configure(baseURL: baseURL, modelName: modelName)
         try await backend.loadModel(from: baseURL, plan: .cloud(requestedContextSize: 8192))
         return backend
-        #else
-        throw ServerError.backendUnavailable("Ollama endpoints require the Ollama trait in this build.")
-        #endif
     }
 }
 

--- a/Sources/ManifoldTools/README.md
+++ b/Sources/ManifoldTools/README.md
@@ -14,8 +14,8 @@
 swift run --disable-default-traits manifold-tools --backend mock --scenario all
 
 # Real Ollama — requires a local server with tool-capable models installed,
-# and the Ollama trait (the CLI's Ollama path is compiled out without it).
-swift run --disable-default-traits --traits Ollama manifold-tools --backend ollama --scenario 02-calc \
+# (the Ollama path is always compiled in since v0.48 — no trait needed).
+swift run --disable-default-traits manifold-tools --backend ollama --scenario 02-calc \
     --ollama-base-url http://localhost:11434 --model llama3.1:8b
 ```
 
@@ -78,7 +78,7 @@ Local developers with Ollama can run the real-model E2E with:
 ```sh
 ollama serve &                          # in another terminal
 ollama pull llama3.1:8b
-swift run --disable-default-traits --traits Ollama manifold-tools --backend ollama --scenario all
+swift run --disable-default-traits manifold-tools --backend ollama --scenario all
 ```
 
 ## Why a dedicated harness?

--- a/Sources/ManifoldUIModelManagement/Views/Settings/APIConfigurationView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Settings/APIConfigurationView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
-#if Ollama || CloudSaaS
 import ManifoldRuntime
 import ManifoldInference
-#endif
 
 /// Main settings view for managing cloud API endpoints.
 ///
@@ -14,15 +12,12 @@ import ManifoldInference
 /// the SwiftUI environment (typically `ManifoldBootstrap.endpointStore`); the
 /// view itself does not import SwiftData.
 ///
-/// The type itself is **always public** — even when neither `Ollama` nor
-/// `CloudSaaS` traits are enabled — so that consumer migration code like
-/// `apiConfiguration: { APIConfigurationView() }` compiles for chat-only
-/// apps that don't pull in cloud backends. With the traits off the body
-/// renders an `EmptyView`, so the unused sheet content has zero visual
-/// footprint. This mirrors the `BackendRegistrar` idiom in `ManifoldBackends`.
+/// Compiles unconditionally since v0.48 (the Ollama / CloudSaaS traits are
+/// retired — cloud support is always built in). Whether to *show* cloud UI
+/// is a runtime decision for the host, keyed on endpoint configuration
+/// state, not a compile flag.
 public struct APIConfigurationView: View {
 
-    #if Ollama || CloudSaaS
     @Environment(\.dismiss) private var dismiss
     @Environment(\.endpointStore) private var endpointStore
 
@@ -31,12 +26,10 @@ public struct APIConfigurationView: View {
     @State private var endpointToEdit: APIEndpointRecord?
     @State private var showDeleteConfirmation = false
     @State private var endpointToDelete: APIEndpointRecord?
-    #endif
 
     public init() {}
 
     public var body: some View {
-        #if Ollama || CloudSaaS
         NavigationStack {
             Form {
                 Section("Endpoints") {
@@ -110,15 +103,8 @@ public struct APIConfigurationView: View {
                 }
             }
         }
-        #else
-        // Cloud APIs are not available in this build configuration. Keeping
-        // the type public-but-empty lets host apps wire `apiConfiguration:`
-        // unconditionally without a per-trait `#if` at the call site.
-        EmptyView()
-        #endif
     }
 
-    #if Ollama || CloudSaaS
     private func refresh() async {
         guard let endpointStore else { return }
         do {
@@ -148,13 +134,10 @@ public struct APIConfigurationView: View {
             Log.persistence.error("Failed to delete endpoint: \(error)")
         }
     }
-    #endif
 }
 
 // MARK: - Preview
 
-#if Ollama || CloudSaaS
 #Preview("API Configuration") {
     APIConfigurationView()
 }
-#endif

--- a/Sources/ManifoldUIModelManagement/Views/Settings/APIEndpointEditorView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Settings/APIEndpointEditorView.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import SwiftUI
 import ManifoldRuntime
 import ManifoldInference
@@ -239,4 +238,3 @@ public struct APIEndpointEditorView: View {
 #Preview("Add Endpoint") {
     APIEndpointEditorView(endpoint: nil)
 }
-#endif

--- a/Sources/ManifoldUIModelManagement/Views/Settings/EndpointStoreEnvironment.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Settings/EndpointStoreEnvironment.swift
@@ -5,7 +5,7 @@ import ManifoldRuntime
 /// ``APIConfigurationView``, ``APIEndpointEditorView``, and
 /// ``RemoteServerConfigSheet``.
 ///
-/// Declared unconditionally (not behind the `Ollama` / `CloudSaaS` traits) so
+/// Declared unconditionally (cloud support is always compiled in since v0.48) so
 /// host apps can wire `runtime.endpointStore` via `.environment(\.endpointStore, …)`
 /// without per-trait `#if`s at the call site. The endpoint editor views
 /// themselves remain trait-gated; they no-op (render `EmptyView`) when the

--- a/Sources/ManifoldUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Settings/RemoteServerConfigSheet.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import SwiftUI
 import ManifoldRuntime
 import ManifoldInference
@@ -230,4 +229,3 @@ private extension String {
 #Preview("Remote Server Config") {
     RemoteServerConfigSheet()
 }
-#endif

--- a/Sources/fuzz-chat/FuzzChatCLI.swift
+++ b/Sources/fuzz-chat/FuzzChatCLI.swift
@@ -208,14 +208,14 @@ struct FuzzChatCLI {
         let factory: any FuzzBackendFactory
         switch backend {
         case .ollama:
-            #if Fuzz && Ollama
+            #if Fuzz
             do {
                 factory = try OllamaFuzzFactory.makeCampaignFactory(modelHint: modelHint, blockSize: rotateEvery)
             } catch {
                 fail(String(describing: error))
             }
             #else
-            fail("Ollama backend requires the Fuzz and Ollama build traits. Run via: scripts/fuzz.sh")
+            fail("Ollama backend requires the Fuzz build trait. Run via: scripts/fuzz.sh")
             #endif
         case .mock:
             factory = MockFuzzFactory()
@@ -238,7 +238,7 @@ struct FuzzChatCLI {
             fail("Foundation backend requires macOS 26+ with FoundationModels and the Fuzz build trait. Run via: scripts/fuzz.sh")
             #endif
         case .openai:
-            #if CloudSaaS && Fuzz
+            #if Fuzz
             factory = makeOpenAIFactory(
                 baseURLString: baseURLString,
                 apiKeyArg: apiKeyArg,
@@ -246,7 +246,7 @@ struct FuzzChatCLI {
                 requestTimeout: requestTimeout
             )
             #else
-            fail("openai backend requires the Fuzz and CloudSaaS build traits. Run via: swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat --backend openai ... (or scripts/fuzz.sh --backend openai)")
+            fail("openai backend requires the Fuzz build trait. Run via: swift run --traits Fuzz,MLX,Llama fuzz-chat --backend openai ... (or scripts/fuzz.sh --backend openai)")
             #endif
         case .mlx:
             fail("MLX cannot run via `swift run` (needs Xcode-compiled metallib). Use scripts/fuzz.sh --with-mlx or --backend mlx.")
@@ -574,7 +574,7 @@ struct FuzzChatCLI {
         }
     }
 
-    #if CloudSaaS && Fuzz
+    #if Fuzz
     /// Builds the OpenAI-compatible cloud factory, validating the base URL and
     /// resolving the API key. The key is read from `--api-key` when present,
     /// otherwise from the environment (`OPENROUTER_API_KEY` preferred, then
@@ -620,15 +620,15 @@ struct FuzzChatCLI {
         let lines = [
             "fuzz-chat — chat anomaly fuzzer",
             "",
-            "Usage: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat [options]",
+            "Usage: swift run --traits Fuzz,MLX,Llama fuzz-chat [options]",
             "",
             "Options:",
             "  --backend ollama|mock|chaos|llama|foundation|mlx|openai|all   default: llama",
             "                      mock   = MockInferenceBackend (hardware-free, used by PR-tier CI)",
             "                      chaos  = ChaosBackend (hardware-free; injects stream failures)",
             "                      openai = OpenAI-compatible cloud endpoint (OpenRouter, OpenAI, …)",
-            "                               via OpenAIBackend. Needs the CloudSaaS trait:",
-            "                               swift run --traits Fuzz,CloudSaaS,MLX,Llama,Ollama fuzz-chat",
+            "                               via OpenAIBackend:",
+            "                               swift run --traits Fuzz,MLX,Llama fuzz-chat",
             "                               --backend openai --base-url <url> --model <slug>",
             "                               Replay/shrink are unavailable (cloud is non-deterministic).",
             "  --minutes N         time budget (default 5 if neither flag set)",

--- a/Sources/manifold-tools/main.swift
+++ b/Sources/manifold-tools/main.swift
@@ -1,6 +1,6 @@
-// Does not require the Fuzz trait. The Ollama path is gated behind the
-// `Ollama` trait (not in the default set); pass `--traits Ollama` to enable
-// it. The mock path is always available.
+// Does not require the Fuzz trait. The Ollama and mock paths are always
+// available — the Ollama trait was retired in v0.48 (PR A4) and
+// ManifoldOllama now compiles unconditionally.
 // For generation fuzzing with real backends, see scripts/fuzz.sh.
 //
 // The `Tools` trait was retired in v0.48 (PR A3) — the CLI body compiles
@@ -10,9 +10,7 @@
 import Foundation
 import ManifoldInference
 import ManifoldTools
-#if Ollama
 import ManifoldOllama
-#endif
 
 /// Hand-rolled argument parser — `swift-argument-parser` would be the right
 /// call in a larger CLI, but pulling in an external SPM dependency for a
@@ -375,15 +373,10 @@ func makeBackend(cli: CLI, scenario: Scenario, model: String) async throws -> an
     case .mock:
         return MockFactory.make(for: scenario)
     case .ollama:
-        #if Ollama
         let backend = OllamaBackend(_registrar: ())
         backend.configure(baseURL: cli.ollamaBaseURL, modelName: model)
         try await backend.loadModel(from: cli.ollamaBaseURL, plan: .cloud())
         return backend
-        #else
-        struct OllamaUnavailable: Error, CustomStringConvertible { var description: String { "Ollama backend not available — rebuild with the `Ollama` trait enabled (e.g. `swift build --traits Ollama`)." } }
-        throw OllamaUnavailable()
-        #endif
     }
 }
 

--- a/Tests/ManifoldBackendsTests/AllBackendsAcceptPlanTests.swift
+++ b/Tests/ManifoldBackendsTests/AllBackendsAcceptPlanTests.swift
@@ -43,7 +43,6 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
 
     // MARK: - Cloud Backends
 
-    #if CloudSaaS
     func test_openAIBackendAcceptsPlan() async throws {
         let backend = OpenAIBackend()
         backend.configure(
@@ -73,9 +72,7 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
             // Acceptable — the test's contract is the signature, not the outcome.
         }
     }
-    #endif
 
-    #if Ollama
     func test_ollamaBackendAcceptsPlan() async throws {
         let backend = OllamaBackend()
         backend.configure(
@@ -85,7 +82,6 @@ final class AllBackendsAcceptPlanTests: XCTestCase {
         try await backend.loadModel(from: URL(string: "unused:")!, plan: .cloud())
         XCTAssertTrue(backend.isModelLoaded)
     }
-    #endif
 
     // MARK: - Local Backends (hardware-gated)
 

--- a/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
@@ -13,7 +13,6 @@ final class BackendCapabilitiesContractTests: XCTestCase {
 
     // MARK: - Remote backends
 
-    #if Ollama && CloudSaaS
     func test_cloudBackends_reportIsRemote() {
         XCTAssertTrue(ClaudeBackend().capabilities.isRemote,
                       "ClaudeBackend makes network calls — isRemote must be true")
@@ -22,11 +21,9 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(OllamaBackend().capabilities.isRemote,
                       "OllamaBackend makes network calls — isRemote must be true")
     }
-    #endif
 
     // MARK: - Tool Calling
 
-    #if Ollama && CloudSaaS
     func test_cloudBackends_toolCallingCapabilities() {
         // Tool calling is advertised by every cloud backend now that the
         // per-vendor wire-format work in #435 has landed:
@@ -43,18 +40,14 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(OllamaBackend().capabilities.supportsToolCalling,
                       "OllamaBackend advertises tool calling since Wave 2 dispatch wiring")
     }
-    #endif
 
-    #if CloudSaaS
     func test_cloudBackends_structuredOutputCapabilities() {
         XCTAssertTrue(ClaudeBackend().capabilities.supportsStructuredOutput,
                       "ClaudeBackend supports structured output")
         XCTAssertTrue(OpenAIBackend().capabilities.supportsStructuredOutput,
                       "OpenAIBackend supports structured output via json_schema")
     }
-    #endif
 
-    #if Ollama && CloudSaaS
     func test_backends_nativeJSONModeCapabilities() {
         XCTAssertFalse(ClaudeBackend().capabilities.supportsNativeJSONMode,
                        "ClaudeBackend does not advertise a dedicated native JSON mode")
@@ -63,7 +56,6 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(OllamaBackend().capabilities.supportsNativeJSONMode,
                       "OllamaBackend supports format=json")
     }
-    #endif
 
     // MARK: - supportsThinking
 
@@ -74,7 +66,6 @@ final class BackendCapabilitiesContractTests: XCTestCase {
     /// `OpenAIBackend`'s default `gpt-4o-mini` is a chat model (no thinking),
     /// and `OllamaBackend` resolves at load time via `/api/show` so an
     /// unloaded instance reports the manifest-default `false`.
-    #if Ollama && CloudSaaS
     func test_cloudBackends_advertiseThinkingFromManifest() {
         XCTAssertTrue(ClaudeBackend().capabilities.supportsThinking,
                       "ClaudeBackend default model is claude-sonnet-4, which the manifest table reports as a thinking model")
@@ -83,7 +74,6 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertFalse(OllamaBackend().capabilities.supportsThinking,
                        "OllamaBackend reports thinking only after /api/show probe runs at loadModel time")
     }
-    #endif
 
     // MARK: - Local backends
 

--- a/Tests/ManifoldBackendsTests/CancellationLivenessContractTest.swift
+++ b/Tests/ManifoldBackendsTests/CancellationLivenessContractTest.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS || Ollama
 import XCTest
 @testable import ManifoldCloudCore
 
@@ -135,4 +134,3 @@ final class CancellationLivenessContractTest: XCTestCase {
         return contents.filter { $0.pathExtension == "swift" }
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudeBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeBackendTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -9,12 +8,8 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Tests for ClaudeBackend configuration, state, and capabilities.
@@ -568,4 +563,3 @@ extension ClaudeBackendTests {
     }
 }
 
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudeBackendToolCallingTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeBackendToolCallingTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -516,4 +511,3 @@ final class ClaudeBackendToolCallingTests: XCTestCase {
         XCTAssertNil(messages[0]["content"] as? [[String: Any]])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudeImageInputTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeImageInputTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldTestSupport
@@ -6,12 +5,8 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Tests for #20 (part): image content blocks on the Anthropic Messages API.
@@ -311,4 +306,3 @@ final class ClaudeImageInputTests: XCTestCase {
     // (test_claudeVisionGate_rejectsLegacyTextOnlyFamilies) when the helper
     // was lifted out of ClaudeBackend into BackendVisionCapability.
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudePayloadHandlerTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudePayloadHandlerTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import ManifoldTestSupport
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -149,4 +144,3 @@ struct ByteSequenceForClaudeTests: AsyncSequence {
         AsyncIterator(index: data.startIndex, data: data)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudePromptCacheTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudePromptCacheTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -298,4 +293,3 @@ final class ClaudePayloadParserCacheUsageTests: XCTestCase {
         XCTAssertNil(ClaudePayloadParser.parseCacheUsage(from: payload))
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -162,10 +157,8 @@ final class ClaudeStreamEventExtractorTests: XCTestCase {
     func test_makeClaudeStreamConsumer_returnsNilForOtherProviders() {
         XCTAssertNil(CloudPayloadHandler.openAI.makeClaudeStreamConsumer())
         XCTAssertNil(CloudPayloadHandler.openAIResponses.makeClaudeStreamConsumer())
-#if Ollama
         // `.ollama` is published by ManifoldOllama; only reachable when both families build.
         XCTAssertNil(CloudPayloadHandler.ollama.makeClaudeStreamConsumer())
-#endif
     }
 
     // MARK: - Sabotage: cancellation suppresses tool finalisation
@@ -406,4 +399,3 @@ final class ClaudeStreamEventExtractorParityTests: XCTestCase {
         ])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudeStructuredReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStructuredReplayTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldTestSupport
@@ -6,12 +5,8 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Tests for #604: structured multi-turn replay against the Anthropic
@@ -265,4 +260,3 @@ final class ClaudeStructuredReplayTests: XCTestCase {
             "Signature must precede thinkingCompleted so the consumer has it before applying the finalize")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ClaudeThinkingErrorPathTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeThinkingErrorPathTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -98,4 +93,3 @@ final class ClaudeThinkingErrorPathTests: XCTestCase {
                       ".thinkingCompleted must fire before the throw so consumers don't hang in a thinking-only state")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudBackendErrorSanitizedFactoryTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudBackendErrorSanitizedFactoryTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
@@ -59,4 +58,3 @@ final class CloudBackendErrorSanitizedFactoryTests: XCTestCase {
         XCTAssertEqual(viaFactory.errorDescription?.contains(once), true)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudBackendSSETests.swift
+++ b/Tests/ManifoldBackendsTests/CloudBackendSSETests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import Testing
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -934,4 +929,3 @@ struct SSECloudBackendErrorBodyDrainTests {
         }
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudEncoderGeneratedImageSkipTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudEncoderGeneratedImageSkipTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Pins the contract that cloud encoders skip ``MessagePart/generatedImage(_:)``
@@ -159,4 +154,3 @@ final class CloudEncoderGeneratedImageSkipTests: XCTestCase {
         assertNoGeneratedImageLeaked(in: json)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudEndpointSelectionIntegrationTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudEndpointSelectionIntegrationTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import SwiftData
 @testable import ManifoldBackends
@@ -656,4 +655,3 @@ private final class ConfiguringClaudeCloudBackend: InferenceBackend,
     func unloadModel() { backend.unloadModel() }
     func resetConversation() { backend.resetConversation() }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudErrorSanitizerCoverageTest.swift
+++ b/Tests/ManifoldBackendsTests/CloudErrorSanitizerCoverageTest.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS || Ollama
 import XCTest
 @testable import ManifoldCloudCore
 
@@ -120,4 +119,3 @@ final class CloudErrorSanitizerCoverageTest: XCTestCase {
         return contents.filter { $0.pathExtension == "swift" }
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudErrorSanitizerTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudErrorSanitizerTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import Testing
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -408,4 +403,3 @@ struct CloudErrorSanitizerInStreamTests {
         return String(decoding: bytes, as: UTF8.self)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudImageEncodeCountTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudImageEncodeCountTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldTestSupport
@@ -6,12 +5,8 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Grounds audit claim #4 ("raw image bytes live in `MessagePart.image`,
@@ -173,4 +168,3 @@ final class CloudImageEncodeCountTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudMessageEncoderContractTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudMessageEncoderContractTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS || Ollama
 import XCTest
 import ManifoldInference
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Phase 1b/B contract suite for ``CloudMessageEncoder``.
@@ -33,14 +28,10 @@ final class CloudMessageEncoderContractTests: XCTestCase {
     /// source for test parameterisation.
     private static var allCases: [(name: String, encoder: CloudMessageEncoder)] {
         var cases: [(String, CloudMessageEncoder)] = []
-        #if CloudSaaS
         cases.append(("openAI", .openAI))
         cases.append(("openAIResponses", .openAIResponses))
         cases.append(("claude", .claude))
-        #endif
-        #if Ollama
         cases.append(("ollama", .ollama))
-        #endif
         return cases
     }
 
@@ -91,11 +82,9 @@ final class CloudMessageEncoderContractTests: XCTestCase {
                 plainHistory: nil
             )
             switch encoder {
-            #if CloudSaaS
             case .claude:
                 XCTAssertEqual(messages.first?["role"] as? String, "user",
                                "\(name): Claude must NOT inline a system entry — caller hoists it to the top-level system field")
-            #endif
             default:
                 XCTAssertEqual(messages.first?["role"] as? String, "system",
                                "\(name): expected an inline system entry as the first message")
@@ -137,13 +126,11 @@ final class CloudMessageEncoderContractTests: XCTestCase {
             let entry = encoded[0]
 
             switch encoder {
-            #if CloudSaaS
             case .claude:
                 XCTAssertEqual(entry["name"] as? String, "get_weather", "\(name): top-level name")
                 XCTAssertEqual(entry["description"] as? String, "Get the current weather for a location")
                 XCTAssertNotNil(entry["input_schema"], "\(name): Anthropic uses input_schema, not parameters")
                 XCTAssertNil(entry["type"], "\(name): Anthropic shape has no top-level type")
-            #endif
             default:
                 XCTAssertEqual(entry["type"] as? String, "function", "\(name): OpenAI-shape tools require type:function")
                 let function = entry["function"] as? [String: Any]
@@ -178,7 +165,6 @@ final class CloudMessageEncoderContractTests: XCTestCase {
             let encoded = encoder.encodeToolResults(results)
 
             switch encoder {
-            #if CloudSaaS
             case .claude:
                 XCTAssertEqual(encoded.count, 1, "\(name): Claude bundles all tool results into one user turn")
                 XCTAssertEqual(encoded.first?["role"] as? String, "user", "\(name): Claude tool_result turns are role=user")
@@ -193,7 +179,6 @@ final class CloudMessageEncoderContractTests: XCTestCase {
                 XCTAssertEqual(encoded[0]["call_id"] as? String, "call_1",
                                "\(name): Responses uses call_id (not tool_call_id)")
                 XCTAssertEqual(encoded[0]["output"] as? String, "{\"temperature\": 72}")
-            #endif
             default:
                 // .openAI, .ollama
                 XCTAssertEqual(encoded.count, 2, "\(name): one tool turn per result")
@@ -250,7 +235,6 @@ final class CloudMessageEncoderContractTests: XCTestCase {
     /// Claude with both cacheSystem + cacheToolsTail must rewrite the
     /// system block to a content-array form (so it has a slot for
     /// `cache_control`) AND tag the last tool entry.
-    #if CloudSaaS
     func test_annotateCacheBreakpoints_claude_addsExplicitMarkers() throws {
         var systemBlock: Any? = "you are helpful"
         var toolEntries: [[String: Any]] = [
@@ -295,6 +279,4 @@ final class CloudMessageEncoderContractTests: XCTestCase {
         XCTAssertNil(toolEntries[0]["cache_control"],
                      "second breakpoint must be suppressed once maxBreakpoints is exhausted")
     }
-    #endif
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudPayloadHandlerContractTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudPayloadHandlerContractTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS || Ollama
 import XCTest
 import ManifoldBackendTestKit
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -67,7 +62,6 @@ final class CloudPayloadHandlerContractTests: XCTestCase {
 
     // `.claude` / `.openAIResponses` are published by ManifoldCloudSaaS;
     // this file also compiles in Ollama-only builds where they don't exist.
-#if CloudSaaS
     func test_openAIResponses_extractEvents_outputTextDelta() {
         // Responses API delivers the per-token text under `delta` for
         // both reasoning and visible-text named events. The handler
@@ -143,11 +137,9 @@ final class CloudPayloadHandlerContractTests: XCTestCase {
         // surfaced verbatim at this layer (CloudErrorSanitizer runs
         // envelope-level on HTTP errors, not stream events).
     }
-#endif
 
     // MARK: - Ollama
 
-#if Ollama
     func test_ollama_extractEvents_chatMessageContent() {
         // `/api/chat` shape: content under `message.content`.
         let payload = #"{"model":"llama3","message":{"role":"assistant","content":"Hi"},"done":false}"#
@@ -185,18 +177,15 @@ final class CloudPayloadHandlerContractTests: XCTestCase {
         let payload = #"{"message":{"content":"streaming"},"done":false}"#
         XCTAssertNil(CloudPayloadHandler.ollama.extractUsage(from: payload))
     }
-#endif
 
     // MARK: - Sabotage-style cross-provider isolation
 
-#if CloudSaaS
     func test_handlerCases_doNotCrossContaminate_eventClassification() {
         // OpenAI shape MUST NOT be parsed as Claude content delta.
         let openAIShape = #"{"choices":[{"delta":{"content":"hello"}}]}"#
         XCTAssertNil(CloudPayloadHandler.claude.extractToken(from: openAIShape))
         XCTAssertTrue(CloudPayloadHandler.claude.extractEvents(from: openAIShape).isEmpty)
     }
-#endif
 }
 
 // MARK: - StreamFinalizer contract
@@ -261,7 +250,6 @@ final class StreamFinalizerContractTests: XCTestCase {
         XCTAssertEqual(f.finalize(frame: frame), .streamContinue)
     }
 
-#if Ollama
     func test_ollamaDoneFlag_doneTrueTerminatesWithUsage() {
         let f = OllamaDoneFlagFinalizer()
         let frame = data(#"{"done":true,"eval_count":50,"prompt_eval_count":10}"#)
@@ -277,18 +265,12 @@ final class StreamFinalizerContractTests: XCTestCase {
         let frame = data(#"{"done":false,"message":{"content":"x"}}"#)
         XCTAssertEqual(f.finalize(frame: frame), .streamContinue)
     }
-#endif
 
     func test_anyFinalizer_malformedJSONReturnsNil() {
         let frame = data("not json")
         XCTAssertNil(OpenAIDoneSentinelFinalizer().finalize(frame: frame))
-#if CloudSaaS
         XCTAssertNil(ClaudeMessageStopFinalizer().finalize(frame: frame))
         XCTAssertNil(OpenAIResponsesEventFinalizer().finalize(frame: frame))
-#endif
-#if Ollama
         XCTAssertNil(OllamaDoneFlagFinalizer().finalize(frame: frame))
-#endif
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CloudThinkingTokenTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudThinkingTokenTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import Testing
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -352,4 +347,3 @@ struct OpenAIReasoningTests {
         #expect(!sawThinkingComplete, ".thinkingCompleted must not fire for plain Chat Completions streams")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/ClaudeBackendConformanceTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldBackendTestKit
@@ -100,4 +99,3 @@ final class ClaudeBackendConformanceTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/Conformance/OllamaBackendConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/OllamaBackendConformanceTests.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import XCTest
 import ManifoldInference
 import ManifoldBackendTestKit
@@ -82,4 +81,3 @@ final class OllamaBackendConformanceTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/OpenAIBackendConformanceTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldBackendTestKit
@@ -92,4 +91,3 @@ final class OpenAIBackendConformanceTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
+++ b/Tests/ManifoldBackendsTests/Conformance/OpenAIResponsesBackendConformanceTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldBackendTestKit
@@ -90,4 +89,3 @@ final class OpenAIResponsesBackendConformanceTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ConnectAddressPinningDelegateTests.swift
+++ b/Tests/ManifoldBackendsTests/ConnectAddressPinningDelegateTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 @testable import ManifoldCloudCore
 import ManifoldInference
@@ -115,4 +114,3 @@ final class ConnectAddressPinningDelegateTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/ContractSuiteRuntimeBudgetTest.swift
+++ b/Tests/ManifoldBackendsTests/ContractSuiteRuntimeBudgetTest.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS || Ollama
 import XCTest
 @testable import ManifoldInference
 
@@ -12,9 +11,8 @@ import XCTest
 /// pathological regression (e.g. reading an accidentally huge fixture file
 /// in a loop).
 ///
-/// Gated on `#if CloudSaaS || Ollama` because that is the same condition
-/// wrapping ``InferenceBackendContractTests``. Without cloud traits, there
-/// are no cloud participants and nothing to measure.
+/// Compiles unconditionally since v0.48 — the cloud families (and therefore
+/// the cloud contract participants) are always built in.
 final class ContractSuiteRuntimeBudgetTest: XCTestCase {
 
     func test_cloudTierContractSuite_completesUnder15Seconds() throws {
@@ -74,7 +72,6 @@ final class ContractSuiteRuntimeBudgetTest: XCTestCase {
 
     private func buildParticipants() throws -> [BudgetParticipant] {
         var list: [BudgetParticipant] = []
-        #if CloudSaaS
         list.append(BudgetParticipant(
             label: "openai.chat_completions",
             fixtureDirectory: "openai",
@@ -93,15 +90,12 @@ final class ContractSuiteRuntimeBudgetTest: XCTestCase {
             wireFormat: .sse,
             supportsToolCalling: true
         ))
-        #endif
-        #if Ollama
         list.append(BudgetParticipant(
             label: "ollama.chat",
             fixtureDirectory: "ollama",
             wireFormat: .ndjson,
             supportsToolCalling: true
         ))
-        #endif
         return list
     }
 
@@ -158,4 +152,3 @@ final class ContractSuiteRuntimeBudgetTest: XCTestCase {
         ])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/Contracts/URLSessionProviderContractTests.swift
+++ b/Tests/ManifoldBackendsTests/Contracts/URLSessionProviderContractTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 @testable import ManifoldCloudCore
 import ManifoldInference
@@ -142,7 +141,6 @@ final class URLSessionProviderContractTests: XCTestCase, URLSessionProviderContr
         )
     }
 
-    #if CloudSaaS
     /// The pinned session must differ from the unpinned session (they serve
     /// distinct trust policies).
     func test_pinnedAndUnpinned_areDifferentObjects() {
@@ -161,6 +159,4 @@ final class URLSessionProviderContractTests: XCTestCase, URLSessionProviderContr
             "Pinned session composite must carry a PinnedSessionDelegate"
         )
     }
-    #endif
 }
-#endif

--- a/Tests/ManifoldBackendsTests/CrossBackendReplayParityTests.swift
+++ b/Tests/ManifoldBackendsTests/CrossBackendReplayParityTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS || Ollama
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -65,7 +60,6 @@ final class CrossBackendReplayParityTests: XCTestCase {
     /// and asserts the resulting call matches the expected shape.
     ///
     /// Sabotage: change fixture 'name' to 'get_weather_wrong', confirm XCTAssertEqual on name fails.
-#if CloudSaaS
     func test_openai_fixtureReplay_producesExpectedToolCall() throws {
         let json = try loadFixture(named: "openai_tool_call.json")
 
@@ -80,14 +74,12 @@ final class CrossBackendReplayParityTests: XCTestCase {
         let args = try parseArgs(call.arguments)
         XCTAssertEqual(args["city"], "Dublin", "arguments must contain city=Dublin")
     }
-#endif
 
     // MARK: - Anthropic fixture replay
 
     /// Decodes `anthropic_tool_use.json` through
     /// ``ClaudeBackend/parseWholeMessageToolUseBlocks(from:)`` and asserts
     /// the resulting block matches the expected shape.
-#if CloudSaaS
     func test_anthropic_fixtureReplay_producesExpectedToolCall() throws {
         let json = try loadFixture(named: "anthropic_tool_use.json")
 
@@ -102,13 +94,11 @@ final class CrossBackendReplayParityTests: XCTestCase {
         let args = try parseArgs(block.serializedInput)
         XCTAssertEqual(args["city"], "Dublin", "serializedInput must contain city=Dublin")
     }
-#endif
 
     // MARK: - Ollama fixture replay
 
     /// Decodes `ollama_tool_call.json` through ``OllamaBackend/parseLine(_:)``
     /// and asserts the resulting ``ToolCall`` matches the expected shape.
-#if Ollama
     func test_ollama_fixtureReplay_producesExpectedToolCall() throws {
         let json = try loadFixture(named: "ollama_tool_call.json")
 
@@ -124,7 +114,6 @@ final class CrossBackendReplayParityTests: XCTestCase {
         let args = try parseArgs(call.arguments)
         XCTAssertEqual(args["city"], "Dublin", "arguments must contain city=Dublin")
     }
-#endif
 
     // MARK: - Cross-backend parity gate
 
@@ -136,7 +125,6 @@ final class CrossBackendReplayParityTests: XCTestCase {
     ///
     /// This is the cross-cutting assertion: different wire formats from
     /// three vendors must all resolve to `["city": "Dublin"]`.
-#if CloudSaaS && Ollama
     func test_allVendors_argumentParity_cityDublin() throws {
         // OpenAI
         let openAIJson = try loadFixture(named: "openai_tool_call.json")
@@ -164,6 +152,4 @@ final class CrossBackendReplayParityTests: XCTestCase {
         // as "all equal" (e.g. all empty).
         XCTAssertEqual(openAIArgs["city"], "Dublin")
     }
-#endif
 }
-#endif

--- a/Tests/ManifoldBackendsTests/DNSRebindingGuardTests.swift
+++ b/Tests/ManifoldBackendsTests/DNSRebindingGuardTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloudCore
@@ -237,4 +236,3 @@ final class DNSRebindingGuardTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/DefaultBackendsCapabilityTests.swift
+++ b/Tests/ManifoldBackendsTests/DefaultBackendsCapabilityTests.swift
@@ -67,9 +67,8 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
         let service = InferenceService()
         DefaultBackends.register(with: service)
 
-        // Cloud providers compiled into this build must be declared after
-        // registration. Providers gated out by `Ollama` / `CloudSaaS` traits
-        // intentionally stay un-declared.
+        // Every built-in cloud provider must be declared after registration
+        // (cloud families always compile since v0.48).
         for provider in APIProvider.availableInBuild {
             XCTAssertTrue(service.canLoad(provider: provider),
                           "Expected \(provider) to be declared after DefaultBackends.register")
@@ -147,9 +146,8 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
                        DefaultBackends.supportedModelTypes,
                        "FrameworkCapabilityService.enabledBackends should match static query after refresh")
 
-        // Cloud inference support tracks whichever providers the build's
-        // traits compiled in. Offline builds (neither `Ollama` nor
-        // `CloudSaaS`) declare none, so `supportsCloudInference` is false.
+        // Cloud families always compile since v0.48, so the provider list is
+        // never empty and cloud inference support is always reported.
         let expected = !APIProvider.availableInBuild.isEmpty
         XCTAssertEqual(capService.enabledBackends.supportsCloudInference, expected,
                        "Cloud inference support should match the trait-gated provider list")
@@ -159,8 +157,6 @@ final class DefaultBackendsCapabilityTests: XCTestCase {
     func test_withoutRegister_cloudProvidersNotDeclared_sabotageCheck() {
         let service = InferenceService()
         // Do NOT call register(with:).
-        // Use whichever provider the current build can build, falling back to
-        // `.claude` purely so the assertion compiles in offline builds.
         let probe = APIProvider.availableInBuild.first ?? .claude
         XCTAssertFalse(service.canLoad(provider: probe),
                        "Without registration, no provider should be declared")

--- a/Tests/ManifoldBackendsTests/DefaultBackendsTests.swift
+++ b/Tests/ManifoldBackendsTests/DefaultBackendsTests.swift
@@ -38,43 +38,23 @@ final class DefaultBackendsRoutingTests: XCTestCase {
     }
 
     func test_routing_openAI_mapsToOpenAIBackend() {
-        #if CloudSaaS
         XCTAssertEqual(DefaultBackends.backendTypeName(for: .openAI), "OpenAIBackend")
-        #else
-        XCTAssertNil(DefaultBackends.backendTypeName(for: .openAI))
-        #endif
     }
 
     func test_routing_claude_mapsToClaudeBackend() {
-        #if CloudSaaS
         XCTAssertEqual(DefaultBackends.backendTypeName(for: .claude), "ClaudeBackend")
-        #else
-        XCTAssertNil(DefaultBackends.backendTypeName(for: .claude))
-        #endif
     }
 
     func test_routing_ollama_mapsToOllamaBackend() {
-        #if Ollama
         XCTAssertEqual(DefaultBackends.backendTypeName(for: .ollama), "OllamaBackend")
-        #else
-        XCTAssertNil(DefaultBackends.backendTypeName(for: .ollama))
-        #endif
     }
 
     func test_routing_lmStudio_mapsToOpenAIBackend() {
-        #if CloudSaaS
         XCTAssertEqual(DefaultBackends.backendTypeName(for: .lmStudio), "OpenAIBackend")
-        #else
-        XCTAssertNil(DefaultBackends.backendTypeName(for: .lmStudio))
-        #endif
     }
 
     func test_routing_custom_mapsToOpenAIBackend() {
-        #if CloudSaaS
         XCTAssertEqual(DefaultBackends.backendTypeName(for: .custom), "OpenAIBackend")
-        #else
-        XCTAssertNil(DefaultBackends.backendTypeName(for: .custom))
-        #endif
     }
 }
 
@@ -151,10 +131,11 @@ final class DefaultBackendsTests: XCTestCase {
 /// 1. **Drop a local declareSupport.** In `MLXBackends.swift` comment out
 ///    `service.declareSupport(for: .mlx)`. With `--traits MLX`,
 ///    `test_mlxRegistrar_declaresMLX` must fail.
-/// 2. **Drop a cloud declareSupport.** In `CloudBackends.swift` comment out
-///    the `for provider in APIProvider.availableInBuild { ... }` loop. With
-///    `--traits CloudSaaS` or `--traits Ollama`,
-///    `test_cloudRegistrar_declaresAvailableProviders` must fail.
+/// 2. **Drop a cloud declareSupport.** In `OllamaBackends.swift` /
+///    `CloudSaaSBackends.swift` comment out the
+///    `for provider in APIProvider.availableInBuild { ... }` loop.
+///    `test_cloudRegistrar_declaresAvailableProviders` must fail in any
+///    build shape (cloud always compiles since v0.48).
 /// 3. **Drop a registrar from the fold.** In `DefaultBackends.swift` remove
 ///    `LlamaBackends.self` from `registrars`. With `--traits Llama`,
 ///    `test_defaultRegister_equalsExplicitFold` must fail on `localModelTypes`
@@ -264,7 +245,6 @@ final class DefaultBackendsRegistrarTests: XCTestCase {
 
 // MARK: - Cloud Pin Loading (CloudSaaS only)
 
-#if CloudSaaS
 /// Verifies `CloudBackends.register(with:)` loads default certificate pins
 /// before any URLSession factory could be exercised. The `_defaultPinsLoaded`
 /// guard makes `loadDefaultPins()` idempotent across multiple calls but the
@@ -302,4 +282,3 @@ final class CloudBackendsPinLoadingTests: XCTestCase {
                                     "CloudBackends.register must populate OpenAI pins (at minimum: intermediate + root)")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/DefaultWebSearchRuntimeTests.swift
+++ b/Tests/ManifoldBackendsTests/DefaultWebSearchRuntimeTests.swift
@@ -1,14 +1,9 @@
-#if CloudSaaS
 import XCTest
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -185,4 +180,3 @@ private extension URLRequest {
         return data
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceBackendContractTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS || Ollama
 import XCTest
 import ManifoldBackendTestKit
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -64,7 +59,6 @@ final class InferenceBackendContractTests: XCTestCase {
         }
     }
 
-    #if CloudSaaS
     private static let openAIParticipant = Participant(
         label: "openai.chat_completions",
         fixtureDirectory: "openai",
@@ -98,9 +92,7 @@ final class InferenceBackendContractTests: XCTestCase {
         ),
         wireFormat: .sse
     )
-    #endif
 
-    #if CloudSaaS
     /// OpenAI Responses API participant (Phase 3/Responses). Routes
     /// through ``CloudPayloadHandler/openAIResponses`` for the
     /// extractEvents surface — for the Responses wire shape that means
@@ -145,9 +137,7 @@ final class InferenceBackendContractTests: XCTestCase {
         wireFormat: .sse
     )
 
-    #endif
 
-    #if Ollama
     private static let ollamaParticipant = Participant(
         label: "ollama.chat",
         fixtureDirectory: "ollama",
@@ -182,9 +172,7 @@ final class InferenceBackendContractTests: XCTestCase {
         ),
         wireFormat: .ndjson
     )
-    #endif
 
-    #if CloudSaaS
     private static let claudeParticipant = Participant(
         label: "anthropic.messages",
         fixtureDirectory: "claude",
@@ -224,18 +212,13 @@ final class InferenceBackendContractTests: XCTestCase {
         ),
         wireFormat: .sse
     )
-    #endif
 
     private static let participants: [Participant] = {
         var list: [Participant] = []
-        #if CloudSaaS
         list.append(openAIParticipant)
         list.append(openAIResponsesParticipant)
         list.append(claudeParticipant)
-        #endif
-        #if Ollama
         list.append(ollamaParticipant)
-        #endif
         return list
     }()
 
@@ -290,16 +273,12 @@ final class InferenceBackendContractTests: XCTestCase {
             case "openai.chat_completions":
                 let shape = OpenAIDeltaToolCalls()
                 XCTAssertEqual(shape.shapeName, "openai.delta")
-            #if CloudSaaS
             case "openai.responses":
                 let shape = OpenAIResponsesItemIdToolCalls()
                 XCTAssertEqual(shape.shapeName, "openai_responses.item_id")
-            #endif
-            #if Ollama
             case "ollama.chat":
                 let shape = OllamaWholeToolCalls()
                 XCTAssertEqual(shape.shapeName, "ollama.whole")
-            #endif
             case "anthropic.messages":
                 let shape = AnthropicBlockToolCalls()
                 XCTAssertEqual(shape.shapeName, "anthropic.block")
@@ -465,4 +444,3 @@ final class InferenceBackendContractTests: XCTestCase {
         ])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/InferenceMetricTests.swift
+++ b/Tests/ManifoldBackendsTests/InferenceMetricTests.swift
@@ -216,9 +216,8 @@ struct InMemoryMetricSinkTests {
     }
 }
 
-// MARK: - SSECloudBackend integration tests (require CloudSaaS or Ollama trait)
+// MARK: - SSECloudBackend integration tests
 
-#if Ollama || CloudSaaS
 
 // Minimal SSE payload handler for tests that exercise SSECloudBackend directly.
 private struct TestPayloadHandler: SSEPayloadHandler {
@@ -368,4 +367,3 @@ struct SSECloudBackendMetricTests {
     }
 }
 
-#endif // Ollama || CloudSaaS

--- a/Tests/ManifoldBackendsTests/MemoryStrategyBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/MemoryStrategyBackendTests.swift
@@ -7,7 +7,6 @@ final class MemoryStrategyBackendTests: XCTestCase {
 
     // MARK: - Cloud Backends (no hardware needed)
 
-    #if CloudSaaS
     func test_openAIBackend_declaresExternalStrategy() {
         let backend = OpenAIBackend()
         XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
@@ -17,7 +16,6 @@ final class MemoryStrategyBackendTests: XCTestCase {
         let backend = ClaudeBackend()
         XCTAssertEqual(backend.capabilities.memoryStrategy, .external)
     }
-    #endif
 
     // MARK: - Local Backends (hardware gated)
 

--- a/Tests/ManifoldBackendsTests/ModelManifestContractTests.swift
+++ b/Tests/ManifoldBackendsTests/ModelManifestContractTests.swift
@@ -14,7 +14,6 @@ final class ModelManifestContractTests: XCTestCase {
 
     // MARK: - Cloud backends — supportsThinking matches the manifest table
 
-    #if CloudSaaS
     func test_claude_sonnet4_manifestReflectsThinking() throws {
         let backend = ClaudeBackend()
         backend.modelName = "claude-sonnet-4-5"
@@ -60,7 +59,6 @@ final class ModelManifestContractTests: XCTestCase {
         XCTAssertEqual(manifest.supportsSeed, false,
                        "Unknown OpenAI model must not advertise seed")
     }
-    #endif
 
     // MARK: - MockInferenceBackend — invariant scaffolding
 

--- a/Tests/ManifoldBackendsTests/OllamaAdversarialJSONTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaAdversarialJSONTests.swift
@@ -1,16 +1,11 @@
-#if Ollama
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -238,4 +233,3 @@ final class OllamaAdversarialJSONTests: XCTestCase {
         XCTAssertEqual(parsed?["city"] as? String, "Paris", "re-serialised arguments must round-trip as valid JSON")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import Testing
 import XCTest
 import Foundation
@@ -6,12 +5,8 @@ import Foundation
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -1926,4 +1921,3 @@ private func extractBody(from request: URLRequest?) throws -> Data {
     Issue.record("Request has neither httpBody nor httpBodyStream")
     return Data()
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaBackendToolCallingTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendToolCallingTests.swift
@@ -1,16 +1,11 @@
-#if Ollama
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -413,4 +408,3 @@ final class OllamaBackendToolCallingTests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaManifestProbeTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaManifestProbeTests.swift
@@ -1,15 +1,10 @@
-#if Ollama
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -204,4 +199,3 @@ final class OllamaManifestProbeTests: XCTestCase {
                      "no markers detected → manifest carries nil")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaPayloadHandlerTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaPayloadHandlerTests.swift
@@ -1,16 +1,11 @@
-#if Ollama
 import XCTest
 import ManifoldTestSupport
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -156,4 +151,3 @@ final class OllamaPayloadHandlerTests: XCTestCase {
         XCTAssertTrue(handler.extractEvents(from: payload).isEmpty)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaStreamEventExtractorTests.swift
@@ -1,16 +1,11 @@
-#if Ollama
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -138,13 +133,11 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
         XCTAssertNotNil(CloudPayloadHandler.ollama.makeOllamaStreamConsumer(config: GenerationConfig()))
     }
 
-    #if CloudSaaS
     func test_makeOllamaStreamConsumer_returnsNilForOtherProviders() {
         XCTAssertNil(CloudPayloadHandler.openAI.makeOllamaStreamConsumer(config: GenerationConfig()))
         XCTAssertNil(CloudPayloadHandler.claude.makeOllamaStreamConsumer(config: GenerationConfig()))
         XCTAssertNil(CloudPayloadHandler.openAIResponses.makeOllamaStreamConsumer(config: GenerationConfig()))
     }
-    #endif
 
     // MARK: - Helpers
 
@@ -338,4 +331,3 @@ final class OllamaStreamEventExtractorParityTests: XCTestCase {
         ])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -1,16 +1,11 @@
-#if Ollama
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -270,4 +265,3 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
         }
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OllamaToolCallingTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaToolCallingTests.swift
@@ -1,16 +1,11 @@
-#if Ollama
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -354,4 +349,3 @@ final class OllamaToolCallingTests: XCTestCase {
         XCTAssertNil(messages[0]["tool_call_id"])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIBackendImageInputTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIBackendImageInputTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldInference
 import ManifoldTestSupport
@@ -6,12 +5,8 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Tests for #943 (part of #20): `image_url` content parts on the OpenAI
@@ -406,4 +401,3 @@ final class OpenAIBackendImageInputTests: XCTestCase {
             "MIME must pass through verbatim — got \(dataURI.prefix(40))")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIBackendManifestRequestTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIBackendManifestRequestTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -168,4 +163,3 @@ final class OpenAIBackendManifestRequestTests: XCTestCase {
                      "o1 reasoning models reject frequency_penalty — manifest must omit it")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIBackendTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -9,12 +8,8 @@ import ManifoldTestSupport
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 
 /// Tests for OpenAIBackend configuration, state, and capabilities.
@@ -379,4 +374,3 @@ extension OpenAIBackendTests {
         BackendContractChecks.assertAllInvariants { OpenAIBackend() }
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIBackendToolCallingTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIBackendToolCallingTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -478,4 +473,3 @@ final class OpenAIBackendToolCallingTests: XCTestCase {
         XCTAssertNil(messages[0]["tool_call_id"])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAICompatEndpointTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAICompatEndpointTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import Testing
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -659,4 +654,3 @@ struct ProviderSSEPayloadTests {
 // 5. Authentication:
 //    - Ollama does not require API keys by default.
 //    - OpenAIBackend correctly omits the Authorization header when apiKey is nil.
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesBackendTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -367,4 +362,3 @@ final class OpenAIResponsesBackendTests: XCTestCase {
                        ".thinkingCompleted must fire before the throw — got \(observed)")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesBackendToolCallingTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesBackendToolCallingTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -360,4 +355,3 @@ final class OpenAIResponsesBackendToolCallingTests: XCTestCase {
         XCTAssertNil(input[0]["type"])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesPayloadHandlerTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesPayloadHandlerTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import ManifoldTestSupport
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -161,4 +156,3 @@ struct ByteSequenceForOpenAITests: AsyncSequence {
         AsyncIterator(index: data.startIndex, data: data)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesStreamEventExtractorTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -135,10 +130,8 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
     func test_makeOpenAIResponsesStreamConsumer_returnsNilForOtherProviders() {
         XCTAssertNil(CloudPayloadHandler.openAI.makeOpenAIResponsesStreamConsumer())
         XCTAssertNil(CloudPayloadHandler.claude.makeOpenAIResponsesStreamConsumer())
-#if Ollama
         // `.ollama` is published by ManifoldOllama; only reachable when both families build.
         XCTAssertNil(CloudPayloadHandler.ollama.makeOpenAIResponsesStreamConsumer())
-#endif
     }
 
     // MARK: - Helpers
@@ -442,4 +435,3 @@ final class OpenAIResponsesStreamEventExtractorParityTests: XCTestCase {
         ])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/OpenAIStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIStreamEventExtractorTests.swift
@@ -1,16 +1,11 @@
-#if CloudSaaS
 import XCTest
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -170,10 +165,8 @@ final class OpenAIStreamEventExtractorTests: XCTestCase {
     func test_makeOpenAIStreamConsumer_returnsNilForOtherProviders() {
         XCTAssertNil(CloudPayloadHandler.claude.makeOpenAIStreamConsumer())
         XCTAssertNil(CloudPayloadHandler.openAIResponses.makeOpenAIStreamConsumer())
-#if Ollama
         // `.ollama` is published by ManifoldOllama; only reachable when both families build.
         XCTAssertNil(CloudPayloadHandler.ollama.makeOpenAIStreamConsumer())
-#endif
     }
 
     // MARK: - Helpers
@@ -394,4 +387,3 @@ final class OpenAIStreamEventExtractorParityTests: XCTestCase {
         ])
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/PinnedSessionDelegateTests.swift
+++ b/Tests/ManifoldBackendsTests/PinnedSessionDelegateTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import CommonCrypto
 import Security
@@ -481,4 +480,3 @@ private final class StubChallengeSender: NSObject, URLAuthenticationChallengeSen
     func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
     func cancel(_ challenge: URLAuthenticationChallenge) {}
 }
-#endif

--- a/Tests/ManifoldBackendsTests/RetryPolicyIntegrationTests.swift
+++ b/Tests/ManifoldBackendsTests/RetryPolicyIntegrationTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import XCTest
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -194,4 +193,3 @@ final class RetryPolicyIntegrationTests: XCTestCase {
                           "Retry should complete well under 5s for a 0.1s Retry-After")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/SSECloudBackendAdapterRoutingTests.swift
+++ b/Tests/ManifoldBackendsTests/SSECloudBackendAdapterRoutingTests.swift
@@ -1,4 +1,3 @@
-#if CloudSaaS
 import Testing
 import Foundation
 @testable import ManifoldCloudCore
@@ -466,4 +465,3 @@ private final class UsageRecorder: @unchecked Sendable {
         lock.unlock()
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/SSEExtractEventsTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEExtractEventsTests.swift
@@ -1,16 +1,11 @@
-#if Ollama || CloudSaaS
 import Testing
 import Foundation
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -302,4 +297,3 @@ struct SSEExtractEventsTests {
                 "Multiple events in one payload must preserve order and boundary injection; got \(events)")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEPayloadReplayTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -386,4 +381,3 @@ final class SSEPayloadReplayTests: XCTestCase {
         XCTAssertEqual(tokens[2], " \u{4F60}\u{597D}") // Chinese characters (你好)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/SSEStreamLimitsRoutingTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEStreamLimitsRoutingTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 import ManifoldTestSupport
@@ -158,4 +153,3 @@ final class SSEStreamLimitsRoutingTests: XCTestCase {
                        "effectiveSSEStreamLimits must reflect the latest per-instance override")
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/SSEStreamParserCohortTests.swift
+++ b/Tests/ManifoldBackendsTests/SSEStreamParserCohortTests.swift
@@ -1,15 +1,10 @@
-#if CloudSaaS
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloud
 // v0.48 product split: internal symbols moved into the family targets and
 // ManifoldCloudCore; the ManifoldCloud shim only re-exports public surface.
-#if Ollama
 @testable import ManifoldOllama
-#endif
-#if CloudSaaS
 @testable import ManifoldCloudSaaS
-#endif
 @testable import ManifoldCloudCore
 @testable import ManifoldInference
 
@@ -104,4 +99,3 @@ final class SSEStreamParserCohortTests: XCTestCase {
 }
 
 extension OpenAIResponsesBackend.ResponsesEventKind: Equatable {}
-#endif

--- a/Tests/ManifoldBackendsTests/SecureBytesTests.swift
+++ b/Tests/ManifoldBackendsTests/SecureBytesTests.swift
@@ -4,7 +4,6 @@ import Foundation
 @testable import ManifoldSecrets
 @testable import ManifoldBackends
 
-#if Ollama || CloudSaaS
 // Minimal payload handler for tests that exercise SSECloudBackend state directly.
 private struct NoOpPayloadHandler: SSEPayloadHandler {
     func extractToken(from payload: String) -> String? { nil }
@@ -12,7 +11,6 @@ private struct NoOpPayloadHandler: SSEPayloadHandler {
     func isStreamEnd(_ payload: String) -> Bool { false }
     func extractStreamError(from payload: String) -> Error? { nil }
 }
-#endif
 
 @Suite("SecureBytes")
 struct SecureBytesTests {
@@ -77,7 +75,6 @@ struct SecureBytesTests {
     #endif
 }
 
-#if Ollama || CloudSaaS
 @Suite("SSECloudBackend ephemeralAPIKey")
 struct EphemeralAPIKeyTests {
 
@@ -129,4 +126,3 @@ struct EphemeralAPIKeyTests {
         #expect(backend.ephemeralAPIKey == nil)
     }
 }
-#endif

--- a/Tests/ManifoldBackendsTests/URLSessionProviderNetworkDisabledTests.swift
+++ b/Tests/ManifoldBackendsTests/URLSessionProviderNetworkDisabledTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 import ManifoldInference
 @testable import ManifoldBackends
@@ -21,7 +20,6 @@ final class URLSessionProviderNetworkDisabledTests: XCTestCase {
         super.tearDown()
     }
 
-    #if CloudSaaS
     func test_pinned_throws_whenNetworkDisabled() {
         URLSessionProvider.networkDisabled = true
 
@@ -44,7 +42,6 @@ final class URLSessionProviderNetworkDisabledTests: XCTestCase {
         let session = try URLSessionProvider.throwingPinned()
         XCTAssertNotNil(session.delegate, "pinned session should still install its delegate when network is enabled")
     }
-    #endif
 
     func test_unpinned_throws_whenNetworkDisabled() {
         URLSessionProvider.networkDisabled = true
@@ -70,7 +67,6 @@ final class URLSessionProviderNetworkDisabledTests: XCTestCase {
     }
 
     func test_killSwitch_propagates_throughOllamaBackendMakeChecked() throws {
-        #if Ollama
         URLSessionProvider.networkDisabled = true
         do {
             _ = try OllamaBackend.makeChecked()
@@ -84,12 +80,8 @@ final class URLSessionProviderNetworkDisabledTests: XCTestCase {
         } catch {
             XCTFail("Expected CloudBackendError.networkDisabled but got \(error)")
         }
-        #else
-        throw XCTSkip("Ollama trait not enabled in this build.")
-        #endif
     }
 
-    #if CloudSaaS
     func test_killSwitch_propagates_throughOpenAIBackendMakeChecked() throws {
         URLSessionProvider.networkDisabled = true
         do {
@@ -121,6 +113,4 @@ final class URLSessionProviderNetworkDisabledTests: XCTestCase {
             XCTFail("Expected CloudBackendError.networkDisabled but got \(error)")
         }
     }
-    #endif
 }
-#endif

--- a/Tests/ManifoldBackendsTests/URLSessionProviderTests.swift
+++ b/Tests/ManifoldBackendsTests/URLSessionProviderTests.swift
@@ -1,4 +1,3 @@
-#if Ollama || CloudSaaS
 import XCTest
 @testable import ManifoldBackends
 @testable import ManifoldCloudCore
@@ -6,7 +5,6 @@ import ManifoldInference
 
 final class URLSessionProviderTests: XCTestCase {
 
-    #if CloudSaaS
     func test_pinnedSession_hasExpectedTimeouts() {
         let session = URLSessionProvider.pinned
         // Sabotage check: changing timeoutIntervalForRequest in URLSessionProvider causes this to fail
@@ -35,7 +33,6 @@ final class URLSessionProviderTests: XCTestCase {
         XCTAssertNotNil(composite?.redirectGuard,
                         "Pinned session composite should always carry a RedirectGuardDelegate")
     }
-    #endif
 
     func test_unpinnedSession_hasExpectedTimeouts() {
         let session = URLSessionProvider.unpinned
@@ -68,12 +65,9 @@ final class URLSessionProviderTests: XCTestCase {
                      "Unpinned session composite must not carry a serverTrustHandler — pinning is reserved for the pinned session")
     }
 
-    #if CloudSaaS
     func test_pinnedAndUnpinned_areDifferentInstances() {
         // Sabotage check: returning the same session instance for both causes this to fail
         XCTAssertFalse(URLSessionProvider.pinned === URLSessionProvider.unpinned,
                        "Pinned and unpinned sessions should be different instances")
     }
-    #endif
 }
-#endif

--- a/Tests/ManifoldCoreTests/PackageTraitGateAuditTest.swift
+++ b/Tests/ManifoldCoreTests/PackageTraitGateAuditTest.swift
@@ -2,11 +2,11 @@ import XCTest
 
 /// Guards against regressions on issue #951: `Package.swift` must keep the
 /// optional modules that still have declared traits — `ManifoldFuzz` (plus
-/// its `ManifoldFuzzBackends` sibling) and the Ollama/CloudSaaS family
-/// products — gated behind those traits. Mirrors the pattern PR #946
-/// established for the `Server` trait around `ManifoldServer`. (The MCP /
-/// MCPBuiltinCatalog traits were retired in v0.48 PR A2; Voice / Tools /
-/// AppIntents / Skills in PR A3. Former entries are gone, not relaxed.)
+/// its `ManifoldFuzzBackends` sibling) — gated behind those traits. Mirrors
+/// the pattern PR #946 established for the `Server` trait around
+/// `ManifoldServer`. (The MCP / MCPBuiltinCatalog traits were retired in
+/// v0.48 PR A2; Voice / Tools / AppIntents / Skills in PR A3; Ollama /
+/// CloudSaaS in PR A4. Former entries are gone, not relaxed.)
 ///
 /// ## Why this matters
 ///
@@ -80,14 +80,6 @@ final class PackageTraitGateAuditTest: XCTestCase {
         .init(description: "ManifoldFuzzTests → ManifoldFuzz", module: "ManifoldFuzz", trait: "Fuzz"),
         .init(description: "ManifoldFuzzTests → ManifoldFuzzBackends", module: "ManifoldFuzzBackends", trait: "Fuzz"),
 
-        // v0.48 product split (PR A1): the Ollama / CloudSaaS traits moved
-        // from gating source compilation inside the old mixed ManifoldCloud
-        // target to gating the consumer→family edges. The substring check
-        // can't distinguish the three consumers (umbrella, shim, tests) —
-        // each gated edge shape appears at least once, which is what the
-        // audit can enforce.
-        .init(description: "consumers → ManifoldOllama", module: "ManifoldOllama", trait: "Ollama"),
-        .init(description: "consumers → ManifoldCloudSaaS", module: "ManifoldCloudSaaS", trait: "CloudSaaS"),
     ]
 
     func test_packageManifestDeclaresExpectedTraitGates() throws {

--- a/Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift
+++ b/Tests/ManifoldE2ETests/BackendBenchmarkE2ETests.swift
@@ -9,7 +9,7 @@
 /// ```bash
 /// # Ollama backend (requires Ollama at localhost:11434):
 /// MANIFOLD_BENCH_OLLAMA_MODEL=llama3.1:8b \
-///   xcrun swift test --traits Ollama \
+///   xcrun swift test \
 ///   --filter OllamaBackendBenchmark --skip-update
 ///
 /// # LlamaBackend (set MANIFOLD_BENCH_LLAMA_MODEL to an absolute .gguf path):
@@ -80,7 +80,6 @@ private func printResults(
 
 // MARK: - Ollama backend
 
-#if Ollama
 @MainActor
 final class OllamaBackendBenchmark: XCTestCase {
 
@@ -125,7 +124,6 @@ final class OllamaBackendBenchmark: XCTestCase {
         XCTAssertGreaterThan(results.map { Double($0.tokens) / ($0.totalMs / 1000) }.max() ?? 0, 5)
     }
 }
-#endif
 
 // MARK: - Llama backend
 

--- a/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioE2EHarness.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import Foundation
 import XCTest
 import ManifoldInference
@@ -288,4 +287,3 @@ enum DemoScenarioE2EFixtures {
         }
     }
 }
-#endif

--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaE2ETests.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import XCTest
 import ManifoldInference
 import ManifoldTools
@@ -434,4 +433,3 @@ final class DemoScenarioOllamaE2ETests: XCTestCase {
         try content.write(to: destination, atomically: true, encoding: .utf8)
     }
 }
-#endif

--- a/Tests/ManifoldE2ETests/DemoScenarioOllamaHelpers.swift
+++ b/Tests/ManifoldE2ETests/DemoScenarioOllamaHelpers.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import Foundation
 import XCTest
 import ManifoldInference
@@ -236,4 +235,3 @@ private enum FakeMCPLookupTool {
         }
     }
 }
-#endif

--- a/Tests/ManifoldE2ETests/OllamaE2ETests.swift
+++ b/Tests/ManifoldE2ETests/OllamaE2ETests.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import XCTest
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -241,4 +240,3 @@ final class OllamaE2ETests: XCTestCase {
     }
 
 }
-#endif

--- a/Tests/ManifoldE2ETests/OllamaThinkingE2ETests.swift
+++ b/Tests/ManifoldE2ETests/OllamaThinkingE2ETests.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import XCTest
 import ManifoldRuntime
 import ManifoldPersistenceSwiftData
@@ -293,4 +292,3 @@ final class OllamaThinkingE2ETests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldE2ETests/OllamaToolCallingE2ETests.swift
+++ b/Tests/ManifoldE2ETests/OllamaToolCallingE2ETests.swift
@@ -1,4 +1,3 @@
-#if Ollama
 import XCTest
 import ManifoldInference
 @testable import ManifoldTestSupport
@@ -186,4 +185,3 @@ final class OllamaToolCallingE2ETests: XCTestCase {
         )
     }
 }
-#endif

--- a/Tests/ManifoldFuzzTests/OllamaFuzzFactoryTests.swift
+++ b/Tests/ManifoldFuzzTests/OllamaFuzzFactoryTests.swift
@@ -1,5 +1,4 @@
 #if Fuzz
-#if Ollama
 import XCTest
 import ManifoldFuzz
 import ManifoldInference
@@ -90,5 +89,4 @@ final class OllamaFuzzFactoryTests: XCTestCase {
                        "selectModel must match hints case-insensitively so --model gemma4 finds gemma4:12b-it")
     }
 }
-#endif
 #endif

--- a/Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift
+++ b/Tests/ManifoldFuzzTests/OpenAIFuzzFactoryTests.swift
@@ -1,5 +1,4 @@
 #if Fuzz
-#if CloudSaaS
 import XCTest
 import ManifoldFuzz
 import ManifoldInference
@@ -75,5 +74,4 @@ final class OpenAIFuzzFactoryTests: XCTestCase {
         )
     }
 }
-#endif
 #endif

--- a/Tests/ManifoldInferenceTests/CompiledBackendsTests.swift
+++ b/Tests/ManifoldInferenceTests/CompiledBackendsTests.swift
@@ -5,10 +5,10 @@ final class CompiledBackendsTests: XCTestCase {
 
     // MARK: - Profile mapping (trait-set → build profile)
     //
-    // These exercise every combination of (Ollama, CloudSaaS) against the
-    // statically-defined `BackendBuildProfile` values, independently of which
-    // SwiftPM traits the test binary itself was compiled with. Sabotaging the
-    // mapping in `CompiledBackends.buildProfile(for:)` will break these.
+    // `buildProfile(for:)` is a pure function over hand-constructed trait
+    // sets, so every combination stays testable even though
+    // `CompiledBackends.current` always carries both cloud members since
+    // v0.48. Sabotaging `CompiledBackends.buildProfile(for:)` breaks these.
 
     func test_buildProfile_offline_whenNoNetworkTraits() {
         XCTAssertEqual(CompiledBackends.buildProfile(for: []), .offline)
@@ -34,22 +34,28 @@ final class CompiledBackendsTests: XCTestCase {
 
     // MARK: - Concrete shape under the current build configuration
 
-    // The shipped CI invocation uses `--disable-default-traits`, which means
-    // none of MLX/Llama/Ollama/CloudSaaS are compiled in. Foundation Models
-    // remain conditionally available based on the host OS. The assertions
-    // below check the *concrete* set, not a derivation that mirrors the
-    // production code.
+    // Since v0.48 (PR A4) the cloud families compile unconditionally, so
+    // `CompiledBackends.current` always reports the full cloud surface in
+    // every lane, including `--disable-default-traits`. Only MLX / Llama /
+    // HuggingFace remain build-dependent until the companion split (C2).
+    // Foundation Models remain conditionally available based on the host OS.
 
-    func test_current_offlineBuild_hasNoCloudProvidersAndNoLlamaOrMLX() {
+    func test_current_alwaysIncludesCloudFamilies() {
         let compiled = CompiledBackends.current
 
-        // Cloud providers come exclusively from Ollama + CloudSaaS traits.
-        if !compiled.traits.contains(.ollama) && !compiled.traits.contains(.cloudSaaS) {
-            XCTAssertEqual(compiled.cloudProviders, [],
-                "Build with neither Ollama nor CloudSaaS must compile zero cloud providers")
-            XCTAssertEqual(compiled.orderedCloudProviders, [],
-                "orderedCloudProviders must be empty when cloudProviders is empty")
-        }
+        XCTAssertTrue(compiled.traits.contains(.ollama),
+            "Ollama is always compiled in since v0.48 — its trait is retired")
+        XCTAssertTrue(compiled.traits.contains(.cloudSaaS),
+            "CloudSaaS is always compiled in since v0.48 — its trait is retired")
+        XCTAssertEqual(compiled.buildProfile, .full,
+            "With both cloud families constant, the current profile is always .full")
+        XCTAssertTrue(compiled.supportsCloudInference)
+        XCTAssertTrue(compiled.shouldPresentCloudAPIManagement,
+            "Cloud API management UI is always presentable; endpoint configuration is the runtime gate")
+    }
+
+    func test_current_localModelTypes_trackHardwareTraits() {
+        let compiled = CompiledBackends.current
 
         // GGUF support requires the Llama trait.
         if !compiled.traits.contains(.llama) {
@@ -64,8 +70,7 @@ final class CompiledBackendsTests: XCTestCase {
         }
     }
 
-    #if CloudSaaS
-    func test_current_cloudSaaSBuild_includesClaudeAndOpenAI() {
+    func test_current_cloudBuild_includesClaudeAndOpenAI() {
         let compiled = CompiledBackends.current
 
         XCTAssertTrue(compiled.cloudProviders.contains(.claude))
@@ -74,13 +79,10 @@ final class CompiledBackendsTests: XCTestCase {
         XCTAssertTrue(compiled.cloudProviders.contains(.lmStudio))
         XCTAssertTrue(compiled.cloudProviders.contains(.custom))
     }
-    #endif
 
-    #if Ollama
     func test_current_ollamaBuild_includesOllamaProvider() {
         XCTAssertTrue(CompiledBackends.current.cloudProviders.contains(.ollama))
     }
-    #endif
 
     #if Llama
     func test_current_llamaBuild_includesGGUF() {

--- a/Tests/ManifoldInferenceTests/ProviderParityFixtureCoverageTest.swift
+++ b/Tests/ManifoldInferenceTests/ProviderParityFixtureCoverageTest.swift
@@ -31,29 +31,24 @@ final class ProviderParityFixtureCoverageTest: XCTestCase {
 
     /// All registered backends with their fixture directory names.
     ///
-    /// Cloud entries are guarded by `#if CloudSaaS` / `#if Ollama` so the
-    /// manifest only grows when a trait that compiles the backend is active.
-    /// Local entries are unconditional because their fixture stub directories
-    /// exist even without hardware traits — the directories hold `.gitkeep`
+    /// Cloud and local entries are all unconditional: the cloud families
+    /// compile in every build since v0.48, and the local fixture stub
+    /// directories exist even without hardware traits — they hold `.gitkeep`
     /// files that satisfy the coverage check.
     private static var manifest: [(backendName: String, fixtureDirectory: String)] {
         var entries: [(backendName: String, fixtureDirectory: String)] = []
 
-        // Cloud backends — compiled when CloudSaaS trait is enabled.
-        #if CloudSaaS
+        // SaaS backends — always compiled since v0.48.
         entries += [
             (backendName: "openai.chat_completions", fixtureDirectory: "openai"),
             (backendName: "openai.responses",        fixtureDirectory: "openai_responses"),
             (backendName: "anthropic.messages",      fixtureDirectory: "claude"),
         ]
-        #endif
 
-        // Ollama backend — compiled when Ollama trait is enabled.
-        #if Ollama
+        // Ollama backend — always compiled since v0.48.
         entries += [
             (backendName: "ollama.chat", fixtureDirectory: "ollama"),
         ]
-        #endif
 
         // Local backends — always compiled; fixture directories are stubs.
         entries += [

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -622,7 +622,7 @@ final class TrafficBoundaryAuditTest: XCTestCase {
 
         // Sanity: the traits we know exist on `main` must all be present.
         // If this fails, the parser regressed before we even check Sources/.
-        for expected in ["MLX", "Llama", "Ollama", "CloudSaaS", "Fuzz"] {
+        for expected in ["MLX", "Llama", "Fuzz"] {
             XCTAssertTrue(
                 declaredTraits.contains(expected),
                 "parseDeclaredTraits failed to find expected trait '\(expected)' in Package.swift — the .trait(name: \"...\") regex has regressed."

--- a/Tests/ManifoldRuntimeTests/PromptContextPipelineConcurrencyTests.swift
+++ b/Tests/ManifoldRuntimeTests/PromptContextPipelineConcurrencyTests.swift
@@ -35,9 +35,12 @@ final class PromptContextPipelineConcurrencyTests: XCTestCase {
     }
 
     /// Three 50 ms providers run concurrently; total wall time is ~the slowest
-    /// single provider (~50 ms), not the sum (~150 ms). Asserts < 120 ms, which
-    /// is comfortably below the 140 ms sequential floor while leaving generous
-    /// scheduling-jitter slack for loaded CI runners.
+    /// single provider (~50 ms), not the sum (~150 ms). The assertion is
+    /// relative — pipeline wall time vs a same-process sequential walk of the
+    /// identical providers — because an absolute ceiling cannot tolerate
+    /// loaded CI runners (a 120 ms ceiling flaked twice at ~160 ms while the
+    /// fan-out was demonstrably still concurrent). Scheduler load inflates
+    /// both measurements together; the ratio survives it.
     func test_threeProvidersRunConcurrently() async throws {
         let providers: [any PromptContextProvider] = [
             SleepingProvider(sleep: .milliseconds(50)),
@@ -47,23 +50,30 @@ final class PromptContextPipelineConcurrencyTests: XCTestCase {
         let pipeline = PromptContextPipeline(providers: providers)
 
         let clock = ContinuousClock()
-        let elapsed = try await clock.measure {
+        let concurrent = try await clock.measure {
             _ = try await pipeline.assemble(messageCount: 0)
         }
+        // Sequential baseline: the same three providers awaited back-to-back
+        // under the same scheduler conditions (~150 ms unloaded).
+        let sequential = try await clock.measure {
+            for provider in providers {
+                _ = try await provider.contributeSlots(messageCount: 0)
+            }
+        }
 
-        // Concurrent fan-out: three 50 ms sleeps overlap = ~50 ms.
-        // Sequential execution would land at ~150 ms.
-        // The 120 ms ceiling distinguishes the two and tolerates scheduling
-        // jitter on loaded CI runners.
+        // True fan-out lands near 1/3 of the sequential walk; a regression to
+        // sequential execution lands near 1.0. 0.75 splits them with generous
+        // jitter slack in both directions.
         // Tracked by https://github.com/roryford/ManifoldKit/issues/1684
+        let ratio = concurrent / sequential
         XCTAssertLessThan(
-            elapsed,
-            .milliseconds(120),
+            ratio,
+            0.75,
             """
-            PromptContextPipeline ran in \(elapsed) — expected < 120 ms for \
-            concurrent execution of three 50 ms providers. If this exceeded \
-            120 ms, the pipeline is no longer running providers concurrently \
-            (regressed to the sequential ~150 ms walk).
+            PromptContextPipeline ran in \(concurrent) vs \(sequential) for the \
+            sequential walk of the same providers (ratio \(ratio)) — expected \
+            < 0.75 for concurrent fan-out. A ratio near 1.0 means the pipeline \
+            is no longer running providers concurrently.
             """
         )
     }

--- a/Tests/ManifoldSnapshotTests/SidebarAndSheetControlTests.swift
+++ b/Tests/ManifoldSnapshotTests/SidebarAndSheetControlTests.swift
@@ -257,7 +257,6 @@ final class SidebarAndSheetControlTests: XCTestCase {
 
     // MARK: - APIConfigurationView: Empty State
 
-    #if Ollama || CloudSaaS
     func test_apiConfigurationView_emptyState_showsNoneConfiguredMessage() throws {
         let container = try makeInMemoryContainer()
 
@@ -356,6 +355,5 @@ final class SidebarAndSheetControlTests: XCTestCase {
             "APIConfigurationView must be wrapped in a NavigationStack"
         )
     }
-    #endif
 
 }

--- a/Tests/ManifoldUIModelManagementTests/APIConfigurationViewMigrationGuardTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/APIConfigurationViewMigrationGuardTests.swift
@@ -14,25 +14,12 @@ import SwiftUI
 /// )
 /// ```
 ///
-/// The cloud-API content is gated behind `#if Ollama || CloudSaaS`, but the
-/// **type and `init()`** must remain public under disabled traits so the
-/// migration call-site compiles for chat-only consumers (e.g. Fireside,
-/// which builds without `Ollama`/`CloudSaaS`). The view body falls back to
-/// `EmptyView()` when the traits are off.
-///
-/// This file is intentionally **not** wrapped in `#if Ollama || CloudSaaS`
-/// — that's the whole point. It runs in the
-/// `swift test --filter ManifoldUIModelManagementTests --disable-default-traits`
-/// CI lane, which is exactly the configuration where Fireside lives.
-///
-/// ## Sabotage verification
-///
-/// To confirm the test actually catches a regression, restore whole-file
-/// `#if Ollama || CloudSaaS` gating around `APIConfigurationView` (the
-/// pre-fix layout) and re-run with default traits disabled. The build —
-/// and therefore this test — must fail to compile, because
-/// `APIConfigurationView` would no longer exist as a symbol. Restore the
-/// always-public layout before committing. (Verified 2026-04-26.)
+/// The **type and `init()`** must remain public in every build shape so the
+/// migration call-site compiles for chat-only consumers (e.g. Fireside).
+/// Historically the view body was gated behind the Ollama / CloudSaaS
+/// traits; those retired in v0.48 (PR A4) and the view now compiles whole
+/// in every configuration — this guard keeps the symbol public under
+/// `--disable-default-traits`, the lane where Fireside lives.
 final class APIConfigurationViewMigrationGuardTests: XCTestCase {
 
     @MainActor

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -34,8 +34,6 @@ ManifoldKit's test targets are conditionally linked on Swift package traits:
 | `Llama` | yes | LlamaBackend, llama.swift dependency |
 | `HuggingFace` | yes | HF model browser |
 | `AnyLanguageModel` | no | AnyLanguageModel bridge backend target |
-| `Ollama` | no | Ollama backend, requires `localhost:11434` |
-| `CloudSaaS` | no | OpenAI/Claude/Responses backends |
 | `Server` | no | ManifoldServer |
 | `Operational` | (planned, T4) | Nightly soak/migration/throughput |
 
@@ -190,7 +188,7 @@ This proves the assertion (a) exercises a real production code path, (b) is valu
 
 - **MLX integration**: `scripts/test-mlx-integration.sh` — Xcode-only, metallib required. See #986.
 - **MCP E2E**: `RUN_MCP_E2E=1 swift test --filter ManifoldMCPE2ESmokeTests` — gated by env var (the target compiles unconditionally since the MCP trait was retired in v0.48). The `everything-server` smoke has hung in past runs; filter to the streamable subset.
-- **Ollama**: requires `localhost:11434` and `--traits Ollama`.
+- **Ollama**: requires `localhost:11434` (backend always compiled since v0.48).
 - **Operational tier** (planned): nightly trait `Operational` for soak/migration/throughput/quality baseline.
 
 ### Local fixture manifest
@@ -292,7 +290,7 @@ Cold-start gates scaffold a fresh SwiftPM consumer in a tmpdir, depend on this r
 | Audience | Suite |
 |---|---|
 | Per-PR CI | All default-trait suites (the two-call shape above) |
-| Per-PR CI (matrix) | Per-trait builds for Ollama, CloudSaaS |
+| Per-PR CI (matrix) | Reduced-shape (`--disable-default-traits`) build incl. the always-compiled cloud backends |
 | Nightly | `ManifoldE2ETests`, MLX integration, `Operational` (planned T4) |
 | Pre-push (local) | The two-call shape |
 | Hardware-specific | `ManifoldE2ETests/LlamaThinkingE2ETests` etc. — install fixtures via `~/Library/Caches/ManifoldKit/test-models/manifest.json` |

--- a/docs/AppStoreSubmission.md
+++ b/docs/AppStoreSubmission.md
@@ -18,7 +18,7 @@ backends. That counts as encryption under U.S. export law.
 - **FoundationOnly / offline build** (`traits: ["FoundationOnly"]` or no
   cloud backends compiled in): set `ITSAppUsesNonExemptEncryption=false` in
   your `Info.plist`. No further filing needed.
-- **Cloud backends compiled in** (`CloudSaaS`, `Ollama`): set
+- **Cloud backends linked in** (always compiled since v0.48; linked unless you exclude the cloud products): set
   `ITSAppUsesNonExemptEncryption=true` and complete the annual
   self-classification form on App Store Connect. Most developers qualify
   for the "uses encryption only for app-specific authentication and HTTPS
@@ -141,9 +141,9 @@ ManifoldKit's overhead in your final IPA varies by build profile:
 | Profile | ManifoldKit overhead | Notes |
 |---------|--------------|-------|
 | `traits: ["FoundationOnly"]` | < 5 MB | Foundation Models only. Enforced by CI. |
-| Cloud-only (`CloudSaaS`, no MLX/Llama) | ~10 MB | Adds OpenAI / Claude SSE clients. |
+| Cloud-only (no MLX/Llama traits) | ~10 MB | Adds OpenAI / Claude SSE clients. |
 | Default (`MLX`, `Llama`, `HuggingFace`) | ~700 MB | MLX checkout (~100 MB) + LlamaSwift xcframework (~563 MB). |
-| Full (`MLX`, `Llama`, `Ollama`, `CloudSaaS`, `HuggingFace`) | ~700 MB | Same — Ollama and CloudSaaS are ~MB-scale text. |
+| Full (`MLX`, `Llama`, `HuggingFace`) | ~700 MB | Same — the always-compiled Ollama and SaaS clients are ~MB-scale text. |
 
 The MLX and Llama figures are checkout sizes; what lands in your IPA is
 smaller after dead-code stripping but still substantial. If your app

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -226,10 +226,15 @@ language in its ATO (Authority to Operate) or vendor questionnaire response:
 3. **Distribute via MDM** with a configuration profile that locks the OS
    version, disables jailbreak, and (if required by the cert) enables FIPS
    mode.
-4. **Disable cloud backends** if your deployment is local-only. Use the
-   `Ollama` and `CloudSaaS` traits to compile out SaaS code paths entirely
-   (see #714 Phases 1–4). This shrinks the audit surface for "data leaves
-   the device" review.
+4. **Exclude cloud backends** if your deployment is local-only. Since v0.48
+   the `Ollama`/`CloudSaaS` traits are retired and SaaS code paths are no
+   longer compiled out by a flag — exclusion is a **link-out** decision:
+   depend only on the products you need (e.g. `ManifoldInference` +
+   `ManifoldUI`, never `ManifoldBackends`/`ManifoldCloudSaaS`) and verify via
+   the per-mode symbol audit (`scripts/build-modes.sh <mode> --audit`), which
+   asserts no SaaS symbols or cloud hostname literals appear in the product
+   graph. This is a deliberate discontinuity from the pre-v0.48 compile-out
+   story (v0.48 plan decision #4); the audit artifact series continues.
 5. **Consider Keychain access groups + the Data Protection class
    `NSFileProtectionComplete`** for any persisted data adjacent to ManifoldKit
    (SwiftData stores, exports). ManifoldKit uses
@@ -274,8 +279,9 @@ Use this when responding to a procurement security review:
       CMVP certificate for Apple corecrypto.
 - [ ] If FIPS mode is required by the cert, an MDM configuration profile
       activates it on managed devices.
-- [ ] Cloud backends are either disabled (via `Ollama`/`CloudSaaS` traits) or
-      explicitly approved for the data classification in scope.
+- [ ] Cloud backends are either linked out (product-scoped dependency graph,
+      verified by the `scripts/build-modes.sh` symbol audit) or explicitly
+      approved for the data classification in scope.
 - [ ] The application code's own crypto usage (your code, not ManifoldKit's) has
       been audited against the same boundary criteria as §3 above.
 - [ ] The gap list (§"Gap list") has been reviewed and any

--- a/docs/FeatureMatrix.md
+++ b/docs/FeatureMatrix.md
@@ -6,7 +6,6 @@ Do not edit by hand — re-run the script.
 | Trait | Description | Capabilities Unlocked |
 |-------|-------------|-----------------------|
 | `AnyLanguageModel` | Reach providers without a native backend (Gemini, xAI, Groq, Mistral, OpenRouter, and others) through the AnyLanguageModel bridge. | `providerBridge` |
-| `CloudSaaS` | Third-party SaaS providers (Claude, OpenAI). Off by default. | `cloudOpenAI`, `cloudClaude`, `toolCalling`, `visionInput` |
 | `CoreAI` | Placeholder for Apple's rumoured Core AI framework (Core ML successor). No-op until WWDC 2026 confirms the surface. | _(none — harness/build lever)_ |
 | `FoundationOnly` | App Store-lean: Apple Foundation Models only. Pass `traits: ["FoundationOnly"]` from the consumer manifest — overrides the MLX/Llama/HuggingFace default trait set. | `foundationBackend` |
 | `Fuzz` | Enable real inference backends in fuzz-chat (Ollama, Llama, Foundation). Required by scripts/fuzz.sh; not needed for swift test or xcodebuild test. | _(none — harness/build lever)_ |
@@ -14,6 +13,5 @@ Do not edit by hand — re-run the script.
 | `Llama` | Enable the llama.cpp (GGUF) inference backend | `localInference`, `llamaBackend`, `embeddings` |
 | `Macros` | Enable the @ToolSchema macro plugin and its swift-syntax dependency. Off by default — pulls ~647 source files into the build graph. | `toolCalling` |
 | `MLX` | Enable the MLX inference backend (requires Apple Silicon) | `localInference`, `mlxBackend`, `visionInput`, `imageGeneration` |
-| `Ollama` | Self-hosted / private-datacenter HTTP inference. Moves out of defaults in next major. | `ollama`, `toolCalling`, `embeddings` |
 | `Server` | Enable ManifoldServer (OpenAI-compatible HTTP server) and its Hummingbird dependency. | `embeddings` |
 | `SystemAIProviderExtension` | Stubs for the iOS 27 system AI provider extension surface (Siri/Writing Tools backend slot). No-op until WWDC 2026 ships the API. | _(none — harness/build lever)_ |

--- a/docs/PROVIDER-BRIDGE.md
+++ b/docs/PROVIDER-BRIDGE.md
@@ -15,7 +15,7 @@ The bridge is the supported path for providers ManifoldKit does not implement na
 - **OpenRouter** (and any OpenAI-compatible `/responses` endpoint)
 - Any OpenAI- or Anthropic-API-compatible endpoint
 
-OpenAI, Anthropic, and Ollama also resolve through the bridge, but the native `CloudSaaS` / `Ollama` backends are preferred for those — they add certificate pinning, retry, circuit-breaking, and latest-wins cancellation that the bridge does not.
+OpenAI, Anthropic, and Ollama also resolve through the bridge, but the native backends (always compiled since v0.48) are preferred for those — they add certificate pinning, retry, circuit-breaking, and latest-wins cancellation that the bridge does not.
 
 ## Enabling the trait
 

--- a/docs/QUICKSTART-CLI.md
+++ b/docs/QUICKSTART-CLI.md
@@ -14,7 +14,7 @@ A one-page tutorial for getting from "empty terminal" to "streaming tokens" with
 
 Each section below is a complete, compile-tested example: a full `Package.swift` plus a full `main.swift`, ready to copy-paste into an empty directory and `swift run`.
 
-> **Evaluating against a local checkout?** Swap the `.package(url:from:)` line in each section for `.package(name: "ManifoldKit", path: "/path/to/ManifoldKit")`. The `name:` argument is required — SwiftPM derives package identity from the last path component of `.package(path:)`, which breaks under non-default checkout paths (e.g. worktrees, custom directory names). `traits:` works on this form too — `.package(name: "ManifoldKit", path: "/path/to/ManifoldKit", traits: [.trait(name: "Ollama")])` for the §3 cloud snippet.
+> **Evaluating against a local checkout?** Swap the `.package(url:from:)` line in each section for `.package(name: "ManifoldKit", path: "/path/to/ManifoldKit")`. The `name:` argument is required — SwiftPM derives package identity from the last path component of `.package(path:)`, which breaks under non-default checkout paths (e.g. worktrees, custom directory names). `traits:` works on this form too — `.package(name: "ManifoldKit", path: "/path/to/ManifoldKit", traits: [.trait(name: "Llama")])` for the §2 local snippet.
 
 ---
 
@@ -45,16 +45,16 @@ dependencies: [
         url: "https://github.com/roryford/ManifoldKit.git",
         from: "0.47.0", // x-release-please-version
         traits: [
-            .trait(name: "Ollama"),     // local Ollama server
-            .trait(name: "CloudSaaS"),  // OpenAI / Anthropic
             // Omit "MLX" / "Llama" to skip those backends entirely
-            // (saves compile time if you're cloud-only).
+            // (saves compile time if you're cloud-only — cloud backends
+            // always compile since v0.48; no trait needed).
+            .trait(name: "Llama"),
         ]
     ),
 ],
 ```
 
-> **Both forms are composable.** A local-path dependency can specify traits too: `.package(name: "ManifoldKit", path: "../ManifoldKit", traits: [.trait(name: "Ollama")])`.
+> **Both forms are composable.** A local-path dependency can specify traits too: `.package(name: "ManifoldKit", path: "../ManifoldKit", traits: [.trait(name: "Llama")])`.
 
 ---
 
@@ -369,7 +369,7 @@ If you're not sure whether your GGUF is a reasoning model, the simplest test is 
 
 For any HTTP-speaking provider — Ollama at `localhost:11434`, OpenAI, Anthropic, LM Studio, or a custom OpenAI-compatible endpoint — the entry point is `InferenceService.loadEndpointBackend(from:)` with an `APIEndpointRecord` describing the endpoint.
 
-> **Trait requirement.** Cloud backends are trait-gated. Add `Ollama` to your `traits:` for `localhost:11434`, or `CloudSaaS` for OpenAI / Claude. The default trait set (`MLX`, `Llama`, `HuggingFace`) does **not** include either. See [docs/FeatureMatrix.md](FeatureMatrix.md).
+> **No trait required.** Cloud backends (Ollama, OpenAI, Claude, LM Studio, custom endpoints) always compile since v0.48 — the former `Ollama`/`CloudSaaS` traits are retired. See [docs/FeatureMatrix.md](FeatureMatrix.md).
 
 **`Package.swift`:**
 
@@ -387,10 +387,7 @@ let package = Package(
         .package(
             url: "https://github.com/roryford/ManifoldKit.git",
             from: "0.47.0", // x-release-please-version
-            traits: [
-                .trait(name: "Ollama"),     // for localhost:11434
-                .trait(name: "CloudSaaS"),  // for OpenAI / Anthropic
-            ]
+            traits: []  // cloud backends need no traits since v0.48
         ),
     ],
     targets: [

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -69,7 +69,7 @@ struct MyChatApp: App {
 Run the app. `quickStart()` will compile, launch, and render a usable composer — but the chat will be inert until a backend is selected. See [First-launch backend selection](#first-launch-backend-selection) for the next step.
 
 > [!IMPORTANT]
-> **The trait cliff: no backend trait → a *runtime* throw, not a compile error.** If your build compiles in **zero** inference backends for the active trait / OS combination, `ManifoldKit.quickStart()` throws [`ManifoldKitError.noBackendsRegistered`](../Sources/ManifoldModelCatalog/ManifoldKitError.swift) when you call it — it compiles fine, then fails at launch. This is deliberate: it surfaces the real cause ("no backend traits enabled") at the assembly boundary instead of a confusing "No model loaded" on the first turn. The defaults (`MLX`, `Llama`, `HuggingFace`) always include at least one backend, so you only hit this if you pass a custom `traits:` array that selects no inference backend, or build with `--disable-default-traits`. Pick at least one of `MLX`, `Llama`, `CloudSaaS`, `Ollama`, or `FoundationOnly` — see [Customizing backends](#customizing-backends) for the per-profile trait sets.
+> **The trait cliff: no backend trait → a *runtime* throw, not a compile error.** If your build compiles in **zero** inference backends for the active trait / OS combination, `ManifoldKit.quickStart()` throws [`ManifoldKitError.noBackendsRegistered`](../Sources/ManifoldModelCatalog/ManifoldKitError.swift) when you call it — it compiles fine, then fails at launch. This is deliberate: it surfaces the real cause ("no backend traits enabled") at the assembly boundary instead of a confusing "No model loaded" on the first turn. The defaults (`MLX`, `Llama`, `HuggingFace`) always include at least one backend, so you only hit this if you pass a custom `traits:` array that selects no inference backend, or build with `--disable-default-traits`. Since v0.48 the cloud backends (Ollama, OpenAI, Claude) always compile, so a registered build always has cloud support — the throw only fires if nothing was *registered* (e.g. you skipped `quickStart()`/`DefaultBackends.register(with:)`). For local inference pick at least one of `MLX`, `Llama`, or `FoundationOnly` — see [Customizing backends](#customizing-backends) for the per-profile trait sets.
 
 > **Session bootstrap.** `quickStart()` auto-creates an initial empty `ChatSessionRecord` and activates it on first launch when the persistent store has no sessions yet, so `ChatView`'s composer is enabled the moment the view appears. On subsequent launches the most-recent existing session is selected. Hosts that need finer control over the initial session (custom title, system prompt, restoring from a deep link) can drop down to `ManifoldBootstrap.build(...)` directly and seed through the canonical composite accessor `bootstrap.persistenceStores` before constructing the view model — `quickStart()` only auto-creates when the store is *empty*, so seeding one session first opts out cleanly. The full session-management surface (list sidebar, create/delete/rename) lives on `SessionManagerViewModel` — see the [Building a Chat UI](../Sources/ManifoldUI/ManifoldUI.docc/Articles/BuildingAChatUI.md) DocC article for the worked example.
 
@@ -217,7 +217,7 @@ struct MyChatApp: App {
 
 For cloud / LAN backends (Ollama, OpenAI Chat Completions, OpenAI Responses, Anthropic Claude), the host inserts an `APIEndpointRecord` into the endpoint store *before* the view appears. `quickStart()` exposes the store on `result.bootstrap.endpointStore`; `ChatViewModel.refreshAvailableEndpointsFromStore()` is wired up automatically and will pick up the new endpoint. If you want a seeded endpoint to be live immediately (single-endpoint apps, scripted demos, kiosk flows), also set `selectedEndpoint` and call `loadSelectedEndpoint()` before exposing the view model.
 
-⚠️ Ollama is gated behind the `Ollama` SwiftPM trait — see [Customizing backends](#customizing-backends) for the manifest snippet. Without that trait, no Ollama backend is registered for the seeded endpoint.
+Ollama support is always compiled in since v0.48 (the `Ollama` trait was retired) — the seeded endpoint is the only configuration step.
 
 ```swift,no-build
 import SwiftUI
@@ -308,7 +308,7 @@ If you don't want the full model-management UI (e.g. cloud-only apps that seed a
 
 ## Customizing backends
 
-`quickStart()` registers every backend that's compiled into your build (gated by SwiftPM traits). To control which backends ship, pass a `traits:` array on your `.package(...)` dependency:
+`quickStart()` registers every backend that's compiled into your build. The cloud backends (Ollama, OpenAI, Claude) always compile since v0.48; the local backends are gated by SwiftPM traits. To control which local backends ship, pass a `traits:` array on your `.package(...)` dependency:
 
 ```swift
 .package(
@@ -317,8 +317,6 @@ If you don't want the full model-management UI (e.g. cloud-only apps that seed a
     traits: [
         .trait(name: "MLX"),           // default-on
         .trait(name: "Llama"),         // default-on
-        .trait(name: "CloudSaaS"),     // opt-in: OpenAI, Claude
-        .trait(name: "Ollama"),        // opt-in: localhost:11434
     ]
 )
 ```
@@ -329,9 +327,8 @@ Common profiles:
 |----------|--------|
 | Default consumer app | leave defaults (`MLX`, `Llama`, `HuggingFace`) |
 | App Store-lean (Foundation Models only) | `["FoundationOnly"]` — see [docs/AppStoreSubmission.md](AppStoreSubmission.md) |
-| SaaS-only | `["CloudSaaS"]` (drop MLX/Llama if you don't need local models) |
-| Self-hosted / private datacenter | `["MLX", "Llama", "Ollama"]` |
-| Full | `["MLX", "Llama", "Ollama", "CloudSaaS"]` |
+| Cloud-only (no local models) | `["FoundationOnly"]` or `--disable-default-traits` — cloud is always compiled in |
+| Full | leave defaults (`MLX`, `Llama`, `HuggingFace`) — cloud included automatically |
 
 See [`docs/FeatureMatrix.md`](FeatureMatrix.md) for the full trait → capability table.
 

--- a/docs/TRAIT-COSTS.md
+++ b/docs/TRAIT-COSTS.md
@@ -25,8 +25,6 @@
 | `MLX` | ManifoldMLX + StableDiffusion + FluxSwift | `mlx-swift`, `mlx-swift-lm` | ~121 | — | +42652 | +464 |
 | `Llama` | ManifoldLlama | `llama.swift` | — | ~617 | +8 | — |
 | `HuggingFace` | ManifoldHuggingFace | `swift-huggingface` | ~2 | — | +5026 | — |
-| `CloudSaaS` | ManifoldCloud (SaaS bodies) | _(none beyond baseline)_ | — | — | +731 | — |
-| `Ollama` | ManifoldCloud (Ollama bodies) | _(none beyond baseline)_ | — | — | +731 | — |
 | `Server` | ManifoldServer + Hummingbird | `EventSource`, `swift-nio`, `swift-crypto`, `swift-collections`, `swift-atomics`, `swift-system` | ~74 | — | +12157 | — |
 | `Macros` | ManifoldMacrosPlugin + @ToolSchema | `swift-syntax` | ~11 | — | +0 | — |
 | `AnyLanguageModel` | AnyLanguageModel bridge | _(none beyond baseline)_ | — | — | — | — |
@@ -52,7 +50,7 @@ These map to the modes in `scripts/build-modes.sh`. Costs here are **not** the s
 |------|----------------|-------------------------------|-------|
 | **FoundationOnly** | `FoundationOnly` | ~259 cloned, ~0 compiled | ≤5 MB compiled; all ~876 MB fetched once |
 | **local-only** (default) | `MLX`, `Llama`, `HuggingFace` | ~259 cloned | Default when no `traits:` override; on-device only |
-| **cloud-only** | `CloudSaaS` or `Ollama` | ~259 cloned | Pure HTTP; no local model deps compiled |
+| **cloud-only** | _(none — cloud always compiled since v0.48; build the `ManifoldOllama` / `ManifoldCloudSaaS` products)_ | ~259 cloned | Pure HTTP; no local model deps compiled |
 | **full** | all non-Fuzz traits | ~259 cloned | ~617 MB xcframework + Metal compile |
 
 ¹ All modes clone the same ~259 MB of source checkouts plus the ~617 MB llama.cpp xcframework on first resolve. The FoundationOnly mode _compiles_ ~5 MB. See footnote 1 in the table above and the resolution note.

--- a/docs/trait-costs.json
+++ b/docs/trait-costs.json
@@ -62,32 +62,6 @@
   "method_version": "1",
   "notes": "swift-huggingface: HuggingFace Hub browsing/download library. ManifoldHuggingFace wrapper=9 KB, HuggingFace library=5017 KB stripped."
 },{
-  "trait": "CloudSaaS",
-  "modules_added": "ManifoldCloud (SaaS bodies)",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "731",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "ManifoldCloud SaaS bodies (Claude, OpenAI Chat, OpenAI Responses) + ManifoldCloudCore. ManifoldCloud=140 KB + ManifoldCloudCore=591 KB. No unique external checkout."
-},{
-  "trait": "Ollama",
-  "modules_added": "ManifoldCloud (Ollama bodies)",
-  "transitive_deps": [],
-  "checkout_attributed_mb": 0,
-  "artifact_mb": 0,
-  "binary_delta_kb": "731",
-  "cold_build_delta_s": "N/A",
-  "measured_at": "2026-06-10T19:40:00Z",
-  "toolchain": "swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)",
-  "machine": "Apple Silicon (arm64)",
-  "method_version": "1",
-  "notes": "Same ManifoldCloud + ManifoldCloudCore modules as CloudSaaS; Ollama HTTP dialect compiled in instead of SaaS endpoints."
-},{
   "trait": "Server",
   "modules_added": "ManifoldServer + Hummingbird",
   "transitive_deps": ["EventSource", "swift-nio", "swift-crypto", "swift-collections", "swift-atomics", "swift-system"],

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -44,7 +44,7 @@
 #
 # ## First-run note
 #
-# On a clean checkout, run `xcrun swift build --traits Ollama,Llama,MLX` once
+# On a clean checkout, run `xcrun swift build --traits Llama,MLX` once
 # before invoking this script. The warm-up step below does this automatically.
 
 set -euo pipefail
@@ -94,7 +94,7 @@ fi
 # Ensures _NumericsShims and all module interfaces are cached before the
 # parallel xcrun swift test compilations start. No-op on subsequent runs.
 log "Warming up build artifacts (xcrun swift build)…"
-xcrun swift build --traits Ollama,Llama,MLX 2>&1 | { grep -E "Build complete|^error:" || true; } | head -3 || true
+xcrun swift build --traits Llama,MLX 2>&1 | { grep -E "Build complete|^error:" || true; } | head -3 || true
 
 # ── Backend detection ─────────────────────────────────────────────────────────
 OLLAMA_AVAILABLE=0
@@ -184,7 +184,7 @@ if [[ $OLLAMA_AVAILABLE -eq 1 ]] && \
    [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "sdk-ollama" ]]; then
     head_ "ManifoldKit SDK → OllamaBackend"
     SDK_OUT=$(MANIFOLD_BENCH_OLLAMA_MODEL="$OLLAMA_MODEL" \
-        xcrun swift test --traits Ollama \
+        xcrun swift test \
             --filter OllamaBackendBenchmark \
             --skip-update 2>&1)
     echo "$SDK_OUT" | grep -E "ManifoldKit→Ollama run|BENCH_RESULT" || true
@@ -255,7 +255,7 @@ run_server_bench() {
 if [[ $OLLAMA_AVAILABLE -eq 1 ]] && \
    [[ -z "$ONLY_PATH" || "$ONLY_PATH" == "server-ollama" ]]; then
     head_ "ManifoldKit server → OllamaBackend"
-    run_server_bench "Server,Ollama" "ollama" \
+    run_server_bench "Server" "ollama" \
         "--model $OLLAMA_MODEL --ollama-base-url $OLLAMA_URL" \
         "ManifoldKit server→Ollama"
 fi

--- a/scripts/build-modes.sh
+++ b/scripts/build-modes.sh
@@ -8,12 +8,30 @@
 # Usage:
 #   scripts/build-modes.sh <mode> [--build-only|--audit]
 #
-# Modes:
-#   offline   No network backends. `--disable-default-traits`.
-#   ollama    Self-hosted Ollama only. `--disable-default-traits --traits Ollama`.
-#   saas      Cloud SaaS only. `--disable-default-traits --traits CloudSaaS`.
-#   full      Everything. `--traits MLX,Llama,Ollama,CloudSaaS` (default-traits enabled).
+# Modes (v0.48 PR A4 — the Ollama/CloudSaaS traits are retired; cloud sources
+# always compile, so the modes are now PRODUCT-scoped builds. The audit claim
+# shifted from compile-out — "the trait excluded the source" — to link-out —
+# "the product dependency graph never includes the module". Decision #4 of the
+# v0.48 plan accepted this artifact-series discontinuity; the per-mode
+# artifact files keep their names and cadence.):
+#   offline   Chat stack with no backend products: `--disable-default-traits
+#             --target ManifoldUI`. No cloud module in the graph.
+#   ollama    Self-hosted family only: `--disable-default-traits --target
+#             ManifoldOllama`. ManifoldCloudCore (shared TLS-pinning/SSE
+#             infra) IS in this graph; the SaaS backends are not.
+#   saas      SaaS family only: `--disable-default-traits --target
+#             ManifoldCloudSaaS`.
+#   full      Everything: plain `swift build` (default traits MLX/Llama/
+#             HuggingFace; cloud is always compiled).
 #   all       Run every mode in sequence.
+#
+# `--target`, not `--product`: `swift build --product <automatic library>`
+# does NOT prune the build to the product's graph (it compiles every target
+# in the package — verified empirically), which would put SaaS objects in
+# every mode's scan. `--target` builds exactly the target's dependency
+# closure. The audit additionally wipes the release object dir before each
+# build so a scan can never pass (or fail) on stale objects from a previous
+# mode or branch.
 #
 # Subcommands:
 #   --build-only  Build the mode (debug). Default when no subcommand given.
@@ -34,15 +52,16 @@ if [[ -z "$MODE" ]]; then
   exit 2
 fi
 
-# Trait flags per mode. `--disable-default-traits` strips MLX+Llama (the
-# default set) so that offline really means offline. `full` keeps the defaults
-# and layers Ollama+CloudSaaS on top.
-traits_for_mode() {
+# Build arguments per mode. Product-scoped since v0.48 (see header):
+# excluding cloud code is a link-out decision at the product edge, not a
+# compile flag. `--disable-default-traits` additionally strips MLX+Llama so
+# the offline/family graphs stay minimal.
+build_args_for_mode() {
   case "$1" in
-    offline) echo "--disable-default-traits" ;;
-    ollama)  echo "--disable-default-traits --traits Ollama" ;;
-    saas)    echo "--disable-default-traits --traits CloudSaaS" ;;
-    full)    echo "--traits MLX,Llama,Ollama,CloudSaaS" ;;
+    offline) echo "--disable-default-traits --target ManifoldUI" ;;
+    ollama)  echo "--disable-default-traits --target ManifoldOllama" ;;
+    saas)    echo "--disable-default-traits --target ManifoldCloudSaaS" ;;
+    full)    echo "" ;;
     *)
       echo "Unknown mode: $1 (expected offline|ollama|saas|full)" >&2
       exit 2
@@ -50,15 +69,21 @@ traits_for_mode() {
   esac
 }
 
-# Symbols that must NOT appear in modes which exclude the CloudSaaS trait.
+# Symbols that must NOT appear in modes which exclude the SaaS product.
 # Matched against `nm -gU` output, which surfaces both the Swift mangled form
-# (`$s17ManifoldBackends13ClaudeBackendC`) and the Obj-C metaclass form
-# (`_OBJC_CLASS_$_ManifoldBackends.ClaudeBackend`). Catches both runtime
-# entry points (Tin-foil-hat SEV-2.6 in the plan).
-CLOUD_SYMBOLS=(
+# (`$s17ManifoldCloudSaaS13ClaudeBackendC`) and the Obj-C metaclass form.
+# Catches both runtime entry points (Tin-foil-hat SEV-2.6 in the plan).
+SAAS_SYMBOLS=(
   "ClaudeBackend"
   "OpenAIBackend"
   "OpenAIResponsesBackend"
+)
+
+# Additionally banned in OFFLINE mode only. PinnedSessionDelegate lives in
+# ManifoldCloudCore — shared TLS-pinning infrastructure that the Ollama
+# product legitimately links (discontinuity vs the pre-v0.48 trait-mode
+# audit, where the umbrella-scoped scan never saw it at all).
+OFFLINE_ONLY_SYMBOLS=(
   "PinnedSessionDelegate"
 )
 
@@ -85,20 +110,20 @@ ARTIFACT_DIR="${BUILD_MODES_ARTIFACT_DIR:-build-modes-audit}"
 
 build_mode() {
   local mode="$1"
-  local traits
-  traits=$(traits_for_mode "$mode")
+  local build_args
+  build_args=$(build_args_for_mode "$mode")
 
   echo ""
   echo "=== build-modes: building [$mode] (debug) ==="
-  echo "    swift build $traits"
+  echo "    swift build $build_args"
   # shellcheck disable=SC2086
-  swift build $traits
+  swift build $build_args
 }
 
 audit_mode() {
   local mode="$1"
-  local traits
-  traits=$(traits_for_mode "$mode")
+  local build_args
+  build_args=$(build_args_for_mode "$mode")
 
   # The audit relies on Darwin-only flags (`nm -gU`, `otool -L`, `strings -e l`)
   # against Mach-O object files. Refuse to run on non-macOS rather than emit
@@ -111,23 +136,34 @@ audit_mode() {
 
   echo ""
   echo "=== build-modes: auditing [$mode] (release) ==="
-  echo "    swift build -c release $traits"
+
+  # Clean-room scan: wipe the release object dir first so the symbol scan
+  # below can only see objects produced by THIS mode's build. Without this,
+  # a previous mode (or branch) leaves stale .o files in release/ and the
+  # whole-graph scan reports them as violations (or silently vouches for a
+  # graph it didn't build).
+  find .build -maxdepth 2 -type d -name 'release' -path '*-apple-macosx*' -exec rm -rf {} + 2>/dev/null || true
+
+  echo "    swift build -c release $build_args"
   # shellcheck disable=SC2086
-  swift build -c release $traits
+  swift build -c release $build_args
 
   mkdir -p "$ARTIFACT_DIR/$mode"
 
-  # Locate the ManifoldBackends release object directory. SwiftPM emits per-
-  # target build folders under .build/<arch>-apple-macosx/release/<Target>.build/.
-  local backends_dir
-  backends_dir=$(find .build -type d -path '*/release/ManifoldBackends.build' 2>/dev/null | head -n 1 || true)
+  # Scan the ENTIRE product build graph (every <Target>.build directory under
+  # release/), not just the umbrella. Product-scoped modes make the link-out
+  # claim at the product edge: a banned symbol anywhere in the graph means the
+  # product's dependency closure includes a module it must not.
+  local release_dir
+  release_dir=$(find .build -type d -name 'release' -path '*-apple-macosx*' 2>/dev/null | head -n 1 || true)
 
   local audit_failures=0
 
-  if [[ -z "$backends_dir" ]]; then
-    echo "    note: ManifoldBackends.build not found — module excluded from this mode."
+  if [[ -z "$release_dir" ]]; then
+    echo "::error::build-modes audit [$mode]: release build directory not found" >&2
+    return 1
   else
-    echo "    ManifoldBackends.build at: $backends_dir"
+    echo "    scanning release graph at: $release_dir"
 
     # Snapshot per-mode artifacts for the procurement evidence archive.
     # `nm.txt` is the *gating* file: every line in it must be a real symbol
@@ -172,45 +208,69 @@ audit_mode() {
         # surface as UTF-16 when bridged through ObjC NSString or NSURL.
         strings -a -e l "$obj" 2>/dev/null || true
       } >> "$strings_utf16_out"
-    done < <(find "$backends_dir" -name '*.o' -print0)
+    done < <(find "$release_dir" -path '*.build/*' -name '*.o' \
+               ! -name 'APIProvider.swift.o' \
+               ! -name 'BackendDescriptor.swift.o' \
+               ! -name 'APIEndpointRecord.swift.o' -print0)
+    # Excluded objects hold provider hostnames as *data*, not cloud code:
+    # APIProvider.swift / BackendDescriptor.swift (ManifoldHardware) carry
+    # defaultBaseURL metadata for the provider registry; APIEndpointRecord
+    # (ManifoldModelCatalog) carries per-provider endpoint defaults. Every
+    # mode links these leaf modules. Same scoping exemption as the
+    # pre-v0.48 audit documented in SECURITY.md. None of them define any
+    # symbol on the banned lists, so excluding them from the nm scan too
+    # is safe and keeps the find expression single-purpose.
 
-    # otool -L runs against the linked dylib if one was produced; SwiftPM
-    # produces a static archive for libraries by default, so this is a best-
+    # otool -L runs against linked dylibs if any were produced; SwiftPM
+    # produces static archives for libraries by default, so this is a best-
     # effort capture for the artifact rather than a hard gate.
-    local backends_dylib
-    backends_dylib=$(find .build -type f \( -name 'libManifoldBackends.dylib' -o -name 'ManifoldBackends.o' \) 2>/dev/null | head -n 1 || true)
-    if [[ -n "$backends_dylib" ]]; then
+    local linked_dylib
+    linked_dylib=$(find "$release_dir" -maxdepth 1 -type f -name '*.dylib' 2>/dev/null | head -n 1 || true)
+    if [[ -n "$linked_dylib" ]]; then
       {
-        echo "### $backends_dylib"
-        otool -L "$backends_dylib" 2>/dev/null || true
+        echo "### $linked_dylib"
+        otool -L "$linked_dylib" 2>/dev/null || true
       } >> "$otool_out"
     fi
 
-    # Audit gate: in modes WITHOUT CloudSaaS, no cloud symbols must appear.
-    # `grep -F` (fixed strings) avoids regex surprises if a symbol name ever
-    # contains a metacharacter; it also avoids matching the per-object-path
-    # `### …` headers because we wrote a header-free `$nm_out`.
+    # Audit gate: in modes that exclude the SaaS product, no SaaS symbols
+    # must appear anywhere in the product graph. `grep -F` (fixed strings)
+    # avoids regex surprises if a symbol name ever contains a metacharacter;
+    # it also avoids matching the per-object-path `### …` headers because we
+    # wrote a header-free `$nm_out`.
     if [[ "$mode" == "offline" || "$mode" == "ollama" ]]; then
       echo ""
-      echo "    asserting NO cloud symbols in [$mode]"
-      for sym in "${CLOUD_SYMBOLS[@]}"; do
+      echo "    asserting NO SaaS symbols in [$mode]"
+      for sym in "${SAAS_SYMBOLS[@]}"; do
         if grep -Fq "$sym" "$nm_out"; then
-          echo "::error::build-modes audit [$mode]: cloud symbol '$sym' present in ManifoldBackends release objects"
+          echo "::error::build-modes audit [$mode]: SaaS symbol '$sym' present in the [$mode] product graph"
           grep -F "$sym" "$nm_out" | head -n 5 >&2 || true
           audit_failures=$((audit_failures + 1))
         fi
       done
 
-      # Hostname literals in ManifoldBackends. APIProvider.swift in
-      # ManifoldInference legitimately holds these as data — that module is
-      # intentionally out of scope here (see SECURITY.md).
+      if [[ "$mode" == "offline" ]]; then
+        # Offline additionally bans the shared cloud-networking infra that the
+        # ollama product legitimately links via ManifoldCloudCore.
+        for sym in "${OFFLINE_ONLY_SYMBOLS[@]}"; do
+          if grep -Fq "$sym" "$nm_out"; then
+            echo "::error::build-modes audit [offline]: cloud-infra symbol '$sym' present in the offline product graph"
+            grep -F "$sym" "$nm_out" | head -n 5 >&2 || true
+            audit_failures=$((audit_failures + 1))
+          fi
+        done
+      fi
+
+      # Hostname literals anywhere in the offline product graph.
+      # APIProvider.swift (ManifoldHardware) legitimately holds these as
+      # data and is excluded from the scan above (see SECURITY.md).
       if [[ "$mode" == "offline" ]]; then
         echo "    asserting NO cloud hostname literals in [$mode]"
         for host in "${CLOUD_HOSTS[@]}"; do
           # `grep -F` (fixed strings) is required — `$host` contains dots,
           # which would otherwise match arbitrary characters in default BRE.
           if grep -Fq "$host" "$strings_ascii_out" || grep -Fq "$host" "$strings_utf16_out"; then
-            echo "::error::build-modes audit [$mode]: hostname literal '$host' present in ManifoldBackends release objects"
+            echo "::error::build-modes audit [$mode]: hostname literal '$host' present in the offline product graph"
             audit_failures=$((audit_failures + 1))
           fi
         done

--- a/scripts/ci-selective-test.sh
+++ b/scripts/ci-selective-test.sh
@@ -74,13 +74,14 @@ run_swift_test() {
 for suite in "$@"; do
   case "$suite" in
     ManifoldBackendsTests)
-      run_swift_test "$suite" --disable-default-traits --traits CloudSaaS
+      run_swift_test "$suite" --disable-default-traits
       ;;
     ManifoldVoiceTests|ManifoldSkillsTests|ManifoldToolsTests|ManifoldAppIntentsTests)
       # No .xcscheme for these suites; their traits were retired in v0.48
-      # (PR A3) so they compile under the shared MCP,CloudSaaS lane shape and
-      # reuse its .build. swift test routing avoids the no-scheme failure path.
-      run_swift_test "$suite" --disable-default-traits --traits MCP,CloudSaaS
+      # (PR A3) so they compile under the shared --disable-default-traits
+      # lane shape and reuse its .build. swift test routing avoids the
+      # no-scheme failure path.
+      run_swift_test "$suite" --disable-default-traits
       ;;
     *)
       run_xcodebuild "$suite"

--- a/scripts/cold-start-specialised-uimodelmanagement.sh
+++ b/scripts/cold-start-specialised-uimodelmanagement.sh
@@ -11,8 +11,8 @@
 # changes that drop ManifoldUI / ManifoldRuntime / ManifoldInference (all of
 # which ManifoldUIModelManagement depends on unconditionally).
 #
-# ManifoldUIModelManagement compiles unconditionally — HuggingFace / Ollama /
-# CloudSaaS traits only add conditional-compilation defines that expand model
+# ManifoldUIModelManagement compiles unconditionally — the HuggingFace
+# trait only adds conditional-compilation defines that expand model
 # source and API-key editor surface. The gate runs without those traits so it
 # exercises the baseline, always-present slice.
 #

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/fuzz.sh — Run the ManifoldFuzz harness with a friendly preflight.
 #
-# Default behaviour (no args): runs `swift run --traits Fuzz,MLX,Llama,Ollama
+# Default behaviour (no args): runs `swift run --traits Fuzz,MLX,Llama
 # fuzz-chat --minutes 5` against llama.cpp. Discovers which backends are usable and
 # prints a one-line summary before kicking off the harness.
 #
@@ -25,7 +25,7 @@ for arg in "$@"; do
         --with-mlx) WITH_MLX=1 ;;
         -h|--help)
             cd "$PACKAGE_DIR"
-            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat\` (default backend: llama)"
+            echo "scripts/fuzz.sh — wrapper around \`swift run --traits Fuzz,MLX,Llama fuzz-chat\` (default backend: llama)"
             echo ""
             echo "Local flags:"
             echo "  --with-mlx   Also run the MLX XCTest fuzz suite via xcodebuild"
@@ -36,7 +36,7 @@ for arg in "$@"; do
             echo "  export OPENROUTER_API_KEY=sk-or-...   # preferred; or OPENAI_API_KEY"
             echo "  scripts/fuzz.sh --backend openai --base-url https://openrouter.ai/api \\"
             echo "                  --model deepseek/deepseek-r1:free --minutes 5"
-            echo "  Adds the CloudSaaS trait automatically. Caveats: replay/shrink unavailable"
+            echo "  Caveats: replay/shrink unavailable"
             echo "  (non-deterministic); free models are rate-limited (429) and ':free' slugs may"
             echo "  404 on data-policy gating; --base-url must omit /v1 (backend appends it)."
             echo "  --request-timeout N   per-request HTTP idle timeout in seconds (default 90)."
@@ -44,9 +44,9 @@ for arg in "$@"; do
             echo "                        per request; detectors flag >60s, so 90s loses no signal"
             echo "                        while protecting throughput. openai path only."
             echo ""
-            echo "Forwarding to: swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h"
+            echo "Forwarding to: swift run --traits Fuzz,MLX,Llama fuzz-chat -h"
             echo "─────────────────────────────────────────────────────────────"
-            swift run --traits Fuzz,MLX,Llama,Ollama fuzz-chat -h || true
+            swift run --traits Fuzz,MLX,Llama fuzz-chat -h || true
             exit 0
             ;;
         *) FORWARDED_ARGS+=("$arg") ;;
@@ -83,13 +83,12 @@ if ! [[ "$REQUESTED_WORKERS" =~ ^[0-9]+$ ]] || (( REQUESTED_WORKERS < 1 )); then
     exit 2
 fi
 
-# Trait set forwarded to `swift run`. The openai (OpenAI-compatible cloud)
-# backend additionally needs the CloudSaaS trait so ManifoldCloud's
-# OpenAIBackend links into fuzz-chat.
-TRAITS="Fuzz,MLX,Llama,Ollama"
+# Trait set forwarded to `swift run`. The Ollama and CloudSaaS traits were
+# retired in v0.48 (PR A4) — the cloud families (including the openai
+# OpenAI-compatible backend) always compile into fuzz-chat under Fuzz.
+TRAITS="Fuzz,MLX,Llama"
 CLOUD_BACKEND=0
 if [[ "$REQUESTED_BACKEND" == "openai" ]]; then
-    TRAITS="Fuzz,CloudSaaS,MLX,Llama,Ollama"
     CLOUD_BACKEND=1
 fi
 

--- a/scripts/measure-trait-costs.sh
+++ b/scripts/measure-trait-costs.sh
@@ -148,8 +148,6 @@ declare -A TRAIT_DEPS
 TRAIT_DEPS["MLX"]="mlx-swift mlx-swift-lm"
 TRAIT_DEPS["Llama"]="llama.swift"          # xcframework in artifacts/llama.swift
 TRAIT_DEPS["HuggingFace"]="swift-huggingface"
-TRAIT_DEPS["CloudSaaS"]=""                 # ManifoldCloudCore always compiled; no unique checkout
-TRAIT_DEPS["Ollama"]=""                    # same ManifoldCloudCore path, no unique checkout
 TRAIT_DEPS["Server"]="EventSource swift-nio swift-crypto swift-collections swift-atomics swift-system"
 TRAIT_DEPS["Macros"]="swift-syntax"
 TRAIT_DEPS["Fuzz"]=""                     # fuzz-chat executable only
@@ -161,8 +159,6 @@ declare -A TRAIT_MODULES
 TRAIT_MODULES["MLX"]="ManifoldMLX + StableDiffusion + FluxSwift"
 TRAIT_MODULES["Llama"]="ManifoldLlama"
 TRAIT_MODULES["HuggingFace"]="ManifoldHuggingFace"
-TRAIT_MODULES["CloudSaaS"]="ManifoldCloud (SaaS bodies)"
-TRAIT_MODULES["Ollama"]="ManifoldCloud (Ollama bodies)"
 TRAIT_MODULES["Server"]="ManifoldServer + Hummingbird"
 TRAIT_MODULES["Macros"]="ManifoldMacrosPlugin + @ToolSchema"
 TRAIT_MODULES["Fuzz"]="fuzz-chat executable (real backends)"
@@ -176,8 +172,6 @@ declare -A TRAIT_FLAGS
 TRAIT_FLAGS["MLX"]="--traits MLX"
 TRAIT_FLAGS["Llama"]="--traits Llama"
 TRAIT_FLAGS["HuggingFace"]="--traits HuggingFace"
-TRAIT_FLAGS["CloudSaaS"]="--disable-default-traits --traits CloudSaaS"
-TRAIT_FLAGS["Ollama"]="--disable-default-traits --traits Ollama"
 TRAIT_FLAGS["Server"]="--disable-default-traits --traits Server"
 TRAIT_FLAGS["Macros"]="--disable-default-traits --traits Macros"
 TRAIT_FLAGS["Fuzz"]="--disable-default-traits --traits Fuzz,MLX,Llama"
@@ -190,8 +184,6 @@ TRAITS_TO_MEASURE=(
     MLX
     Llama
     HuggingFace
-    CloudSaaS
-    Ollama
     Server
     Macros
     AnyLanguageModel
@@ -472,7 +464,7 @@ lines.append("| Mode | Traits enabled | Approx. checkout+artifact MB¹ | Notes |
 lines.append("|------|----------------|-------------------------------|-------|")
 lines.append("| **FoundationOnly** | `FoundationOnly` | ~\(checkoutTotal) cloned, ~0 compiled | ≤5 MB compiled; all ~\(checkoutTotal + artifactTotal) MB fetched once |")
 lines.append("| **local-only** (default) | `MLX`, `Llama`, `HuggingFace` | ~\(checkoutTotal) cloned | Default when no `traits:` override; on-device only |")
-lines.append("| **cloud-only** | `CloudSaaS` or `Ollama` | ~\(checkoutTotal) cloned | Pure HTTP; no local model deps compiled |")
+lines.append("| **cloud-only** | _(none — cloud always compiled since v0.48; build the `ManifoldOllama` / `ManifoldCloudSaaS` products)_ | ~\(checkoutTotal) cloned | Pure HTTP; no local model deps compiled |")
 lines.append("| **full** | all non-Fuzz traits | ~\(checkoutTotal) cloned | ~\(artifactTotal) MB xcframework + Metal compile |")
 lines.append("")
 lines.append("¹ All modes clone the same ~\(checkoutTotal) MB of source checkouts plus the ~\(artifactTotal) MB llama.cpp xcframework on first resolve. The FoundationOnly mode _compiles_ ~5 MB. See footnote 1 in the table above and the resolution note.")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -232,7 +232,7 @@ PROFILE_LOCAL_XCTEST_FILTERS=(
 PROFILE_SWIFT_TESTING_FILTER="ManifoldInferenceSwiftTestingTests"
 
 # Local profile trait set: every trait minus Fuzz (which is build-only).
-PROFILE_LOCAL_TRAITS="MLX,Llama,Ollama,CloudSaaS,HuggingFace,Macros"
+PROFILE_LOCAL_TRAITS="MLX,Llama,HuggingFace,Macros"
 
 if [[ -n "$PROFILE" ]]; then
     case "$PROFILE" in


### PR DESCRIPTION
Part of #1749 / v0.48 packaging release — **PR A4**. Retires the `Ollama` and `CloudSaaS` SwiftPM traits: the cloud backend families now compile unconditionally in every build shape.

## Consumer migration

- **Remove the traits.** `.trait(name: "Ollama")` / `.trait(name: "CloudSaaS")` in your `traits:` array now hard-error at resolution (`package 'manifoldkit' has no trait named 'Ollama'`). Delete them — cloud backends are always compiled in.
- **Opting out of cloud code is now a link-out decision, not a compile flag.** Depend on the specific products you need (`ManifoldInference`, `ManifoldUI`, `ManifoldOllama`, `ManifoldCloudSaaS`) instead of the `ManifoldBackends` umbrella, and don't register what you don't want. The FIPS / procurement "SaaS code not present" claim now rests on the product dependency graph, verified by the per-mode symbol audit — see [docs/FIPS.md](docs/FIPS.md) (decision #4 of the v0.48 plan accepted this discontinuity).
- Cloud *availability* in UI is a runtime endpoint-configuration question; nothing hides behind compile flags anymore.

## CompiledBackends consistency decisions (review blocker, §2 item 2)

- `CompiledBackends` **stays compile-time truth**: `.ollama` / `.cloudSaaS` members are now constant `true` (cases retained for Codable stability); MLX/Llama/HuggingFace keep their `#if`s until the C-stream split. `CompiledBackends.current.buildProfile` is therefore always `.full`; the other `BackendBuildProfile` cases remain for hand-constructed values (tests, ManifoldServer's injectable provider).
- `APIProvider.availableInBuild` keeps its role as the single registration/UI iteration point — now always the full provider list, documented as such (runtime endpoint configuration is the availability gate; B2 already moved consumer-facing checks to runtime).
- `CloudBackends.register` forwards unconditionally to `OllamaBackends` + `CloudSaaSBackends`; the registrars keep declaring via `availableInBuild` (now never empty).
- `TraitAwareServerBackendProvider` keeps its name (still literally trait-aware for MLX/Llama until C2) and gains a doc comment stating that the cloud members of its injected `CompiledBackends` are constant `true` outside tests.
- `unavailableReason` strings no longer name traits; provider-unavailable wording is only reachable for hand-constructed `CompiledBackends` values.

## build-modes mode mapping (product-scoped)

| Mode | Old (trait-scoped) | New (product-scoped) |
|---|---|---|
| offline | `--disable-default-traits` | `--disable-default-traits --target ManifoldUI` |
| ollama | `--disable-default-traits --traits Ollama` | `--disable-default-traits --target ManifoldOllama` |
| saas | `--disable-default-traits --traits CloudSaaS` | `--disable-default-traits --target ManifoldCloudSaaS` |
| full | `--traits MLX,Llama,Ollama,CloudSaaS` | plain `swift build` (defaults) |

**SwiftPM finding:** `swift build --product <automatic library>` does NOT prune the build to the product graph — it compiles every target in the package (verified empirically during this PR). The modes therefore use `--target`, which builds exactly the dependency closure, and the audit wipes the release object dir before each build (clean-room scan — no stale-object false positives/negatives).

The symbol audit now scans the **entire built graph** (every `*.build` dir in release/), not just the umbrella's objects — the honest link-out claim. Two documented discontinuities: `PinnedSessionDelegate` moves from banned to expected in `ollama` mode (ManifoldCloudCore is legitimately linked there; still banned in `offline`), and `APIProvider.swift.o` is excluded from the hostname scan (hostnames as data, same SECURITY.md exemption as before). Artifact filenames/cadence unchanged.

## Strip counts

- 91 files mechanically de-gated (`#if Ollama` / `#if CloudSaaS` and compounds); `#if CloudSaaS && Fuzz` → `#if Fuzz`, `#if Fuzz && Ollama` → `#if Fuzz` (Fuzz halves preserved). Zero residual directives (grep-verified).
- Package.swift: 2 trait declarations deleted, 26 `.define` lines removed, 8 conditional edges made unconditional (umbrella→cloud, shim→families, tests→families, manifold-tools→ManifoldOllama).
- 134 files changed, +414 / −1,110.

## Lockstep list

- ci.yml: three `--traits CloudSaaS` lanes → plain `--disable-default-traits`; all-traits-build list → `MLX,Llama,HuggingFace,Fuzz`
- ci-selective-test.sh: Backends case and the Voice/Skills/Tools/AppIntents case drop trait flags (the latter still referenced the **already-retired MCP trait** — latent hard-error on main, fixed here)
- test.sh: `PROFILE_LOCAL_TRAITS` → `MLX,Llama,HuggingFace,Macros`
- build-modes.sh + build-modes.yml (saas test step; stale `Sources/ManifoldBackends/**` + `Sources/ManifoldServerBackends/**` + `Sources/ManifoldInference/Models/APIProvider.swift` paths-filter entries fixed to real paths)
- fuzz.sh / benchmark.sh / cold-start-specialised-uimodelmanagement.sh trait flags
- measure-trait-costs.sh + docs/trait-costs.json + docs/TRAIT-COSTS.md (rows removed, regenerated)
- `PackageTraitGateAuditTest.expectedGates`: Ollama/CloudSaaS family-product entries removed (4 Fuzz entries remain — audit stays non-vacuous); `TrafficBoundaryAuditTest` Rule 7 expected-traits list shrunk
- FeatureMatrix.swift + regenerated docs/FeatureMatrix.md; `CompiledBackendsTests` rewritten (cloud members asserted constant; profile mapping still tested as a pure function)
- scripts/affected-suites-graph.json regenerated (byte-identical — conditions don't appear in the normalized graph)
- Docs: CLAUDE.md (targets table, dependency rules, sweep command, local profile), README, Tests/README.md, QUICKSTART{,-CLI}.md, SECURITY.md, FIPS.md, AppStoreSubmission.md, CONTRIBUTING.md, AGENTS.md, PROVIDER-BRIDGE.md, FUZZING.md, manifold-tools README, ManifoldKit DocC
- String sweep: `OllamaBackend.init(urlSession:)` deprecation no longer says "add the Ollama trait" (B2 finding); `ManifoldKitError.noBackendsRegistered`, fuzz-chat usage text, and all user-facing trait mentions rewritten

## Test plan

- `swift build --build-tests --disable-default-traits` — clean (new CI lane shape; cloud + UIMM views compile here)
- `swift build --build-tests --traits MLX,Llama,HuggingFace,Fuzz` — clean (matches ci.yml all-traits list byte-for-byte)
- `swift build --build-tests --traits Fuzz --disable-default-traits` — clean (Fuzz compounds survive)
- `scripts/test.sh --profile local` — full gate, honest pass; cloud suites (ManifoldBackendsTests cloud files, UIMM) ran with N>0

Remaining trait inventory after this PR: `MLX`, `Llama`, `HuggingFace`, `Server`, `Macros`, `Fuzz`, `AnyLanguageModel`, `FoundationOnly`, `SystemAIProviderExtension`, `CoreAI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
