### PR TITLE
fix: move model discovery off main thread (#1774)

### DIFF
--- a/Sources/ManifoldInference/Services/ModelRegistry.swift
+++ b/Sources/ManifoldInference/Services/ModelRegistry.swift
@@ -107,6 +107,42 @@ public final class ModelRegistry {
         }
     }
 
+    /// Off-main equivalent of ``refresh()``: re-scans the models directory on a
+    /// background task and rebuilds ``availableModels`` without stalling the
+    /// main thread on the synchronous GGUF/MLX scan (#1774).
+    ///
+    /// The Foundation-availability flag is read on the main actor *before* the
+    /// `await` so the `@MainActor` provider closure is never sent across an
+    /// isolation boundary; only the directory scan hops off-main (inside
+    /// ``ModelStorageService/discoverModelsOffMain()``). The discovered
+    /// `[ModelInfo]` / `[ModelDiscoveryError]` are `Sendable` and assigned back
+    /// on the main actor on resume. Mirrors ``refresh()`` semantics exactly.
+    ///
+    /// - Throws: A directory-creation error if the underlying models directory
+    ///   could not be ensured (raised before any background work).
+    public func refreshAsync() async throws {
+        try modelStorage.ensureModelsDirectory()
+
+        // Read the @MainActor provider before suspending — do not send the
+        // closure off-actor.
+        let includeFoundation = foundationModelProvider?() ?? false
+
+        let result = await modelStorage.discoverModelsOffMain()
+
+        var models: [ModelInfo] = []
+        if includeFoundation {
+            models.append(.builtInFoundation)
+        }
+        models.append(contentsOf: result.models)
+        availableModels = models
+        lastDiscoveryErrors = result.errors
+
+        if let selected = selectedModel,
+           !availableModels.contains(where: { $0.id == selected.id }) {
+            selectedModel = nil
+        }
+    }
+
     // MARK: - Selection
 
     /// Canonical programmatic entry point for changing ``selectedModel``.

--- a/Sources/ManifoldModelCatalog/ModelStorageService.swift
+++ b/Sources/ManifoldModelCatalog/ModelStorageService.swift
@@ -165,6 +165,27 @@ public final class ModelStorageService: @unchecked Sendable {
         return models.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
+    /// Off-main equivalent of ``discoverModels(reportingErrors:)`` for callers
+    /// (notably `ModelManagementSheet`) that must not stall the main thread on
+    /// the synchronous GGUF/MLX directory scan (~2s cold; #1774).
+    ///
+    /// Hops off the calling actor via `Task.detached` and runs the existing
+    /// synchronous scan body, collecting per-file failures into a returned
+    /// array rather than calling back through an escaping `@Sendable` closure —
+    /// a tuple return sidesteps the Swift 6 non-isolated-async-helper trap (a
+    /// sent closure that closes over `@MainActor` state). Both `ModelInfo` and
+    /// `ModelDiscoveryError` are `Sendable`, so the result crosses the actor
+    /// boundary cleanly.
+    public func discoverModelsOffMain() async -> (models: [ModelInfo], errors: [ModelDiscoveryError]) {
+        await Task.detached(priority: .userInitiated) { [self] in
+            // The error handler fires only synchronously on this detached
+            // task's own thread, so a plain local array needs no lock.
+            var errors: [ModelDiscoveryError] = []
+            let models = discoverModels(reportingErrors: { errors.append($0) })
+            return (models: models, errors: errors)
+        }.value
+    }
+
     /// Per-directory scan used by both the public ``discoverModels()`` and
     /// the diagnostics-reporting overload.
     private func scanDirectory(

--- a/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
@@ -45,11 +45,17 @@ struct HuggingFaceBrowserView: View {
     /// (the legacy path surfaces them via `errorMessage`, but this view is
     /// invoked only after the directory is already populated, so the error
     /// path is unreachable in practice).
+    ///
+    /// Runs the directory scan off-main via `refreshAsync()` (#1774) so an
+    /// import/download-completion refresh never re-blocks the main thread.
+    /// `Task {}` inherits @MainActor; the off-main hop happens in the callee.
     private func refreshModels() {
-        do {
-            try modelRegistry.refresh()
-        } catch {
-            Log.download.warning("HuggingFaceBrowserView: registry refresh failed: \(error)")
+        Task {
+            do {
+                try await modelRegistry.refreshAsync()
+            } catch {
+                Log.download.warning("HuggingFaceBrowserView: registry refresh failed: \(error)")
+            }
         }
     }
 
@@ -373,10 +379,12 @@ struct HuggingFaceBrowserView: View {
             if let match = modelRegistry.availableModels.first(where: { $0.fileName == model.fileName }) {
                 modelRegistry.selectedModel = match
             } else {
-                // refreshModels() runs synchronously in onChange, so this branch is
-                // only reachable if the file was deleted between download completion
-                // and the user tapping "Use Now".
-                Log.download.warning("Use Now: \(model.fileName) not found in availableModels — file may have been deleted")
+                // refreshModels() now rescans off-main (#1774), so this branch is
+                // reachable either if the file was deleted between download
+                // completion and the tap, or if the user taps before the rescan
+                // lands. Either way the safe action is to log and skip — the model
+                // appears in Select once the rescan completes.
+                Log.download.warning("Use Now: \(model.fileName) not found in availableModels — file may have been deleted or rescan still in flight")
             }
             pendingUseNowModel = nil
         }

--- a/Sources/ManifoldUIModelManagement/Views/Models/LocalModelStorageView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/LocalModelStorageView.swift
@@ -137,10 +137,15 @@ struct LocalModelStorageView: View {
     private func deleteModel(_ model: ModelInfo) {
         do {
             try managementViewModel.deleteModel(model)
-            do {
-                try modelRegistry.refresh()
-            } catch {
-                Log.download.warning("LocalModelStorageView: registry refresh after delete failed: \(error)")
+            // Off-main rescan so a post-delete refresh never re-blocks the main
+            // thread (#1774); `Task {}` inherits @MainActor, the scan hops off
+            // inside `refreshAsync()`.
+            Task {
+                do {
+                    try await modelRegistry.refreshAsync()
+                } catch {
+                    Log.download.warning("LocalModelStorageView: registry refresh after delete failed: \(error)")
+                }
             }
         } catch {
             Log.download.error("Failed to delete model: \(error)")

--- a/Sources/ManifoldUIModelManagement/Views/Models/ModelManagementSheet.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/ModelManagementSheet.swift
@@ -42,6 +42,10 @@ public struct ModelManagementSheet: View {
     }
 
     @State private var selectedTab: Tab
+    /// True while the first off-main directory scan is in flight. Surfaces a
+    /// small ``ProgressView`` row so the sheet chrome can render immediately
+    /// while the model list fills in asynchronously (#1774).
+    @State private var isScanning = false
 
     /// Canonical init — pass the registry the host already constructed
     /// (typically `chatViewModel.modelRegistry`). The sheet works without
@@ -132,24 +136,30 @@ public struct ModelManagementSheet: View {
         .frame(minWidth: 560, idealWidth: 720, minHeight: 480, idealHeight: 640)
         #endif
         .onAppear {
+            // Tab selection is cheap and must apply synchronously so the chrome
+            // renders correctly on first frame.
             if !availableTabs.contains(selectedTab) {
                 selectedTab = .select
             } else if selectedTab != initialTab {
                 selectedTab = initialTab
             }
+        }
+        .task {
+            // why: the GGUF/MLX directory scan is the ~2s main-thread stall in
+            // #1774. `refreshAsync()` hops the scan off-main inside
+            // `ModelStorageService.discoverModelsOffMain()`, so the sheet chrome
+            // (tab picker, frame) paints immediately and only the model list
+            // waits. `Task {}`/`.task` inherits @MainActor — the off-main hop
+            // happens in the callee, never here. The cache is invalidated only
+            // on real mutations (download/delete/import), so a re-appear with no
+            // change keeps the cache.
+            isScanning = true
+            defer { isScanning = false }
             do {
-                try modelRegistry.refresh()
+                try await modelRegistry.refreshAsync()
             } catch {
                 Log.download.warning("ModelManagementSheet: registry refresh on appear failed: \(error)")
             }
-            // why: do NOT blanket-invalidate the discovery cache here. The old
-            // unconditional invalidateModelCache() forced a full synchronous GGUF
-            // rescan on every sheet open (~2s main-thread stall, #1774). The cache
-            // is now invalidated only on real mutations — download completion
-            // (startDownloadSync), delete (deleteModel), and import (importModel) —
-            // so a re-appear with no change keeps the cache. Deferred follow-up:
-            // move discoverModels() off the main thread so even the first scan
-            // doesn't stall.
         }
     }
 
@@ -206,6 +216,14 @@ public struct ModelManagementSheet: View {
         switch selectedTab {
         case .select:
             ModelSelectionTabView(modelRegistry: modelRegistry, onSelect: { dismiss() })
+                // Lightweight affordance while the first off-main scan lands
+                // (#1774); `availableModels` is @Observable, so the list itself
+                // repaints automatically once the scan resolves.
+                .overlay(alignment: .top) {
+                    if isScanning && modelRegistry.availableModels.isEmpty {
+                        scanningIndicator
+                    }
+                }
         case .download:
             HuggingFaceBrowserView(
                 modelRegistry: modelRegistry,
@@ -216,6 +234,21 @@ public struct ModelManagementSheet: View {
         case .storage:
             LocalModelStorageView(modelRegistry: modelRegistry)
         }
+    }
+
+    private var scanningIndicator: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Scanning for models…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(.bar, in: Capsule())
+        .padding(.top, 8)
+        .accessibilityIdentifier("model-management-scanning-indicator")
     }
 }
 

--- a/Sources/ManifoldUIModelManagement/Views/Models/StorageManagementView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/StorageManagementView.swift
@@ -181,10 +181,15 @@ public struct StorageManagementView: View {
     private func deleteModel(_ model: ModelInfo, modelRegistry: ModelRegistry) {
         do {
             try managementViewModel.deleteModel(model)
-            do {
-                try modelRegistry.refresh()
-            } catch {
-                Log.download.warning("StorageManagementView: registry refresh after delete failed: \(error)")
+            // Off-main rescan so a post-delete refresh never re-blocks the main
+            // thread (#1774); `Task {}` inherits @MainActor, the scan hops off
+            // inside `refreshAsync()`.
+            Task {
+                do {
+                    try await modelRegistry.refreshAsync()
+                } catch {
+                    Log.download.warning("StorageManagementView: registry refresh after delete failed: \(error)")
+                }
             }
         } catch {
             Log.download.error("Failed to delete model: \(error)")

--- a/Tests/ManifoldInferenceTests/ModelRegistryTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelRegistryTests.swift
@@ -117,6 +117,74 @@ final class ModelRegistryTests: XCTestCase {
         )
     }
 
+    // MARK: - refreshAsync()
+
+    func test_refreshAsync_populatesSameModelsAsSyncRefresh() async throws {
+        try createFakeGgufFile(named: "async-a.gguf")
+        try createFakeGgufFile(named: "async-b.gguf")
+
+        let syncRegistry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+        try syncRegistry.refresh()
+
+        let asyncRegistry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+        try await asyncRegistry.refreshAsync()
+
+        XCTAssertEqual(
+            asyncRegistry.availableModels.map(\.id),
+            syncRegistry.availableModels.map(\.id),
+            "refreshAsync() should yield the same availableModels (and order) as refresh()"
+        )
+    }
+
+    func test_refreshAsync_includesFoundationWhenProviderReturnsTrue() async throws {
+        let registry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage,
+            foundationModelProvider: { true }
+        )
+
+        try await registry.refreshAsync()
+
+        XCTAssertTrue(
+            registry.availableModels.contains(where: { $0.modelType == .foundation }),
+            "Foundation model should be prepended when foundationModelProvider returns true"
+        )
+        XCTAssertEqual(
+            registry.availableModels.first?.modelType,
+            .foundation,
+            "Foundation entry must be prepended, mirroring sync refresh() ordering"
+        )
+    }
+
+    func test_refreshAsync_clearsSelectedModelWhenNoLongerOnDisk() async throws {
+        let modelFile = try createFakeGgufFile(named: "async-ephemeral.gguf")
+
+        let registry = ModelRegistry(
+            inferenceService: inferenceService,
+            modelStorage: modelStorage
+        )
+        try await registry.refreshAsync()
+
+        guard let discovered = registry.availableModels.first(where: { $0.fileName == "async-ephemeral.gguf" }) else {
+            return XCTFail("Pre-condition: model file should be discoverable")
+        }
+        registry.selectedModel = discovered
+
+        try FileManager.default.removeItem(at: modelFile)
+        try await registry.refreshAsync()
+
+        XCTAssertNil(
+            registry.selectedModel,
+            "selectedModel should clear when its model is no longer in availableModels"
+        )
+    }
+
     // MARK: - selectedModel round-trip
 
     func test_selectedModel_writeReadRoundTrip() {

--- a/Tests/ManifoldUIModelManagementTests/ModelManagementSheetLogicTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/ModelManagementSheetLogicTests.swift
@@ -140,6 +140,69 @@ final class ModelManagementSheetLogicTests: XCTestCase {
         // In the existing GenerationViewModelTests, actual GGUF files are created.
     }
 
+    // MARK: - Off-main discovery (#1774)
+
+    /// The sheet's `.task` drives `refreshAsync()` so the chrome paints
+    /// immediately and only the model list waits. This proves the registry
+    /// exposes content asynchronously, not via a synchronous main-thread scan:
+    /// the registry starts empty on appear, and is populated only after the
+    /// async refresh resolves.
+    func test_refreshAsync_exposesEmptyListBeforeScanResolves_thenPopulated() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SheetScan-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Write a GGUF-shaped file so a completed scan would find one model.
+        let gguf = dir.appendingPathComponent("sheet-async.gguf")
+        var data = Data([0x47, 0x47, 0x55, 0x46]) // "GGUF"
+        data.append(Data(repeating: 0xAA, count: 4092))
+        try data.write(to: gguf)
+
+        let registry = ModelRegistry(
+            inferenceService: InferenceService(),
+            modelStorage: ModelStorageService(baseDirectory: dir)
+        )
+
+        // The sheet renders its chrome with an empty list on appear.
+        XCTAssertTrue(registry.availableModels.isEmpty, "Registry exposes an empty list before any scan resolves")
+
+        try await registry.refreshAsync()
+
+        XCTAssertTrue(
+            registry.availableModels.contains(where: { $0.fileName == "sheet-async.gguf" }),
+            "availableModels must be populated once the off-main scan resolves"
+        )
+    }
+
+    /// `discoverModelsOffMain()` is the off-main scan that backs `refreshAsync()`
+    /// (#1774). Called from the main actor it returns a `(models, errors)` tuple
+    /// equivalent to the synchronous `discoverModels(reportingErrors:)` overload,
+    /// proving the async API surfaces the same content the sync path would.
+    func test_discoverModelsOffMain_matchesSyncDiscovery() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OffMainScan-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let gguf = dir.appendingPathComponent("offmain.gguf")
+        var data = Data([0x47, 0x47, 0x55, 0x46]) // "GGUF"
+        data.append(Data(repeating: 0xAA, count: 4092))
+        try data.write(to: gguf)
+
+        let storage = ModelStorageService(baseDirectory: dir)
+
+        let sync = storage.discoverModels()
+        let asyncResult = await storage.discoverModelsOffMain()
+
+        XCTAssertEqual(
+            asyncResult.models.map(\.id),
+            sync.map(\.id),
+            "discoverModelsOffMain() must yield the same models (and order) as the synchronous discoverModels()"
+        )
+        XCTAssertTrue(asyncResult.errors.isEmpty, "A clean GGUF directory yields no discovery errors")
+    }
+
     // MARK: - ModelInfo properties
 
     func test_modelInfo_ggufType() {


### PR DESCRIPTION
## Summary

`ModelManagementSheet` blocked ~2s on every cold open and after every download/delete/import because the GGUF/MLX directory scan ran synchronously on the main thread (#1774). PR #1775 removed the redundant per-open cache invalidation (fixing repeat opens); this is the deferred follow-up that moves the scan itself off the main thread (Option A — async, off-main discovery).

## What changed

**`ManifoldModelCatalog` — `ModelStorageService`**
- Adds `public func discoverModelsOffMain() async -> (models: [ModelInfo], errors: [ModelDiscoveryError])`. It hops off-actor via `Task.detached(priority: .userInitiated)` and runs the **existing** synchronous scan body, collecting per-file failures into a returned array. Returns a tuple rather than taking an escaping `@Sendable` error closure, which sidesteps the Swift 6 non-isolated-async-helper trap. `ModelInfo` and `ModelDiscoveryError` were already `Sendable` — no conformance changes needed.
- The synchronous `discoverModels()` / `discoverModels(reportingErrors:)` overloads are **preserved unchanged** (13 call sites + ~20 tests depend on them).

**`ManifoldInference` — `ModelRegistry`**
- Adds `public func refreshAsync() async throws`, mirroring sync `refresh()` exactly: ensures the directory, reads the `@MainActor` Foundation-availability flag **before** suspending (never sends the closure off-actor), awaits `discoverModelsOffMain()`, then rebuilds `availableModels` (prepending `.builtInFoundation` when available), assigns `lastDiscoveryErrors`, and clears a vanished `selectedModel`.
- Sync `refresh()` stays for the startup/session callers (out of scope).

**`ManifoldUIModelManagement` — view sites**
- `ModelManagementSheet`: tab selection stays in `onAppear` (instant chrome), the scan moves to `.task { await modelRegistry.refreshAsync() }`. A `@State isScanning` toggle surfaces a small "Scanning for models…" `ProgressView` overlay while the first scan is in flight; the `@Observable` model list repaints automatically when it lands.
- `LocalModelStorageView`, `StorageManagementView`, `HuggingFaceBrowserView`: post-mutation refreshes converted to `Task { await modelRegistry.refreshAsync() }` (using `Task {}`, not `Task.detached`, so the off-main hop happens only inside `discoverModelsOffMain`).

## API surface

Additive only — both new methods are public; all synchronous overloads (`discoverModels`, `refresh`) are preserved, so no caller breaks.

## Tests added

- `ModelRegistryTests`: `refreshAsync()` yields the same `availableModels` (and order) as `refresh()`; prepends Foundation when the provider returns true; clears `selectedModel` when its file vanishes. Real temp-dir `ModelStorageService`, no persistence mocking.
- `ModelManagementSheetLogicTests`: registry exposes an empty list before the async scan resolves then is populated after the await (proves no synchronous block); `discoverModelsOffMain()` matches the synchronous `discoverModels()` result.
- Each new assertion was sabotage-verified (e.g. dropping the discovered-models append makes the equality test fail) and the sabotage removed before commit.

## Gate

`scripts/test.sh --profile local` — **PASSED**, exit code 0. Full XCTest surface (478+ suites) and Swift Testing runs all green with 0 failures/0 unexpected; new tests confirmed passing in the full run.

Refs #1774

🤖 Generated with [Claude Code](https://claude.com/claude-code)