### PR TITLE
fix: harden model-load memory budgeting

### DIFF
--- a/Sources/ManifoldHardware/GGUFKVCacheEstimator.swift
+++ b/Sources/ManifoldHardware/GGUFKVCacheEstimator.swift
@@ -74,8 +74,13 @@ public enum GGUFKVCacheEstimator {
         // unchecked UInt64 multiply would wrap to a tiny per-token estimate, so
         // ModelLoadPlan would report `.allow` and then OOM at inference. On any
         // overflow, return nil so the caller's conservative no-estimate fallback
-        // (legacyFallbackBytesPerToken) engages instead.
-        let widthSum = keyWidth + valueWidth
+        // (legacyFallbackBytesPerToken) engages instead. The Int sum below is
+        // also overflow-checked: a trapping `+` would crash the process on a
+        // crafted file rather than route to the fallback (gqaWidth itself is
+        // overflow-hardened for the same reason).
+        let (widthSum, sumOverflow) = keyWidth.addingReportingOverflow(valueWidth)
+        guard !sumOverflow else { return nil }
+
         let (perTokenElements, widthOverflow) = UInt64(blockCount)
             .multipliedReportingOverflow(by: UInt64(widthSum))
         guard !widthOverflow else { return nil }
@@ -103,8 +108,12 @@ public enum GGUFKVCacheEstimator {
         headCount: Int?,
         kvHeadCount: Int
     ) -> Int? {
+        // Overflow-checked Int multiplies: a crafted GGUF can pair a huge head
+        // length with a huge kvHeadCount; a trapping `*` would crash the process
+        // instead of routing to the conservative fallback. Return nil on overflow.
         if let explicitHeadLength = positive(explicitHeadLength) {
-            return explicitHeadLength * kvHeadCount
+            let (width, overflow) = explicitHeadLength.multipliedReportingOverflow(by: kvHeadCount)
+            return overflow ? nil : width
         }
 
         guard let embeddingLength = positive(embeddingLength),
@@ -113,7 +122,8 @@ public enum GGUFKVCacheEstimator {
             return nil
         }
 
-        return (embeddingLength / headCount) * kvHeadCount
+        let (width, overflow) = (embeddingLength / headCount).multipliedReportingOverflow(by: kvHeadCount)
+        return overflow ? nil : width
     }
 
     private static func positive(_ value: Int?) -> Int? {

--- a/Sources/ManifoldHardware/GGUFKVCacheEstimator.swift
+++ b/Sources/ManifoldHardware/GGUFKVCacheEstimator.swift
@@ -70,7 +70,21 @@ public enum GGUFKVCacheEstimator {
             return nil
         }
 
-        return UInt64(blockCount) * UInt64(keyWidth + valueWidth) * bytesPerElement
+        // A malformed or crafted GGUF can supply enormous block/width values. An
+        // unchecked UInt64 multiply would wrap to a tiny per-token estimate, so
+        // ModelLoadPlan would report `.allow` and then OOM at inference. On any
+        // overflow, return nil so the caller's conservative no-estimate fallback
+        // (legacyFallbackBytesPerToken) engages instead.
+        let widthSum = keyWidth + valueWidth
+        let (perTokenElements, widthOverflow) = UInt64(blockCount)
+            .multipliedReportingOverflow(by: UInt64(widthSum))
+        guard !widthOverflow else { return nil }
+
+        let (bytesPerToken, byteOverflow) = perTokenElements
+            .multipliedReportingOverflow(by: bytesPerElement)
+        guard !byteOverflow else { return nil }
+
+        return bytesPerToken
     }
 
     package static func estimateBytesPerToken(

--- a/Sources/ManifoldHardware/ModelLoadPlan.swift
+++ b/Sources/ManifoldHardware/ModelLoadPlan.swift
@@ -259,7 +259,14 @@ public struct ModelLoadPlan: Sendable {
             && inputs.modelFileSize / available >= impossibleFitRatio
 
         // Verdict thresholds: allow ≤85% of available, warn up to 100%, deny above.
-        let allowThreshold = UInt64(Double(available) * 0.85)
+        // Budget against `effective_available` (raw available minus app overhead),
+        // NOT raw `available`. The resident/KV math above already subtracts the
+        // platform overhead; budgeting the verdict against raw `available` would
+        // mark a model that exceeds true usable memory as `.allow`/`.warn` and then
+        // jetsam/SIGKILL it on load. The catastrophic `impossibleFit` gate below
+        // intentionally stays on raw `available` (file-vs-RAM ratio, independent of
+        // app overhead). See issue #471.
+        let allowThreshold = UInt64(Double(effective_available) * 0.85)
         let verdict: Verdict
         var finalReasons = reasons
         if impossibleFit {
@@ -270,19 +277,19 @@ public struct ModelLoadPlan: Sendable {
             ))
         } else if total <= allowThreshold {
             verdict = .allow
-        } else if total <= available {
+        } else if total <= effective_available {
             verdict = .warn
         } else {
             verdict = .deny
-            if residentBudget > available {
+            if residentBudget > effective_available {
                 finalReasons.append(.insufficientResident(
                     required: residentBudget,
-                    available: available
+                    available: effective_available
                 ))
             } else {
                 finalReasons.append(.insufficientKVCache(
                     required: total,
-                    available: available
+                    available: effective_available
                 ))
             }
         }

--- a/Tests/ManifoldHardwareTests/GGUFKVCacheEstimatorTests.swift
+++ b/Tests/ManifoldHardwareTests/GGUFKVCacheEstimatorTests.swift
@@ -171,4 +171,52 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
             GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters, bytesPerElement: 0)
         )
     }
+
+    // MARK: - Overflow hardening
+
+    /// A malformed or crafted GGUF can supply enormous block/width values whose
+    /// `block × (K+V)` product exceeds `UInt64.max`. An unchecked multiply would
+    /// wrap to a tiny per-token estimate, ModelLoadPlan would see "KV is cheap"
+    /// and `.allow`, then the load OOMs at inference. The estimator must instead
+    /// return `nil` so the caller's conservative legacy-fallback path engages.
+    ///
+    /// Uses explicit key/value lengths so `gqaWidth` returns
+    /// `explicitHeadLength * kvHeadCount` directly. With kvHeadCount == 1,
+    /// keyWidth == valueWidth == 4_000_000_000 → widthSum == 8_000_000_000.
+    /// 5_000_000_000 × 8_000_000_000 ≈ 4e19 > UInt64.max (~1.8e19) → overflow on
+    /// the block × width multiply.
+    func test_estimateBytesPerToken_blockTimesWidthOverflow_returnsNil() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 5_000_000_000,
+            attentionHeadCount: 1,
+            attentionHeadCountKV: 1,
+            attentionKeyLength: 4_000_000_000,
+            attentionValueLength: 4_000_000_000
+        )
+
+        XCTAssertNil(
+            GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters),
+            "block × (K+V) overflowing UInt64 must yield nil, not a wrapped tiny estimate"
+        )
+    }
+
+    /// Overflow on the *second* multiply (`perTokenElements × bytesPerElement`).
+    /// Here block × width fits in UInt64, but scaling by a large bytes-per-element
+    /// pushes it past the ceiling. Both multiply guards must hold, not just the
+    /// first. blockCount 4_000_000_000 × widthSum 4_000_000_000 == 1.6e19 (fits),
+    /// then × 100 overflows.
+    func test_estimateBytesPerToken_bytesPerElementScaleOverflow_returnsNil() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 4_000_000_000,
+            attentionHeadCount: 1,
+            attentionHeadCountKV: 1,
+            attentionKeyLength: 2_000_000_000,
+            attentionValueLength: 2_000_000_000
+        )
+
+        XCTAssertNil(
+            GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters, bytesPerElement: 100),
+            "scaling a near-ceiling product by bytesPerElement must guard overflow and yield nil"
+        )
+    }
 }

--- a/Tests/ManifoldHardwareTests/GGUFKVCacheEstimatorTests.swift
+++ b/Tests/ManifoldHardwareTests/GGUFKVCacheEstimatorTests.swift
@@ -219,4 +219,23 @@ final class GGUFKVCacheEstimatorTests: XCTestCase {
             "scaling a near-ceiling product by bytesPerElement must guard overflow and yield nil"
         )
     }
+
+    /// `gqaWidth`'s Int multiply (`explicitHeadLength * kvHeadCount`) is itself
+    /// reachable with crafted values and a trapping `*` would crash the process
+    /// before the UInt64 guards run. A huge head length paired with a huge KV
+    /// head count must return nil, not abort. (5e9 × 5e9 ≈ 2.5e19 > Int.max.)
+    func test_estimateBytesPerToken_gqaWidthIntOverflow_returnsNil() {
+        let parameters = GGUFKVCacheParameters(
+            blockCount: 1,
+            attentionHeadCount: 5_000_000_000,
+            attentionHeadCountKV: 5_000_000_000,
+            attentionKeyLength: 5_000_000_000,
+            attentionValueLength: 5_000_000_000
+        )
+
+        XCTAssertNil(
+            GGUFKVCacheEstimator.estimateBytesPerToken(from: parameters),
+            "gqaWidth Int multiply overflowing must yield nil, not trap the process"
+        )
+    }
 }

--- a/Tests/ManifoldHardwareTests/ModelLoadPlanTests.swift
+++ b/Tests/ManifoldHardwareTests/ModelLoadPlanTests.swift
@@ -861,6 +861,64 @@ final class ModelLoadPlanTests: XCTestCase {
             "Total estimated bytes must not contain a UInt64 underflow value")
     }
 
+    /// Verdict must budget against effective-available (raw minus app overhead),
+    /// not raw available. Regression guard for the jetsam bug: a model that fits
+    /// under raw `available` but exceeds true usable memory once the ~800 MB iOS
+    /// reserve is subtracted was marked `.allow` and then SIGKILLed on load.
+    ///
+    /// Fixture: 250 MB resident model, 1 GB raw available, 800 MB overhead →
+    /// 200 MB effective. Against raw available the 250 MB total is ~25% (well
+    /// under the 85% allow threshold → `.allow`). Against the 200 MB effective
+    /// budget it overruns entirely → must `.deny` with an insufficient-resident
+    /// reason. The verdict flips, proving the fix budgets the right number.
+    func test_appOverhead_verdictBudgetsAgainstEffectiveAvailable_notRaw() {
+        let rawAvailable: UInt64 = 1_000_000_000
+        let overhead: UInt64 = 800_000_000  // ~iOS jetsam reserve
+        let residentModel: UInt64 = 250_000_000
+
+        let inputs = ModelLoadPlan.Inputs(
+            modelFileSize: residentModel,
+            memoryStrategy: .resident,           // resident budget == file size, not context-clamped
+            requestedContextSize: 256,           // tiny context → KV is negligible
+            trainedContextLength: 4096,
+            kvBytesPerToken: 8,
+            availableMemoryBytes: rawAvailable,
+            physicalMemoryBytes: 8 * oneGB,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.0,               // isolate the overhead effect from headroom
+            appOverheadBytes: overhead
+        )
+        let plan = ModelLoadPlan.compute(inputs: inputs)
+
+        // The impossible-fit gate stays on RAW available; 250 MB / 1 GB ratio 0
+        // does not fire it. The deny here comes purely from effective-budget math.
+        XCTAssertEqual(plan.verdict, .deny,
+            "Model exceeding effective-available (raw − overhead) must deny, not allow into a jetsam kill")
+        let hasInsufficientResident = plan.reasons.contains { reason in
+            if case .insufficientResident = reason { return true }
+            return false
+        }
+        XCTAssertTrue(hasInsufficientResident,
+            "Expected .insufficientResident keyed off effective-available; got \(plan.reasons)")
+
+        // Sanity anchor: the same model with zero overhead is comfortably allowed,
+        // confirming the flip is driven by overhead, not the model being too big.
+        let noOverhead = ModelLoadPlan.compute(inputs: ModelLoadPlan.Inputs(
+            modelFileSize: residentModel,
+            memoryStrategy: .resident,
+            requestedContextSize: 256,
+            trainedContextLength: 4096,
+            kvBytesPerToken: 8,
+            availableMemoryBytes: rawAvailable,
+            physicalMemoryBytes: 8 * oneGB,
+            absoluteContextCeiling: 128_000,
+            headroomFraction: 0.0,
+            appOverheadBytes: 0
+        ))
+        XCTAssertEqual(noOverhead.verdict, .allow,
+            "Without overhead the model fits raw available and must allow — proves overhead drives the flip")
+    }
+
     /// Default `appOverheadBytes: 0` must produce exactly the same
     /// `effectiveContextSize` as inputs constructed without the field — no-op
     /// regression guard for existing callers.


### PR DESCRIPTION
Two memory-safety bugs in \`ManifoldHardware\`, both confirmed by a 2/2 adversarial audit. No existing issue tracks these — untracked findings.

## Finding 1 — verdict ignores app overhead (high, correctness)
\`Sources/ManifoldHardware/ModelLoadPlan.swift:261-288\`

The KV/resident math computes \`effective_available = available - appOverheadBytes\` (line 157), but the allow/warn/deny verdict thresholds (\`allowThreshold\`, the \`total <= available\` warn check, and the \`residentBudget > available\` deny branch) all used the **raw** \`available\`. On <12GB iOS devices the ~800MB jetsam reserve was therefore ignored at verdict time: a model exceeding true usable memory was marked \`.allow\`/\`.warn\` and then jetsam/SIGKILLed on load.

Fix: budget the thresholds and the total-fit/insufficient-resident checks against \`effective_available\`. The catastrophic \`impossibleFit\` gate is left on **raw** \`available\` deliberately (it's a file-vs-RAM ratio, independent of app overhead).

## Finding 2 — unchecked KV-estimator multiply (high, correctness)
\`Sources/ManifoldHardware/GGUFKVCacheEstimator.swift:73\`

The \`UInt64\` chain \`blockCount × (keyWidth+valueWidth) × bytesPerElement\` had no overflow guard. A malformed or crafted GGUF (or a future huge model) wraps to a tiny per-token estimate → \`ModelLoadPlan\` reports \`.allow\` → OOM at inference.

Fix: both multiplies now use \`multipliedReportingOverflow(by:)\` and return \`nil\` on overflow, engaging the caller's conservative legacy-fallback path (matching the function's existing \`nil\` no-estimate contract).

## Tests
Extended the existing hardware suites:
- \`ModelLoadPlanTests.test_appOverhead_verdictBudgetsAgainstEffectiveAvailable_notRaw\` — fixture where the model fits raw available but overruns effective-available; asserts the verdict flips to \`.deny\` (and an anchor case with zero overhead stays \`.allow\`).
- \`GGUFKVCacheEstimatorTests.test_estimateBytesPerToken_blockTimesWidthOverflow_returnsNil\` and \`..._bytesPerElementScaleOverflow_returnsNil\` — overflow on each multiply yields \`nil\`.

Each was sabotage-verified (reverted the fix, confirmed the test fails) and the sabotage removed before commit.

## Gate (spike profile)
- \`swift build --build-tests\` — Build complete
- \`swift test --filter ManifoldHardware\` — 133 tests, 0 failures
- \`swift build --build-tests --traits Server,Macros\` — Build complete