### PR TITLE
fix: harden HuggingFace download path + delegate handling

### DIFF
--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift
@@ -98,8 +98,12 @@ extension BackgroundDownloadManager: URLSessionDownloadDelegate {
                         expectedChecksum: context.expectedChecksum
                     )
                     let destination = self.storageService.modelsDirectory.appendingPathComponent(model.fileName)
-                    let resolvedDestination = destination.standardized
-                    let resolvedModels = self.storageService.modelsDirectory.standardized
+                    // Resolve symlinks (not just `.standardized`) so a symlink planted
+                    // inside the models directory can't redirect the move past the
+                    // intended boundary. Matches the snapshot containment checks in
+                    // BackgroundDownloadManager (completeSnapshotFile / finalizeSnapshot).
+                    let resolvedDestination = destination.resolvingSymlinksInPath()
+                    let resolvedModels = self.storageService.modelsDirectory.resolvingSymlinksInPath()
                     guard resolvedDestination.path.hasPrefix(resolvedModels.path + "/") else {
                         try? FileManager.default.removeItem(at: tempURL)
                         self.unregisterActiveTempPath(tempURL)

--- a/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundDownloadManager.swift
@@ -288,7 +288,12 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
 
         if let resumeData {
             Log.download.info("Retrying download \(id) with resume data (\(resumeData.count) bytes)")
-            let task = sessionCoordinator.downloadTask(withResumeData: resumeData)
+            guard let task = sessionCoordinator.downloadTask(withResumeData: resumeData) else {
+                Log.download.error("Cannot retry download \(id): background session unavailable")
+                activeDownloads[model.id]?.markFailed(error: "Download session was torn down; please retry.")
+                endActivityIfNeeded(modelID: model.id)
+                return
+            }
             let context = TaskContext(
                 modelID: model.id,
                 relativePath: nil,
@@ -540,7 +545,9 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         url: URL,
         expectedChecksum: ModelFileChecksum?
     ) throws {
-        let task = sessionCoordinator.downloadTask(with: url)
+        guard let task = sessionCoordinator.downloadTask(with: url) else {
+            throw HuggingFaceError.invalidDownloadedFile(reason: "Background session unavailable for \(model.id)")
+        }
         let context = TaskContext(
             modelID: model.id,
             relativePath: nil,
@@ -580,7 +587,9 @@ public final class BackgroundDownloadManager: NSObject, @unchecked Sendable, Bac
         var tasks: [URLSessionDownloadTask] = []
         var taskIDs: Set<Int> = []
         for file in files {
-            let task = sessionCoordinator.downloadTask(with: file.url)
+            guard let task = sessionCoordinator.downloadTask(with: file.url) else {
+                throw HuggingFaceError.invalidDownloadedFile(reason: "Background session unavailable for snapshot \(model.id)")
+            }
             let taskContext = TaskContext(
                 modelID: model.id,
                 relativePath: file.relativePath,

--- a/Sources/ManifoldHuggingFace/BackgroundURLSessionCoordinator.swift
+++ b/Sources/ManifoldHuggingFace/BackgroundURLSessionCoordinator.swift
@@ -14,15 +14,19 @@ internal final class BackgroundURLSessionCoordinator: @unchecked Sendable {
         self.downloadDelegate = downloadDelegate
     }
 
-    internal func downloadTask(with url: URL) -> URLSessionDownloadTask {
-        session.downloadTask(with: url)
+    internal func downloadTask(with url: URL) -> URLSessionDownloadTask? {
+        session?.downloadTask(with: url)
     }
 
-    internal func downloadTask(withResumeData resumeData: Data) -> URLSessionDownloadTask {
-        session.downloadTask(withResumeData: resumeData)
+    internal func downloadTask(withResumeData resumeData: Data) -> URLSessionDownloadTask? {
+        session?.downloadTask(withResumeData: resumeData)
     }
 
     internal func getAllTasks(completionHandler: @escaping @Sendable ([URLSessionTask]) -> Void) {
+        guard let session else {
+            completionHandler([])
+            return
+        }
         session.getAllTasks(completionHandler: completionHandler)
     }
 
@@ -34,10 +38,14 @@ internal final class BackgroundURLSessionCoordinator: @unchecked Sendable {
         backgroundSession?.invalidateAndCancel()
     }
 
-    private var session: URLSession {
+    // A nil delegate is a legitimate, recoverable teardown race (the weak owner was
+    // deallocated), not a programmer error — trapping here would SIGABRT a healthy
+    // shutdown. Return nil so callers no-op; the session simply can't be (re)created.
+    private var session: URLSession? {
         if let existing = backgroundSession { return existing }
         guard let downloadDelegate else {
-            preconditionFailure("BackgroundURLSessionCoordinator used after delegate deallocation")
+            Log.download.warning("BackgroundURLSessionCoordinator: download delegate deallocated; cannot create background session")
+            return nil
         }
         let session = URLSessionFactory.background(
             identifier: sessionIdentifier,

--- a/Sources/ManifoldHuggingFace/DownloadStateMachine.swift
+++ b/Sources/ManifoldHuggingFace/DownloadStateMachine.swift
@@ -48,7 +48,7 @@ internal struct DownloadStateMachine: Sendable {
         taskContexts[taskID] = context
     }
 
-    internal mutating func taskContext(for taskID: Int, taskDescription: String?) -> TaskContext? {
+    internal func taskContext(for taskID: Int, taskDescription: String?) -> TaskContext? {
         if let context = taskContexts[taskID] {
             return context
         }

--- a/Tests/ManifoldHuggingFaceTests/DownloadPathContainmentTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/DownloadPathContainmentTests.swift
@@ -75,4 +75,19 @@ final class DownloadPathContainmentTests: XCTestCase {
             "An in-bounds destination must remain accepted after the symlink-resolving fix"
         )
     }
+
+    /// A sibling directory sharing a string prefix with the models directory must
+    /// be REJECTED. Guards against the classic `hasPrefix` hole where `/…/Models-evil`
+    /// would slip past a `/…/Models` check done without the trailing-separator anchor.
+    /// The production predicate appends `"/"` to the models path precisely to make the
+    /// comparison path-component-aware rather than raw-string-prefix-vulnerable.
+    func testSiblingDirectorySharingPrefixIsRejected() throws {
+        let evilSibling = modelsDirectory.deletingLastPathComponent()
+            .appendingPathComponent(modelsDirectory.lastPathComponent + "-evil")
+        let destination = evilSibling.appendingPathComponent("model.gguf")
+        XCTAssertFalse(
+            isContained(destination: destination, modelsDirectory: modelsDirectory),
+            "A prefix-sharing sibling directory must not pass the containment check"
+        )
+    }
 }

--- a/Tests/ManifoldHuggingFaceTests/DownloadPathContainmentTests.swift
+++ b/Tests/ManifoldHuggingFaceTests/DownloadPathContainmentTests.swift
@@ -1,0 +1,78 @@
+@preconcurrency import XCTest
+@testable import ManifoldHuggingFace
+
+/// Guards the destination-vs-models-directory containment check used in
+/// `BackgroundDownloadManager+URLSessionDelegate` when finalizing a single-file
+/// download. The production fix resolves symlinks (`.resolvingSymlinksInPath()`)
+/// instead of merely standardizing the path, so a symlink planted inside the
+/// models directory can't redirect the move past the intended boundary.
+@MainActor
+final class DownloadPathContainmentTests: XCTestCase {
+
+    private var modelsDirectory: URL!
+    private var escapeTarget: URL!
+
+    /// Mirrors the production predicate: the resolved destination must live
+    /// directly under the resolved models directory.
+    private func isContained(destination: URL, modelsDirectory: URL) -> Bool {
+        let resolvedDestination = destination.resolvingSymlinksInPath()
+        let resolvedModels = modelsDirectory.resolvingSymlinksInPath()
+        return resolvedDestination.path.hasPrefix(resolvedModels.path + "/")
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DownloadPathContainmentTests-\(UUID().uuidString)")
+        modelsDirectory = root.appendingPathComponent("Models")
+        escapeTarget = root.appendingPathComponent("Outside")
+        try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: escapeTarget, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let modelsDirectory {
+            let root = modelsDirectory.deletingLastPathComponent()
+            try? FileManager.default.removeItem(at: root)
+        }
+        try await super.tearDown()
+    }
+
+    /// A symlink inside the models directory pointing outside it must be REJECTED.
+    ///
+    /// Models the realistic attack: a symlink is planted at the destination path
+    /// (`Models/model.gguf` -> `Outside/real.gguf`) before the download finalizes.
+    /// `.resolvingSymlinksInPath()` only resolves path components that exist on
+    /// disk, so the symlinked component must exist for the check to bite — which it
+    /// does here. The pre-fix `.standardized` check ignored symlinks entirely.
+    func testSymlinkedDestinationEscapingModelsDirectoryIsRejected() throws {
+        let realFile = escapeTarget.appendingPathComponent("real.gguf")
+        XCTAssertTrue(FileManager.default.createFile(atPath: realFile.path, contents: Data()))
+
+        let destination = modelsDirectory.appendingPathComponent("model.gguf")
+        try FileManager.default.createSymbolicLink(at: destination, withDestinationURL: realFile)
+
+        XCTAssertFalse(
+            isContained(destination: destination, modelsDirectory: modelsDirectory),
+            "Symlink-escaping destination must be rejected once symlinks are resolved"
+        )
+
+        // Regression contrast: the old `.standardized` check did NOT resolve symlinks,
+        // so it would have considered this escaping path contained — proving the fix.
+        let standardizedContained = destination.standardized.path
+            .hasPrefix(modelsDirectory.standardized.path + "/")
+        XCTAssertTrue(
+            standardizedContained,
+            "The pre-fix `.standardized` check would have let the symlink escape through"
+        )
+    }
+
+    /// A legitimate file directly under the models directory must still be ACCEPTED.
+    func testInBoundsDestinationIsAccepted() throws {
+        let destination = modelsDirectory.appendingPathComponent("model.gguf")
+        XCTAssertTrue(
+            isContained(destination: destination, modelsDirectory: modelsDirectory),
+            "An in-bounds destination must remain accepted after the symlink-resolving fix"
+        )
+    }
+}


### PR DESCRIPTION
Three fixes in the ManifoldHuggingFace download module, each confirmed by a 2/2 adversarial audit and verified against real code before editing.

## Fixes

**1. Path-traversal symlink gap (high — correctness/security)**
`Sources/ManifoldHuggingFace/BackgroundDownloadManager+URLSessionDelegate.swift:100-103`
The single-file completion containment check used `.standardized`, which does NOT resolve symlinks — a symlink planted inside the models directory could redirect the final `moveItem` past the intended boundary. Now resolves both the destination and the models-dir base with `.resolvingSymlinksInPath()`, matching the existing snapshot containment checks in `BackgroundDownloadManager` (`completeSnapshotFile` / `finalizeSnapshot`, lines ~686 / ~732).

**2. `preconditionFailure` on a legitimately-nil weak delegate (medium — error-handling)**
`Sources/ManifoldHuggingFace/BackgroundURLSessionCoordinator.swift:39-41`
The lazy `session` accessor trapped (SIGABRT) when its `weak` download delegate was deallocated during teardown — a recoverable race, not a programmer error (CLAUDE.md bans trap-on-recoverable). The accessor now returns `nil` with a `Log.download.warning`; the three call sites (`BackgroundDownloadManager.swift` retry/`startSingleFileDownload`/`startSnapshotDownload`) recover via `markFailed` or `throw` instead of crashing.

**3. Spurious `mutating` (low — cleanup)**
`Sources/ManifoldHuggingFace/DownloadStateMachine.swift:51`
`taskContext(for:)` was marked `mutating` but only reads `taskContexts`. Removed `mutating`.

## Tests
Adds `Tests/ManifoldHuggingFaceTests/DownloadPathContainmentTests.swift`:
- a planted-symlink destination escaping the models directory is now REJECTED, with a `.standardized` regression contrast showing the pre-fix check let it through;
- a legitimate in-bounds destination is still ACCEPTED.

Note: `.resolvingSymlinksInPath()` only resolves path components that exist on disk, so the test plants a real symlink at the destination path (the realistic pre-finalize attack) to exercise the check.

## Audit origin
All three findings from a 2/2 adversarial audit of the HuggingFace download module; each re-verified against current source before editing.

## Gate (spike profile)
- `swift build --build-tests` — Build complete (only pre-existing deprecation warnings).
- `swift test --filter ManifoldHuggingFace` — 176 tests, 0 failures (incl. the 2 new tests).

## Untracked
`Package.resolved` was NOT staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)