### PR TITLE
docs(ManifoldFoundation): capture #1710 multimodal plan as code comment

### DIFF
--- a/Sources/ManifoldFoundation/FoundationBackend.swift
+++ b/Sources/ManifoldFoundation/FoundationBackend.swift
@@ -131,12 +131,27 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         maxOutputTokens: 4096,
         supportsStreaming: true,
         isRemote: false,
-        // Apple's FoundationModels SDK (Xcode 26.4) exposes no image-input
-        // surface — `Transcript.Segment` is text/structure only, `Prompt`
-        // carries only segments, and there is no `Data`/`CGImage` ingress
-        // anywhere in the public API. See the type-level doc comment above
-        // for the full audit. Flip to `true` and wire MessagePart.image
-        // through the SDK when Apple ships an image-bearing segment.
+        // Apple's FoundationModels SDK (Xcode 26.4, module 1.4.34) exposes no
+        // image-input surface — `Transcript.Segment` is text/structure only,
+        // `Prompt` carries only segments, and there is no `Data`/`CGImage`
+        // ingress anywhere in the public API. See the type-level doc comment
+        // above for the full audit.
+        //
+        // OUTSTANDING (#1710 — multimodal image input, blocked on post-WWDC
+        // Xcode beta): WWDC 2026 announced multimodal AFM 3; a later SDK should
+        // ship `Attachment(UIImage(...))` inside the `respond {}`/`streamResponse`
+        // result builder. When it lands:
+        //   1. Probe the installed SDK first — grep FoundationModels.swiftinterface
+        //      for image/attachment/pixelbuffer ingress; if absent, this stays false.
+        //   2. Make this RUNTIME-conditional, not a static `false`: the backend
+        //      exists on iOS/macOS 26, but vision needs 26.4+, e.g.
+        //        supportsVision: { if #available(iOS 26.4, macOS 26.4, *) { return true }; return false }()
+        //   3. In generate(), map each `MessagePart.image(data:mimeType:)` to an
+        //      `Attachment` and build the multimodal prompt under the same guard.
+        //   4. Confirm whether image requests route to Private Cloud Compute before
+        //      advertising on-device for image inputs (`isRemote`/doc-comment impact).
+        // Flipping this flag auto-enables the composer's PhotoAttachmentButton /
+        // VisionInputButton (they gate on BackendCapabilities.supportsVision).
         supportsVision: false,
         // Whole-call emission only — Apple's GuidedGeneration streams the
         // partially-decoded structure but we do not surface name/argument


### PR DESCRIPTION
## What

Folds the FoundationBackend multimodal image-input work plan into a code comment next to `supportsVision: false` in `FoundationBackend.swift`, replacing an untracked working brief (`WWDC-IMPL-BRIEF.md`) that was removed during a worktree/branch/stash cleanup pass.

The brief's other two items (#1711 M5 Neural Accelerator probe, #1712 isolated conformances) are already shipped/closed; #1710 is the only outstanding item, and it's blocked on the post-WWDC Xcode beta — so it belongs as a cross-session note in the code, not a loose file.

## The captured plan (#1710)

When a post-WWDC SDK ships the AFM 3 multimodal API:
1. Probe the installed `FoundationModels.swiftinterface` for image/attachment ingress first; if absent, `supportsVision` stays `false`.
2. Make `supportsVision` runtime-conditional on `#available(iOS 26.4, macOS 26.4, *)` — not a static `false`.
3. Map each `MessagePart.image(data:mimeType:)` to an `Attachment` and build the multimodal prompt under the same guard.
4. Confirm Private Cloud Compute routing before advertising on-device for image inputs.

Flipping the flag auto-enables the composer's `PhotoAttachmentButton` / `VisionInputButton`.

## Scope

Comment-only change — no behavioral or API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)