### PR TITLE
perf: eliminate O(n²) work in UI streaming path

### DIFF
--- a/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
@@ -133,6 +133,20 @@ final class ChatGenerationCoordinator {
     @ObservationIgnored
     private var streamingThinkingIDs: Set<UUID> = []
 
+    /// Accumulator for the in-flight assistant message's trailing visible-text
+    /// run. why: appending each token delta straight into the message's last
+    /// `.text` part did `existing + batch` — an O(N) string copy per batch and
+    /// O(N²) over the turn. Instead we `append` to this buffer (amortized O(1))
+    /// and write the whole buffer into the message. `contentParts` stays
+    /// authoritative — the buffer is purely a copy-avoidance cache.
+    @ObservationIgnored
+    private var streamingTailBuffer: String = ""
+
+    /// The assistant message id the ``streamingTailBuffer`` is keyed to. Cleared
+    /// on every terminal path so a stale buffer can never leak into a later turn.
+    @ObservationIgnored
+    private var streamingTailMessageID: UUID?
+
     // MARK: - Init
 
     init(conversationRuntime: ConversationRuntime, ownsDefaultRuntime: Bool) {
@@ -283,6 +297,11 @@ final class ChatGenerationCoordinator {
     // MARK: - Content-part Mutation Helpers
 
     /// Appends streamed visible-token text without clobbering sibling parts.
+    ///
+    /// Pure, buffer-free helper retained for tests and non-hot-path callers
+    /// (`ChatViewModel.appendVisibleText` forwards here). The streaming hot path
+    /// goes through ``appendStreamingDelta(_:to:)`` instead, which avoids the
+    /// O(N) `existing + batch` copy this helper performs.
     static func appendVisibleText(_ batch: String, into msg: inout ChatMessage) {
         if let lastIdx = msg.contentParts.indices.reversed().first(where: {
             if case .text = msg.contentParts[$0] { return true } else { return false }
@@ -291,6 +310,57 @@ final class ChatGenerationCoordinator {
         } else {
             msg.contentParts.append(.text(batch))
         }
+    }
+
+    /// Streaming-path text append. Accumulates into ``streamingTailBuffer``
+    /// (amortized O(1)) and writes the whole buffer into the message's trailing
+    /// `.text` run, killing the O(N²) per-batch string concat.
+    ///
+    /// The buffer is keyed to a single trailing text run. If a non-text part
+    /// (tool result, thinking) has started a NEW trailing text run since the
+    /// last delta, the buffer is reset so we never append the second run's
+    /// tokens onto the first run's text.
+    private func appendStreamingDelta(_ delta: String, to messageID: UUID) {
+        // Detect a fresh trailing text run: either we switched messages, or the
+        // current message's last text part no longer matches our buffer (a
+        // sibling part was appended, opening a new run).
+        let trailingText = currentTrailingTextRun(of: messageID)
+        if streamingTailMessageID != messageID || trailingText != streamingTailBuffer {
+            streamingTailMessageID = messageID
+            streamingTailBuffer = trailingText ?? ""
+        }
+
+        streamingTailBuffer.append(delta)
+        let whole = streamingTailBuffer
+        _ = mutateMessage(messageID) { msg in
+            Self.writeTrailingText(whole, into: &msg)
+        }
+    }
+
+    /// Returns the text of the current trailing `.text` run of the message, or
+    /// `nil` when the message has no parts / does not end in a text run.
+    private func currentTrailingTextRun(of messageID: UUID) -> String? {
+        guard let msg = currentMessages().first(where: { $0.id == messageID }) else { return nil }
+        guard case .text(let existing)? = msg.contentParts.last else { return nil }
+        return existing
+    }
+
+    /// Replaces the message's trailing `.text` run with `whole`, or appends a
+    /// new `.text` part when the trailing part is not text.
+    private static func writeTrailingText(_ whole: String, into msg: inout ChatMessage) {
+        if case .text? = msg.contentParts.last {
+            msg.contentParts[msg.contentParts.count - 1] = .text(whole)
+        } else {
+            msg.contentParts.append(.text(whole))
+        }
+    }
+
+    /// Clears the streaming text accumulator. Called on every terminal path
+    /// (finish / cancel / error / empty) so a stale buffer cannot bleed into a
+    /// later turn.
+    private func clearStreamingTailBuffer() {
+        streamingTailBuffer = ""
+        streamingTailMessageID = nil
     }
 
     /// Writes `partial` into the last in-flight `.thinking` part for live preview.
@@ -344,6 +414,8 @@ final class ChatGenerationCoordinator {
             onSetLastTurnState(.generating)
             transitionPhase(to: .waitingForFirstToken)
             activeConversationMessageID = messageID
+            // Fresh turn — drop any leftover accumulator and re-key on demand.
+            clearStreamingTailBuffer()
             if let activeSessionID = currentActiveSessionID(),
                !currentMessages().contains(where: { $0.id == messageID }) {
                 let placeholder = ChatMessage(
@@ -357,7 +429,7 @@ final class ChatGenerationCoordinator {
 
         case .tokenEmitted(let messageID, let delta):
             transitionPhase(to: .streaming)
-            _ = mutateMessage(messageID) { Self.appendVisibleText(delta, into: &$0) }
+            appendStreamingDelta(delta, to: messageID)
 
         case .tokenUsageRecorded(let messageID, let promptTokens, let completionTokens):
             _ = mutateMessage(messageID) {
@@ -368,6 +440,7 @@ final class ChatGenerationCoordinator {
         case .streamFinished(let messageID, let reason):
             guard messageID == activeConversationMessageID else { break }
             activeConversationMessageID = nil
+            clearStreamingTailBuffer()
 
             activeConversationStreamHandle = nil
             resumeStreamCompletionWaiters()
@@ -420,6 +493,7 @@ final class ChatGenerationCoordinator {
             }
             activeConversationStreamHandle = nil
             activeConversationMessageID = nil
+            clearStreamingTailBuffer()
             resumeStreamCompletionWaiters()
             transitionPhase(to: .idle)
 
@@ -536,6 +610,7 @@ final class ChatGenerationCoordinator {
         activeConversationStreamHandle = nil
         resumeStreamCompletionWaiters()
         activeConversationMessageID = nil
+        clearStreamingTailBuffer()
         transitionPhase(to: .idle)
 
         if let error = outcome.error {

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+Generation.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+Generation.swift
@@ -19,6 +19,15 @@ extension ChatViewModel {
     /// ensuring the index is never stale. Returns `true` if the message was found.
     @discardableResult
     func mutateMessage(id: UUID, _ body: (inout ChatMessage) -> Void) -> Bool {
+        // Fast path: streaming mutates the trailing message ~30×/sec. The
+        // common case is "mutate the last message", so check the tail in O(1)
+        // before falling back to the O(N) scan. This re-validates the tail id
+        // on every call (no cached index), so branch/edit/cancel that reshape
+        // the tail safely take the scan fallback.
+        if let lastIdx = messages.indices.last, messages[lastIdx].id == id {
+            body(&messages[lastIdx])
+            return true
+        }
         guard let idx = messages.firstIndex(where: { $0.id == id }) else { return false }
         body(&messages[idx])
         return true

--- a/Sources/ManifoldUI/Views/Chat/ChatHistoryView.swift
+++ b/Sources/ManifoldUI/Views/Chat/ChatHistoryView.swift
@@ -40,8 +40,20 @@ struct ChatHistoryView: View {
                         ChatHistoryEmptyPlaceholder(customContent: customEmptyPlaceholder)
                     }
 
-                    ForEach(Array(viewModel.messages.enumerated()), id: \.element.id) { index, message in
-                        messageRow(at: index, message: message)
+                    // why: iterate `messages` directly (ChatMessage is
+                    // Identifiable) instead of materializing a fresh
+                    // `enumerated()` tuple array on every body eval — that array
+                    // was an O(N) allocation per streaming batch (~30/sec). The
+                    // only index consumer was the handoff chip, which needs the
+                    // PREVIOUS message; we precompute the handoff boundaries in
+                    // one O(N) pass keyed by message id so no per-row scan is
+                    // reintroduced.
+                    let handoffBoundaries = ChatHistoryHandoffResolver.boundaries(
+                        messages: viewModel.messages,
+                        session: viewModel.activeSession
+                    )
+                    ForEach(viewModel.messages) { message in
+                        messageRow(message: message, handoffChip: handoffBoundaries[message.id])
                     }
 
                     Color.clear
@@ -85,13 +97,9 @@ struct ChatHistoryView: View {
     }
 
     @ViewBuilder
-    private func messageRow(at index: Int, message: ChatMessage) -> some View {
-        if let chip = ChatHistoryHandoffResolver.chip(
-            at: index,
-            messages: viewModel.messages,
-            session: viewModel.activeSession
-        ) {
-            chip
+    private func messageRow(message: ChatMessage, handoffChip: HandoffChipView?) -> some View {
+        if let handoffChip {
+            handoffChip
         }
 
         // A host renderer (if any) gets first refusal on the row; it can take
@@ -148,6 +156,29 @@ struct ChatHistoryEmptyPlaceholder: View {
 }
 
 enum ChatHistoryHandoffResolver {
+
+    /// Computes, in a single O(N) pass, the handoff chip to render *above* each
+    /// message — keyed by the message's id.
+    ///
+    /// why: `ChatHistoryView` used to call ``chip(at:messages:session:)`` per
+    /// row, and each call did its own adjacency lookup. Iterating `messages`
+    /// directly (rather than `enumerated()`) means rows no longer carry their
+    /// index, so we resolve every boundary up front. Output is byte-for-byte
+    /// equivalent to calling ``chip(at:messages:session:)`` for each index.
+    @MainActor
+    static func boundaries(
+        messages: [ChatMessage],
+        session: ChatSession?
+    ) -> [UUID: HandoffChipView] {
+        guard let session, messages.count > 1 else { return [:] }
+        var result: [UUID: HandoffChipView] = [:]
+        for index in 1..<messages.count {
+            if let chip = chip(at: index, messages: messages, session: session) {
+                result[messages[index].id] = chip
+            }
+        }
+        return result
+    }
 
     /// Returns a ``HandoffChipView`` when adjacent persisted messages transition
     /// between two agents resolved from the active session.

--- a/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
@@ -99,11 +99,18 @@ public struct MessageBubbleView: View {
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(Self.accessibilityLabel(for: message))
 
-                LinkPreviewAttachmentView(
-                    text: message.content,
-                    provider: linkPreviewProvider
-                )
-                .frame(maxWidth: 700, alignment: alignment)
+                // why: gate on `!isStreaming` so NSDataDetector runs once at
+                // stream end, not on every streaming batch (~30/sec). The
+                // detector re-scans the whole accumulated text each pass — O(N²)
+                // over a turn — and the preview is only meaningful once the URL
+                // is fully streamed anyway.
+                if !isStreaming {
+                    LinkPreviewAttachmentView(
+                        text: message.content,
+                        provider: linkPreviewProvider
+                    )
+                    .frame(maxWidth: 700, alignment: alignment)
+                }
             }
 
             if message.role == .assistant { Spacer(minLength: spacerMinLength) }

--- a/Tests/ManifoldUITests/MessageBubbleViewLogicTests.swift
+++ b/Tests/ManifoldUITests/MessageBubbleViewLogicTests.swift
@@ -464,6 +464,45 @@ final class MessageBubbleViewLogicTests: XCTestCase {
         )
     }
 
+    /// Parity guard for the #1786 perf fix: `ChatHistoryView` now iterates
+    /// `messages` directly (no `enumerated()`) and resolves handoff chips via
+    /// the id-keyed ``ChatHistoryHandoffResolver/boundaries(messages:session:)``
+    /// precompute. Its output must be byte-for-byte identical to calling the
+    /// per-index ``chip(at:messages:session:)`` across an agent-transition
+    /// fixture.
+    ///
+    /// Sabotage-evidence:
+    ///   M1: off-by-one the boundary loop → a transition is keyed to the wrong id.
+    ///   M2: drop the session guard in `boundaries` → chips appear without agents.
+    func test_handoffBoundaries_matchPerIndexChipResolution() {
+        let (a, b) = agentPair()
+        let session = ManifoldInference.ChatSession(id: sessionID, agents: [a, b])
+        let messages = [
+            ManifoldInference.ChatMessage(role: .user, content: "q1", sessionID: sessionID, agentID: a.id),
+            ManifoldInference.ChatMessage(role: .assistant, content: "a1", sessionID: sessionID, agentID: a.id),
+            ManifoldInference.ChatMessage(role: .assistant, content: "a2", sessionID: sessionID, agentID: b.id),
+            ManifoldInference.ChatMessage(role: .assistant, content: "a3", sessionID: sessionID, agentID: b.id),
+            ManifoldInference.ChatMessage(role: .assistant, content: "a4", sessionID: sessionID, agentID: a.id),
+        ]
+
+        let boundaries = ChatHistoryHandoffResolver.boundaries(messages: messages, session: session)
+
+        for index in messages.indices {
+            let perIndex = ChatHistoryHandoffResolver.chip(at: index, messages: messages, session: session)
+            let keyed = boundaries[messages[index].id]
+            XCTAssertEqual(perIndex?.from?.id, keyed?.from?.id,
+                           "from-agent mismatch at index \(index)")
+            XCTAssertEqual(perIndex?.to?.id, keyed?.to?.id,
+                           "to-agent mismatch at index \(index)")
+        }
+
+        // Exactly the two real transitions (a→b at index 2, b→a at index 4)
+        // produce chips.
+        XCTAssertEqual(boundaries.count, 2, "Only genuine agent transitions get a chip")
+        XCTAssertNotNil(boundaries[messages[2].id])
+        XCTAssertNotNil(boundaries[messages[4].id])
+    }
+
     /// Snapshot the natural arrival ordering of `.tokenEmitted`-style events
     /// vs `.agentHandoff` for a single turn. The chip in our renderer is
     /// derived from the persisted sequence — but the *event* stream must

--- a/Tests/ManifoldUITests/StreamingTailBufferTests.swift
+++ b/Tests/ManifoldUITests/StreamingTailBufferTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+import ManifoldInference
+import ManifoldRuntime
+@testable import ManifoldUI
+import ManifoldTestSupport
+
+/// Pins the O(n²)-elimination fixes for the UI streaming path (issue #1786):
+///   * `ChatGenerationCoordinator` accumulates streamed tokens into a tail
+///     buffer and writes the whole buffer each batch, so `contentParts` always
+///     holds exactly one trailing `.text` part equal to the running total.
+///   * The accumulator resets when a sibling part (tool result) opens a new
+///     trailing text run, so the second run is a separate `.text` part.
+///   * `ChatViewModel.mutateMessage` takes the O(1) tail fast path when the id
+///     is the last message, and the O(N) scan fallback otherwise.
+@MainActor
+final class StreamingTailBufferTests: XCTestCase {
+
+    // MARK: - Backing store + coordinator harness
+
+    /// Mutable message store shared with the coordinator via its closure seams.
+    private final class MessageBox {
+        var messages: [ChatMessage] = []
+    }
+
+    private func makeInMemoryRuntime() -> ConversationRuntime {
+        ConversationRuntime(
+            messageStore: NoopMessageStore(),
+            inferenceService: InferenceService()
+        )
+    }
+
+    /// Builds a coordinator whose message-mutation seams read/write `box`.
+    private func makeCoordinator(box: MessageBox, sessionID: UUID) -> ChatGenerationCoordinator {
+        let coord = ChatGenerationCoordinator(
+            conversationRuntime: makeInMemoryRuntime(),
+            ownsDefaultRuntime: true
+        )
+        coord.onTransitionPhase = { _ in true }
+        coord.onSetLastTurnState = { _ in }
+        coord.onSetBackgroundTaskError = { _ in }
+        coord.onSetMessageIDsWithStreamingThinking = { _ in }
+        coord.currentActiveSessionID = { sessionID }
+        coord.currentActiveSession = { ChatSession(id: sessionID, title: "Test") }
+        coord.currentMessages = { box.messages }
+        coord.currentPostGenerationTasks = { [] }
+        coord.appendMessage = { box.messages.append($0) }
+        coord.removeMessages = { predicate in box.messages.removeAll(where: predicate) }
+        coord.updateContextEstimate = {}
+        coord.surfaceError = { _, _ in }
+        coord.setErrorMessage = { _ in }
+        coord.setShowUpgradeHint = { _ in }
+        // Mirror ChatViewModel.mutateMessage including its tail fast path so the
+        // coordinator behaves exactly as in production.
+        coord.mutateMessage = { id, body in
+            if let lastIdx = box.messages.indices.last, box.messages[lastIdx].id == id {
+                body(&box.messages[lastIdx])
+                return true
+            }
+            guard let idx = box.messages.firstIndex(where: { $0.id == id }) else { return false }
+            body(&box.messages[idx])
+            return true
+        }
+        return coord
+    }
+
+    private func trailingTextParts(_ msg: ChatMessage) -> [String] {
+        msg.contentParts.compactMap { part in
+            if case .text(let t) = part { return t } else { return nil }
+        }
+    }
+
+    // MARK: - 1. K batches concatenate; one trailing .text always equals the buffer
+
+    func test_streamingTokens_accumulateIntoSingleTrailingTextPart() async {
+        let box = MessageBox()
+        let sessionID = UUID()
+        let coord = makeCoordinator(box: box, sessionID: sessionID)
+
+        let msgID = UUID()
+        await coord.handle(runtimeEvent: .streamStarted(messageID: msgID))
+
+        let batches = ["Hel", "lo, ", "wor", "ld", "!"]
+        var running = ""
+        for batch in batches {
+            await coord.handle(runtimeEvent: .tokenEmitted(messageID: msgID, delta: batch))
+            running += batch
+
+            // Invariant: after every batch the message ends in exactly one
+            // trailing `.text` part equal to the running concatenation.
+            let msg = box.messages.first(where: { $0.id == msgID })!
+            guard case .text(let trailing)? = msg.contentParts.last else {
+                return XCTFail("Trailing part must be .text after a token batch")
+            }
+            XCTAssertEqual(trailing, running, "Trailing text must equal the running buffer")
+            XCTAssertEqual(
+                msg.contentParts.filter { $0.textContent != nil }.count, 1,
+                "There must be exactly one text part during a contiguous text run"
+            )
+        }
+
+        let final = box.messages.first(where: { $0.id == msgID })!
+        XCTAssertEqual(final.content, batches.joined())
+    }
+
+    // MARK: - 2. Buffer resets when a tool result opens a new trailing text run
+
+    func test_streamingTokens_resetBufferAcrossInterleavedToolResult() async {
+        let box = MessageBox()
+        let sessionID = UUID()
+        let coord = makeCoordinator(box: box, sessionID: sessionID)
+
+        let msgID = UUID()
+        await coord.handle(runtimeEvent: .streamStarted(messageID: msgID))
+        coord.activeConversationMessageID = msgID
+
+        // First text run.
+        await coord.handle(runtimeEvent: .tokenEmitted(messageID: msgID, delta: "before"))
+
+        // A tool result lands, ending the trailing text run.
+        let result = ToolResult(callId: "c1", content: "done")
+        await coord.handle(runtimeEvent: .toolCallCompleted("c1", result))
+
+        // Second text run.
+        await coord.handle(runtimeEvent: .tokenEmitted(messageID: msgID, delta: "after"))
+
+        let msg = box.messages.first(where: { $0.id == msgID })!
+        let textParts = trailingTextParts(msg)
+        XCTAssertEqual(textParts, ["before", "after"],
+                       "Second text run must be a separate .text part; first run untouched")
+
+        // Tool result must sit between the two text runs.
+        XCTAssertTrue(msg.contentParts.contains(where: { $0.toolResultContent != nil }),
+                      "Tool result part must be preserved between the text runs")
+    }
+
+    // MARK: - 3. mutateMessage fast path correctness
+
+    func test_mutateMessage_fastPath_mutatesLastMessage() throws {
+        let harness = try makeTestChatViewModel()
+        defer { harness.cleanup() }
+        let vm = harness.vm
+
+        let sessionID = UUID()
+        let first = ChatMessage(role: .assistant, content: "first", sessionID: sessionID)
+        let last = ChatMessage(role: .assistant, content: "last", sessionID: sessionID)
+        vm.messages = [first, last]
+
+        let mutated = vm.mutateMessage(id: last.id) { $0.content = "last-edited" }
+
+        XCTAssertTrue(mutated)
+        XCTAssertEqual(vm.messages.last?.content, "last-edited")
+        XCTAssertEqual(vm.messages.first?.content, "first", "Non-tail message must be untouched")
+    }
+
+    func test_mutateMessage_fallbackScan_mutatesNonTailMessage() throws {
+        let harness = try makeTestChatViewModel()
+        defer { harness.cleanup() }
+        let vm = harness.vm
+
+        let sessionID = UUID()
+        let first = ChatMessage(role: .assistant, content: "first", sessionID: sessionID)
+        let last = ChatMessage(role: .assistant, content: "last", sessionID: sessionID)
+        vm.messages = [first, last]
+
+        // Mutating the NON-tail message must hit the firstIndex fallback.
+        let mutated = vm.mutateMessage(id: first.id) { $0.content = "first-edited" }
+
+        XCTAssertTrue(mutated)
+        XCTAssertEqual(vm.messages.first?.content, "first-edited")
+        XCTAssertEqual(vm.messages.last?.content, "last", "Tail message must be untouched")
+    }
+
+    func test_mutateMessage_unknownID_returnsFalse() throws {
+        let harness = try makeTestChatViewModel()
+        defer { harness.cleanup() }
+        let vm = harness.vm
+
+        vm.messages = [ChatMessage(role: .assistant, content: "only", sessionID: UUID())]
+
+        XCTAssertFalse(vm.mutateMessage(id: UUID()) { $0.content = "nope" })
+    }
+}
+
+/// Minimal in-memory MessageStore so these coordinator unit tests don't depend
+/// on SwiftData. The coordinator's text-accumulation path never touches the
+/// store — it exists only to construct a `ConversationRuntime`.
+private final class NoopMessageStore: MessageStore, @unchecked Sendable {
+    private var messages: [UUID: ChatMessage] = [:]
+    private var hooks: [any MessageStorePostWriteHook] = []
+
+    func insertMessage(_ message: ChatMessage) async throws {
+        messages[message.id] = message
+        for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+    }
+    func updateMessage(_ message: ChatMessage) async throws {
+        messages[message.id] = message
+        for hook in hooks { await hook.messageDidWrite(message, in: message.sessionID) }
+    }
+    func deleteMessage(_ messageID: UUID) async throws { messages.removeValue(forKey: messageID) }
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessage] {
+        messages.values.filter { $0.sessionID == sessionID }.sorted { $0.timestamp < $1.timestamp }
+    }
+    func deleteMessages(for sessionID: UUID) async throws {
+        messages = messages.filter { $0.value.sessionID != sessionID }
+    }
+    func addPostWriteHook(_ hook: any MessageStorePostWriteHook) { hooks.append(hook) }
+}


### PR DESCRIPTION
Closes #1786

During streaming (~30 batches/sec, `streamingUpdateInterval=33ms`) three costs compounded to O(n²). This PR keeps `messages` authoritative and removes all three, plus an orthogonal NSDataDetector fix.

## Fixes

1. **ChatHistoryView** — stop materializing `Array(messages.enumerated())` (a fresh tuple array every body eval). Iterate `messages` directly (`ChatMessage` is `Identifiable`). The only index consumer was the handoff chip (needs the *previous* message); replaced the per-row `firstIndex` lookup with `ChatHistoryHandoffResolver.boundaries(...)`, a single O(N) id-keyed precompute built once per body. Handoff-chip behavior is byte-for-byte identical (parity test included).

2. **mutateMessage fast path** — streaming mutates the trailing message ~30x/sec via an O(N) `firstIndex(where:)` scan. Added an O(1) last-message fast path that re-validates the tail id on every call (no cached index), so branch/edit/cancel that reshape the tail safely take the existing scan fallback.

3. **Kill the O(N²) concat** — `appendVisibleText` did `contentParts[last] = .text(existing + batch)`, an O(N) string copy per batch. Added an `@ObservationIgnored streamingTailBuffer` + `streamingTailMessageID`: tokens `append` to the buffer (amortized O(1)) and the whole buffer is written into the trailing `.text` part each batch. `contentParts` stays authoritative — the buffer is a cache. The buffer is keyed to the current trailing text run and **reset when a tool result / thinking part opens a new trailing text run** (adversarial finding), and cleared on every terminal path (finish / cancel / error / empty, including `applyTerminalOutcome`). The static `appendVisibleText` shim is retained for existing test callsites.

4. **Bonus** — gate `LinkPreviewAttachmentView` on `!isStreaming` so NSDataDetector runs once at stream end rather than re-scanning the whole accumulated text per batch.

The rejected alternative (a separate `@Observable` streaming-tail object) is *not* used — it breaks LazyVStack view identity at `.streamFinished`, the `onChange(messages.last?.content)` auto-scroll, and the "streaming msg is last" invariant.

## Tests (Tests/ManifoldUITests)

- `StreamingTailBufferTests`: K equal token batches → `messages.last.content` equals the concatenation and intermediate `contentParts` is always exactly one trailing `.text` equal to the running buffer; interleave-desync (text → tool result → text) → second run is a separate `.text`, first untouched; `mutateMessage` fast-path / fallback-scan / unknown-id correctness (sabotage-verified that breaking the `id == last.id` guard fails the fallback test, then removed).
- `MessageBubbleViewLogicTests`: handoff-chip parity — `boundaries(...)` output identical to per-index `chip(at:)` across an agent-transition fixture.

## Gate

`scripts/test.sh --profile local`: **0 test failures across 4080+ tests** (all new tests pass). Both gate runs reported INCOMPLETE due to a non-deterministic signal-11 at process teardown attributed to a *different* unrelated suite each run (GGUF hardware-probe / QuickStart, with CoreData delete-propagation teardown noise) — an environmental SwiftData/CoreData at-exit artifact, not a regression from this UI-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
