### PR TITLE
feat(catalog/hardware): selection-time model profile + MoE-aware recommender inputs (Apple FM Tier 0)

### DIFF
--- a/Sources/ManifoldHardware/AppleSiliconBandwidth.swift
+++ b/Sources/ManifoldHardware/AppleSiliconBandwidth.swift
@@ -236,8 +236,10 @@ package enum QuantizationBits {
 /// ## Dimensions
 /// - **quality**: capability proxy from `ModelCapabilityTier` (size tier) scaled by
 ///   quantization bits-per-weight. Larger + wider-quant ⇒ higher.
-/// - **speed**: `bandwidthGBs / modelSizeGB × efficiencyFactor`, normalised. Decode
-///   throughput is memory-bandwidth bound, so this approximates tokens/sec.
+/// - **speed**: `bandwidthGBs / activeBytesGB × efficiencyFactor`, normalised. Decode
+///   throughput is memory-bandwidth bound by the bytes streamed per token-pass, so this
+///   approximates tokens/sec. For MoE models the denominator is `activeParameterBytes`
+///   (active experts), not the total weight set — they decode fast despite being large.
 /// - **fit**: derived from `ModelLoadPlan.estimate(...)` — `.allow` ⇒ high, `.warn` ⇒
 ///   mid, `.deny` ⇒ 0. We reuse the load plan rather than recomputing memory math.
 /// - **context**: known context length vs. the use case's `contextNeed`. Neutral
@@ -312,9 +314,17 @@ public struct ModelFitScorer: Sendable {
         // --- quality: size tier × quantization width. ---
         let quality = qualityScore(for: model)
 
-        // --- speed: bandwidth ÷ footprint, scaled, normalised against saturation. ---
-        let modelSizeGB = max(Double(model.sizeBytes) / 1_073_741_824, 0.001)
-        let estimatedTPS = (device.memoryBandwidthGBs / modelSizeGB) * efficiencyFactor
+        // --- speed: bandwidth ÷ active-bytes-per-token, scaled, normalised. ---
+        // why: decode throughput is bound by the bytes streamed through the memory bus
+        // per token-pass, not by the total resident weight set. For a mixture-of-experts
+        // model only the active experts (+ always-on weights) are touched each token, so
+        // `activeParameterBytes` is the correct denominator — an MoE is *big in RAM* (the
+        // fit dimension above still uses ModelLoadPlan with the full footprint, because
+        // every expert must be RAM-resident) yet *fast in decode*. Dense or unknown models
+        // have nil activeParameterBytes and fall back to sizeBytes, preserving prior behavior.
+        let activeBytes = model.activeParameterBytes ?? model.sizeBytes
+        let activeGB = max(Double(activeBytes) / 1_073_741_824, 0.001)
+        let estimatedTPS = (device.memoryBandwidthGBs / activeGB) * efficiencyFactor
         let speed = clamp01(estimatedTPS / speedSaturationTokensPerSecond)
 
         // --- context: known length vs. need; neutral when unknown. ---
@@ -375,6 +385,158 @@ public struct ModelFitScorer: Sendable {
             return (model, s)
         }
         .sorted { $0.1.composite > $1.1.composite }
+    }
+
+    // MARK: - Unified candidate scoring (Apple FM Tier 0)
+
+    /// Conservative active footprint assumed for an OS-resident model whose internals
+    /// are opaque (Apple Foundation Models). Apple FM is a small, on-device, guardrailed
+    /// model; we treat its decode cost as a ~3B-class active size (~1.6 GB at Q4) so it
+    /// lands in the fast/usable speed band rather than fabricating a precise figure.
+    package static let osResidentAssumedActiveBytes: UInt64 = 1_610_612_736 // ~1.5 GiB
+
+    /// Neutral-to-modest quality base for a resident model with no size tier to read.
+    /// Apple FM is a small guardrailed on-device model — capable for everyday tasks but
+    /// not frontier — so we anchor it mid-band rather than scoring it as a large model.
+    package static let osResidentQualityBase: Double = 0.55
+
+    /// Scores a single selection candidate under a use case.
+    ///
+    /// Unifies the downloadable and resident (OS-resident / on-disk) shapes so an
+    /// Apple-Foundation-Models "Tier 0" model ranks head-to-head against downloadable
+    /// upgrades in one list.
+    ///
+    /// - Parameters:
+    ///   - candidate: A `.downloadable` (delegates to `score(_:...)`) or `.resident`.
+    ///   - useCase: Biases the dimension weights and context need.
+    ///   - device: Device profile supplying memory + bandwidth.
+    ///   - requestedContextSize: Context size used by the downloadable fit estimate.
+    ///   - foundationAvailable: Whether the OS-resident provider (Apple FM) is usable
+    ///     right now. An unavailable FM is collapsed to the bottom exactly like a
+    ///     `.deny` downloadable.
+    /// - Returns: A `ModelFitScore`, or `nil` if the candidate cannot be scored.
+    public func score(
+        candidate: ModelSelectionCandidate,
+        useCase: ModelUseCase,
+        device: DeviceProfile = .current,
+        requestedContextSize: Int = 4_096,
+        foundationAvailable: Bool = true
+    ) -> ModelFitScore? {
+        switch candidate {
+        case .downloadable(let model):
+            return score(
+                model,
+                useCase: useCase,
+                requestedContextSize: requestedContextSize,
+                device: device
+            )
+        case .resident(let profile):
+            return scoreResident(
+                profile,
+                useCase: useCase,
+                device: device,
+                foundationAvailable: foundationAvailable
+            )
+        }
+    }
+
+    /// Ranks selection candidates best-first (descending composite). Candidates that
+    /// fail to score are dropped. Mirrors `rank(_:...)`.
+    public func rank(
+        candidates: [ModelSelectionCandidate],
+        useCase: ModelUseCase,
+        device: DeviceProfile = .current,
+        requestedContextSize: Int = 4_096,
+        foundationAvailable: Bool = true
+    ) -> [(ModelSelectionCandidate, ModelFitScore)] {
+        candidates.compactMap { candidate in
+            guard let s = score(
+                candidate: candidate,
+                useCase: useCase,
+                device: device,
+                requestedContextSize: requestedContextSize,
+                foundationAvailable: foundationAvailable
+            ) else { return nil }
+            return (candidate, s)
+        }
+        .sorted { $0.1.composite > $1.1.composite }
+    }
+
+    /// Builds a `ModelFitScore` for a resident model from its selection profile alone —
+    /// no `DownloadableModel`, no `ModelLoadPlan` (the profile carries the footprint the
+    /// plan would have produced). Honest qualitative buckets, no fabricated precision.
+    private func scoreResident(
+        _ profile: ModelSelectionProfile,
+        useCase: ModelUseCase,
+        device: DeviceProfile,
+        foundationAvailable: Bool
+    ) -> ModelFitScore {
+        let weights = useCase.weights
+        let footprint = profile.estimatedFootprintBytes ?? 0
+
+        // --- fit / willRun: residency-aware. ---
+        let willRun: Bool
+        let fit: Double
+        switch profile.residency {
+        case .osResident:
+            // The OS owns loading; the only gate is whether the provider is available.
+            willRun = foundationAvailable
+            fit = foundationAvailable ? 1.0 : 0.0
+        case .downloaded, .downloadable:
+            // Runnable unless the declared footprint exceeds usable device memory.
+            let fits = footprint == 0 || footprint <= device.usableMemoryBytes
+            willRun = fits
+            fit = fits ? 1.0 : 0.0
+        }
+
+        // --- speed: bandwidth ÷ active-bytes-per-token. ---
+        // why: same memory-bandwidth model as downloadable scoring. Use the profile's
+        // activeParameterBytes when known; for an opaque OS-resident model (Apple FM)
+        // assume a small ~3B-class active footprint so it lands in the fast/usable band
+        // rather than inventing a precise figure we cannot read.
+        let activeBytes: UInt64
+        if let active = profile.activeParameterBytes, active > 0 {
+            activeBytes = active
+        } else if case .osResident = profile.residency {
+            activeBytes = Self.osResidentAssumedActiveBytes
+        } else {
+            // Non-FM resident with no active figure: fall back to its footprint.
+            activeBytes = footprint > 0 ? footprint : Self.osResidentAssumedActiveBytes
+        }
+        let activeGB = max(Double(activeBytes) / 1_073_741_824, 0.001)
+        let estimatedTPS = (device.memoryBandwidthGBs / activeGB) * efficiencyFactor
+        let speed = clamp01(estimatedTPS / speedSaturationTokensPerSecond)
+
+        // --- quality: resident models lack a size tier; use an honest mid-band base. ---
+        let quality = Self.osResidentQualityBase
+
+        // --- context: declared length vs. need; neutral when unknown. ---
+        let context: Double
+        if let known = profile.declaredContextLength, known > 0 {
+            context = clamp01(Double(known) / Double(max(useCase.contextNeed, 1)))
+        } else {
+            context = 0.5
+        }
+
+        let weightedSum = quality * weights.quality
+            + speed * weights.speed
+            + fit * weights.fit
+            + context * weights.context
+
+        // Reuse the willRun-collapse convention: an unavailable/over-budget resident
+        // model sinks to the bottom exactly like a `.deny` downloadable.
+        let composite = willRun ? weightedSum : weightedSum * 0.1
+
+        return ModelFitScore(
+            quality: quality,
+            speed: speed,
+            fit: fit,
+            context: context,
+            composite: composite,
+            estimatedTokensPerSecond: estimatedTPS,
+            memoryBytes: footprint,
+            willRun: willRun
+        )
     }
 
     // MARK: - Quality

--- a/Sources/ManifoldHardware/CuratedModel.swift
+++ b/Sources/ManifoldHardware/CuratedModel.swift
@@ -37,6 +37,13 @@ public struct CuratedModel: Identifiable, Sendable {
     /// unverified.
     public let expectedSHA256: String?
 
+    /// Approximate quantized bytes streamed per decode token-pass — the active
+    /// experts plus always-on weights. For dense models this equals the total
+    /// weight size; `nil` means dense-or-unknown, and callers fall back to total
+    /// size. Used only to rank MoE decode speed, never for memory-fit (all
+    /// experts must be resident).
+    public let activeParameterBytes: UInt64?
+
     public init(
         id: String,
         displayName: String,
@@ -49,7 +56,8 @@ public struct CuratedModel: Identifiable, Sendable {
         promptTemplate: PromptTemplate,
         description: String,
         mmprojFileName: String? = nil,
-        expectedSHA256: String? = nil
+        expectedSHA256: String? = nil,
+        activeParameterBytes: UInt64? = nil
     ) {
         self.id = id
         self.displayName = displayName
@@ -63,6 +71,7 @@ public struct CuratedModel: Identifiable, Sendable {
         self.description = description
         self.mmprojFileName = mmprojFileName
         self.expectedSHA256 = expectedSHA256
+        self.activeParameterBytes = activeParameterBytes
     }
 
     /// The curated model list to display in model discovery UI.

--- a/Sources/ManifoldHardware/DownloadableModel.swift
+++ b/Sources/ManifoldHardware/DownloadableModel.swift
@@ -54,6 +54,13 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
     /// UI as unverified.
     public let expectedSHA256: String?
 
+    /// Approximate quantized bytes streamed per decode token-pass — the active
+    /// experts plus always-on weights. For dense models this equals the total
+    /// weight size; `nil` means dense-or-unknown, and callers fall back to total
+    /// size. Used only to rank MoE decode speed, never for memory-fit (all
+    /// experts must be resident).
+    public let activeParameterBytes: UInt64?
+
     /// Human-readable size (e.g., "4.1 GB").
     public var sizeFormatted: String {
         ByteCountFormatter.string(fromByteCount: Int64(sizeBytes), countStyle: .file)
@@ -92,6 +99,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.mmprojFileName = curated.mmprojFileName
         self.packageKind = nil
         self.expectedSHA256 = curated.expectedSHA256
+        self.activeParameterBytes = curated.activeParameterBytes
     }
 
     // MARK: - Memberwise
@@ -108,7 +116,8 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         description: String? = nil,
         mmprojFileName: String? = nil,
         packageKind: ModelPackageKind? = nil,
-        expectedSHA256: String? = nil
+        expectedSHA256: String? = nil,
+        activeParameterBytes: UInt64? = nil
     ) {
         self.id = "\(repoID)/\(fileName)"
         self.repoID = repoID
@@ -123,6 +132,7 @@ public struct DownloadableModel: Identifiable, Sendable, Hashable {
         self.mmprojFileName = mmprojFileName
         self.packageKind = packageKind
         self.expectedSHA256 = expectedSHA256
+        self.activeParameterBytes = activeParameterBytes
     }
 }
 

--- a/Sources/ManifoldHardware/ModelSelectionProfile.swift
+++ b/Sources/ManifoldHardware/ModelSelectionProfile.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// This file defines the pure value types for a *selection-time* model descriptor.
+// A host reads these to rank candidate models BEFORE committing to loading one —
+// including Apple Foundation Models as a zero-download "Tier 0". The whole point
+// is that these facts are queryable without instantiating a backend, mirroring the
+// `LocalInferenceAdapter.declaredCapabilities` precedent ("read the claims without
+// booting the backend"). They complement — and do NOT replace — the runtime fit
+// machinery (`ModelLoadPlan`, `ModelFitScorer`): a later step extends the scorer to
+// consume these, but the types here carry no logic and no I/O.
+
+/// A product-visible disclosure that a backend may sanitize generated content.
+///
+/// This is a *selection* decision, not a runtime one: a host ranks candidates by
+/// whether their output is subject to a content filter before it ever loads one,
+/// so a user who needs unfiltered generation can prefer a model that declares
+/// `.none`. Apple Foundation Models ⇒ `.applied` (the OS sanitizes); local
+/// GGUF/MLX ⇒ `.none` (no filtering layer); cloud providers ⇒ provider-declared.
+/// `.unknown` is the honest default when no claim is available.
+public enum ContentFilteringDisclosure: Sendable, Equatable, Codable {
+    /// No content-filtering layer is applied (e.g. local GGUF / MLX).
+    case none
+    /// The backend sanitizes generated content (e.g. Apple Foundation Models).
+    case applied
+    /// No disclosure is available; the host should not assume either way.
+    case unknown
+}
+
+/// Where a candidate model physically lives at selection time.
+///
+/// Distinct from the catalog's `DownloadState`: that tracks *live* progress
+/// (queued / downloading / failed, with byte counters that change as a transfer
+/// runs). `ResidencyState` is the *static* selection-time fact — what it would
+/// take to make this model usable right now — so the recommender can rank a
+/// zero-download OS-resident model against an N-byte pull without subscribing to
+/// any download machinery.
+public enum ResidencyState: Sendable, Equatable {
+    /// Provided by the OS with zero download (e.g. Apple Foundation Models).
+    case osResident
+    /// Already present on disk; usable without a network transfer.
+    case downloaded
+    /// Not yet present; would require pulling `sizeBytes` bytes to use.
+    case downloadable(sizeBytes: UInt64)
+}
+
+/// A selection-time descriptor a host reads to rank a model before loading it.
+///
+/// Every field is a claim that can be answered without instantiating a backend —
+/// the `LocalInferenceAdapter.declaredCapabilities` precedent. The recommender
+/// uses these to order candidates (footprint vs. device memory, MoE decode speed
+/// via active-parameter bytes, context budget, filtering disclosure) so the
+/// "which model should I pick?" decision happens entirely pre-boot.
+public struct ModelSelectionProfile: Sendable, Equatable {
+    /// Stable identifier for the model this profile describes.
+    public let modelID: String
+    /// Where the model lives at selection time (OS-resident, on disk, or a pull).
+    public let residency: ResidencyState
+    /// Estimated total resident + KV footprint from a load plan, in bytes.
+    ///
+    /// `nil` when unknown (e.g. an OS-resident model whose internals are opaque).
+    /// Lets the recommender compare a candidate's memory cost against device RAM
+    /// before loading.
+    public let estimatedFootprintBytes: UInt64?
+    /// Quantized bytes streamed per decode token-pass, in bytes.
+    ///
+    /// For mixture-of-experts models only a subset of weights is touched per token,
+    /// so this is smaller than the resident footprint and is the right proxy for
+    /// decode throughput. `nil` means dense or unknown — fall back to footprint.
+    public let activeParameterBytes: UInt64?
+    /// Whether generated content is subject to a backend content filter.
+    public let contentFiltering: ContentFilteringDisclosure
+    /// Declared maximum context length in tokens, or `nil` when not advertised.
+    public let declaredContextLength: Int?
+
+    public init(
+        modelID: String,
+        residency: ResidencyState,
+        estimatedFootprintBytes: UInt64? = nil,
+        activeParameterBytes: UInt64? = nil,
+        contentFiltering: ContentFilteringDisclosure,
+        declaredContextLength: Int? = nil
+    ) {
+        self.modelID = modelID
+        self.residency = residency
+        self.estimatedFootprintBytes = estimatedFootprintBytes
+        self.activeParameterBytes = activeParameterBytes
+        self.contentFiltering = contentFiltering
+        self.declaredContextLength = declaredContextLength
+    }
+}
+
+/// A single rankable entry in a model recommendation list.
+///
+/// Unifies two otherwise-incompatible shapes so the recommender can rank an
+/// OS-resident "Tier 0" model (described by a `ModelSelectionProfile`) in the same
+/// ordered list as downloadable upgrades (described by `DownloadableModel`). Without
+/// this, Tier 0 would have to live in a separate code path and could never be
+/// compared head-to-head against a model the user could download.
+public enum ModelSelectionCandidate: Sendable {
+    /// A model already usable now — OS-resident or on disk — with its profile.
+    case resident(ModelSelectionProfile)
+    /// A model that would need downloading, with its catalog entry.
+    case downloadable(DownloadableModel)
+}

--- a/Sources/ManifoldModelCatalog/ModelInfo.swift
+++ b/Sources/ManifoldModelCatalog/ModelInfo.swift
@@ -42,6 +42,19 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     /// Best-effort KV-cache bytes-per-token estimate derived from GGUF metadata.
     public var estimatedKVBytesPerToken: UInt64?
 
+    /// Approximate quantized bytes streamed per decode token-pass — the active
+    /// experts plus always-on weights. For dense models this equals the total
+    /// weight size; `nil` means dense-or-unknown, and callers fall back to total
+    /// size. Used only to rank MoE decode speed, never for memory-fit (all
+    /// experts must be resident).
+    ///
+    // Left `nil` on every GGUF path for now: the header-only GGUFMetadataReader
+    // never sums per-tensor bytes (it deliberately skips the tensor section), so
+    // a sound active-byte estimate from expert_count/feed_forward_length alone is
+    // not derivable here without inventing numbers. Reserved for curated/manifest
+    // population, which carries trustworthy active-weight sizes.
+    public var activeParameterBytes: UInt64?
+
     // MARK: - Capability
 
     /// Static capability tier for this model, derived from file size at init time.
@@ -357,6 +370,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         modelArchitecture: String? = nil,
         chatTemplateRaw: String? = nil,
         estimatedKVBytesPerToken: UInt64? = nil,
+        activeParameterBytes: UInt64? = nil,
         capabilityTier: ModelCapabilityTier? = nil,
         benchmarkResult: ModelBenchmarkResult? = nil,
         huggingFaceRepoID: String? = nil
@@ -373,6 +387,7 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         self.modelArchitecture = modelArchitecture
         self.chatTemplateRaw = chatTemplateRaw
         self.estimatedKVBytesPerToken = estimatedKVBytesPerToken
+        self.activeParameterBytes = activeParameterBytes
         self.capabilityTier = capabilityTier
         self.benchmarkResult = benchmarkResult
         self.huggingFaceRepoID = huggingFaceRepoID

--- a/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/DeviceAwareModelRecommendations.md
+++ b/Sources/ManifoldUIModelManagement/ManifoldUIModelManagement.docc/DeviceAwareModelRecommendations.md
@@ -68,6 +68,13 @@ for (model, score) in ranked {
 - Keep size and quantization visible — they are the ground truth a power user reasons about.
 - The authoritative will-it-run gate stays `ModelLoadPlan`; ``ModelFitScore/willRun`` mirrors its verdict, and a non-runnable model is always ``FitQuality/notRecommended``.
 
+### Apple Foundation Models as Tier 0, and MoE decode speed
+
+Two refinements let the ranking reflect how models actually behave on-device:
+
+- **Apple Foundation Models is an instant "Tier 0."** Wrap candidates as ``ModelSelectionCandidate`` and an OS-resident model (Apple FM, a zero-download `ModelSelectionProfile`) ranks head-to-head against downloadable upgrades in one list via `ModelFitScorer.rank(candidates:useCase:device:foundationAvailable:)`. When the provider is unavailable (`foundationAvailable: false`) it collapses to the bottom exactly like a model that won't load — no separate code path.
+- **Mixture-of-experts models decode fast despite being large.** Decode throughput is bound by the bytes streamed per token-pass, which for MoE is only the active experts, not the full resident weight set. When a model declares `activeParameterBytes`, the speed dimension uses it — so an MoE that is *big in RAM* (the memory-fit dimension still counts every expert, because all must be resident) is scored as *fast in decode*. Dense or unknown models fall back to total size, so nothing regresses.
+
 ## When recommendations do nothing
 
 Recommendations require models to be *surfaced* in the first place. They have nothing to rank for:

--- a/Tests/ManifoldInferenceTests/ModelFitScorerTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelFitScorerTests.swift
@@ -229,4 +229,149 @@ final class ModelFitScorerTests: XCTestCase {
             QuantizationBits.neutralBitsPerWeight
         )
     }
+
+    // MARK: - MoE-aware decode speed
+
+    /// A GGUF download with an explicit active-parameter footprint (mixture-of-experts).
+    private func moeModel(
+        totalGB: Double,
+        activeGB: Double,
+        quant: String,
+        name: String = "MoE"
+    ) -> DownloadableModel {
+        DownloadableModel(
+            repoID: "test/\(name)-GGUF",
+            fileName: "\(name).\(quant).gguf",
+            displayName: "\(name) \(quant)",
+            modelType: .gguf,
+            sizeBytes: UInt64(totalGB * Double(oneGB)),
+            activeParameterBytes: UInt64(activeGB * Double(oneGB))
+        )
+    }
+
+    func test_moe_decodesFasterButNotBetterFit_thanDense() {
+        // Big device so both models run and the willRun gate doesn't mask the speed math.
+        let dev = device(ramGB: 96, bandwidthGBs: 400)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        // MoE: ~60 GB resident, ~10 GB active per token. Dense: ~32 GB, all active.
+        // Dense uses a wider quant (Q6) so it reads as higher quality within the shared
+        // frontier tier — that quality edge is what reasoning rewards.
+        let moe = moeModel(totalGB: 60.0, activeGB: 10.0, quant: "Q4_K_M", name: "Mixtral")
+        let dense = ggufModel(sizeGB: 32.0, quant: "Q6_K", name: "Dense")
+
+        let sMoE = scorer.score(moe, useCase: .general, device: dev, environment: env)!
+        let sDense = scorer.score(dense, useCase: .general, device: dev, environment: env)!
+
+        // Speed is bound by bytes streamed per token: MoE streams 10 GB, dense streams 32 GB.
+        XCTAssertGreaterThan(
+            sMoE.speed, sDense.speed,
+            "MoE decodes faster: active 10 GB beats dense 32 GB on the same bandwidth"
+        )
+        XCTAssertGreaterThan(
+            sMoE.estimatedTokensPerSecond, sDense.estimatedTokensPerSecond,
+            "MoE tok/s should exceed the dense model's"
+        )
+        // But the MoE is bigger in RAM — its fit must NOT be better than the dense model.
+        XCTAssertLessThanOrEqual(
+            sMoE.fit, sDense.fit,
+            "MoE is bigger in RAM (all experts resident); fit must not improve"
+        )
+
+        // Bonus: composite ordering can flip with the use case. chat is speed-weighted
+        // (favours the faster MoE); reasoning is quality-weighted (favours the dense,
+        // which reads a higher size tier).
+        let chatMoE = scorer.score(moe, useCase: .chat, device: dev, environment: env)!
+        let chatDense = scorer.score(dense, useCase: .chat, device: dev, environment: env)!
+        XCTAssertGreaterThan(
+            chatMoE.composite, chatDense.composite,
+            "chat (speed-weighted) should prefer the faster MoE"
+        )
+        let reasonMoE = scorer.score(moe, useCase: .reasoning, device: dev, environment: env)!
+        let reasonDense = scorer.score(dense, useCase: .reasoning, device: dev, environment: env)!
+        XCTAssertGreaterThan(
+            reasonDense.composite, reasonMoE.composite,
+            "reasoning (quality-weighted) should prefer the larger dense model"
+        )
+    }
+
+    func test_nilActiveParameterBytes_matchesSizeBytesDenominator() {
+        // A model with nil activeParameterBytes must score the SAME speed/tok-s as an
+        // otherwise-identical model whose activeParameterBytes equals its sizeBytes —
+        // i.e. the MoE change is a no-op for dense models (no regression).
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let dense = ggufModel(sizeGB: 8.0, quant: "Q4_K_M", name: "Dense")
+        let denseExplicit = moeModel(totalGB: 8.0, activeGB: 8.0, quant: "Q4_K_M", name: "Dense")
+
+        let sNil = scorer.score(dense, useCase: .general, device: dev, environment: env)!
+        let sExplicit = scorer.score(denseExplicit, useCase: .general, device: dev, environment: env)!
+
+        XCTAssertEqual(sNil.speed, sExplicit.speed, accuracy: 0.0001)
+        XCTAssertEqual(
+            sNil.estimatedTokensPerSecond, sExplicit.estimatedTokensPerSecond, accuracy: 0.0001
+        )
+    }
+
+    // MARK: - Apple FM Tier 0 candidate ranking
+
+    /// An OS-resident Apple-FM-style profile.
+    private func fmProfile(contextLength: Int? = 8_192) -> ModelSelectionProfile {
+        ModelSelectionProfile(
+            modelID: "apple.foundation",
+            residency: .osResident,
+            estimatedFootprintBytes: nil,
+            activeParameterBytes: nil,
+            contentFiltering: .applied,
+            declaredContextLength: contextLength
+        )
+    }
+
+    func test_fmTier0_available_runsAndRanksAmongRunnable() {
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let scorer = ModelFitScorer()
+
+        let fm = ModelSelectionCandidate.resident(fmProfile())
+        let download = ModelSelectionCandidate.downloadable(
+            ggufModel(sizeGB: 4.0, quant: "Q4_K_M", name: "Local")
+        )
+
+        let fmScore = scorer.score(candidate: fm, useCase: .chat, device: dev, foundationAvailable: true)!
+        XCTAssertTrue(fmScore.willRun, "available Apple FM must be runnable")
+
+        let ranked = scorer.rank(
+            candidates: [download, fm], useCase: .chat, device: dev, foundationAvailable: true
+        )
+        XCTAssertEqual(ranked.count, 2)
+        // Both runnable: FM (small active footprint) ranks among them, not collapsed.
+        XCTAssertTrue(ranked.allSatisfy { $0.1.willRun }, "both candidates run when FM is available")
+    }
+
+    func test_fmTier0_unavailable_sinksBelowEveryRunnable() {
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let scorer = ModelFitScorer()
+
+        let fm = ModelSelectionCandidate.resident(fmProfile())
+        let download = ModelSelectionCandidate.downloadable(
+            ggufModel(sizeGB: 4.0, quant: "Q4_K_M", name: "Local")
+        )
+
+        let fmScore = scorer.score(candidate: fm, useCase: .chat, device: dev, foundationAvailable: false)!
+        XCTAssertFalse(fmScore.willRun, "unavailable Apple FM must not be runnable")
+
+        let ranked = scorer.rank(
+            candidates: [fm, download], useCase: .chat, device: dev, foundationAvailable: false
+        )
+        XCTAssertEqual(ranked.count, 2)
+        // The unavailable FM must land last, below the runnable download.
+        if case .resident = ranked.last!.0 {
+            // expected: FM sank to the bottom
+        } else {
+            XCTFail("unavailable FM must rank below every runnable candidate")
+        }
+        XCTAssertFalse(ranked.last!.1.willRun, "the last candidate is the non-runnable FM")
+    }
 }


### PR DESCRIPTION
Closes #1782.

## What & why

Adds the **selection-time** surface a host needs to rank local models *before* loading one — with Apple Foundation Models as an instant, zero-download Tier 0 and downloadable GGUF/MLX models as opt-in upgrades. Per the audit on #1782, most inputs already existed (`DeviceProfile`/`AppleSiliconBandwidth` bandwidth table, `ModelLoadPlan` footprint, `ModelFitScorer` ranking, cached benchmarks), so this is a focused extension, not a new layer.

## Changes

**MoE-aware decode speed (the core fix).** `ModelFitScorer`'s speed dimension divided device bandwidth by *total* weights, so a 109B-A17B MoE was ranked as if it streamed all 109B per token. The speed denominator now uses `activeParameterBytes ?? sizeBytes` — active experts, not the full set. The **fit** dimension is untouched (it still uses `ModelLoadPlan` total footprint, because every expert must be RAM-resident). Net: an MoE is *big in RAM, fast in decode*, and now ranks accordingly. Dense/unknown models pass `nil` and keep their prior behavior exactly.

**`activeParameterBytes: UInt64?`** added to `DownloadableModel`, `CuratedModel`, and `ModelInfo` (all default `nil`, threaded through every initializer — no call sites broken). Left `nil` on GGUF paths for now: the header reader does not expose expert metadata, and an honest `nil` (callers fall back to total size) beats a fabricated estimate. Reserved for curated/manifest population.

**`ModelSelectionProfile` descriptor** (new, in `ManifoldHardware`) — `residency` (`ResidencyState`: osResident / downloaded / downloadable), `estimatedFootprintBytes`, `activeParameterBytes`, `contentFiltering` (`ContentFilteringDisclosure`: none / applied / unknown — a product-visible guardrail disclosure, a selection decision not a runtime one), `declaredContextLength`. Pure value type, queryable without booting a backend (mirrors the `LocalInferenceAdapter.declaredCapabilities` precedent).

**Apple FM Tier 0 ranking.** `ModelSelectionCandidate` (`.resident` | `.downloadable`) plus `ModelFitScorer.rank(candidates:useCase:device:foundationAvailable:)` rank an OS-resident model head-to-head with downloadable upgrades. An unavailable FM is collapsed to the bottom exactly like a `.deny` downloadable, so the host's "smallest local fallback" path falls out for free. Resident scoring uses documented, honest constants (FM treated as a ~3B-class, mid-capability, guardrailed on-device model) — no fabricated precision.

## Tests
`ModelFitScorerTests` (ManifoldInferenceTests): MoE decodes faster but does not fit better than a dense 32B (with a composite flip between `.chat` and `.reasoning`); `nil` active-bytes is a no-op vs. the old denominator; FM Tier 0 runs when available and sinks when not. Sabotage-verified during development. Full `scripts/test.sh --profile local` gate: **PASSED**, 0 failures.

## Not in scope (per #1782 audit)
- The hardware probe + per-chip bandwidth table (request #2) already shipped in `AppleSiliconBandwidth`/`DeviceProfile` — no work needed.
- Ranking on the guardrail flag stays host policy; the scorer only exposes the disclosure.

## Backend checklist
- [x] Apple FM (Tier 0 candidate)
- [x] GGUF / MLX (downloadable candidates; active-params field present, populated from manifest/curated)
- [x] Pure value types — no per-backend runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
