### PR TITLE
fix: make CloudImageEncoding encodeHook access race-free

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -81,3 +81,4 @@ API breakage: var InferenceBackend.isGenerating has been removed
 API breakage: var InferenceBackend.isModelLoaded has been removed
 API breakage: var InferenceBackend.manifest has been removed
 API breakage: constructor ChatViewModel.init(inferenceService:deviceCapability:modelStorage:memoryPressure:toolApprovalGate:userDefaults:conversationRuntime:) is now with @_spi
+API breakage: var CloudImageEncoding.encodeHook has been removed

--- a/Sources/ManifoldCloudCore/Internal/CloudImageEncoding.swift
+++ b/Sources/ManifoldCloudCore/Internal/CloudImageEncoding.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import ManifoldInference
 
 /// Shared image-encoding helpers for cloud backends that send images as
@@ -31,11 +32,14 @@ package enum CloudImageEncoding {
     /// no padding tweaks).
     package static func base64String(from data: Data) -> String {
         let encoded = data.base64EncodedString()
-        encodeHook?()
+        // Read the hook under the lock so a concurrent `setEncodeHook` from a
+        // test cannot race the optional-closure pointer (a Swift 6
+        // memory-safety violation). The closure itself runs outside the lock.
+        _encodeHook.withLock { $0 }?()
         return encoded
     }
 
-    /// Test-only hook fired once per ``base64String(from:)`` call.
+    /// Lock-guarded storage for the test-injection hook.
     ///
     /// Mirrors `GenerationQueue.toolDispatchLogHook`: production callers
     /// never set this; it exists so tests can count how many times a cloud
@@ -44,7 +48,21 @@ package enum CloudImageEncoding {
     /// `tearDown` to avoid cross-test leakage. See
     /// `CloudImageEncodeCountTests` for the invariant the perf-audit plan
     /// (PR-α work unit α-3) is grounding on.
-    package nonisolated(unsafe) static var encodeHook: (@Sendable () -> Void)?
+    ///
+    /// The previous `nonisolated(unsafe) static var` raced when cloud backends
+    /// encoded images on concurrent threads while a test mutated the hook. An
+    /// `OSAllocatedUnfairLock` (available below the macOS 15 / iOS 18 floor)
+    /// makes every read/write atomic without an actor hop on the hot path.
+    private static let _encodeHook =
+        OSAllocatedUnfairLock<(@Sendable () -> Void)?>(initialState: nil)
+
+    /// Installs (or clears, with `nil`) the test-injection hook race-free.
+    ///
+    /// Keeps the readable `CloudImageEncoding.setEncodeHook { ... }` call shape
+    /// at test sites while routing the write through the lock.
+    package static func setEncodeHook(_ hook: (@Sendable () -> Void)?) {
+        _encodeHook.withLock { $0 = hook }
+    }
 
     /// Returns a `data:` URI (RFC 2397) suitable for OpenAI's
     /// `image_url.url` field — `data:<mime>;base64,<payload>`. OpenAI also

--- a/Tests/ManifoldBackendsTests/CloudImageEncodeCountTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudImageEncodeCountTests.swift
@@ -20,7 +20,7 @@ import ManifoldTestSupport
 /// assertion atomically.
 ///
 /// The encoder is observed via a per-test hook
-/// (``CloudImageEncoding/encodeHook``) installed in `setUp` and torn down in
+/// (``CloudImageEncoding/setEncodeHook(_:)``) installed in `setUp` and torn down in
 /// `tearDown`. The hook fires exactly once per `base64String` call, so
 /// counting hook invocations equals counting encode calls — without having
 /// to instrument every backend's request-builder by hand.
@@ -56,14 +56,14 @@ final class CloudImageEncodeCountTests: XCTestCase {
         DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34"] }
         counter = EncodeCounter()
         let counter = counter!
-        CloudImageEncoding.encodeHook = { counter.increment() }
+        CloudImageEncoding.setEncodeHook { counter.increment() }
     }
 
     override func tearDown() {
         DNSRebindingGuard._resolverForTesting = nil
         // Reset before nilling out the local ref so a leftover hook from a
         // prior failure cannot leak into the next test in the same process.
-        CloudImageEncoding.encodeHook = nil
+        CloudImageEncoding.setEncodeHook(nil)
         counter = nil
         super.tearDown()
     }


### PR DESCRIPTION
## Finding

Verified data race in `Sources/ManifoldCloudCore/Internal/CloudImageEncoding.swift` (pre-fix lines 34 and 47), surfaced by a 2/2 adversarial concurrency audit.

`CloudImageEncoding.encodeHook` was a `package nonisolated(unsafe) static var` — a test-injection closure read on every `base64String(from:)` call (the cloud image-encode hot path, line 34) and written/cleared from `CloudImageEncodeCountTests` setUp/tearDown (line 47 declaration). Concurrent backend encode threads race the optional-closure pointer against a test mutating it: a Swift 6 memory-safety violation plus a cross-test contamination vector.

**Reproduced:** yes — confirmed against real code before editing.

## Fix

- Replace the `nonisolated(unsafe)` storage with an `OSAllocatedUnfairLock<(@Sendable () -> Void)?>` (available below the macOS 15 / iOS 18 platform floor per CLAUDE.md). Every read (hot path) and write (`setEncodeHook(_:)`) routes through the lock; the closure runs outside the lock.
- Per CLAUDE.md Swift-6 rules: a real lock, not `@unchecked Sendable`; no `try?`; comments explain *why*.
- `setEncodeHook(_:)` keeps the test injection API readable. Updated the two test call sites in `Tests/ManifoldBackendsTests/CloudImageEncodeCountTests.swift` (the only consumers — grepped Sources + Tests).

## Gate (spike profile)

- `swift build --build-tests` — Build complete (only pre-existing deprecation warnings).
- `swift test --filter CloudImageEncodeCountTests` — 2 tests passed (the suite that exercises the hook; `--filter ManifoldCloudCore` matched 0 since the encode tests live in `ManifoldBackendsTests`).

Untracked plan file `docs/plans/v0.49-zero-to-first-token.md` was not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)