### PR TITLE
fix: update Package.resolved for unconditional AnyLanguageModel dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "239949b1a24a03452836d2aab7958f545d1f798c7ec0c7875117e9a5871e7182",
+  "originHash" : "41661774c7dd4f9be62d04e23e2eb1b2b0136dd7eb970fa3d51dfbf0bb8c6d1a",
   "pins" : [
+    {
+      "identity" : "anylanguagemodel",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/AnyLanguageModel",
+      "state" : {
+        "revision" : "163f3855a53235b4ebeb69cf5e9f228215ae35b5",
+        "version" : "0.8.0"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "jsonschema",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/JSONSchema",
+      "state" : {
+        "revision" : "4c6f2467d5bc72b062c7a9b7e4cd77a09635ea8b",
+        "version" : "1.3.1"
       }
     },
     {
@@ -35,6 +53,15 @@
       "state" : {
         "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
         "version" : "3.31.3"
+      }
+    },
+    {
+      "identity" : "partialjsondecoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/PartialJSONDecoder",
+      "state" : {
+        "revision" : "e4d389e6bcc6771bb988d1a8a17695d8bfa97172",
+        "version" : "1.0.0"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ManifoldKit is a full-stack, multi-backend AI chat framework for iOS 18+ / macOS
 
 Three steps: add **ManifoldKit** (core) plus the **manifold-llama** companion package (the on-device GGUF backend), then drop this into your app entry point. `ManifoldKit.quickStart(backends:seed:)` builds the SwiftData container, registers the compiled-in backends plus the companion registrars you pass, and seeds a curated ~400 MB starter model on first launch — one call to a live, generating chat. Errors surface as [`ManifoldKitError`](Sources/ManifoldModelCatalog/ManifoldKitError.swift).
 
-```swift
+```text
 .package(url: "https://github.com/roryford/ManifoldKit.git", from: "0.48.0"),
 .package(url: "https://github.com/roryford/manifold-llama.git", from: "0.1.0"),
 // target dependencies: "ManifoldKit", .product(name: "ManifoldLlama", package: "manifold-llama")


### PR DESCRIPTION
Repairs main after #1769 (three issues, one PR):

1. **Stale Package.resolved** — the unconditional AnyLanguageModel edge changed the resolved graph; freshness gate flagged it. Lockfile updated.
2. **deps-ok justification:** the 3 "new" pins (AnyLanguageModel + transitives) are not new dependencies — they were previously trait-gated behind `AnyLanguageModel` and only became unconditional in #1769 per the v0.48 plan (§2 A5, approved decision #7). No net-new third-party code enters the graph relative to a traits-on v0.47 build.
3. **Tier-4 Hello World gate** — #1769's README put a non-compilable manifest fragment as the first swift fence under Hello World; demoted to a text fence so the gate compiles the actual app snippet (verified locally: tier-4 OK, check-readme OK).

The cold-start job's DNS failures on the prior run were runner-transient.

Part of #1749 / v0.48 packaging release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)