### PR TITLE
fix: branch flow uses transactional copy with rollback

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift
@@ -336,19 +336,32 @@ package struct ConversationTurnExecutor: Sendable {
         }
 
         // Copy messages into the new session with fresh IDs and updated
-        // sessionID.
-        for original in slice {
-            let copy = ChatMessage(
+        // sessionID. Drive the copy through the transactional batch API (same
+        // as the edit flow) so a transactional store commits the whole slice
+        // atomically and never exposes a half-copied branch.
+        //
+        // The session insert above commits separately from the message batch
+        // (the adapter's transaction spans messages only), so if the copy
+        // throws we must manually unwind the orphaned session — otherwise a
+        // failed branch strands a ghost/empty session that surfaces as a
+        // phantom in the sidebar. `transaction(block:)` does NOT roll back on
+        // throw in this codebase, so the rollback is an explicit delete.
+        let copyMutations: [MessageStoreMutation] = slice.map { original in
+            .insert(ChatMessage(
                 role: original.role,
                 contentParts: original.contentParts,
                 timestamp: original.timestamp,
                 sessionID: newSessionID
-            )
-            do {
-                try await persistence.insertMessage(copy)
-            } catch {
-                throw ConversationError.persistence(error)
-            }
+            ))
+        }
+        do {
+            try await persistence.performMessageMutations(copyMutations)
+        } catch {
+            // Roll back the session we just inserted before surfacing the copy
+            // failure. `deleteSession` is best-effort and logs on its own
+            // failure so the original copy error stays the caller-visible one.
+            await persistence.deleteSession(newSessionID)
+            throw ConversationError.persistence(error)
         }
 
         emit(.sessionBranched(newSessionID: newSessionID, copiedCount: slice.count))
@@ -828,7 +841,14 @@ package struct ConversationTurnExecutor: Sendable {
                     if var current = sessionRecord {
                         let previousID = current.activeAgentID
                         current.activeAgentID = handoff.targetAgentID
-                        _ = await persistence.updateSession(current)
+                        // Use the narrow single-column write rather than
+                        // rewriting the whole record: a concurrent edit to
+                        // another session field (title, agents, updatedAt) must
+                        // not be clobbered by this stale snapshot mid-stream.
+                        _ = await persistence.setActiveAgent(
+                            sessionID: current.id,
+                            agentID: handoff.targetAgentID
+                        )
                         sessionRecord = current
                         emit(.agentHandoff(from: previousID, to: handoff.targetAgentID))
                     } else {

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -202,11 +202,23 @@ final class ConversationRuntimeTests: XCTestCase {
         /// of performing the insert. Cleared after the throw so subsequent
         /// inserts succeed normally.
         var insertError: (any Error)?
+        /// When set, the insert at this 0-based call index throws instead of
+        /// performing the write — lets a test fail *mid*-batch (e.g. the 2nd
+        /// message of a branch copy) rather than only on the first insert.
+        /// Inserts before the failing index commit normally, exercising the
+        /// non-transactional fallback's partial-write window.
+        var failInsertAtIndex: Int?
+        private(set) var insertCallCount = 0
 
         func insertMessage(_ message: ChatMessage) async throws {
+            let currentIndex = insertCallCount
+            insertCallCount += 1
             if let error = insertError {
                 insertError = nil
                 throw error
+            }
+            if let failIndex = failInsertAtIndex, currentIndex == failIndex {
+                throw ChatPersistenceError.providerNotConfigured
             }
             messages[message.id] = message
             for hook in hooks {
@@ -2513,6 +2525,110 @@ final class ConversationRuntimeTests: XCTestCase {
         XCTAssertEqual(newMessages.count, 0, "No messages copied when insertSession fails")
         // Source unchanged.
         XCTAssertEqual(store.messages.count, 2, "Source session messages unchanged")
+    }
+
+    // MARK: - Branch: mid-copy message-insert failure rolls back the session
+
+    /// Integration test (in-memory SwiftData-shaped fakes): when copying the
+    /// branch slice fails partway through, the new session must NOT be left
+    /// behind as an orphan/phantom in the sidebar — the executor rolls it back
+    /// via `deleteSession` before rethrowing.
+    func test_branch_midCopyInsertFails_rollsBackSessionLeavingNoOrphan() async throws {
+        let sessionStore = RuntimeSessionStore()
+        let (runtime, store, _, _) = makeRuntime(sessionStore: sessionStore)
+        let sessionID = UUID()
+        let newSessionID = UUID()
+
+        // Seed: user + assistant + user (branch at the last user, index 2 → a
+        // 3-message slice so the failing copy lands mid-batch).
+        let base = Date(timeIntervalSinceReferenceDate: 0)
+        let msg0 = ChatMessage(role: .user, content: "q1", timestamp: base, sessionID: sessionID)
+        let msg1 = ChatMessage(role: .assistant, content: "a1", timestamp: base.addingTimeInterval(1), sessionID: sessionID)
+        let msg2 = ChatMessage(role: .user, content: "q2", timestamp: base.addingTimeInterval(2), sessionID: sessionID)
+        try await store.insertMessage(msg0)
+        try await store.insertMessage(msg1)
+        try await store.insertMessage(msg2)
+        let sourceSession = ChatSession(id: sessionID, title: "Source")
+        try await sessionStore.insertSession(sourceSession)
+
+        // The three seed inserts above used call indices 0..2; fail the copy
+        // insert at call index 4 (the 2nd of three branch copies) so the first
+        // copy commits and we exercise the partial-write window.
+        store.failInsertAtIndex = 4
+
+        do {
+            _ = try await runtime.processTurn(TurnInput(
+                sessionID: sessionID,
+                kind: .branch(
+                    messageID: msg2.id,
+                    newSessionID: newSessionID,
+                    newSessionTitle: nil,
+                    generateAfter: false
+                )
+            ))
+            XCTFail("Expected ConversationError.persistence to be thrown")
+        } catch let error as ConversationError {
+            if case .persistence = error {
+                // Expected — the mid-copy failure surfaces as a persistence error.
+            } else {
+                XCTFail("Expected .persistence, got \(error)")
+            }
+        }
+
+        // The new session must have been rolled back: no phantom in the store.
+        let survivingSessions = try await sessionStore.fetchSessions()
+        XCTAssertNil(
+            survivingSessions.first { $0.id == newSessionID },
+            "Branch rollback must delete the orphaned session"
+        )
+        // Source session itself untouched.
+        XCTAssertNotNil(
+            survivingSessions.first { $0.id == sessionID },
+            "Source session unchanged by a failed branch"
+        )
+    }
+
+    // MARK: - Branch: successful copy writes the full slice
+
+    /// Integration test: a successful branch copies every message in the slice
+    /// (up to and including the branch point) into the new session.
+    func test_branch_success_copiesEveryMessageInSlice() async throws {
+        let sessionStore = RuntimeSessionStore()
+        let (runtime, store, _, _) = makeRuntime(sessionStore: sessionStore)
+        let sessionID = UUID()
+        let newSessionID = UUID()
+
+        let base = Date(timeIntervalSinceReferenceDate: 0)
+        let msg0 = ChatMessage(role: .user, content: "q1", timestamp: base, sessionID: sessionID)
+        let msg1 = ChatMessage(role: .assistant, content: "a1", timestamp: base.addingTimeInterval(1), sessionID: sessionID)
+        let msg2 = ChatMessage(role: .user, content: "q2", timestamp: base.addingTimeInterval(2), sessionID: sessionID)
+        try await store.insertMessage(msg0)
+        try await store.insertMessage(msg1)
+        try await store.insertMessage(msg2)
+        let sourceSession = ChatSession(id: sessionID, title: "Source")
+        try await sessionStore.insertSession(sourceSession)
+
+        // Branch at the last user (index 2) → all three messages copied.
+        let handle = try await runtime.processTurn(TurnInput(
+            sessionID: sessionID,
+            kind: .branch(
+                messageID: msg2.id,
+                newSessionID: newSessionID,
+                newSessionTitle: nil,
+                generateAfter: false
+            )
+        ))
+        XCTAssertNil(handle, "branch returns nil when generateAfter is false")
+
+        let newMessages = try await store.fetchMessages(for: newSessionID)
+        XCTAssertEqual(newMessages.count, 3, "Full slice copied into the new session")
+        XCTAssertEqual(newMessages.map(\.content), ["q1", "a1", "q2"])
+        // New session exists.
+        let allSessions = try await sessionStore.fetchSessions()
+        XCTAssertNotNil(
+            allSessions.first { $0.id == newSessionID },
+            "New session persisted on a successful branch"
+        )
     }
 
     // MARK: - Regenerate: cancel mid-stream


### PR DESCRIPTION
## Summary

Fixes verified correctness bugs in the branch flow of `ConversationTurnExecutor`. Findings confirmed by a 2/2 adversarial audit and re-verified against the live code in this branch.

### Finding 1+2 — branch orphans a session + non-transactional copy (high, correctness)
`Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift:338-352` (pre-fix): `runBranchFlow` inserted the new session, then copied messages with a per-message `insertMessage(...)` loop that rethrew on the first failure **without** rolling back the already-inserted session. A failed branch left a ghost/partially-copied session that surfaces as a phantom in the sidebar; the copy also bypassed the transactional batch API the edit flow already uses.

**Fix:** build `[MessageStoreMutation]` inserts for the slice and call `performMessageMutations(...)` once (atomic on transactional stores), wrapped in a `do/catch` that calls `deleteSession(newSessionID)` before rethrowing. `transaction(block:)` does not roll back on throw in this codebase, so the rollback is an explicit best-effort delete (the port's `deleteSession` already logs rather than throwing, preserving the original copy error as caller-visible).

### Finding 3 — handoff writes a stale full session record (medium, concurrency)
`Sources/ManifoldRuntime/Services/ConversationTurnExecutor.swift:828-833` (pre-fix): the mid-stream handoff path wrote the whole record via `updateSession(current)`, clobbering concurrent edits to other session columns.

**Fix:** switch to the narrow `setActiveAgent(sessionID:agentID:)` write, which the persistence port and `SessionStore` already expose for exactly this purpose. No new port surface added.

## Tests
Added two integration tests (in-memory SwiftData-shaped fakes) in `Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift`:
- `test_branch_midCopyInsertFails_rollsBackSessionLeavingNoOrphan` — extends the mock store with a fail-at-Nth-insert hook so the 2nd of three branch copies fails mid-batch; asserts the new session is rolled back (no orphan). Sabotage-verified: removing the `deleteSession` rollback fails this test (then removed).
- `test_branch_success_copiesEveryMessageInSlice` — asserts a successful branch copies the full slice.

Existing handoff scenario tests (`HandoffScenarioTests`) still pass — the default `setActiveAgent` extension routes through `updateSession`, so persisted state is unchanged.

## Gate (spike profile)
- `swift build --build-tests` — passed (deprecation warnings only)
- `swift test --filter ManifoldRuntime` — 466 tests, 0 failures, 2 skipped

No `Package.resolved` staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)