### PR TITLE
fix: surface swallowed error details in MCP OAuth and SwiftData encoding

### DIFF
--- a/Sources/ManifoldMCP/MCPOAuth.swift
+++ b/Sources/ManifoldMCP/MCPOAuth.swift
@@ -98,7 +98,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
                 do {
                     try await tokenStore.delete(serverID)
                 } catch {
-                    Log.inference.warning("MCPOAuthAuthorization: failed to clear token store after invalid_grant")
+                    Log.inference.warning("MCPOAuthAuthorization: failed to clear token store after invalid_grant (\(error.localizedDescription))")
                 }
             }
             return .fail(error)
@@ -152,7 +152,7 @@ public actor MCPOAuthAuthorization: MCPAuthorization {
                     return refreshed
                 } catch {
                     try await tokenStore.delete(serverID)
-                    Log.inference.warning("MCPOAuthAuthorization: refresh failed, forcing full OAuth authorization")
+                    Log.inference.warning("MCPOAuthAuthorization: refresh failed, forcing full OAuth authorization (\(error.localizedDescription))")
                 }
             }
         }

--- a/Sources/ManifoldMCP/OAuthTokenExchange.swift
+++ b/Sources/ManifoldMCP/OAuthTokenExchange.swift
@@ -164,7 +164,7 @@ struct OAuthTokenExchange {
         do {
             rawJSON = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
         } catch {
-            Log.inference.warning("OAuthTokenExchange: token response subject metadata was not JSON decodable")
+            Log.inference.warning("OAuthTokenExchange: token response subject metadata was not JSON decodable (\(error.localizedDescription))")
             rawJSON = [:]
         }
         let subjectID = MCPOAuthTokenStore.subjectIdentifier(from: rawJSON)

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV9.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV9.swift
@@ -243,12 +243,20 @@ public enum ManifoldSchemaV9: VersionedSchema {
                 if let json = String(data: data, encoding: .utf8) {
                     return json
                 }
-                Log.persistence.warning("Failed to convert encoded MessagePart data to UTF-8 string")
+                Log.persistence.error("Failed to convert encoded MessagePart data to UTF-8 string; substituting visible placeholder")
             } catch {
                 Log.persistence.error("Failed to encode MessagePart array: \(error)")
             }
-            return "[]"
+            // Returning "[]" here would be indistinguishable from a legitimately empty
+            // message and would silently lose the content. A non-JSON sentinel makes the
+            // failure visible: decode() falls back to .text(...) for non-JSON input, so the
+            // user sees the placeholder instead of a vanished message.
+            return Self.encodeFailurePlaceholder
         }
+
+        /// Sentinel persisted when MessagePart encoding fails. Intentionally not valid JSON so
+        /// decode() surfaces it as visible text rather than swallowing it as empty content.
+        static let encodeFailurePlaceholder = "[message content could not be encoded]"
 
         static func decode(_ json: String) -> [MessagePart] {
             guard let data = json.data(using: .utf8) else {

--- a/Tests/ManifoldPersistenceSwiftDataTests/MessagePartTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/MessagePartTests.swift
@@ -187,6 +187,21 @@ final class MessagePartTests: XCTestCase {
         XCTAssertEqual(message.content, "hello world")
     }
 
+    // MARK: - Encode failure is visible, not silent
+
+    // The encode() failure path must not collapse to "[]" — that is indistinguishable from a
+    // legitimately empty message and would silently drop content. The sentinel placeholder is
+    // intentionally non-JSON so decode() surfaces it as a visible .text part. This locks that
+    // contract: a persisted encode-failure row renders as visible text, never as empty content.
+    func test_chatMessage_encodeFailurePlaceholder_decodesToVisibleText() {
+        let placeholder = ManifoldSchemaV9.ChatMessage.encodeFailurePlaceholder
+        XCTAssertFalse(placeholder.isEmpty)
+
+        let parts = ManifoldSchemaV9.ChatMessage.decode(placeholder)
+        XCTAssertEqual(parts, [.text(placeholder)])
+        XCTAssertNotEqual(parts, [], "encode-failure placeholder must not decode to empty content")
+    }
+
     // MARK: - V1 -> V2 migration safety
 
     func test_chatMessage_v2Model_preservesContentColumn() throws {


### PR DESCRIPTION
Caught errors in four error-propagation paths were logged with static strings (or, for SwiftData encode, collapsed to `"[]"`), making production failures undiagnosable — and in the encode case, silently losing message content. Origin: 2/2 adversarial error-handling (silent-failure) audit. Per CLAUDE.md, error-propagation paths must surface the error via `Log.*` (never `try?`, never empty/static catch).

This is one coherent "surface swallowed error details" change spanning two modules (ManifoldMCP + ManifoldPersistenceSwiftData).

## Fixes

1. **`Sources/ManifoldMCP/MCPOAuth.swift:155`** — `activeTokens()` refresh failure logged a static "refresh failed" string. Now interpolates `\(error.localizedDescription)` (matches the file's existing Log convention, e.g. lines 133/481).

2. **`Sources/ManifoldMCP/MCPOAuth.swift:101`** — token-store cleanup failure after `invalid_grant` logged without detail. Now appends `\(error.localizedDescription)`.

3. **`Sources/ManifoldMCP/OAuthTokenExchange.swift:167`** — subject-metadata decode failure logged without detail. Now appends `\(error.localizedDescription)`.

4. **`Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV9.swift:240`** — `encode(parts)` returned `"[]"` on a JSON-encode/UTF-8 failure, indistinguishable from a legitimately empty message → silent content loss. It already logged at `.error`, but the *data* loss was invisible. Now returns a non-JSON sentinel (`encodeFailurePlaceholder`); `decode()` falls back to `.text(...)` for non-JSON input, so the user sees a visible placeholder instead of a vanished message. Also bumped the UTF-8-conversion branch from `.warning` to `.error`.

## Tests

Added `test_chatMessage_encodeFailurePlaceholder_decodesToVisibleText` (MessagePartTests) locking the contract that the encode-failure sentinel decodes to a visible `.text` part, never empty content.

Fixes 1–3 are pure log-string interpolation changes with no test-observable behavior — a log-capture test would be brittle, so none added (intentional).

## Gate (spike profile)

- `swift build --build-tests` — Build complete! (469s)
- `swift test --filter ManifoldMCP` — 224 tests, 0 failures (4 skipped)
- `swift test --filter ManifoldPersistenceSwiftData` — 222 tests, 0 failures (6 skipped), including the new test

Package.resolved not staged.