### PR TITLE
feat(persistence): P3b — resumable ConversationRun persistence + resume-from-store + wiring

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataRunStore.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataRunStore.swift
@@ -1,0 +1,104 @@
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+import SwiftData
+
+/// Default ``RunStore`` backed by SwiftData.
+///
+/// Operates on the ``ModelContext`` injected at init time, converting between
+/// the ``ManifoldSchemaV10/ConversationRunModel`` / ``ManifoldSchemaV10/RunStepModel``
+/// `@Model` rows and the ``ConversationRun`` / ``RunStep`` value types at the
+/// boundary. No `@Model` escapes the port. Mirrors the isolation and `save()`
+/// discipline of ``SwiftDataBenchmarkCache`` / ``SwiftDataSamplerPresetStore``.
+@MainActor
+public final class SwiftDataRunStore: RunStore {
+
+    private let modelContext: ModelContext
+
+    public init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Runs
+
+    public func insertRun(_ run: ConversationRun) async throws {
+        modelContext.insert(ConversationRunModel(run))
+        try modelContext.save()
+    }
+
+    public func updateRun(_ run: ConversationRun) async throws {
+        guard let existing = try fetchRunModel(run.id) else {
+            throw RunStoreError.runNotFound(run.id)
+        }
+        existing.update(from: run)
+        try modelContext.save()
+    }
+
+    public func deleteRun(_ id: UUID) async throws {
+        guard let existing = try fetchRunModel(id) else {
+            throw RunStoreError.runNotFound(id)
+        }
+        // Steps are not a cascade relationship — delete them explicitly so a
+        // deleted run does not strand orphaned step rows.
+        for step in try fetchStepModels(for: id) {
+            modelContext.delete(step)
+        }
+        modelContext.delete(existing)
+        try modelContext.save()
+    }
+
+    public func fetchRuns(for sessionID: UUID) async throws -> [ConversationRun] {
+        let descriptor = FetchDescriptor<ConversationRunModel>(
+            predicate: #Predicate { $0.sessionID == sessionID },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor).map { $0.toRecord() }
+    }
+
+    public func fetchRun(_ id: UUID) async throws -> ConversationRun? {
+        try fetchRunModel(id)?.toRecord()
+    }
+
+    // MARK: - Steps
+
+    public func insertStep(_ step: RunStep) async throws {
+        modelContext.insert(RunStepModel(step))
+        try modelContext.save()
+    }
+
+    public func updateStep(_ step: RunStep) async throws {
+        guard let existing = try fetchStepModel(step.id) else {
+            throw RunStoreError.stepNotFound(step.id)
+        }
+        existing.update(from: step)
+        try modelContext.save()
+    }
+
+    public func fetchSteps(for runID: UUID) async throws -> [RunStep] {
+        try fetchStepModels(for: runID).map { $0.toRecord() }
+    }
+
+    // MARK: - Private fetch helpers
+
+    private typealias ConversationRunModel = ManifoldSchemaV10.ConversationRunModel
+    private typealias RunStepModel = ManifoldSchemaV10.RunStepModel
+
+    private func fetchRunModel(_ id: UUID) throws -> ConversationRunModel? {
+        try modelContext.fetch(FetchDescriptor<ConversationRunModel>(
+            predicate: #Predicate { $0.id == id }
+        )).first
+    }
+
+    private func fetchStepModel(_ id: UUID) throws -> RunStepModel? {
+        try modelContext.fetch(FetchDescriptor<RunStepModel>(
+            predicate: #Predicate { $0.id == id }
+        )).first
+    }
+
+    private func fetchStepModels(for runID: UUID) throws -> [RunStepModel] {
+        try modelContext.fetch(FetchDescriptor<RunStepModel>(
+            predicate: #Predicate { $0.runID == runID },
+            sortBy: [SortDescriptor(\.stepIndex, order: .forward)]
+        ))
+    }
+}

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -130,6 +130,25 @@ public final class ManifoldBootstrap {
     public var isInMemory: Bool { _isInMemory }
     private let _isInMemory: Bool
 
+    /// The SwiftData-backed ``RunStore`` for durable, resumable multi-step runs
+    /// (P3b #1784), or `nil` when the host did not opt in via
+    /// `enableResumableRuns: true`.
+    ///
+    /// When non-`nil`, ``conversationRuntime`` was built with a
+    /// `ResumableRunDriver` over this store, so you can:
+    ///
+    /// ```swift
+    /// let bootstrap = try ManifoldBootstrap(configuration: config, enableResumableRuns: true)
+    /// let run = ConversationRun(sessionID: sessionID, goal: "Plan the launch", maxSteps: 4)
+    /// for await event in bootstrap.conversationRuntime.startRun(run) { /* observe */ }
+    /// // After a relaunch over the same store:
+    /// for await event in bootstrap.conversationRuntime.resumeRun(run.id) { /* observe */ }
+    /// ```
+    ///
+    /// Query persisted runs directly through this store
+    /// (`fetchRuns(for:)` / `fetchRun(_:)`).
+    public let runStore: SwiftDataRunStore?
+
     /// The shared turn-loop runtime, pre-wired against ``persistence`` and
     /// ``inferenceService``. Apps that bootstrap through this type should pass
     /// this instance to ``ChatViewModel/configure(conversationRuntime:)`` (or
@@ -203,6 +222,7 @@ public final class ManifoldBootstrap {
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
+        enableResumableRuns: Bool = false,
         makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() },
         isInMemory: Bool = false
     ) throws {
@@ -236,6 +256,20 @@ public final class ManifoldBootstrap {
             )
             self.ragService = resolvedRAGService
 
+            // Opt-in durable resumable runs (P3b #1784): construct a
+            // SwiftData-backed RunStore over the main context and thread it
+            // into the runtime options so makeConversationRuntime wires a
+            // ResumableRunDriver. When `enableResumableRuns` is false the store
+            // stays nil and the runtime keeps SingleTurnDriver — unchanged.
+            let resolvedRunStore = enableResumableRuns
+                ? SwiftDataRunStore(modelContext: mainContext)
+                : nil
+            self.runStore = resolvedRunStore
+            var resolvedRuntimeOptions = runtimeOptions
+            if let resolvedRunStore {
+                resolvedRuntimeOptions.runStore = resolvedRunStore
+            }
+
             // ManifoldPersistenceSwiftData does not depend on ManifoldFoundation,
             // so FoundationBackend cannot be instantiated here directly. Host apps
             // that run on iOS 26+ / macOS 26+ can wire their own auxiliary service
@@ -246,7 +280,7 @@ public final class ManifoldBootstrap {
                 inferenceService: resolvedInferenceService,
                 ragService: resolvedRAGService,
                 usageStore: resolvedUsageStore,
-                runtimeOptions: runtimeOptions,
+                runtimeOptions: resolvedRuntimeOptions,
                 sessionToolSources: sessionToolSources,
                 hookRegistry: hookRegistry
             )
@@ -287,6 +321,7 @@ public final class ManifoldBootstrap {
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
+        runStore: SwiftDataRunStore? = nil,
         isInMemory: Bool = false
     ) {
         self.inferenceService = inferenceService
@@ -298,13 +333,18 @@ public final class ManifoldBootstrap {
         self.endpointStore = endpointStore
         self.usageStore = usageStore
         self.ragService = ragService
+        self.runStore = runStore
         self._isInMemory = isInMemory
+        var resolvedRuntimeOptions = runtimeOptions
+        if let runStore {
+            resolvedRuntimeOptions.runStore = runStore
+        }
         self.conversationRuntime = Self.makeConversationRuntime(
             persistence: persistence,
             inferenceService: inferenceService,
             ragService: ragService,
             usageStore: usageStore,
-            runtimeOptions: runtimeOptions,
+            runtimeOptions: resolvedRuntimeOptions,
             sessionToolSources: sessionToolSources,
             hookRegistry: hookRegistry
         )
@@ -366,7 +406,8 @@ public final class ManifoldBootstrap {
             hostTurnContextProvider: runtimeOptions.hostTurnContextProvider,
             turnContextProvider: runtimeOptions.turnContextProvider,
             sessionToolSources: sessionToolSources,
-            hookRegistry: hookRegistry
+            hookRegistry: hookRegistry,
+            runStore: runtimeOptions.runStore
         )
     }
 
@@ -425,6 +466,7 @@ public final class ManifoldBootstrap {
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
+        enableResumableRuns: Bool = false,
         makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
     ) -> (progress: AsyncStream<RuntimeBootstrapMilestone>, task: Task<ManifoldBootstrap, any Error>) {
         let (stream, continuation) = AsyncStream.makeStream(
@@ -460,6 +502,9 @@ public final class ManifoldBootstrap {
                     ragConfiguration: ragConfiguration,
                     modelContext: mainContext
                 )
+                let runStore = enableResumableRuns
+                    ? SwiftDataRunStore(modelContext: mainContext)
+                    : nil
                 await Task.yield()
 
                 continuation.yield(.complete)
@@ -479,7 +524,8 @@ public final class ManifoldBootstrap {
                     ragService: ragService,
                     runtimeOptions: runtimeOptions,
                     sessionToolSources: sessionToolSources,
-                    hookRegistry: hookRegistry
+                    hookRegistry: hookRegistry,
+                    runStore: runStore
                 )
             } catch {
                 ManifoldConfiguration.shared = previousConfiguration

--- a/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ModelContainerFactory.swift
@@ -25,7 +25,7 @@ import ManifoldInference
 public enum ModelContainerFactory {
     /// The current schema version.
     public static var currentSchema: any VersionedSchema.Type {
-        ManifoldSchemaV9.self
+        ManifoldSchemaV10.self
     }
 
     /// Returns an on-disk `ModelContainer` configured with the current schema.

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldMigrationPlan.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldMigrationPlan.swift
@@ -10,6 +10,7 @@ public enum ManifoldMigrationPlan: SchemaMigrationPlan {
             ManifoldSchemaV7.self,
             ManifoldSchemaV8.self,
             ManifoldSchemaV9.self,
+            ManifoldSchemaV10.self,
         ]
     }
 
@@ -27,6 +28,10 @@ public enum ManifoldMigrationPlan: SchemaMigrationPlan {
             // agentID to ChatMessage, and a new Agent @Model. All new fields default
             // to nil/empty so no data motion is required.
             .lightweight(fromVersion: ManifoldSchemaV8.self, toVersion: ManifoldSchemaV9.self),
+            // V10 adds ConversationRunModel + RunStepModel for resumable runs
+            // (P3b #1784). Two new @Model types, purely additive — no existing
+            // column changes, no data motion.
+            .lightweight(fromVersion: ManifoldSchemaV9.self, toVersion: ManifoldSchemaV10.self),
         ]
     }
 }

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV10.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ManifoldSchemaV10.swift
@@ -1,0 +1,247 @@
+import Foundation
+import ManifoldInference
+import ManifoldRuntime
+@preconcurrency import SwiftData
+
+/// ManifoldKit SwiftData schema version 10.
+///
+/// Adds durable storage for resumable runs (P3b, #1784): two new `@Model`
+/// types mapping the ``ManifoldRuntime/ConversationRun`` / ``ManifoldRuntime/RunStep``
+/// value types persisted by ``SwiftDataRunStore``.
+///
+/// - ``ConversationRunModel`` — one row per run; stores `status` as its
+///   `RunStatus.rawValue` string and carries the run's goal, step count, step
+///   cap, and lifecycle timestamps.
+/// - ``RunStepModel`` — one row per step; carries `stepIndex`, completion /
+///   failure flags, an optional produced-message id, and a best-effort
+///   JSON-encoded `TurnInput` blob (see the field doc for the lossiness
+///   contract).
+///
+/// Both new types are purely additive — no existing column changes, no data
+/// motion. Every other model type (ChatSession, ChatMessage, Agent, sampler
+/// preset, API endpoint, benchmark cache, RAG document, usage record) is
+/// carried forward from V9 unchanged.
+public enum ManifoldSchemaV10: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(10, 0, 0)
+
+    public static var models: [any PersistentModel.Type] {
+        [
+            // Carried forward verbatim from V9 — V10 does not redefine these.
+            ManifoldSchemaV9.ChatMessage.self,
+            ManifoldSchemaV9.ChatSession.self,
+            ManifoldSchemaV9.Agent.self,
+            ManifoldSchemaV4.SamplerPreset.self,
+            ManifoldSchemaV4.APIEndpoint.self,
+            ManifoldSchemaV4.ModelBenchmarkCache.self,
+            ManifoldSchemaV5.RagDocument.self,
+            ManifoldSchemaV6.TurnUsageModel.self,
+            // New in V10.
+            ConversationRunModel.self,
+            RunStepModel.self,
+        ]
+    }
+
+    // MARK: - ConversationRunModel (V10 — new model)
+
+    /// SwiftData row backing ``ManifoldRuntime/ConversationRun``.
+    ///
+    /// `status` is stored as its ``RunStatus`` raw string so the persisted
+    /// shape is stable across enum-case reordering. `maxSteps` is optional and
+    /// mirrors the value type's "nil means unlimited" contract.
+    @Model
+    public final class ConversationRunModel {
+        @Attribute(.unique) public var id: UUID
+        public var sessionID: UUID
+        public var goal: String
+
+        /// ``RunStatus`` raw value. Rows decode through `RunStatus(rawValue:)`,
+        /// defaulting to `.pending` if an unknown string ever lands here.
+        public var statusRaw: String
+
+        public var stepCount: Int
+        public var maxSteps: Int?
+        public var createdAt: Date
+        public var updatedAt: Date
+
+        public init(
+            id: UUID,
+            sessionID: UUID,
+            goal: String,
+            statusRaw: String,
+            stepCount: Int,
+            maxSteps: Int?,
+            createdAt: Date,
+            updatedAt: Date
+        ) {
+            self.id = id
+            self.sessionID = sessionID
+            self.goal = goal
+            self.statusRaw = statusRaw
+            self.stepCount = stepCount
+            self.maxSteps = maxSteps
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+        }
+
+        /// Builds a model row from a ``ConversationRun`` value.
+        public convenience init(_ run: ConversationRun) {
+            self.init(
+                id: run.id,
+                sessionID: run.sessionID,
+                goal: run.goal,
+                statusRaw: run.status.rawValue,
+                stepCount: run.stepCount,
+                maxSteps: run.maxSteps,
+                createdAt: run.createdAt,
+                updatedAt: run.updatedAt
+            )
+        }
+
+        /// Mutating in-place update from a ``ConversationRun`` value. Identity
+        /// columns (`id`, `sessionID`, `createdAt`) are left untouched.
+        public func update(from run: ConversationRun) {
+            goal = run.goal
+            statusRaw = run.status.rawValue
+            stepCount = run.stepCount
+            maxSteps = run.maxSteps
+            updatedAt = run.updatedAt
+        }
+
+        /// Converts back to the value type.
+        public func toRecord() -> ConversationRun {
+            ConversationRun(
+                id: id,
+                sessionID: sessionID,
+                goal: goal,
+                status: RunStatus(rawValue: statusRaw) ?? .pending,
+                stepCount: stepCount,
+                maxSteps: maxSteps,
+                createdAt: createdAt,
+                updatedAt: updatedAt
+            )
+        }
+    }
+
+    // MARK: - RunStepModel (V10 — new model)
+
+    /// SwiftData row backing ``ManifoldRuntime/RunStep``.
+    ///
+    /// `turnInput` is persisted best-effort as a JSON string column
+    /// (``turnInputJSON``). The resume design (M1) replays via the provider,
+    /// so `turnInput` is **inspection metadata, not required for resume
+    /// correctness** — a decode failure surfaces as `nil` on read and is
+    /// logged, never thrown. This matches the value type, where `turnInput`
+    /// is already nil-able for goal-derived steps.
+    @Model
+    public final class RunStepModel {
+        @Attribute(.unique) public var id: UUID
+        public var runID: UUID
+        public var stepIndex: Int
+
+        /// JSON-encoded ``TurnInput``. `nil` when the step had no input
+        /// (goal-derived) or when encoding failed. Decoded best-effort; a
+        /// decode failure yields `nil` and is logged.
+        public var turnInputJSON: String?
+
+        public var messageID: UUID?
+        public var isCompleted: Bool
+        public var isFailed: Bool
+        public var failureReason: String?
+        public var createdAt: Date
+        public var updatedAt: Date
+
+        public init(
+            id: UUID,
+            runID: UUID,
+            stepIndex: Int,
+            turnInputJSON: String?,
+            messageID: UUID?,
+            isCompleted: Bool,
+            isFailed: Bool,
+            failureReason: String?,
+            createdAt: Date,
+            updatedAt: Date
+        ) {
+            self.id = id
+            self.runID = runID
+            self.stepIndex = stepIndex
+            self.turnInputJSON = turnInputJSON
+            self.messageID = messageID
+            self.isCompleted = isCompleted
+            self.isFailed = isFailed
+            self.failureReason = failureReason
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+        }
+
+        /// Builds a model row from a ``RunStep`` value, JSON-encoding the
+        /// optional `turnInput` best-effort.
+        public convenience init(_ step: RunStep) {
+            self.init(
+                id: step.id,
+                runID: step.runID,
+                stepIndex: step.stepIndex,
+                turnInputJSON: Self.encode(step.turnInput),
+                messageID: step.messageID,
+                isCompleted: step.isCompleted,
+                isFailed: step.isFailed,
+                failureReason: step.failureReason,
+                createdAt: step.createdAt,
+                updatedAt: step.updatedAt
+            )
+        }
+
+        /// Mutating in-place update from a ``RunStep`` value. Identity columns
+        /// (`id`, `runID`, `stepIndex`, `createdAt`) are left untouched.
+        public func update(from step: RunStep) {
+            turnInputJSON = Self.encode(step.turnInput)
+            messageID = step.messageID
+            isCompleted = step.isCompleted
+            isFailed = step.isFailed
+            failureReason = step.failureReason
+            updatedAt = step.updatedAt
+        }
+
+        /// Converts back to the value type, decoding `turnInput` best-effort.
+        public func toRecord() -> RunStep {
+            RunStep(
+                id: id,
+                runID: runID,
+                stepIndex: stepIndex,
+                turnInput: Self.decode(turnInputJSON),
+                messageID: messageID,
+                isCompleted: isCompleted,
+                isFailed: isFailed,
+                failureReason: failureReason,
+                createdAt: createdAt,
+                updatedAt: updatedAt
+            )
+        }
+
+        // MARK: - TurnInput JSON Helpers
+
+        static func encode(_ turnInput: TurnInput?) -> String? {
+            guard let turnInput else { return nil }
+            do {
+                let data = try JSONEncoder().encode(turnInput)
+                return String(data: data, encoding: .utf8)
+            } catch {
+                // Lossy by design (M1): turnInput is inspection metadata, not
+                // resume-critical. Drop on encode failure rather than fail the
+                // step write.
+                Log.persistence.warning("Failed to encode RunStep.turnInput; persisting nil: \(error)")
+                return nil
+            }
+        }
+
+        static func decode(_ json: String?) -> TurnInput? {
+            guard let data = json?.data(using: .utf8) else { return nil }
+            do {
+                return try JSONDecoder().decode(TurnInput.self, from: data)
+            } catch {
+                Log.persistence.warning("Failed to decode RunStep.turnInputJSON; returning nil: \(error)")
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime+TurnInput.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime+TurnInput.swift
@@ -15,7 +15,7 @@ import ManifoldInference
 ///
 /// Identical for `send`, `regenerate`, `edit`, and `branch`. The runtime reads
 /// these once per turn and forwards them to ``InferenceService/enqueueAsync(...)``.
-public struct TurnConfig: Sendable, Equatable {
+public struct TurnConfig: Sendable, Equatable, Codable {
     public let systemPrompt: String?
     public let temperature: Float
     public let topP: Float
@@ -64,7 +64,7 @@ public struct TurnConfig: Sendable, Equatable {
 /// turn; `edit` rewrites a message and re-runs trailing generation;
 /// `branch` forks a session at a chosen message and optionally generates on
 /// the new fork.
-public enum TurnKind: Sendable {
+public enum TurnKind: Sendable, Codable {
     /// New user message — persists `text` (and any image/file attachments) as
     /// a `.user` record before generation begins.
     ///
@@ -110,7 +110,7 @@ public enum TurnKind: Sendable {
 /// ``ConversationRuntime/regenerate(_:)`` etc.) are kept as thin wrappers
 /// that build a `TurnInput` for callers still passing the legacy `*Input`
 /// structs.
-public struct TurnInput: Sendable {
+public struct TurnInput: Sendable, Codable {
     /// The session this turn targets. For `.branch`, this is the **source**
     /// session — the new session ID lives on the kind payload.
     public let sessionID: UUID

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -536,6 +536,42 @@ public final class ConversationRuntime: Sendable {
         )
     }
 
+    /// Resumes a previously-checkpointed ``ConversationRun`` from the
+    /// ``RunStore`` and continues it from the first not-yet-completed step.
+    ///
+    /// Available only when the runtime was initialised with a
+    /// ``ResumableRunDriver``. Unlike ``ResumableRunDriver/resumeRun()`` (which
+    /// flips an in-memory pause flag on the live run), this reloads the run and
+    /// its steps from the store, making it a durable cross-process resume.
+    ///
+    /// Calling this method when the runtime uses the default
+    /// ``SingleTurnDriver`` logs a warning and returns an immediately-finishing
+    /// stream.
+    ///
+    /// - Parameters:
+    ///   - runID:  The id of the persisted run to resume.
+    ///   - using:  The input provider that drives step synthesis. Must satisfy
+    ///             the idempotency contract on
+    ///             ``RunInputProvider/nextInput(for:stepIndex:prior:)``.
+    /// - Returns: A stream of ``RunEvent`` values.
+    public func resumeRun(
+        _ runID: UUID,
+        using provider: any RunInputProvider = FixedGoalRunInputProvider()
+    ) -> AsyncStream<RunEvent> {
+        guard let resumableDriver = turnDriver as? ResumableRunDriver else {
+            Log.inference.warning(
+                "ConversationRuntime.resumeRun: runtime was not configured with a ResumableRunDriver; ignoring."
+            )
+            return AsyncStream { $0.finish() }
+        }
+        return resumableDriver.resume(
+            runID: runID,
+            using: provider,
+            executor: executor,
+            taskRegistry: turnTasks
+        )
+    }
+
     // MARK: Secondary event taps
 
     /// Installs a secondary multicast tap on this runtime's event flow.

--- a/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntime.swift
@@ -221,7 +221,8 @@ public final class ConversationRuntime: Sendable {
         hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         sessionToolSources: [any SessionToolSource] = [],
-        hookRegistry: HookRegistry? = nil
+        hookRegistry: HookRegistry? = nil,
+        runStore: (any RunStore)? = nil
     ) {
         self.init(
             messageStore: messageStore,
@@ -242,7 +243,8 @@ public final class ConversationRuntime: Sendable {
             turnContextProvider: turnContextProvider,
             sessionToolSources: sessionToolSources,
             hookRegistry: hookRegistry,
-            turnDriver: nil
+            turnDriver: nil,
+            runStore: runStore
         )
     }
 
@@ -325,7 +327,8 @@ public final class ConversationRuntime: Sendable {
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
-        turnDriver: (any TurnDriver)?
+        turnDriver: (any TurnDriver)?,
+        runStore: (any RunStore)? = nil
     ) {
         self.inferenceService = inferenceService
         self.auxiliaryInferenceService = auxiliaryInferenceService
@@ -365,9 +368,19 @@ public final class ConversationRuntime: Sendable {
             turnContextProvider: turnContextProvider,
             bindings: bindings
         )
-        // Default to SingleTurnDriver to preserve pre-P3 linear behavior.
-        // Callers that need resumable runs inject ResumableRunDriver here.
-        self.turnDriver = turnDriver ?? SingleTurnDriver()
+        // Driver selection (P3b #1784):
+        //   1. An explicit `turnDriver` override always wins (test/power-user seam).
+        //   2. Otherwise, if a `runStore` was supplied, wrap it in a
+        //      ResumableRunDriver so the runtime gains durable startRun/resumeRun.
+        //   3. Otherwise fall back to SingleTurnDriver to preserve pre-P3 linear
+        //      behaviour — every caller that omits both keeps the old behaviour.
+        if let turnDriver {
+            self.turnDriver = turnDriver
+        } else if let runStore {
+            self.turnDriver = ResumableRunDriver(runStore: runStore)
+        } else {
+            self.turnDriver = SingleTurnDriver()
+        }
     }
 
     // MARK: Host-mutable bindings
@@ -570,6 +583,27 @@ public final class ConversationRuntime: Sendable {
             executor: executor,
             taskRegistry: turnTasks
         )
+    }
+
+    /// Requests that the active run pause after its current step (P3b #1784).
+    ///
+    /// No-op when the runtime uses the default ``SingleTurnDriver``. The run
+    /// emits ``RunEvent/runPaused`` once it suspends; the persisted run status
+    /// transitions to ``RunStatus/paused`` so a later ``resumeRun(_:using:)``
+    /// can pick it up — even across a process restart.
+    public func pauseActiveRun() async {
+        guard let resumableDriver = turnDriver as? ResumableRunDriver else { return }
+        await resumableDriver.pauseRun()
+    }
+
+    /// Requests that the active run cancel (P3b #1784).
+    ///
+    /// No-op when the runtime uses the default ``SingleTurnDriver``. The run
+    /// emits ``RunEvent/runCancelled`` and its persisted status becomes
+    /// ``RunStatus/cancelled`` (terminal).
+    public func cancelActiveRun() async {
+        guard let resumableDriver = turnDriver as? ResumableRunDriver else { return }
+        await resumableDriver.cancelRun()
     }
 
     // MARK: Secondary event taps

--- a/Sources/ManifoldRuntime/Services/ConversationRuntimeOptions.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationRuntimeOptions.swift
@@ -64,6 +64,17 @@ public struct ConversationRuntimeOptions {
     /// runtime falls back to the primary ``InferenceService``.
     public var auxiliaryInferenceService: InferenceService?
 
+    /// Optional ``RunStore`` that opts the runtime into durable, resumable
+    /// multi-step runs (P3b #1784).
+    ///
+    /// When set — and no explicit `turnDriver` override is supplied — the
+    /// runtime constructs a ``ResumableRunDriver`` over this store instead of
+    /// the default ``SingleTurnDriver``, enabling
+    /// ``ConversationRuntime/startRun(_:using:)`` /
+    /// ``ConversationRuntime/resumeRun(_:using:)``. Leaving it `nil` (the
+    /// default) reproduces pre-P3 single-turn behaviour exactly.
+    public var runStore: (any RunStore)?
+
     public init(
         pipeline: PromptContextPipeline? = nil,
         budgetPlanner: ContextBudgetPlanner? = nil,
@@ -74,7 +85,8 @@ public struct ConversationRuntimeOptions {
         historyProviders: [any HistoryProvider] = [],
         hostTurnContextProvider: (any HostTurnContextProvider)? = nil,
         turnContextProvider: (@Sendable (UUID) -> (any Sendable)?)? = nil,
-        auxiliaryInferenceService: InferenceService? = nil
+        auxiliaryInferenceService: InferenceService? = nil,
+        runStore: (any RunStore)? = nil
     ) {
         self.pipeline = pipeline
         self.budgetPlanner = budgetPlanner
@@ -86,5 +98,6 @@ public struct ConversationRuntimeOptions {
         self.hostTurnContextProvider = hostTurnContextProvider
         self.turnContextProvider = turnContextProvider
         self.auxiliaryInferenceService = auxiliaryInferenceService
+        self.runStore = runStore
     }
 }

--- a/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
+++ b/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
@@ -79,6 +79,23 @@ public protocol RunInputProvider: Sendable {
     /// Returns the ``TurnInput`` for the next step, or `nil` when the run
     /// is complete. Called before each step; `stepIndex` is 0-based.
     ///
+    /// ## M1 resume contract (idempotency)
+    ///
+    /// `ResumableRunDriver.resume(runID:…)` replays a run from the store by
+    /// re-driving the provider from the first not-yet-completed step. Under
+    /// the M1 "replay-from-provider" design the persisted `RunStep.turnInput`
+    /// is **inspection metadata only** — it is never re-executed. Instead the
+    /// driver calls `nextInput(for:stepIndex:prior:)` again for each index.
+    ///
+    /// Therefore conformers MUST be **deterministic / idempotent**: a given
+    /// `(run, stepIndex, prior)` triple must always yield the same
+    /// ``TurnInput`` (or always `nil`). A provider that returns different
+    /// turns for the same triple will reproduce a *different* turn sequence on
+    /// resume than it did on the original run.
+    ///
+    /// ``FixedGoalRunInputProvider`` (goal-based) satisfies this trivially: it
+    /// keys only on `stepIndex` and the immutable `run.goal`.
+    ///
     /// - Parameters:
     ///   - run:       Current run record.
     ///   - stepIndex: 0-based index of the step about to execute.
@@ -157,6 +174,24 @@ private final class RunStoreProxy: @unchecked Sendable {
     func updateStep(_ step: RunStep) async {
         do { try await store.updateStep(step) } catch {
             Log.persistence.warning("ResumableRunDriver: updateStep failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: Resume reads
+
+    @MainActor
+    func fetchRun(_ id: UUID) async -> ConversationRun? {
+        do { return try await store.fetchRun(id) } catch {
+            Log.persistence.warning("ResumableRunDriver: fetchRun failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    @MainActor
+    func fetchSteps(_ runID: UUID) async -> [RunStep] {
+        do { return try await store.fetchSteps(for: runID) } catch {
+            Log.persistence.warning("ResumableRunDriver: fetchSteps failed: \(error.localizedDescription)")
+            return []
         }
     }
 }
@@ -270,146 +305,310 @@ public final class ResumableRunDriver: TurnDriver, @unchecked Sendable {
                     goal: currentRun.goal
                 ))
 
-                var priorStep: RunStep? = nil
-                var stepIndex = 0
-
-                stepLoop: while true {
-                    // Cancel check.
-                    if await runState.checkCancelled() {
-                        currentRun.status = .cancelled
-                        currentRun.updatedAt = Date()
-                        await storeProxy.updateRun(currentRun)
-                        await runState.setActiveRun(nil)
-                        continuation.yield(.runCancelled(runID: currentRun.id, stepCount: stepIndex))
-                        break stepLoop
-                    }
-
-                    // Pause/resume cycle.
-                    if await runState.checkPaused() {
-                        currentRun.status = .paused
-                        currentRun.updatedAt = Date()
-                        await storeProxy.updateRun(currentRun)
-                        continuation.yield(.runPaused(runID: currentRun.id, stepCount: stepIndex))
-
-                        // Poll until un-paused or cancelled.
-                        while await runState.checkPaused() {
-                            if await runState.checkCancelled() { break }
-                            try? await Task.sleep(for: .milliseconds(100))
-                        }
-
-                        if await runState.checkCancelled() {
-                            currentRun.status = .cancelled
-                            currentRun.updatedAt = Date()
-                            await storeProxy.updateRun(currentRun)
-                            await runState.setActiveRun(nil)
-                            continuation.yield(.runCancelled(runID: currentRun.id, stepCount: stepIndex))
-                            break stepLoop
-                        }
-
-                        currentRun.status = .running
-                        currentRun.updatedAt = Date()
-                        await storeProxy.updateRun(currentRun)
-                        continuation.yield(.runResumed(runID: currentRun.id, stepCount: stepIndex))
-                    }
-
-                    // Step-limit check.
-                    if let max = currentRun.maxSteps, stepIndex >= max {
-                        currentRun.status = .completed
-                        currentRun.stepCount = stepIndex
-                        currentRun.updatedAt = Date()
-                        await storeProxy.updateRun(currentRun)
-                        await runState.setActiveRun(nil)
-                        continuation.yield(.runCompleted(runID: currentRun.id, stepCount: stepIndex))
-                        break stepLoop
-                    }
-
-                    // Ask provider for next input.
-                    guard let turnInput = await provider.nextInput(
-                        for: currentRun,
-                        stepIndex: stepIndex,
-                        prior: priorStep
-                    ) else {
-                        currentRun.status = .completed
-                        currentRun.stepCount = stepIndex
-                        currentRun.updatedAt = Date()
-                        await storeProxy.updateRun(currentRun)
-                        await runState.setActiveRun(nil)
-                        continuation.yield(.runCompleted(runID: currentRun.id, stepCount: stepIndex))
-                        break stepLoop
-                    }
-
-                    // Insert the step record before executing the turn — mirrors
-                    // the #1606 register-before-enqueue discipline: checkpoint
-                    // first so the step is visible if the process dies during
-                    // execution.
-                    var step = RunStep(
-                        runID: currentRun.id,
-                        stepIndex: stepIndex,
-                        turnInput: turnInput
-                    )
-                    await storeProxy.insertStep(step)
-                    continuation.yield(.stepStarted(
-                        runID: currentRun.id,
-                        stepIndex: stepIndex,
-                        stepID: step.id
-                    ))
-
-                    // Execute the turn, capturing the outcome for step attribution.
-                    let outcomeCompletion = ConversationTurnOutcomeCompletion()
-                    do {
-                        let handle = try await driver.executeTurn(
-                            turnInput,
-                            executor: executor,
-                            taskRegistry: taskRegistry,
-                            outcomeCompletion: outcomeCompletion
-                        )
-                        // Wait for the turn to fully complete before advancing.
-                        if handle != nil {
-                            let outcome = await outcomeCompletion.value()
-                            step.messageID = outcome.assistantMessage?.id
-                        }
-                    } catch {
-                        let reason = error.localizedDescription
-                        step.isFailed = true
-                        step.failureReason = reason
-                        step.updatedAt = Date()
-                        await storeProxy.updateStep(step)
-                        currentRun.status = .failed
-                        currentRun.updatedAt = Date()
-                        await storeProxy.updateRun(currentRun)
-                        await runState.setActiveRun(nil)
-                        continuation.yield(.stepFailed(
-                            runID: currentRun.id,
-                            stepIndex: stepIndex,
-                            stepID: step.id,
-                            reason: reason
-                        ))
-                        continuation.yield(.runFailed(runID: currentRun.id, reason: reason))
-                        break stepLoop
-                    }
-
-                    // Mark step complete and checkpoint.
-                    step.isCompleted = true
-                    step.updatedAt = Date()
-                    await storeProxy.updateStep(step)
-                    continuation.yield(.stepCompleted(
-                        runID: currentRun.id,
-                        stepIndex: stepIndex,
-                        stepID: step.id,
-                        messageID: step.messageID
-                    ))
-
-                    // Advance the step counter.
-                    priorStep = step
-                    stepIndex += 1
-                    currentRun.stepCount = stepIndex
-                    currentRun.updatedAt = Date()
-                    await runState.updateActiveRun(currentRun)
-                    await storeProxy.updateRun(currentRun)
-                }
+                // Hand off to the shared step loop seeded at the start.
+                await driver.runStepLoop(
+                    continuation: continuation,
+                    currentRun: currentRun,
+                    startIndex: 0,
+                    priorStep: nil,
+                    provider: provider,
+                    executor: executor,
+                    taskRegistry: taskRegistry
+                )
 
                 continuation.finish()
             }
+        }
+    }
+
+    /// Resumes a previously-checkpointed ``ConversationRun`` from the
+    /// ``RunStore`` and continues execution from the first not-yet-completed
+    /// step (M1 "replay-from-provider").
+    ///
+    /// Unlike ``resumeRun()`` (which only flips an in-memory pause flag on the
+    /// *currently active* run), this is a durable, cross-process resume: it
+    /// reads the run and its steps back from the store and re-drives the loop.
+    ///
+    /// ## M1 semantics
+    ///
+    /// The persisted ``RunStep/turnInput`` is **inspection metadata only** and
+    /// is never re-executed. Instead the driver re-calls
+    /// `provider.nextInput(for:stepIndex:prior:)` for each remaining index,
+    /// relying on the provider's idempotency contract (see
+    /// ``RunInputProvider/nextInput(for:stepIndex:prior:)``) to reproduce the
+    /// same turn sequence. The resume point is computed as the number of
+    /// *completed* steps; the highest-index completed step seeds `prior`.
+    ///
+    /// ## Dangling incomplete steps
+    ///
+    /// A step inserted before a crash but never marked `isCompleted` (the
+    /// process died mid-turn) is treated as never-having-run and is re-driven
+    /// through the provider. ``RunStore`` has no `deleteStep` port, so rather
+    /// than remove the stale record we **mark it failed** (`isFailed = true`,
+    /// `failureReason = "superseded on resume"`) before resuming. This keeps it
+    /// as inspection-only metadata and disambiguates it from the fresh
+    /// completed record the resume produces at the same `stepIndex`. The resume
+    /// point counts only *completed* steps, so the dangling index is always
+    /// re-executed.
+    ///
+    /// - Parameters:
+    ///   - runID:        The id of the persisted run to resume.
+    ///   - provider:     Supplies the ``TurnInput`` for each remaining step.
+    ///   - executor:     The ``ConversationTurnExecutor`` from the runtime.
+    ///   - taskRegistry: The ``ConversationTurnTaskRegistry`` from the runtime.
+    /// - Returns: An `AsyncStream<RunEvent>` delivering lifecycle events until
+    ///   the run reaches a terminal state. If no run is persisted for `runID`,
+    ///   or the run is already terminal, the stream finishes after a single
+    ///   terminal event without executing any steps.
+    package func resume(
+        runID: UUID,
+        using provider: any RunInputProvider,
+        executor: ConversationTurnExecutor,
+        taskRegistry: ConversationTurnTaskRegistry
+    ) -> AsyncStream<RunEvent> {
+        let storeProxy = self.storeProxy
+        let runState = self.runState
+        let driver = self
+
+        return AsyncStream { continuation in
+            Task {
+                // 1. Load the persisted run.
+                guard let fetched = await storeProxy.fetchRun(runID) else {
+                    continuation.yield(.runFailed(
+                        runID: runID,
+                        reason: "no persisted run \(runID.uuidString)"
+                    ))
+                    continuation.finish()
+                    return
+                }
+
+                // Do not re-run a run that already reached a terminal state.
+                switch fetched.status {
+                case .completed:
+                    continuation.yield(.runCompleted(runID: fetched.id, stepCount: fetched.stepCount))
+                    continuation.finish()
+                    return
+                case .cancelled:
+                    continuation.yield(.runCancelled(runID: fetched.id, stepCount: fetched.stepCount))
+                    continuation.finish()
+                    return
+                case .failed:
+                    continuation.yield(.runFailed(
+                        runID: fetched.id,
+                        reason: "run \(fetched.id.uuidString) already failed"
+                    ))
+                    continuation.finish()
+                    return
+                case .pending, .running, .paused:
+                    break
+                }
+
+                // 2. Determine the resume point from persisted steps.
+                let steps = await storeProxy.fetchSteps(fetched.id)
+                let completed = steps.filter(\.isCompleted)
+                let resumeIndex = completed.count
+                let priorStep = completed.max(by: { $0.stepIndex < $1.stepIndex })
+
+                // Mark any dangling incomplete step (inserted before a crash,
+                // never completed) as failed-and-superseded. RunStore has no
+                // deleteStep port, so this keeps the record as inspection-only
+                // metadata; M1 re-drives that index through the provider.
+                for stale in steps where !stale.isCompleted {
+                    var superseded = stale
+                    superseded.isFailed = true
+                    superseded.failureReason = "superseded on resume"
+                    superseded.updatedAt = Date()
+                    await storeProxy.updateStep(superseded)
+                }
+
+                // 3. Transition to running, seed in-memory state, announce resume.
+                await runState.clearFlags()
+                var currentRun = fetched
+                currentRun.status = .running
+                currentRun.stepCount = resumeIndex
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                await runState.setActiveRun(currentRun)
+                continuation.yield(.runResumed(runID: currentRun.id, stepCount: resumeIndex))
+
+                // 4. Hand off to the shared step loop seeded at the resume point.
+                await driver.runStepLoop(
+                    continuation: continuation,
+                    currentRun: currentRun,
+                    startIndex: resumeIndex,
+                    priorStep: priorStep,
+                    provider: provider,
+                    executor: executor,
+                    taskRegistry: taskRegistry
+                )
+
+                continuation.finish()
+            }
+        }
+    }
+
+    // MARK: Shared step loop
+
+    /// The multi-step execution loop shared by ``startRun(_:using:executor:taskRegistry:)``
+    /// and ``resume(runID:using:executor:taskRegistry:)``.
+    ///
+    /// Callers are responsible for the lifecycle preamble (insert/transition to
+    /// `.running`, emit the opening `.runStarted` / `.runResumed` event, seed
+    /// in-memory state) and for `continuation.finish()` afterward. This method
+    /// owns only the per-step body: cancel/pause checks, the step-limit guard,
+    /// provider dispatch, turn execution, and checkpointing.
+    ///
+    /// `currentRun.stepCount` and `startIndex` must already agree at entry.
+    private func runStepLoop(
+        continuation: AsyncStream<RunEvent>.Continuation,
+        currentRun currentRunSeed: ConversationRun,
+        startIndex: Int,
+        priorStep priorStepSeed: RunStep?,
+        provider: any RunInputProvider,
+        executor: ConversationTurnExecutor,
+        taskRegistry: ConversationTurnTaskRegistry
+    ) async {
+        let storeProxy = self.storeProxy
+        let runState = self.runState
+        let driver = self
+
+        var currentRun = currentRunSeed
+        var priorStep: RunStep? = priorStepSeed
+        var stepIndex = startIndex
+
+        stepLoop: while true {
+            // Cancel check.
+            if await runState.checkCancelled() {
+                currentRun.status = .cancelled
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                await runState.setActiveRun(nil)
+                continuation.yield(.runCancelled(runID: currentRun.id, stepCount: stepIndex))
+                break stepLoop
+            }
+
+            // Pause/resume cycle.
+            if await runState.checkPaused() {
+                currentRun.status = .paused
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                continuation.yield(.runPaused(runID: currentRun.id, stepCount: stepIndex))
+
+                // Poll until un-paused or cancelled.
+                while await runState.checkPaused() {
+                    if await runState.checkCancelled() { break }
+                    try? await Task.sleep(for: .milliseconds(100))
+                }
+
+                if await runState.checkCancelled() {
+                    currentRun.status = .cancelled
+                    currentRun.updatedAt = Date()
+                    await storeProxy.updateRun(currentRun)
+                    await runState.setActiveRun(nil)
+                    continuation.yield(.runCancelled(runID: currentRun.id, stepCount: stepIndex))
+                    break stepLoop
+                }
+
+                currentRun.status = .running
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                continuation.yield(.runResumed(runID: currentRun.id, stepCount: stepIndex))
+            }
+
+            // Step-limit check.
+            if let max = currentRun.maxSteps, stepIndex >= max {
+                currentRun.status = .completed
+                currentRun.stepCount = stepIndex
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                await runState.setActiveRun(nil)
+                continuation.yield(.runCompleted(runID: currentRun.id, stepCount: stepIndex))
+                break stepLoop
+            }
+
+            // Ask provider for next input.
+            guard let turnInput = await provider.nextInput(
+                for: currentRun,
+                stepIndex: stepIndex,
+                prior: priorStep
+            ) else {
+                currentRun.status = .completed
+                currentRun.stepCount = stepIndex
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                await runState.setActiveRun(nil)
+                continuation.yield(.runCompleted(runID: currentRun.id, stepCount: stepIndex))
+                break stepLoop
+            }
+
+            // Insert the step record before executing the turn — mirrors
+            // the #1606 register-before-enqueue discipline: checkpoint
+            // first so the step is visible if the process dies during
+            // execution.
+            var step = RunStep(
+                runID: currentRun.id,
+                stepIndex: stepIndex,
+                turnInput: turnInput
+            )
+            await storeProxy.insertStep(step)
+            continuation.yield(.stepStarted(
+                runID: currentRun.id,
+                stepIndex: stepIndex,
+                stepID: step.id
+            ))
+
+            // Execute the turn, capturing the outcome for step attribution.
+            let outcomeCompletion = ConversationTurnOutcomeCompletion()
+            do {
+                let handle = try await driver.executeTurn(
+                    turnInput,
+                    executor: executor,
+                    taskRegistry: taskRegistry,
+                    outcomeCompletion: outcomeCompletion
+                )
+                // Wait for the turn to fully complete before advancing.
+                if handle != nil {
+                    let outcome = await outcomeCompletion.value()
+                    step.messageID = outcome.assistantMessage?.id
+                }
+            } catch {
+                let reason = error.localizedDescription
+                step.isFailed = true
+                step.failureReason = reason
+                step.updatedAt = Date()
+                await storeProxy.updateStep(step)
+                currentRun.status = .failed
+                currentRun.updatedAt = Date()
+                await storeProxy.updateRun(currentRun)
+                await runState.setActiveRun(nil)
+                continuation.yield(.stepFailed(
+                    runID: currentRun.id,
+                    stepIndex: stepIndex,
+                    stepID: step.id,
+                    reason: reason
+                ))
+                continuation.yield(.runFailed(runID: currentRun.id, reason: reason))
+                break stepLoop
+            }
+
+            // Mark step complete and checkpoint.
+            step.isCompleted = true
+            step.updatedAt = Date()
+            await storeProxy.updateStep(step)
+            continuation.yield(.stepCompleted(
+                runID: currentRun.id,
+                stepIndex: stepIndex,
+                stepID: step.id,
+                messageID: step.messageID
+            ))
+
+            // Advance the step counter.
+            priorStep = step
+            stepIndex += 1
+            currentRun.stepCount = stepIndex
+            currentRun.updatedAt = Date()
+            await runState.updateActiveRun(currentRun)
+            await storeProxy.updateRun(currentRun)
         }
     }
 

--- a/Tests/ManifoldPersistenceSwiftDataTests/ResumableRunEndToEndTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ResumableRunEndToEndTests.swift
@@ -1,0 +1,237 @@
+import XCTest
+import SwiftData
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldTestSupport
+
+/// End-to-end durability proof for the P3b resumable-run stack (#1784).
+///
+/// Exercises the *whole* wiring path — `ConversationRuntimeOptions.runStore` →
+/// `ConversationRuntime` driver selection → `ResumableRunDriver` →
+/// `SwiftDataRunStore` over a real `ModelContainer` — and proves that a run
+/// checkpointed by one runtime instance can be resumed to completion by a
+/// fresh runtime over the *same* on-disk store, without re-running the steps
+/// that already completed.
+///
+/// Classification: Integration (real on-disk SwiftData, MockInferenceBackend —
+/// no network, no real model). The persistence layer is never mocked.
+@MainActor
+final class ResumableRunEndToEndTests: XCTestCase {
+
+    private var tempStoreDirectory: URL?
+
+    override func tearDown() async throws {
+        if let tempStoreDirectory {
+            try? FileManager.default.removeItem(at: tempStoreDirectory)
+        }
+        tempStoreDirectory = nil
+        try await super.tearDown()
+    }
+
+    private func makeStoreURL() throws -> URL {
+        let dir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("ResumableRunE2E-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        tempStoreDirectory = dir
+        return dir.appendingPathComponent("Manifold.sqlite")
+    }
+
+    /// Builds a fresh resumable-runs `ManifoldBootstrap` over the given on-disk
+    /// store URL. Each call opens a *new* `ModelContainer` over the same file,
+    /// modelling a fresh process launch — both the message store and the run
+    /// store share that single container's main context (the real host shape).
+    private func makeResumableBootstrap(storeURL: URL) throws -> ManifoldBootstrap {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["ok"]
+        let service = InferenceService(backend: backend, name: "ResumableE2E")
+
+        return try ManifoldBootstrap(
+            configuration: ManifoldConfiguration(
+                appName: "ResumableE2E",
+                bundleIdentifier: "com.manifoldkit.resumable-e2e.\(UUID().uuidString)"
+            ),
+            inferenceService: service,
+            enableResumableRuns: true,
+            makeModelContainer: {
+                try ModelContainerFactory.makeContainer(
+                    configurations: [ModelConfiguration(url: storeURL)]
+                )
+            }
+        )
+    }
+
+    /// Deterministic, idempotent provider that yields `.send(text:)` for the
+    /// first `totalSteps` indices and `nil` afterward. Records every
+    /// `stepIndex` it is asked for in a shared, cross-instance recorder so the
+    /// test can prove completed steps are NOT re-driven on resume.
+    private struct RecordingProvider: RunInputProvider, Sendable {
+        let totalSteps: Int
+        let recorder: IndexRecorder
+
+        func nextInput(
+            for run: ConversationRun,
+            stepIndex: Int,
+            prior: RunStep?
+        ) async -> TurnInput? {
+            await recorder.record(stepIndex)
+            guard stepIndex < totalSteps else { return nil }
+            return TurnInput(
+                sessionID: run.sessionID,
+                kind: .send(text: "\(run.goal) — step \(stepIndex)")
+            )
+        }
+    }
+
+    /// Shared recorder of the step indices the provider was asked to drive.
+    /// Survives across both runtime instances so we can assert the resume run
+    /// only drives indices >= the resume point.
+    private actor IndexRecorder {
+        private(set) var indices: [Int] = []
+        func record(_ index: Int) { indices.append(index) }
+        func snapshot() -> [Int] { indices }
+    }
+
+    // MARK: - The acceptance test
+
+    func test_run_checkpointsThenResumesToCompletionOverFreshStore() async throws {
+        let originalConfiguration = ManifoldConfiguration.shared
+        defer { ManifoldConfiguration.shared = originalConfiguration }
+
+        let storeURL = try makeStoreURL()
+        let sessionID = UUID()
+        let recorder = IndexRecorder()
+        let totalSteps = 3
+
+        // ── Phase 1: start a run, let it checkpoint at least one step, then
+        // simulate process death by dropping the bootstrap mid-flight. We cap
+        // consumption after the first completed step so step 0 is durably
+        // checkpointed but the run never reaches a terminal state.
+        let runID: UUID
+        do {
+            let bootstrap = try makeResumableBootstrap(storeURL: storeURL)
+            let store = try XCTUnwrap(bootstrap.runStore, "enableResumableRuns must expose a runStore")
+            let run = ConversationRun(
+                sessionID: sessionID,
+                goal: "Plan the launch",
+                maxSteps: totalSteps
+            )
+            runID = run.id
+
+            let provider = RecordingProvider(totalSteps: totalSteps, recorder: recorder)
+            var sawFirstStepCompleted = false
+            var sawPaused = false
+            for await event in bootstrap.conversationRuntime.startRun(run, using: provider) {
+                switch event {
+                case .stepCompleted(_, 0, _, _):
+                    sawFirstStepCompleted = true
+                    // Request a pause: the loop parks after the current step
+                    // without driving step 1 to completion.
+                    await bootstrap.conversationRuntime.pauseActiveRun()
+                case .runPaused:
+                    sawPaused = true
+                    // The loop is now parked in its pause-poll. Stop consuming
+                    // and drop the bootstrap — "process death" while paused.
+                default:
+                    break
+                }
+                if sawPaused { break }
+            }
+            XCTAssertTrue(sawFirstStepCompleted, "Run did not checkpoint its first step")
+            XCTAssertTrue(sawPaused, "Run did not reach a durable paused checkpoint")
+
+            // The store must hold a non-terminal run with exactly one completed step.
+            let fetched = try await store.fetchRun(runID)
+            let persisted = try XCTUnwrap(fetched)
+            XCTAssertNotEqual(persisted.status, .completed, "Run should not be terminal yet")
+            let steps = try await store.fetchSteps(for: runID)
+            let completed = steps.filter(\.isCompleted)
+            XCTAssertEqual(completed.count, 1, "Expected exactly one completed step at crash time")
+            XCTAssertEqual(completed.first?.stepIndex, 0)
+        }
+
+        let indicesBeforeResume = await recorder.snapshot()
+
+        // ── Phase 2: a brand-new bootstrap (fresh container + SwiftDataRunStore)
+        // over the SAME on-disk file resumes the run from its checkpoint.
+        let resumeBootstrap = try makeResumableBootstrap(storeURL: storeURL)
+        let resumeRuntime = resumeBootstrap.conversationRuntime
+        let resumeStore = try XCTUnwrap(resumeBootstrap.runStore)
+        let provider = RecordingProvider(totalSteps: totalSteps, recorder: recorder)
+
+        var resumedAtStepCount: Int?
+        var firstStepStartedIndex: Int?
+        var finalStepCount: Int?
+        for await event in resumeRuntime.resumeRun(runID, using: provider) {
+            switch event {
+            case let .runResumed(_, stepCount):
+                if resumedAtStepCount == nil { resumedAtStepCount = stepCount }
+            case let .stepStarted(_, idx, _):
+                if firstStepStartedIndex == nil { firstStepStartedIndex = idx }
+            case let .runCompleted(_, stepCount):
+                finalStepCount = stepCount
+            default:
+                break
+            }
+        }
+
+        // Resume started from the persisted checkpoint (1 completed step).
+        XCTAssertEqual(resumedAtStepCount, 1, "Resume did not start from the persisted checkpoint")
+        // The first step re-driven on resume is index 1 — step 0 was NOT re-run.
+        XCTAssertEqual(firstStepStartedIndex, 1, "Resume re-ran an already-completed step")
+        // The run reached completion with the full step count.
+        XCTAssertEqual(finalStepCount, totalSteps)
+
+        // The provider was asked only for the not-yet-completed indices on
+        // resume — completed step 0 was never re-driven.
+        let indicesAfterResume = await recorder.snapshot()
+        let resumeOnlyIndices = Array(indicesAfterResume.dropFirst(indicesBeforeResume.count))
+        XCTAssertFalse(resumeOnlyIndices.contains(0), "Resume re-drove the completed step 0")
+        XCTAssertEqual(resumeOnlyIndices.min(), 1, "Resume should begin at the first incomplete index")
+
+        // The durable record is terminal-completed with the expected step count.
+        let finalFetched = try await resumeStore.fetchRun(runID)
+        let finalRun = try XCTUnwrap(finalFetched)
+        XCTAssertEqual(finalRun.status, .completed)
+        XCTAssertEqual(finalRun.stepCount, totalSteps)
+
+        // All steps are durably completed exactly once each.
+        let finalSteps = try await resumeStore.fetchSteps(for: runID)
+        let completedIndices = finalSteps.filter(\.isCompleted).map(\.stepIndex).sorted()
+        XCTAssertEqual(completedIndices, Array(0..<totalSteps))
+    }
+
+    // MARK: - Backward compatibility
+
+    func test_runtimeWithoutRunStore_hasNoResumableSurface() async throws {
+        // A runtime built WITHOUT a runStore uses SingleTurnDriver: the run API
+        // is inert (logs + finishes immediately), proving the opt-in is the only
+        // path to resumable behaviour and existing callers are unaffected.
+        let harness = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["ok"]
+        let service = InferenceService(backend: backend, name: "NoRunStore")
+
+        let runtime = ConversationRuntime(
+            messageStore: harness.provider,
+            sessionStore: harness.provider,
+            inferenceService: service
+            // no runStore → SingleTurnDriver
+        )
+
+        // startRun on a non-resumable runtime yields no events and finishes.
+        let run = ConversationRun(sessionID: UUID(), goal: "noop", maxSteps: 2)
+        var eventCount = 0
+        for await _ in runtime.startRun(run) { eventCount += 1 }
+        XCTAssertEqual(eventCount, 0, "Non-resumable runtime must not drive a run")
+
+        // But ordinary single-turn behaviour still works.
+        let handle = try await runtime.processTurnWithOutcome(
+            TurnInput(sessionID: UUID(), kind: .send(text: "Hello"))
+        )
+        _ = await handle?.outcome
+    }
+}

--- a/Tests/ManifoldPersistenceSwiftDataTests/ResumableRunEndToEndTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ResumableRunEndToEndTests.swift
@@ -103,13 +103,14 @@ final class ResumableRunEndToEndTests: XCTestCase {
         let storeURL = try makeStoreURL()
         let sessionID = UUID()
         let recorder = IndexRecorder()
-        let totalSteps = 3
+        let totalSteps = 4
 
         // ── Phase 1: start a run, let it checkpoint at least one step, then
         // simulate process death by dropping the bootstrap mid-flight. We cap
         // consumption after the first completed step so step 0 is durably
         // checkpointed but the run never reaches a terminal state.
         let runID: UUID
+        let completedAtCrash: Int
         do {
             let bootstrap = try makeResumableBootstrap(storeURL: storeURL)
             let store = try XCTUnwrap(bootstrap.runStore, "enableResumableRuns must expose a runStore")
@@ -122,34 +123,52 @@ final class ResumableRunEndToEndTests: XCTestCase {
 
             let provider = RecordingProvider(totalSteps: totalSteps, recorder: recorder)
             var sawFirstStepCompleted = false
-            var sawPaused = false
+            var loopFinished = false
             for await event in bootstrap.conversationRuntime.startRun(run, using: provider) {
                 switch event {
                 case .stepCompleted(_, 0, _, _):
                     sawFirstStepCompleted = true
-                    // Request a pause: the loop parks after the current step
-                    // without driving step 1 to completion.
-                    await bootstrap.conversationRuntime.pauseActiveRun()
-                case .runPaused:
-                    sawPaused = true
-                    // The loop is now parked in its pause-poll. Stop consuming
-                    // and drop the bootstrap — "process death" while paused.
+                    // Stop the loop *cleanly* once a step is durably checkpointed.
+                    // We must not abandon a still-running loop: it would keep a
+                    // second SwiftData ModelContainer live over this same on-disk
+                    // store while phase 2 opens a fresh one, and two containers on
+                    // one file in one process corrupts CoreData (intermittent
+                    // SIGSEGV in sibling suites under the parallel gate). Cancelling
+                    // lets the loop terminate and release its container; we then
+                    // rewrite the persisted status back to a non-terminal value to
+                    // model the real crash state — a process killed mid-run, before
+                    // any terminal transition, with its completed prefix intact.
+                    await bootstrap.conversationRuntime.cancelActiveRun()
+                case .runCancelled, .runCompleted, .runFailed:
+                    loopFinished = true
                 default:
                     break
                 }
-                if sawPaused { break }
+                if loopFinished { break }
             }
             XCTAssertTrue(sawFirstStepCompleted, "Run did not checkpoint its first step")
-            XCTAssertTrue(sawPaused, "Run did not reach a durable paused checkpoint")
+            XCTAssertTrue(loopFinished, "Run loop did not terminate")
 
-            // The store must hold a non-terminal run with exactly one completed step.
-            let fetched = try await store.fetchRun(runID)
-            let persisted = try XCTUnwrap(fetched)
-            XCTAssertNotEqual(persisted.status, .completed, "Run should not be terminal yet")
-            let steps = try await store.fetchSteps(for: runID)
-            let completed = steps.filter(\.isCompleted)
-            XCTAssertEqual(completed.count, 1, "Expected exactly one completed step at crash time")
-            XCTAssertEqual(completed.first?.stepIndex, 0)
+            // The completed steps must form a contiguous prefix from 0. Exactly how
+            // many completed before the cancel took effect is timing-dependent (the
+            // loop may finish the in-flight step first), so we capture the actual
+            // count and drive every downstream assertion off it — testing the real
+            // durability contract (resume from wherever it checkpointed) rather than
+            // a fragile exact count.
+            let completedIndices = try await store.fetchSteps(for: runID)
+                .filter(\.isCompleted).map(\.stepIndex).sorted()
+            XCTAssertGreaterThanOrEqual(completedIndices.count, 1, "Run did not durably checkpoint a step")
+            XCTAssertLessThan(completedIndices.count, totalSteps, "Run finished before it could be resumed")
+            XCTAssertEqual(completedIndices, Array(0..<completedIndices.count),
+                           "Completed steps must form a contiguous prefix from 0")
+            completedAtCrash = completedIndices.count
+
+            // Restore the non-terminal state a kill would have left (the cancel was
+            // only our in-test mechanism for stopping the loop deterministically).
+            let fetchedMidRun = try await store.fetchRun(runID)
+            var midRun = try XCTUnwrap(fetchedMidRun)
+            midRun.status = .running
+            try await store.updateRun(midRun)
         }
 
         let indicesBeforeResume = await recorder.snapshot()
@@ -177,10 +196,11 @@ final class ResumableRunEndToEndTests: XCTestCase {
             }
         }
 
-        // Resume started from the persisted checkpoint (1 completed step).
-        XCTAssertEqual(resumedAtStepCount, 1, "Resume did not start from the persisted checkpoint")
-        // The first step re-driven on resume is index 1 — step 0 was NOT re-run.
-        XCTAssertEqual(firstStepStartedIndex, 1, "Resume re-ran an already-completed step")
+        // Resume started from the persisted checkpoint (the completed-step count).
+        XCTAssertEqual(resumedAtStepCount, completedAtCrash, "Resume did not start from the persisted checkpoint")
+        // The first step re-driven on resume is the first incomplete index — the
+        // already-completed prefix was NOT re-run.
+        XCTAssertEqual(firstStepStartedIndex, completedAtCrash, "Resume re-ran an already-completed step")
         // The run reached completion with the full step count.
         XCTAssertEqual(finalStepCount, totalSteps)
 
@@ -188,8 +208,9 @@ final class ResumableRunEndToEndTests: XCTestCase {
         // resume — completed step 0 was never re-driven.
         let indicesAfterResume = await recorder.snapshot()
         let resumeOnlyIndices = Array(indicesAfterResume.dropFirst(indicesBeforeResume.count))
-        XCTAssertFalse(resumeOnlyIndices.contains(0), "Resume re-drove the completed step 0")
-        XCTAssertEqual(resumeOnlyIndices.min(), 1, "Resume should begin at the first incomplete index")
+        XCTAssertFalse(resumeOnlyIndices.contains(where: { $0 < completedAtCrash }),
+                       "Resume re-drove an already-completed step")
+        XCTAssertEqual(resumeOnlyIndices.min(), completedAtCrash, "Resume should begin at the first incomplete index")
 
         // The durable record is terminal-completed with the expected step count.
         let finalFetched = try await resumeStore.fetchRun(runID)

--- a/Tests/ManifoldPersistenceSwiftDataTests/SchemaMigrationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SchemaMigrationTests.swift
@@ -78,8 +78,8 @@ final class SchemaMigrationTests: XCTestCase {
         XCTAssertNotNil(container)
     }
 
-    func test_containerFactory_currentSchema_isV9() {
-        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(ManifoldSchemaV9.self))
+    func test_containerFactory_currentSchema_isV10() {
+        XCTAssertEqual(ObjectIdentifier(ModelContainerFactory.currentSchema), ObjectIdentifier(ManifoldSchemaV10.self))
     }
 
     func test_containerFactory_reopensPersistedStore() throws {

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataRunStoreTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataRunStoreTests.swift
@@ -1,0 +1,385 @@
+import XCTest
+import SwiftData
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldTestSupport
+
+/// Integration tests for ``SwiftDataRunStore`` (P3b #1784) and the V9→V10
+/// additive schema migration. In-memory SwiftData throughout — the
+/// persistence layer is never mocked.
+@MainActor
+final class SwiftDataRunStoreTests: XCTestCase {
+
+    private var tempStoreDirectory: URL?
+
+    override func tearDown() async throws {
+        if let tempStoreDirectory {
+            try? FileManager.default.removeItem(at: tempStoreDirectory)
+        }
+        tempStoreDirectory = nil
+        try await super.tearDown()
+    }
+
+    private func makeStoreDirectory(named prefix: String) throws -> URL {
+        let storeDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+        tempStoreDirectory = storeDirectory
+        return storeDirectory
+    }
+
+    private func makeRun(
+        sessionID: UUID = UUID(),
+        status: RunStatus = .running,
+        stepCount: Int = 0,
+        maxSteps: Int? = 8
+    ) -> ConversationRun {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        return ConversationRun(
+            id: UUID(),
+            sessionID: sessionID,
+            goal: "Plan the launch",
+            status: status,
+            stepCount: stepCount,
+            maxSteps: maxSteps,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    private func makeStep(
+        runID: UUID,
+        index: Int,
+        turnInput: TurnInput?,
+        isCompleted: Bool = false
+    ) -> RunStep {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        return RunStep(
+            id: UUID(),
+            runID: runID,
+            stepIndex: index,
+            turnInput: turnInput,
+            messageID: nil,
+            isCompleted: isCompleted,
+            isFailed: false,
+            failureReason: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+    }
+
+    // MARK: - 1. CRUD round-trip
+
+    func test_insertThenFetchRun_roundTripsGuaranteedFields() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let run = makeRun(status: .paused, stepCount: 3, maxSteps: 10)
+        try await store.insertRun(run)
+
+        let fetched = try await store.fetchRun(run.id)
+        let unwrapped = try XCTUnwrap(fetched)
+        XCTAssertEqual(unwrapped.id, run.id)
+        XCTAssertEqual(unwrapped.sessionID, run.sessionID)
+        XCTAssertEqual(unwrapped.goal, "Plan the launch")
+        XCTAssertEqual(unwrapped.status, .paused)
+        XCTAssertEqual(unwrapped.stepCount, 3)
+        XCTAssertEqual(unwrapped.maxSteps, 10)
+        XCTAssertEqual(unwrapped.createdAt, run.createdAt)
+    }
+
+    func test_updateRun_persistsStatusAndStepCount() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        var run = makeRun(status: .running, stepCount: 0)
+        try await store.insertRun(run)
+
+        run.status = .completed
+        run.stepCount = 5
+        run.updatedAt = Date(timeIntervalSince1970: 1_700_000_500)
+        try await store.updateRun(run)
+
+        let fetchedRun = try await store.fetchRun(run.id)
+        let fetched = try XCTUnwrap(fetchedRun)
+        XCTAssertEqual(fetched.status, .completed)
+        XCTAssertEqual(fetched.stepCount, 5)
+        XCTAssertEqual(fetched.updatedAt, Date(timeIntervalSince1970: 1_700_000_500))
+    }
+
+    func test_updateRun_unknownID_throwsRunNotFound() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+        let phantom = makeRun()
+        do {
+            try await store.updateRun(phantom)
+            XCTFail("Expected runNotFound for an un-inserted run")
+        } catch let error as RunStoreError {
+            XCTAssertEqual(error, .runNotFound(phantom.id))
+        }
+    }
+
+    func test_deleteRun_removesRunAndItsSteps() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let run = makeRun()
+        try await store.insertRun(run)
+        try await store.insertStep(makeStep(runID: run.id, index: 0, turnInput: nil))
+        try await store.insertStep(makeStep(runID: run.id, index: 1, turnInput: nil))
+
+        try await store.deleteRun(run.id)
+
+        let deletedRun = try await store.fetchRun(run.id)
+        XCTAssertNil(deletedRun)
+        let steps = try await store.fetchSteps(for: run.id)
+        XCTAssertTrue(steps.isEmpty, "Deleting a run must not strand its step rows")
+    }
+
+    func test_deleteRun_unknownID_throwsRunNotFound() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+        let id = UUID()
+        do {
+            try await store.deleteRun(id)
+            XCTFail("Expected runNotFound")
+        } catch let error as RunStoreError {
+            XCTAssertEqual(error, .runNotFound(id))
+        }
+    }
+
+    func test_updateStep_persistsCompletionAndFailureFields() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let run = makeRun()
+        try await store.insertRun(run)
+        var step = makeStep(runID: run.id, index: 0, turnInput: nil)
+        try await store.insertStep(step)
+
+        let producedMessage = UUID()
+        step.isCompleted = true
+        step.messageID = producedMessage
+        try await store.updateStep(step)
+
+        let fetched = try await store.fetchSteps(for: run.id)
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertTrue(fetched[0].isCompleted)
+        XCTAssertEqual(fetched[0].messageID, producedMessage)
+    }
+
+    func test_updateStep_unknownID_throwsStepNotFound() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+        let step = makeStep(runID: UUID(), index: 0, turnInput: nil)
+        do {
+            try await store.updateStep(step)
+            XCTFail("Expected stepNotFound")
+        } catch let error as RunStoreError {
+            XCTAssertEqual(error, .stepNotFound(step.id))
+        }
+    }
+
+    // MARK: - 2. fetch-by-runID + ordering
+
+    func test_fetchSteps_returnedOrderedByStepIndexAscending() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let run = makeRun()
+        try await store.insertRun(run)
+        // Insert out of order to prove the sort, not insertion order.
+        for index in [2, 0, 3, 1] {
+            try await store.insertStep(makeStep(runID: run.id, index: index, turnInput: nil))
+        }
+
+        let steps = try await store.fetchSteps(for: run.id)
+        XCTAssertEqual(steps.map(\.stepIndex), [0, 1, 2, 3])
+    }
+
+    func test_fetchSteps_isScopedToRunID() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let runA = makeRun()
+        let runB = makeRun()
+        try await store.insertRun(runA)
+        try await store.insertRun(runB)
+        try await store.insertStep(makeStep(runID: runA.id, index: 0, turnInput: nil))
+        try await store.insertStep(makeStep(runID: runB.id, index: 0, turnInput: nil))
+        try await store.insertStep(makeStep(runID: runB.id, index: 1, turnInput: nil))
+
+        let stepsA = try await store.fetchSteps(for: runA.id)
+        let stepsB = try await store.fetchSteps(for: runB.id)
+        XCTAssertEqual(stepsA.count, 1)
+        XCTAssertEqual(stepsB.count, 2)
+    }
+
+    func test_fetchRuns_forSession_orderedMostRecentFirst() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let session = UUID()
+        let older = ConversationRun(
+            id: UUID(), sessionID: session, goal: "older", status: .completed,
+            stepCount: 0, maxSteps: nil,
+            createdAt: Date(timeIntervalSince1970: 1_000), updatedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let newer = ConversationRun(
+            id: UUID(), sessionID: session, goal: "newer", status: .running,
+            stepCount: 0, maxSteps: nil,
+            createdAt: Date(timeIntervalSince1970: 2_000), updatedAt: Date(timeIntervalSince1970: 2_000)
+        )
+        // Different session — must be excluded.
+        let otherSession = makeRun(sessionID: UUID())
+
+        try await store.insertRun(older)
+        try await store.insertRun(newer)
+        try await store.insertRun(otherSession)
+
+        let runs = try await store.fetchRuns(for: session)
+        XCTAssertEqual(runs.map(\.goal), ["newer", "older"])
+    }
+
+    // MARK: - TurnInput lossless round-trip (Codable synthesized cleanly)
+
+    func test_turnInput_roundTripsLosslessly() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+
+        let run = makeRun()
+        try await store.insertRun(run)
+
+        let sessionID = UUID()
+        let config = TurnConfig(systemPrompt: "be terse", temperature: 0.3, maxOutputTokens: 512)
+        let input = TurnInput(
+            sessionID: sessionID,
+            kind: .send(text: "hello"),
+            config: config
+        )
+        try await store.insertStep(makeStep(runID: run.id, index: 0, turnInput: input))
+
+        let steps = try await store.fetchSteps(for: run.id)
+        let roundTripped = try XCTUnwrap(steps.first.flatMap(\.turnInput))
+        XCTAssertEqual(roundTripped.sessionID, sessionID)
+        XCTAssertEqual(roundTripped.config, config)
+        guard case .send(let text, _) = roundTripped.kind else {
+            return XCTFail("Expected .send kind, got \(roundTripped.kind)")
+        }
+        XCTAssertEqual(text, "hello")
+    }
+
+    func test_nilTurnInput_staysNil() async throws {
+        let container = try makeInMemoryContainer()
+        let store = SwiftDataRunStore(modelContext: ModelContext(container))
+        let run = makeRun()
+        try await store.insertRun(run)
+        try await store.insertStep(makeStep(runID: run.id, index: 0, turnInput: nil))
+        let steps = try await store.fetchSteps(for: run.id)
+        XCTAssertNil(steps.first?.turnInput)
+    }
+
+    // MARK: - 3. Survives a fresh store instance over the same on-disk container
+
+    func test_runsAndSteps_surviveFreshStoreInstance() async throws {
+        let storeDirectory = try makeStoreDirectory(named: "RunStoreDurability")
+        let storeURL = storeDirectory.appendingPathComponent("Manifold.sqlite")
+
+        let runID: UUID
+        let sessionID = UUID()
+
+        do {
+            let container = try ModelContainerFactory.makeContainer(
+                configurations: [ModelConfiguration(url: storeURL)]
+            )
+            let store = SwiftDataRunStore(modelContext: ModelContext(container))
+            let run = makeRun(sessionID: sessionID, status: .paused, stepCount: 2)
+            try await store.insertRun(run)
+            try await store.insertStep(makeStep(runID: run.id, index: 0, turnInput: nil, isCompleted: true))
+            try await store.insertStep(makeStep(runID: run.id, index: 1, turnInput: nil))
+            runID = run.id
+        }
+
+        // Brand-new container + store over the SAME on-disk file.
+        let reopenedContainer = try ModelContainerFactory.makeContainer(
+            configurations: [ModelConfiguration(url: storeURL)]
+        )
+        let reopenedStore = SwiftDataRunStore(modelContext: ModelContext(reopenedContainer))
+
+        let reopenedRun = try await reopenedStore.fetchRun(runID)
+        let fetchedRun = try XCTUnwrap(reopenedRun)
+        XCTAssertEqual(fetchedRun.status, .paused)
+        XCTAssertEqual(fetchedRun.stepCount, 2)
+        XCTAssertEqual(fetchedRun.sessionID, sessionID)
+
+        let steps = try await reopenedStore.fetchSteps(for: runID)
+        XCTAssertEqual(steps.map(\.stepIndex), [0, 1])
+        XCTAssertTrue(steps[0].isCompleted)
+        XCTAssertFalse(steps[1].isCompleted)
+    }
+
+    // MARK: - 4. V9 -> V10 migration (additive: two new run tables)
+
+    /// Boots a store at V9, writes a session, then re-opens it through the full
+    /// migration plan (which now runs the V9→V10 lightweight stage). The
+    /// pre-existing V9 row must survive, and the two new V10 tables must be
+    /// usable through ``SwiftDataRunStore`` against the migrated container.
+    ///
+    /// Sabotage-evidence: dropping the V9→V10 stage from
+    /// ``ManifoldMigrationPlan/stages`` halts `makeContainer` with a
+    /// schema-mismatch error before the asserts run; removing
+    /// `ConversationRunModel` / `RunStepModel` from `ManifoldSchemaV10.models`
+    /// makes the run-store fetch throw on the unknown entity.
+    func test_migrationPlan_v9StoreMigratesToV10WithUsableRunTables() async throws {
+        let storeDirectory = try makeStoreDirectory(named: "ManifoldSchemaV9ToV10")
+        let storeURL = storeDirectory.appendingPathComponent("Manifold.sqlite")
+        let sessionID: UUID
+
+        do {
+            let config = ModelConfiguration(url: storeURL)
+            let container = try ModelContainer(
+                for: Schema(versionedSchema: ManifoldSchemaV9.self),
+                configurations: [config]
+            )
+            let context = ModelContext(container)
+            let session = ManifoldSchemaV9.ChatSession(title: "Legacy V9 session")
+            session.systemPrompt = "carry forward"
+            context.insert(session)
+            try context.save()
+            sessionID = session.id
+        }
+
+        let migratedContainer = try ModelContainerFactory.makeContainer(
+            configurations: [ModelConfiguration(url: storeURL)]
+        )
+        let migratedContext = ModelContext(migratedContainer)
+
+        // Pre-existing V9 data survived the additive migration.
+        let sessions = try migratedContext.fetch(FetchDescriptor<ManifoldSchemaV9.ChatSession>(
+            predicate: #Predicate { $0.id == sessionID }
+        ))
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.title, "Legacy V9 session")
+        XCTAssertEqual(sessions.first?.systemPrompt, "carry forward")
+
+        // The new V10 tables are usable on the migrated store.
+        let store = SwiftDataRunStore(modelContext: migratedContext)
+        let run = makeRun(sessionID: sessionID, status: .running)
+        try await store.insertRun(run)
+        try await store.insertStep(makeStep(runID: run.id, index: 0, turnInput: nil))
+
+        let migratedRun = try await store.fetchRun(run.id)
+        let fetchedRun = try XCTUnwrap(migratedRun)
+        XCTAssertEqual(fetchedRun.status, .running)
+        let migratedSteps = try await store.fetchSteps(for: run.id)
+        XCTAssertEqual(migratedSteps.count, 1)
+    }
+
+    func test_schemaV10_versionIdentifierAndModelCount() {
+        XCTAssertEqual(ManifoldSchemaV10.versionIdentifier, Schema.Version(10, 0, 0))
+        // V9's 8 models carried forward + 2 new run tables.
+        XCTAssertEqual(ManifoldSchemaV10.models.count, 10)
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRunStateTests.swift
@@ -368,6 +368,230 @@ final class ConversationRunStateTests: XCTestCase {
         XCTAssertEqual(stored.status, .cancelled, "Persisted run must reflect cancelled status")
     }
 
+    // MARK: - Resume from store (M1 replay-from-provider)
+
+    /// Records the step indices a provider was asked for. An actor keeps the
+    /// recorder safe under the driver's off-main-actor step loop.
+    private actor IndexRecorder {
+        private(set) var requested: [Int] = []
+        func record(_ index: Int) { requested.append(index) }
+    }
+
+    /// Counting provider that records which step indices it was asked for, so
+    /// resume tests can assert the loop skipped already-completed steps.
+    /// Idempotent: keys only on `stepIndex` and `run.goal` (satisfies the
+    /// M1 ``RunInputProvider`` contract).
+    private struct RecordingCountingProvider: RunInputProvider {
+        let stepCount: Int
+        let recorder: IndexRecorder
+        func nextInput(
+            for run: ConversationRun,
+            stepIndex: Int,
+            prior: RunStep?
+        ) async -> TurnInput? {
+            await recorder.record(stepIndex)
+            guard stepIndex < stepCount else { return nil }
+            return TurnInput(
+                sessionID: run.sessionID,
+                kind: .send(text: "step-\(stepIndex)"),
+                config: TurnConfig()
+            )
+        }
+    }
+
+    func test_resume_continuesFromCheckpoint() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["ok"]
+        let service = InferenceService(backend: backend, name: "ResumeTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        // Pre-seed: a running run (maxSteps 3) with step 0 already completed.
+        let runID = UUID()
+        let sessionID = UUID()
+        let now = Date()
+        let seededRun = ConversationRun(
+            id: runID, sessionID: sessionID, goal: "resume me",
+            status: .running, stepCount: 1, maxSteps: 3,
+            createdAt: now, updatedAt: now
+        )
+        try await runStore.insertRun(seededRun)
+        let step0 = RunStep(
+            id: UUID(), runID: runID, stepIndex: 0,
+            turnInput: TurnInput(sessionID: sessionID, kind: .send(text: "step-0")),
+            messageID: nil, isCompleted: true, isFailed: false, failureReason: nil,
+            createdAt: now, updatedAt: now
+        )
+        try await runStore.insertStep(step0)
+
+        let recorder = IndexRecorder()
+        let provider = RecordingCountingProvider(stepCount: 3, recorder: recorder)
+        var events: [RunEvent] = []
+        let end = ContinuousClock.now.advanced(by: .seconds(15))
+        for await event in runtime.resumeRun(runID, using: provider) {
+            events.append(event)
+            if case .runCompleted = event { break }
+            if case .runFailed = event { break }
+            if ContinuousClock.now > end { break }
+        }
+
+        // The provider was asked for indices 1 and 2 (not 0 — already done),
+        // then 3 (which returns nil → completion is the maxSteps guard anyway).
+        let requested = await recorder.requested
+        XCTAssertEqual(requested, [1, 2],
+                       "Resume must re-drive only the not-yet-completed indices")
+
+        // Resume announces itself, then runs steps 1 and 2.
+        XCTAssertTrue(events.contains { if case .runResumed = $0 { return true }; return false },
+                      "Expected a .runResumed event on resume")
+        let startedIndices: [Int] = events.compactMap {
+            if case let .stepStarted(_, idx, _) = $0 { return idx }
+            return nil
+        }
+        XCTAssertEqual(startedIndices, [1, 2], "Resume should start steps 1 and 2 only")
+        XCTAssertTrue(events.contains { if case .runCompleted = $0 { return true }; return false },
+                      "Run should complete after reaching maxSteps")
+
+        let fetchedForAssert = try await runStore.fetchRun(runID)
+        let stored = try XCTUnwrap(fetchedForAssert)
+        XCTAssertEqual(stored.status, .completed)
+        XCTAssertEqual(stored.stepCount, 3, "stepCount = 1 seeded + 2 resumed")
+
+        // The completed steps in the store are 0 (seeded), 1, 2.
+        let completed = try await runStore.fetchSteps(for: runID).filter(\.isCompleted)
+        XCTAssertEqual(completed.map(\.stepIndex), [0, 1, 2])
+    }
+
+    func test_resume_unknownRunID_failsWithoutExecution() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        let service = InferenceService(backend: backend, name: "ResumeUnknownTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let unknownID = UUID()
+        let recorder = IndexRecorder()
+        let provider = RecordingCountingProvider(stepCount: 3, recorder: recorder)
+        var events: [RunEvent] = []
+        for await event in runtime.resumeRun(unknownID, using: provider) {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 1, "Unknown run should emit exactly one terminal event")
+        guard case let .runFailed(failedID, reason) = events.first else {
+            return XCTFail("Expected .runFailed for an unknown run id")
+        }
+        XCTAssertEqual(failedID, unknownID)
+        XCTAssertTrue(reason.contains(unknownID.uuidString), "Reason should name the missing run id")
+        let requested = await recorder.requested
+        XCTAssertTrue(requested.isEmpty, "No steps should be driven for an unknown run")
+    }
+
+    func test_resume_alreadyCompletedRun_emitsTerminalWithoutExecution() async throws {
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        let service = InferenceService(backend: backend, name: "ResumeCompletedTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let runID = UUID()
+        let now = Date()
+        let completedRun = ConversationRun(
+            id: runID, sessionID: UUID(), goal: "done",
+            status: .completed, stepCount: 2, maxSteps: nil,
+            createdAt: now, updatedAt: now
+        )
+        try await runStore.insertRun(completedRun)
+
+        let recorder = IndexRecorder()
+        let provider = RecordingCountingProvider(stepCount: 3, recorder: recorder)
+        var events: [RunEvent] = []
+        for await event in runtime.resumeRun(runID, using: provider) {
+            events.append(event)
+        }
+
+        XCTAssertEqual(events.count, 1, "A finished run should emit one terminal event only")
+        guard case let .runCompleted(id, stepCount) = events.first else {
+            return XCTFail("Expected .runCompleted terminal event for an already-completed run")
+        }
+        XCTAssertEqual(id, runID)
+        XCTAssertEqual(stepCount, 2)
+        let requested = await recorder.requested
+        XCTAssertTrue(requested.isEmpty, "No steps should be driven for a finished run")
+    }
+
+    func test_startRun_unchanged_startsAtIndexZero() async throws {
+        // Regression guard: after extracting the shared loop, a fresh startRun
+        // must still begin at index 0 (priorStep nil) and run all provider steps.
+        let persistenceStack = try InMemoryPersistenceHarness.make()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["ok"]
+        let service = InferenceService(backend: backend, name: "StartRunRegressionTest")
+
+        let runStore = InMemoryRunStore2()
+        let driver = ResumableRunDriver(runStore: runStore)
+        let runtime = ConversationRuntime(
+            messageStore: persistenceStack.provider,
+            sessionStore: persistenceStack.provider,
+            inferenceService: service,
+            emptyResponseObserver: nil,
+            turnDriver: driver
+        )
+
+        let recorder = IndexRecorder()
+        let provider = RecordingCountingProvider(stepCount: 2, recorder: recorder)
+        let run = ConversationRun(sessionID: UUID(), goal: "fresh")
+        var events: [RunEvent] = []
+        let end = ContinuousClock.now.advanced(by: .seconds(15))
+        for await event in runtime.startRun(run, using: provider) {
+            events.append(event)
+            if case .runCompleted = event { break }
+            if case .runFailed = event { break }
+            if ContinuousClock.now > end { break }
+        }
+
+        let requested = await recorder.requested
+        XCTAssertEqual(requested.first, 0, "Fresh startRun must begin at index 0")
+        XCTAssertTrue(events.contains { if case .runStarted = $0 { return true }; return false },
+                      "Fresh startRun must emit .runStarted, not .runResumed")
+        XCTAssertFalse(events.contains { if case .runResumed = $0 { return true }; return false },
+                       "Fresh startRun must not emit .runResumed")
+        let startedIndices: [Int] = events.compactMap {
+            if case let .stepStarted(_, idx, _) = $0 { return idx }
+            return nil
+        }
+        XCTAssertEqual(startedIndices, [0, 1])
+    }
+
     // MARK: - startRun on non-ResumableRunDriver runtime
 
     func test_startRun_withoutResumableDriver_returnsEmptyStream() async throws {


### PR DESCRIPTION
Closes #1784.

## What & why

P3 (#1744) shipped the resumable-run **seam** but deferred persistence + reachability to a "P3b" sub-phase, leaving resumable runs unreachable by any host. This completes P3b: a SwiftData-backed `RunStore`, a driver entry point that resumes a run after process death, and the bootstrap wiring that makes it opt-in for hosts.

Deeper investigation of the seam (beyond the original issue) found that "adapter + wiring" alone could **not** satisfy the acceptance criterion — the driver had no way to rehydrate a persisted run; `startRun` always restarts from step 0 and `resumeRun()` only un-pauses a live in-memory run. So this PR also adds the missing **resume-from-store** path, using the **M1 "replay-from-provider"** design: on resume the run + step metadata are reloaded and the `RunInputProvider` deterministically regenerates each turn, rather than re-executing persisted inputs (which would hit idempotency hazards — re-sending a `.send`, re-minting a `.branch` session, etc.). Resume correctness is therefore independent of `TurnInput` serialization fidelity.

## Changes
- **Driver (`ManifoldRuntime`):** extracted the step loop into a shared, seedable method; added `ResumableRunDriver.resume(runID:using:executor:taskRegistry:)` + a public `ConversationRuntime.resumeRun(_:using:)` wrapper. `startRun` behavior is provably unchanged (existing suite untouched). Added the provider-idempotency contract to `RunInputProvider`'s docs.
- **Persistence (`ManifoldPersistenceSwiftData`):** `@Model` run/step records in a new V10 schema, `SwiftDataRunStore: RunStore` adapter, and a **lightweight additive** V9→V10 migration. `TurnInput` persists **losslessly** (synthesized `Codable`; `MessagePart`/`Duration` were already `Codable`) as inspection metadata.
- **Wiring:** opt-in `ManifoldBootstrap(enableResumableRuns: true)` constructs a `SwiftDataRunStore` over the main context and selects `ResumableRunDriver`; default-off keeps `SingleTurnDriver` and unchanged behavior for every existing caller. Driver selection: explicit `turnDriver` override → else `runStore`-derived `ResumableRunDriver` → else `SingleTurnDriver`.

## Host-facing API
```swift
let bootstrap = try ManifoldBootstrap(configuration: config, enableResumableRuns: true)
let run = ConversationRun(sessionID: sessionID, goal: "Plan the launch", maxSteps: 4)
for await event in bootstrap.conversationRuntime.startRun(run) { /* observe RunEvent */ }
// after relaunch over the same store:
for await event in bootstrap.conversationRuntime.resumeRun(run.id) { /* resumes from checkpoint */ }
```

## Tests
- Driver resume unit tests (continues from checkpoint, unknown-runID fails, completed-run is a no-op, `startRun` unchanged).
- `SwiftDataRunStore` integration tests (CRUD round-trip, ordering, survives a fresh container, V9→V10 migration).
- **End-to-end durability:** a run checkpoints, the runtime is torn down (simulated kill), then a **fresh container + store** resumes it from the persisted prefix to completion without re-running completed steps. Hardened to terminate the loop cleanly (no leaked container; avoids two live containers over one store) and to assert the checkpoint prefix rather than a timing-fragile exact count.

Full `scripts/test.sh --profile local` gate: **PASSED** — 4733 XCTest + 83 Swift Testing, 0 failures, 0 crashes.

## Acceptance (#1784)
- [x] `@Model` run/step records + `RunStore` adapter in `ManifoldPersistenceSwiftData`
- [x] V9→V10 schema migration
- [x] Bootstrap/options wiring + driver-selection knob
- [x] Integration test: a run survives a fresh container and resumes via `ResumableRunDriver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
