### PR TITLE
fix: streaming-wait perf + run traffic-boundary audit per-PR

### DIFF
--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -3,10 +3,12 @@ name: Nightly slow tests
 # Runs the expensive tests excluded from per-PR CI:
 #  - LargeSessionListPerformanceTests — XCTMeasure perf baselines (~65s)
 #  - IntegratedStreamingPerformanceTests — full pipeline TTFT/cadence/E2E baselines (~20s)
-#  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s)
+#  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s); as of
+#    issue #1706 this also runs per-PR in ci.yml's ManifoldInferenceTests
+#    batch — it is kept here for nightly double-coverage, no longer gated.
 #  - ManifoldAuditSabotageSuiteTests — SABOTAGE=1 audit tripwire proof
 #  - ManifoldMCPE2ESmokeTests — explicitly gated MCP streamable-HTTP E2E smoke
-# Most are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
+# The perf suites are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`
 # job leaves that unset so they skip there. Local `swift test` runs them
 # unconditionally (CI is also unset locally). The sabotage suite is separately
 # gated by SABOTAGE=1, and MCP E2E remains separately gated by RUN_MCP_E2E=1

--- a/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
@@ -106,6 +106,14 @@ final class ChatGenerationCoordinator {
     /// Handle to the in-flight ConversationRuntime stream.
     var activeConversationStreamHandle: ConversationStreamHandle?
 
+    /// Continuations parked by ``awaitStreamCompletion()`` while a stream is
+    /// in flight. why: replaces a 1ms busy-poll with an event-driven seam —
+    /// each terminal handler resumes these once the handle clears. Because the
+    /// coordinator is `@MainActor`, every append/drain runs on the same actor,
+    /// so the array needs no lock to be race-free.
+    @ObservationIgnored
+    private var streamCompletionWaiters: [CheckedContinuation<Void, Never>] = []
+
     /// The assistant `messageID` from the most-recent `streamStarted` event.
     /// Terminal events for prior turns (post-switch) carry a different ID and
     /// must not clobber the new turn's handle.
@@ -160,6 +168,9 @@ final class ChatGenerationCoordinator {
         if let handle = activeConversationStreamHandle {
             await conversationRuntime.cancel(handle)
             activeConversationStreamHandle = nil
+            // why: teardown clears the handle outside the event drain, so wake
+            // any caller parked in awaitStreamCompletion() here too.
+            resumeStreamCompletionWaiters()
         }
     }
 
@@ -226,21 +237,24 @@ final class ChatGenerationCoordinator {
 
     /// Suspends until `activeConversationStreamHandle` becomes `nil`.
     func awaitStreamCompletion() async {
-        // Yield once before entering the sleep loop so the runtime event drain
-        // task gets an immediate scheduling opportunity on the same actor.
+        // Yield once so the runtime event drain task gets an immediate
+        // scheduling opportunity on the same actor before we park.
         await Task.yield()
-        while activeConversationStreamHandle != nil {
-            // TODO: replace busy-poll with a continuation-based seam signaled
-            // from the `streamFinished` handler. Safe today thanks to the 2s
-            // timeout in the awaitStreamCompletion test.
-            // Sleep rather than yield so concurrent callers don't starve the
-            // runtime event drain task that clears the handle.
-            do {
-                try await Task.sleep(for: .milliseconds(1))
-            } catch {
-                break
-            }
-        }
+        // why: park on a continuation instead of polling. The terminal handlers
+        // clear the handle and call `resumeStreamCompletionWaiters()`, which
+        // wakes every parked caller. @MainActor serialization guarantees the
+        // nil check and the append cannot interleave with a resume.
+        guard activeConversationStreamHandle != nil else { return }
+        await withCheckedContinuation { streamCompletionWaiters.append($0) }
+    }
+
+    /// Wakes every caller parked in ``awaitStreamCompletion()`` once the active
+    /// stream handle has been cleared. No-op while a stream is still in flight.
+    private func resumeStreamCompletionWaiters() {
+        guard activeConversationStreamHandle == nil else { return }
+        let waiters = streamCompletionWaiters
+        streamCompletionWaiters = []
+        for waiter in waiters { waiter.resume() }
     }
 
     // MARK: - Post-Generation Tasks
@@ -356,6 +370,7 @@ final class ChatGenerationCoordinator {
             activeConversationMessageID = nil
 
             activeConversationStreamHandle = nil
+            resumeStreamCompletionWaiters()
             transitionPhase(to: .idle)
             updateContextEstimate()
 
@@ -405,6 +420,7 @@ final class ChatGenerationCoordinator {
             }
             activeConversationStreamHandle = nil
             activeConversationMessageID = nil
+            resumeStreamCompletionWaiters()
             transitionPhase(to: .idle)
 
         // MARK: Thinking-block disclosure
@@ -518,6 +534,7 @@ final class ChatGenerationCoordinator {
 
     private func applyTerminalOutcome(_ outcome: ConversationTurnOutcome) {
         activeConversationStreamHandle = nil
+        resumeStreamCompletionWaiters()
         activeConversationMessageID = nil
         transitionPhase(to: .idle)
 

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -68,15 +68,11 @@ import XCTest
 /// of where `swift test` is invoked.
 final class TrafficBoundaryAuditTest: XCTestCase {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        // Source-tree walk + regex audit (~50s combined). Skipped in main CI to
-        // keep PR feedback fast; nightly job sets RUN_SLOW_TESTS=1. Always runs
-        // locally so contributors get the boundary-rule signal pre-push.
-        let env = ProcessInfo.processInfo.environment
-        try XCTSkipIf(env["CI"] == "true" && env["RUN_SLOW_TESTS"] != "1",
-                      "Source-tree audit — runs in nightly CI only. Set RUN_SLOW_TESTS=1 to force.")
-    }
+    // Runs unconditionally (per-PR CI, nightly, and locally). This is a pure
+    // filesystem grep — no build, no traits, ~50s — so it runs in the per-PR
+    // `ManifoldInferenceTests` batch to catch boundary violations on the PR
+    // instead of a multi-day-lagged nightly job (issue #1706). Previously gated
+    // behind RUN_SLOW_TESTS=1 in setUp; nightly still runs it for double coverage.
 
     // MARK: - Allowlists
 

--- a/Tests/ManifoldUITests/ChatGenerationCoordinatorTests.swift
+++ b/Tests/ManifoldUITests/ChatGenerationCoordinatorTests.swift
@@ -267,23 +267,70 @@ final class ChatGenerationCoordinatorTests: XCTestCase {
 
     func test_awaitStreamCompletion_resumesWhenHandleClears() async {
         let coord = makeSilentCoordinator()
+        let sessionID = UUID()
+        let msgID = UUID()
+        coord.onTransitionPhase = { _ in true }
+        coord.currentActiveSessionID = { sessionID }
+        coord.currentActiveSession = { ChatSession(id: sessionID, title: "Test") }
+        coord.currentMessages = {
+            [ChatMessage(id: msgID, role: .assistant, content: "hi", sessionID: sessionID)]
+        }
 
+        coord.activeConversationMessageID = msgID
         coord.activeConversationStreamHandle = ConversationStreamHandle(id: UUID())
 
-        // Bound the wait so a scheduler-starvation bug fails fast instead of
-        // hanging the entire CI run (awaitStreamCompletion polls with Task.yield).
+        // Bound the wait so a regression that drops the continuation fails fast
+        // instead of hanging the entire CI run.
         let exp = expectation(description: "awaitStreamCompletion returns")
         let awaiter = Task { @MainActor in
             await coord.awaitStreamCompletion()
             exp.fulfill()
         }
 
-        // Clear the handle after one cooperative-scheduler turn.
+        // Let the awaiter park on its continuation, then clear the handle via
+        // the real terminal path so the continuation-resume seam is exercised.
         await Task.yield()
-        coord.activeConversationStreamHandle = nil
+        await coord.handle(runtimeEvent: .streamFinished(messageID: msgID, reason: .stop))
 
         await fulfillment(of: [exp], timeout: 2)
         _ = awaiter  // keep the task alive until the expectation is met
+        XCTAssertNil(coord.activeConversationStreamHandle)
+    }
+
+    // MARK: - 11b. awaitStreamCompletion resumes all concurrent callers
+
+    func test_awaitStreamCompletion_resumesAllConcurrentCallers() async {
+        let coord = makeSilentCoordinator()
+        let sessionID = UUID()
+        let msgID = UUID()
+        coord.onTransitionPhase = { _ in true }
+        coord.currentActiveSessionID = { sessionID }
+        coord.currentActiveSession = { ChatSession(id: sessionID, title: "Test") }
+        coord.currentMessages = {
+            [ChatMessage(id: msgID, role: .assistant, content: "hi", sessionID: sessionID)]
+        }
+
+        coord.activeConversationMessageID = msgID
+        coord.activeConversationStreamHandle = ConversationStreamHandle(id: UUID())
+
+        // Two callers park on the same handle concurrently. Both must resume
+        // from a single terminal event — proves the waiter array drains fully,
+        // not just the first parked continuation.
+        let bothDone = expectation(description: "both awaitStreamCompletion calls return")
+        let waiters = Task { @MainActor in
+            async let first: Void = coord.awaitStreamCompletion()
+            async let second: Void = coord.awaitStreamCompletion()
+            _ = await (first, second)
+            bothDone.fulfill()
+        }
+
+        // Let both callers park before clearing the handle through the real path.
+        await Task.yield()
+        await Task.yield()
+        await coord.handle(runtimeEvent: .streamFinished(messageID: msgID, reason: .stop))
+
+        await fulfillment(of: [bothDone], timeout: 2)
+        _ = waiters
         XCTAssertNil(coord.activeConversationStreamHandle)
     }
 


### PR DESCRIPTION
Patch hardening for the v0.48 line. Two contained, CI-verifiable fixes; no public API change (clears the API-break gate).

## Changes

- [x] **`perf(ui)`: continuation seam for `awaitStreamCompletion`** — replaced a 1ms `Task.sleep` busy-poll (run on every turn) with a `[CheckedContinuation]` resumed from the handle-clear sites. Also closes a latent teardown hang: a caller parked across `cancelActiveStreamHandle` would previously never resume. `@MainActor` serialization keeps the waiter array race-free. New test asserts two concurrent waiters both resume on a single `streamFinished`.
- [x] **`ci`: run `TrafficBoundaryAuditTest` per-PR (#1706)** — removed the `RUN_SLOW_TESTS=1` nightly-only guard. The audit is a pure filesystem walk (~45s, no build/trait deps); the per-PR `--filter ManifoldInferenceTests` batch now picks it up, removing the multi-day detection lag for boundary violations. Nightly keeps running it (double coverage).

## Verification

- `scripts/test.sh --profile local` (full trait surface): **4866 passed, 0 failed**, 15 XCTSkip. Both runner invocations `RESULT: PASSED`.
- New A tests + the now-unguarded `TrafficBoundaryAuditTest` (incl. all 7 sabotage checks) green.

## Not in this PR

- **Ollama `.loading` phase** — investigated, but it turned out to be a cross-layer streaming-kernel + UI-state-machine change (and the original empty-frame detection premise was wrong: Ollama sends *no* bytes during cold load). Split back to **#189** (reopened) with full corrected design notes.
- **Nightly `#1709`** — scoped; the recent coverage-threshold failure was a red herring (real cause already fixed by #1694). Details in the issue. This PR's #1706 change is partial mitigation for the recurring nightly red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)