### PR TITLE
perf: stop full disk scan + GGUF syscall storm on model-management render

### DIFF
--- a/Sources/ManifoldHardware/GGUFMetadataReader.swift
+++ b/Sources/ManifoldHardware/GGUFMetadataReader.swift
@@ -99,14 +99,20 @@ package struct GGUFMetadataReader {
         defer { handle.closeFile() }
 
         return try autoreleasepool {
+            // why: previously each primitive read was one FileHandle.readData
+            // syscall, and skipping a tokenizer vocab array meant one syscall per
+            // element (128k–256k). A 64 KiB forward buffer collapses that to a
+            // chunk read per refill; fixed-width arrays seek past in O(1) (#1787).
+            let reader = BufferedFileReader(handle: handle)
+
             // Magic bytes (4 bytes)
-            guard let magicData = readBytes(from: handle, count: 4),
+            guard let magicData = reader.read(count: 4),
                   Array(magicData) == magicBytes else {
                 throw GGUFReaderError.invalidMagic
             }
 
             // Version (uint32 LE)
-            let version = try readUInt32(from: handle)
+            let version = try readUInt32(from: reader)
             guard version == 2 || version == 3 else {
                 throw GGUFReaderError.unsupportedVersion(Int(version))
             }
@@ -114,10 +120,10 @@ package struct GGUFMetadataReader {
             let isV3 = version == 3
 
             // Tensor count
-            let _: UInt64 = isV3 ? try readUInt64(from: handle) : UInt64(try readUInt32(from: handle))
+            let _: UInt64 = isV3 ? try readUInt64(from: reader) : UInt64(try readUInt32(from: reader))
 
             // Metadata KV count
-            let metadataCount: UInt64 = isV3 ? try readUInt64(from: handle) : UInt64(try readUInt32(from: handle))
+            let metadataCount: UInt64 = isV3 ? try readUInt64(from: reader) : UInt64(try readUInt32(from: reader))
 
             logger.debug("GGUF v\(version): \(metadataCount) metadata entries")
 
@@ -137,25 +143,25 @@ package struct GGUFMetadataReader {
 
             // Iterate KV pairs
             for _ in 0..<metadataCount {
-                let key = try readString(from: handle)
-                let valueTypeRaw = try readUInt32(from: handle)
+                let key = try readString(from: reader)
+                let valueTypeRaw = try readUInt32(from: reader)
 
                 // Check if this is a key we care about
                 switch key {
                 case "general.name":
-                    generalName = try readStringValue(type: valueTypeRaw, from: handle)
+                    generalName = try readStringValue(type: valueTypeRaw, from: reader)
 
                 case "general.architecture":
-                    generalArchitecture = try readStringValue(type: valueTypeRaw, from: handle)
+                    generalArchitecture = try readStringValue(type: valueTypeRaw, from: reader)
                     if inferredArchitecture == nil {
                         inferredArchitecture = generalArchitecture
                     }
 
                 case "general.file_type":
-                    fileType = try readIntegerValue(type: valueTypeRaw, from: handle)
+                    fileType = try readIntegerValue(type: valueTypeRaw, from: reader)
 
                 case "tokenizer.chat_template":
-                    chatTemplate = try readStringValue(type: valueTypeRaw, from: handle)
+                    chatTemplate = try readStringValue(type: valueTypeRaw, from: reader)
 
                 default:
                     let activeArchitecture = generalArchitecture ?? inferredArchitecture
@@ -166,51 +172,51 @@ package struct GGUFMetadataReader {
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        contextLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        contextLength = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else if let prefix = matchingArchitecturePrefix(
                         for: key,
                         suffix: ".block_count",
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        blockCount = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        blockCount = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else if let prefix = matchingArchitecturePrefix(
                         for: key,
                         suffix: ".embedding_length",
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        embeddingLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        embeddingLength = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else if let prefix = matchingArchitecturePrefix(
                         for: key,
                         suffix: ".attention.head_count",
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        attentionHeadCount = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        attentionHeadCount = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else if let prefix = matchingArchitecturePrefix(
                         for: key,
                         suffix: ".attention.head_count_kv",
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        attentionHeadCountKV = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        attentionHeadCountKV = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else if let prefix = matchingArchitecturePrefix(
                         for: key,
                         suffix: ".attention.key_length",
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        attentionKeyLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        attentionKeyLength = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else if let prefix = matchingArchitecturePrefix(
                         for: key,
                         suffix: ".attention.value_length",
                         expectedArchitecture: activeArchitecture
                     ) {
                         inferredArchitecture = inferredArchitecture ?? prefix
-                        attentionValueLength = try readIntegerValue(type: valueTypeRaw, from: handle)
+                        attentionValueLength = try readIntegerValue(type: valueTypeRaw, from: reader)
                     } else {
-                        try skipValue(type: valueTypeRaw, from: handle)
+                        try skipValue(type: valueTypeRaw, from: reader)
                     }
                 }
             }
@@ -251,75 +257,63 @@ package struct GGUFMetadataReader {
 
     // MARK: - Primitive Readers
 
+    /// One-shot 4-byte magic read used only by ``isValidGGUF(at:)`` — no buffered
+    /// reader needed for a single read of a freshly-opened handle.
     private static func readBytes(from handle: FileHandle, count: Int) -> Data? {
         let data = handle.readData(ofLength: count)
         guard data.count == count else { return nil }
         return data
     }
 
-    private static func readUInt8(from handle: FileHandle) throws -> UInt8 {
-        guard let data = readBytes(from: handle, count: 1) else {
+    private static func readUInt8(from reader: BufferedFileReader) throws -> UInt8 {
+        guard let data = reader.read(count: 1) else {
             throw GGUFReaderError.readError("Unexpected end of file reading uint8")
         }
         return data[data.startIndex]
     }
 
-    private static func readUInt16(from handle: FileHandle) throws -> UInt16 {
-        guard let data = readBytes(from: handle, count: 2) else {
+    private static func readUInt16(from reader: BufferedFileReader) throws -> UInt16 {
+        guard let data = reader.read(count: 2) else {
             throw GGUFReaderError.readError("Unexpected end of file reading uint16")
         }
         return data.withUnsafeBytes { $0.loadUnaligned(as: UInt16.self).littleEndian }
     }
 
-    private static func readUInt32(from handle: FileHandle) throws -> UInt32 {
-        guard let data = readBytes(from: handle, count: 4) else {
+    private static func readUInt32(from reader: BufferedFileReader) throws -> UInt32 {
+        guard let data = reader.read(count: 4) else {
             throw GGUFReaderError.readError("Unexpected end of file reading uint32")
         }
         return data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self).littleEndian }
     }
 
-    private static func readInt32(from handle: FileHandle) throws -> Int32 {
-        guard let data = readBytes(from: handle, count: 4) else {
+    private static func readInt32(from reader: BufferedFileReader) throws -> Int32 {
+        guard let data = reader.read(count: 4) else {
             throw GGUFReaderError.readError("Unexpected end of file reading int32")
         }
         return data.withUnsafeBytes { $0.loadUnaligned(as: Int32.self).littleEndian }
     }
 
-    private static func readUInt64(from handle: FileHandle) throws -> UInt64 {
-        guard let data = readBytes(from: handle, count: 8) else {
+    private static func readUInt64(from reader: BufferedFileReader) throws -> UInt64 {
+        guard let data = reader.read(count: 8) else {
             throw GGUFReaderError.readError("Unexpected end of file reading uint64")
         }
         return data.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self).littleEndian }
     }
 
-    private static func readInt64(from handle: FileHandle) throws -> Int64 {
-        guard let data = readBytes(from: handle, count: 8) else {
+    private static func readInt64(from reader: BufferedFileReader) throws -> Int64 {
+        guard let data = reader.read(count: 8) else {
             throw GGUFReaderError.readError("Unexpected end of file reading int64")
         }
         return data.withUnsafeBytes { $0.loadUnaligned(as: Int64.self).littleEndian }
     }
 
-    private static func readFloat32(from handle: FileHandle) throws -> Float {
-        guard let data = readBytes(from: handle, count: 4) else {
-            throw GGUFReaderError.readError("Unexpected end of file reading float32")
-        }
-        return data.withUnsafeBytes { $0.loadUnaligned(as: Float.self) }
-    }
-
-    private static func readFloat64(from handle: FileHandle) throws -> Double {
-        guard let data = readBytes(from: handle, count: 8) else {
-            throw GGUFReaderError.readError("Unexpected end of file reading float64")
-        }
-        return data.withUnsafeBytes { $0.loadUnaligned(as: Double.self) }
-    }
-
     /// Reads a GGUF string: uint64 length prefix followed by that many UTF-8 bytes.
-    private static func readString(from handle: FileHandle) throws -> String {
-        let length = try readUInt64(from: handle)
+    private static func readString(from reader: BufferedFileReader) throws -> String {
+        let length = try readUInt64(from: reader)
         guard length <= 1_000_000 else {
             throw GGUFReaderError.readError("String length \(length) exceeds safety limit")
         }
-        guard let data = readBytes(from: handle, count: Int(length)) else {
+        guard let data = reader.read(count: Int(length)) else {
             throw GGUFReaderError.readError("Unexpected end of file reading string of length \(length)")
         }
         guard let string = String(data: data, encoding: .utf8) else {
@@ -328,30 +322,44 @@ package struct GGUFMetadataReader {
         return string
     }
 
+    /// Skips a GGUF string (uint64 length + bytes) by SEEKING past the bytes
+    /// instead of allocating + UTF-8-decoding them (the cost `readString` pays).
+    /// Used when walking string arrays (`tokenizer.ggml.tokens` / `merges`),
+    /// which carry no array-level byte count and so cannot be block-seeked (#1787).
+    private static func skipString(from reader: BufferedFileReader) throws {
+        let length = try readUInt64(from: reader)
+        guard length <= 1_000_000 else {
+            throw GGUFReaderError.readError("String length \(length) exceeds safety limit")
+        }
+        guard reader.skip(count: Int(length)) else {
+            throw GGUFReaderError.readError("Unexpected end of file skipping string of length \(length)")
+        }
+    }
+
     // MARK: - Typed Value Readers
 
     /// Reads a value expected to be a STRING, returning it. Throws if wrong type.
-    private static func readStringValue(type: UInt32, from handle: FileHandle) throws -> String? {
+    private static func readStringValue(type: UInt32, from reader: BufferedFileReader) throws -> String? {
         guard type == ValueType.string.rawValue else {
-            try skipValue(type: type, from: handle)
+            try skipValue(type: type, from: reader)
             return nil
         }
-        return try readString(from: handle)
+        return try readString(from: reader)
     }
 
     /// Reads a scalar integer value, accepting signed or unsigned 32/64-bit GGUF integers.
-    private static func readIntegerValue(type: UInt32, from handle: FileHandle) throws -> Int? {
+    private static func readIntegerValue(type: UInt32, from reader: BufferedFileReader) throws -> Int? {
         switch ValueType(rawValue: type) {
         case .uint32:
-            return Int(try readUInt32(from: handle))
+            return Int(try readUInt32(from: reader))
         case .int32:
-            return Int(try readInt32(from: handle))
+            return Int(try readInt32(from: reader))
         case .uint64:
-            return Int(try readUInt64(from: handle))
+            return Int(try readUInt64(from: reader))
         case .int64:
-            return Int(try readInt64(from: handle))
+            return Int(try readInt64(from: reader))
         default:
-            try skipValue(type: type, from: handle)
+            try skipValue(type: type, from: reader)
             return nil
         }
     }
@@ -394,43 +402,202 @@ package struct GGUFMetadataReader {
     /// templates + context length + KV-cache estimates. See #1468.
     private static let maxArrayElementCount: UInt64 = 1_000_000
 
+    /// Fixed byte width of a GGUF value type, or `nil` for variable-width types
+    /// (string, array) that have no constant per-element size.
+    private static func fixedWidth(of valueType: ValueType) -> Int? {
+        switch valueType {
+        case .uint8, .int8, .bool: return 1
+        case .uint16, .int16: return 2
+        case .uint32, .int32, .float32: return 4
+        case .uint64, .int64, .float64: return 8
+        case .string, .array: return nil
+        }
+    }
+
     /// Skips a value of the given type without parsing it.
     ///
-    /// For arrays, recursively skips each element up to ``maxArrayDepth`` nesting
-    /// levels and ``maxArrayElementCount`` elements per array.
-    private static func skipValue(type: UInt32, from handle: FileHandle, depth: Int = 0) throws {
+    /// For arrays of FIXED-WIDTH elements (every numeric / bool type), the whole
+    /// block is skipped with a single seek of `count * width` bytes (#1787) —
+    /// this is the fast path for `tokenizer.ggml.scores` (f32) and `token_type`
+    /// (i32). STRING arrays carry no array-level byte count (each element is
+    /// `[uint64 len][len bytes]`), so they are walked element-by-element with
+    /// ``skipString`` (length read + seek, no Data alloc / UTF-8 decode). Nested
+    /// arrays recurse up to ``maxArrayDepth``.
+    private static func skipValue(type: UInt32, from reader: BufferedFileReader, depth: Int = 0) throws {
         guard let valueType = ValueType(rawValue: type) else {
             throw GGUFReaderError.readError("Unknown value type: \(type)")
         }
 
         switch valueType {
         case .uint8, .int8, .bool:
-            _ = try readUInt8(from: handle)
+            _ = try readUInt8(from: reader)
 
         case .uint16, .int16:
-            _ = try readUInt16(from: handle)
+            _ = try readUInt16(from: reader)
 
         case .uint32, .int32, .float32:
-            _ = try readUInt32(from: handle)
+            _ = try readUInt32(from: reader)
 
         case .uint64, .int64, .float64:
-            _ = try readUInt64(from: handle)
+            _ = try readUInt64(from: reader)
 
         case .string:
-            _ = try readString(from: handle)
+            try skipString(from: reader)
 
         case .array:
             guard depth < maxArrayDepth else {
                 throw GGUFReaderError.readError("Array nesting depth exceeds safety limit (\(maxArrayDepth))")
             }
-            let elementType = try readUInt32(from: handle)
-            let count = try readUInt64(from: handle)
+            let elementTypeRaw = try readUInt32(from: reader)
+            let count = try readUInt64(from: reader)
             guard count <= maxArrayElementCount else {
                 throw GGUFReaderError.readError("Array element count \(count) exceeds safety limit (\(maxArrayElementCount))")
             }
+            guard let elementType = ValueType(rawValue: elementTypeRaw) else {
+                throw GGUFReaderError.readError("Unknown array element type: \(elementTypeRaw)")
+            }
+
+            // Fast path: a block of fixed-width elements is `count * width` bytes —
+            // one seek instead of `count` per-element reads.
+            if let width = fixedWidth(of: elementType) {
+                let total = Int(count) * width
+                guard reader.skip(count: total) else {
+                    throw GGUFReaderError.readError("Unexpected end of file skipping \(count)-element array")
+                }
+                return
+            }
+
+            // String arrays: no array-level byte count — walk each element.
+            if elementType == .string {
+                for _ in 0..<count {
+                    try skipString(from: reader)
+                }
+                return
+            }
+
+            // Nested arrays: recurse per element.
             for _ in 0..<count {
-                try skipValue(type: elementType, from: handle, depth: depth + 1)
+                try skipValue(type: elementTypeRaw, from: reader, depth: depth + 1)
             }
         }
+    }
+}
+
+// MARK: - Buffered File Reader
+
+/// A forward-only, fixed-size buffered reader over a `FileHandle`.
+///
+/// Serves the GGUF primitive reads from a 64 KiB window, refilling on underflow,
+/// so reading the metadata region costs roughly one syscall per chunk instead of
+/// one per primitive. ``skip(count:)`` seeks past data (used for fixed-width
+/// arrays and skipped strings) and realigns the buffer.
+///
+/// Peak memory is one chunk plus one bounded primitive read — it never sizes the
+/// buffer to the (unknown) metadata-region length.
+private final class BufferedFileReader {
+    private let handle: FileHandle
+    private let chunkSize: Int
+    /// The current buffer window. Bytes before `cursor` are already consumed.
+    private var buffer = Data()
+    private var cursor = 0
+    /// Total file size, resolved once and reused to bounds-check forward seeks.
+    private let fileSize: UInt64
+
+    init(handle: FileHandle, chunkSize: Int = 64 * 1024) {
+        self.handle = handle
+        self.chunkSize = chunkSize
+        var size: UInt64 = 0
+        do {
+            size = try handle.seekToEnd()
+            // Rewind to the start so the first read sees the magic bytes.
+            try handle.seek(toOffset: 0)
+        } catch {
+            // A handle that can't be sized/rewound yields fileSize 0; every
+            // forward seek then fails its EOF bounds check and surfaces as a
+            // readError to the caller rather than silently mis-parsing.
+            logger.warning("BufferedFileReader: failed to size/rewind handle: \(error.localizedDescription, privacy: .public)")
+        }
+        self.fileSize = size
+    }
+
+    /// Bytes still available in the buffer without a refill.
+    private var available: Int { buffer.count - cursor }
+
+    /// Reads exactly `count` bytes, refilling the buffer as needed. Returns `nil`
+    /// if the file ends before `count` bytes are available.
+    func read(count: Int) -> Data? {
+        guard count >= 0 else { return nil }
+        if count == 0 { return Data() }
+
+        // Fast path: fully satisfied from the current buffer.
+        if available >= count {
+            let start = buffer.index(buffer.startIndex, offsetBy: cursor)
+            let end = buffer.index(start, offsetBy: count)
+            cursor += count
+            return Data(buffer[start..<end])
+        }
+
+        // Slow path: assemble across refills. Bounded by `count` (the caller's
+        // primitive size or a length-prefixed string already capped at 1 MB).
+        var result = Data(capacity: count)
+        var remaining = count
+        while remaining > 0 {
+            if available == 0, !refill() { return nil }
+            let take = min(available, remaining)
+            let start = buffer.index(buffer.startIndex, offsetBy: cursor)
+            let end = buffer.index(start, offsetBy: take)
+            result.append(buffer[start..<end])
+            cursor += take
+            remaining -= take
+        }
+        return result
+    }
+
+    /// Skips `count` bytes. Consumes any buffered bytes first, then seeks the
+    /// underlying handle past the remainder and drops the (now-stale) buffer so
+    /// the next read realigns. Returns `false` if the file ends early.
+    func skip(count: Int) -> Bool {
+        guard count >= 0 else { return false }
+        if count == 0 { return true }
+
+        let fromBuffer = min(available, count)
+        cursor += fromBuffer
+        let remaining = count - fromBuffer
+        if remaining == 0 { return true }
+
+        // The buffer is now fully consumed, so the handle's physical offset is the
+        // logical next byte. Seek forward past the remainder and drop the buffer.
+        do {
+            let currentOffset = try handle.offset()
+            let target = currentOffset + UInt64(remaining)
+            // Guard against seeking past EOF, which FileHandle silently allows —
+            // a subsequent read would then return short and surface as a readError.
+            guard target <= fileSize else {
+                buffer = Data()
+                cursor = 0
+                return false
+            }
+            try handle.seek(toOffset: target)
+        } catch {
+            logger.warning("BufferedFileReader: seek failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+        buffer = Data()
+        cursor = 0
+        return true
+    }
+
+    /// Refills the buffer with the next chunk. Returns `false` at EOF.
+    private func refill() -> Bool {
+        let next: Data
+        do {
+            next = try handle.read(upToCount: chunkSize) ?? Data()
+        } catch {
+            return false
+        }
+        guard !next.isEmpty else { return false }
+        buffer = next
+        cursor = 0
+        return true
     }
 }

--- a/Sources/ManifoldModelCatalog/ModelInfo.swift
+++ b/Sources/ManifoldModelCatalog/ModelInfo.swift
@@ -192,7 +192,14 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     /// context-length fields. Callers that want to react to the metadata
     /// failure can inspect the returned ``ModelInfo/detectedPromptTemplate``
     /// being `nil`.
-    public static func load(ggufURL url: URL) throws -> ModelInfo {
+    ///
+    /// - Parameter mmprojURL: An already-resolved companion projector URL.
+    ///   When a directory scan enumerates the parent directory once and threads
+    ///   the resolved candidate in (see `ModelStorageService.scanDirectory`),
+    ///   the per-file self-enumeration is skipped — turning an O(K²) scan into
+    ///   O(K) (#1787). Pass `nil` from the standalone entry point to keep the
+    ///   self-enumerating fallback.
+    public static func load(ggufURL url: URL, mmprojURL: URL? = nil) throws -> ModelInfo {
         let path = url.path
 
         guard url.pathExtension.lowercased() == "gguf" else {
@@ -264,21 +271,30 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         // and optional paths produce equivalent ModelInfo values for the same file.
         info.capabilityTier = ModelCapabilityTier.estimate(fileSize: info.fileSize, modelType: info.modelType)
 
-        // Auto-detect a companion mmproj file in the same directory.
+        // Auto-detect a companion mmproj file in the same directory. A model that
+        // is itself an mmproj projector never carries a companion.
         if !url.lastPathComponent.lowercased().hasPrefix("mmproj") {
-            let parentDir = url.deletingLastPathComponent()
-            do {
-                let candidates = try fileManager.contentsOfDirectory(
-                    at: parentDir,
-                    includingPropertiesForKeys: nil,
-                    options: [.skipsHiddenFiles]
-                )
-                info.mmprojURL = candidates.first {
-                    $0.lastPathComponent.lowercased().hasPrefix("mmproj") &&
-                    $0.pathExtension.lowercased() == "gguf"
+            if let mmprojURL {
+                // Directory scan already enumerated the parent once and resolved
+                // the candidate — no per-file re-enumeration (#1787).
+                info.mmprojURL = mmprojURL
+            } else {
+                // Standalone entry point (e.g. drag-and-drop import): fall back to
+                // self-enumerating the parent directory.
+                let parentDir = url.deletingLastPathComponent()
+                do {
+                    let candidates = try fileManager.contentsOfDirectory(
+                        at: parentDir,
+                        includingPropertiesForKeys: nil,
+                        options: [.skipsHiddenFiles]
+                    )
+                    info.mmprojURL = candidates.first {
+                        $0.lastPathComponent.lowercased().hasPrefix("mmproj") &&
+                        $0.pathExtension.lowercased() == "gguf"
+                    }
+                } catch {
+                    Log.inference.warning("ModelInfo.load: mmproj companion scan failed in \(parentDir.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
-            } catch {
-                Log.inference.warning("ModelInfo.load: mmproj companion scan failed in \(parentDir.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
 

--- a/Sources/ManifoldModelCatalog/ModelStorageService.swift
+++ b/Sources/ManifoldModelCatalog/ModelStorageService.swift
@@ -206,11 +206,19 @@ public final class ModelStorageService: @unchecked Sendable {
             return
         }
 
+        // Resolve the companion projector ONCE per directory rather than letting
+        // each GGUF re-enumerate the parent (the old O(K²) self-scan in
+        // ModelInfo.load) — see #1787. A directory ships at most one mmproj.
+        let mmprojCandidate = contents.first {
+            $0.lastPathComponent.lowercased().hasPrefix("mmproj") &&
+            $0.pathExtension.lowercased() == "gguf"
+        }
+
         for url in contents {
             // Check for GGUF files.
             if url.pathExtension.lowercased() == "gguf" {
                 do {
-                    let model = try ModelInfo.load(ggufURL: url)
+                    let model = try ModelInfo.load(ggufURL: url, mmprojURL: mmprojCandidate)
                     if seenIDs.insert(model.id).inserted {
                         models.append(model)
                     }

--- a/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
@@ -149,6 +149,26 @@ public final class ModelManagementViewModel {
     /// Cached set of file names from `discoverModels()` to avoid N+1 filesystem scans.
     private var discoveredModelFileNames: Set<String>?
 
+    /// Cached snapshot of models discovered on disk.
+    ///
+    /// Stored `@Observable` state — NOT a computed property — so SwiftUI reads it
+    /// from a cache instead of triggering a ~2s synchronous disk scan on every
+    /// `body` evaluation (#1787). Populated by ``refreshDiscoveredModels()``,
+    /// which hops the scan off the main actor.
+    public private(set) var discoveredModels: [ModelInfo] = []
+
+    /// `true` while an off-main model discovery scan is in flight.
+    public private(set) var isRefreshingModels = false
+
+    /// `true` once the first discovery scan has completed (regardless of result).
+    ///
+    /// Lets the UI distinguish "scan in progress, no data yet" from "scanned,
+    /// genuinely zero models" so it never paints a false "0 GB" on first render.
+    public private(set) var hasLoadedModelsOnce = false
+
+    /// The in-flight discovery task, used for single-flight de-duplication.
+    private var refreshTask: Task<Void, Never>?
+
     // MARK: - Initialisation
 
     public init(
@@ -211,8 +231,13 @@ public final class ModelManagementViewModel {
     }
 
     /// Human-readable total storage used by downloaded models.
+    ///
+    /// Derived PURELY from the cached ``discoveredModels`` snapshot — it never
+    /// touches disk, so reading it from a SwiftUI `body` is free (#1787). The
+    /// cache is refreshed off-main by ``refreshDiscoveredModels()``.
     public var totalStorageUsed: String {
-        modelStorage.storageUsedFormatted
+        let total = discoveredModels.reduce(UInt64(0)) { $0 + $1.fileSize }
+        return ByteCountFormatter.string(fromByteCount: Int64(total), countStyle: .file)
     }
 
     /// All currently active downloads, keyed by model ID.
@@ -249,9 +274,49 @@ public final class ModelManagementViewModel {
         modelStorage.modelsDirectory.path
     }
 
-    /// Models currently on disk.
-    public var discoveredModels: [ModelInfo] {
-        modelStorage.discoverModels()
+    // MARK: - Model Discovery (cached, off-main)
+
+    /// Refreshes ``discoveredModels`` from disk, off the main actor, single-flight.
+    ///
+    /// Reads from disk exactly once per call; concurrent calls collapse into the
+    /// in-flight task (`refreshTask != nil` short-circuit). The scan hops off the
+    /// main actor inside ``ModelStorageService/discoverModelsOffMain()`` (the
+    /// sanctioned `Task.detached` site) — this method itself uses a plain `Task`
+    /// so it inherits `@MainActor` (CLAUDE.md Swift-6 gotcha #5).
+    public func refreshDiscoveredModels() {
+        if refreshTask != nil { return }
+        isRefreshingModels = true
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+            await self.performDiscoveryScan()
+        }
+    }
+
+    /// Forces a fresh discovery scan, cancelling any in-flight scan and ignoring
+    /// the single-flight guard. Use after a disk mutation (download/delete/import)
+    /// or an explicit user pull-to-refresh, where the cached snapshot is known stale.
+    public func forceRefreshDiscoveredModels() {
+        refreshTask?.cancel()
+        refreshTask = nil
+        isRefreshingModels = true
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+            await self.performDiscoveryScan()
+        }
+    }
+
+    /// Shared scan body for the refresh entry points. Runs the off-main scan,
+    /// then assigns the cached state on the main actor.
+    private func performDiscoveryScan() async {
+        defer {
+            isRefreshingModels = false
+            refreshTask = nil
+        }
+        let result = await modelStorage.discoverModelsOffMain()
+        guard !Task.isCancelled else { return }
+        discoveredModels = result.models
+        discoveredModelFileNames = Set(result.models.map(\.fileName))
+        hasLoadedModelsOnce = true
     }
 
     // MARK: - Recommendations
@@ -736,6 +801,12 @@ public final class ModelManagementViewModel {
             default: return true
             }
         }
+        // why: invalidation signals a disk mutation (download finished, delete,
+        // cancel). Drive a fresh off-main scan so the cached discoveredModels /
+        // totalStorageUsed snapshot reflects the new on-disk state without a
+        // render-path scan (#1787). Force-refresh because the cached snapshot is
+        // known stale and a coincidentally in-flight scan may predate the mutation.
+        forceRefreshDiscoveredModels()
     }
 
     /// Returns the active download state for a model, if any.

--- a/Sources/ManifoldUIModelManagement/Views/Models/LocalModelStorageView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/LocalModelStorageView.swift
@@ -25,6 +25,15 @@ struct LocalModelStorageView: View {
         #if os(iOS)
         .listStyle(.insetGrouped)
         #endif
+        // Populate the cached storage snapshot off-main on appear, not on every
+        // body eval (#1787). Single-flight inside the view model.
+        .task {
+            managementViewModel.refreshDiscoveredModels()
+        }
+        // A finished download adds a file on disk; refresh the cached snapshot.
+        .onChange(of: managementViewModel.completedDownloadCount) { _, _ in
+            managementViewModel.forceRefreshDiscoveredModels()
+        }
         .alert(
             "Delete Model",
             isPresented: $showDeleteConfirmation,
@@ -59,8 +68,15 @@ struct LocalModelStorageView: View {
             HStack {
                 Label("Total Used", systemImage: "externaldrive.fill")
                 Spacer()
-                Text(managementViewModel.totalStorageUsed)
-                    .foregroundStyle(.secondary)
+                // Show a placeholder during the first scan rather than a false
+                // "0 KB" before the cache is populated (#1787).
+                if managementViewModel.isRefreshingModels && !managementViewModel.hasLoadedModelsOnce {
+                    Text("Calculating…")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(managementViewModel.totalStorageUsed)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             VStack(alignment: .leading, spacing: 4) {

--- a/Sources/ManifoldUIModelManagement/Views/Models/StorageManagementView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/StorageManagementView.swift
@@ -57,6 +57,16 @@ public struct StorageManagementView: View {
                 downloadedModelsSection(modelRegistry: modelRegistry)
             }
             .navigationTitle("Storage")
+            // Populate the cached storage snapshot off-main on appear, not on every
+            // body eval (#1787). Single-flight inside the view model.
+            .task {
+                managementViewModel.refreshDiscoveredModels()
+            }
+            // A finished download adds a file on disk; refresh the cached snapshot
+            // so totalStorageUsed updates without an app restart.
+            .onChange(of: managementViewModel.completedDownloadCount) { _, _ in
+                managementViewModel.forceRefreshDiscoveredModels()
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
@@ -98,8 +108,15 @@ public struct StorageManagementView: View {
             HStack {
                 Label("Total Used", systemImage: "externaldrive.fill")
                 Spacer()
-                Text(managementViewModel.totalStorageUsed)
-                    .foregroundStyle(.secondary)
+                // Show a placeholder during the first scan rather than a false
+                // "0 KB" before the cache is populated (#1787).
+                if managementViewModel.isRefreshingModels && !managementViewModel.hasLoadedModelsOnce {
+                    Text("Calculating…")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(managementViewModel.totalStorageUsed)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             VStack(alignment: .leading, spacing: 4) {

--- a/Tests/ManifoldHardwareTests/GGUFMetadataReaderTests.swift
+++ b/Tests/ManifoldHardwareTests/GGUFMetadataReaderTests.swift
@@ -260,6 +260,123 @@ final class GGUFMetadataReaderTests: XCTestCase {
         }
     }
 
+    // MARK: - Buffered reads + array seek (#1787)
+
+    func test_readMetadata_stringTokensArray_thenLaterKeys_parse() throws {
+        // The worst case: a large STRING `tokens` array (no array-level byte count,
+        // must be walked element-by-element via skipString) followed by numeric
+        // companions and the keys we extract. Proves the parser lands at the right
+        // offset after skipping a string array.
+        let tokenCount = 5_000
+        let header = makeGGUFV3Header(metadata: [
+            makeStringArrayKV(key: "tokenizer.ggml.tokens", count: tokenCount, element: "tok"),
+            makeFloat32ArrayKV(key: "tokenizer.ggml.scores", count: tokenCount),
+            makeInt32ArrayKV(key: "tokenizer.ggml.token_type", count: tokenCount),
+            makeStringKV(key: "general.name", value: "AfterArrays"),
+            makeStringKV(key: "general.architecture", value: "llama"),
+            makeUInt32KV(key: "llama.context_length", value: 8192)
+        ])
+        let url = try writeTempFile(named: "string-array.gguf", data: header)
+
+        let metadata = try GGUFMetadataReader.readMetadata(from: url)
+
+        XCTAssertEqual(metadata.generalName, "AfterArrays", "Keys after a string array must parse — proves correct post-walk offset")
+        XCTAssertEqual(metadata.generalArchitecture, "llama")
+        XCTAssertEqual(metadata.contextLength, 8192)
+    }
+
+    func test_readMetadata_fixedWidthArray_thenLaterKeys_parse() throws {
+        // A fixed-width (f32) array is skipped via a single seek of count*4 bytes.
+        // The key AFTER it must still parse — proving the seek arithmetic is exact.
+        //
+        // Sabotage proof (verified manually, not committed live): writing a declared
+        // count one element short of the bytes written lands the parser early, so
+        // `general.name` no longer equals "SeekTarget" and the assertion below fails.
+        let count = 50_000
+        let header = makeGGUFV3Header(metadata: [
+            makeFloat32ArrayKV(key: "tokenizer.ggml.scores", count: count),
+            makeStringKV(key: "general.name", value: "SeekTarget"),
+            makeStringKV(key: "general.architecture", value: "llama"),
+            makeUInt32KV(key: "llama.context_length", value: 4096)
+        ])
+        let url = try writeTempFile(named: "fixedwidth-array.gguf", data: header)
+
+        let metadata = try GGUFMetadataReader.readMetadata(from: url)
+        XCTAssertEqual(metadata.generalName, "SeekTarget")
+        XCTAssertEqual(metadata.contextLength, 4096)
+    }
+
+    func test_readMetadata_primitiveStraddlingChunkBoundary_parses() throws {
+        // Force a value to be read across the 64 KiB buffer refill: pad the metadata
+        // region with a filler string larger than one chunk so the keys after it are
+        // served from a later refill, and a multi-byte primitive spans the boundary.
+        //
+        // Sabotage proof (verified manually): if BufferedFileReader.read returned only
+        // the first-chunk bytes instead of reassembling across refills, contextLength
+        // would be garbage and the assertion fails.
+        let chunk = 64 * 1024
+
+        var meta: [Data] = []
+        let fillerValue = String(repeating: "x", count: chunk + 7)  // > one chunk, odd tail
+        meta.append(makeStringKV(key: "filler", value: fillerValue))
+        meta.append(makeStringKV(key: "general.architecture", value: "llama"))
+        meta.append(makeUInt32KV(key: "llama.context_length", value: 123_456))
+        meta.append(makeStringKV(key: "general.name", value: "BoundaryModel"))
+
+        let header = makeGGUFV3Header(metadata: meta)
+        let url = try writeTempFile(named: "boundary.gguf", data: header)
+
+        let metadata = try GGUFMetadataReader.readMetadata(from: url)
+        XCTAssertEqual(metadata.contextLength, 123_456, "uint32 read across a buffer refill must reassemble correctly")
+        XCTAssertEqual(metadata.generalName, "BoundaryModel")
+        XCTAssertEqual(metadata.generalArchitecture, "llama")
+    }
+
+    func test_readMetadata_goldenParity_v2_and_v3() throws {
+        // Golden-parity: a representative metadata set (including a string array +
+        // numeric companion) must produce byte-identical parsed fields across v2 and
+        // v3 envelopes, and match the captured baseline.
+        let kvs: [Data] = [
+            makeStringArrayKV(key: "tokenizer.ggml.tokens", count: 1_000, element: "t"),
+            makeFloat32ArrayKV(key: "tokenizer.ggml.scores", count: 1_000),
+            makeStringKV(key: "general.name", value: "GoldenModel"),
+            makeStringKV(key: "general.architecture", value: "gemma"),
+            makeUInt32KV(key: "general.file_type", value: 15),
+            makeUInt32KV(key: "gemma.context_length", value: 8192),
+            makeUInt32KV(key: "gemma.block_count", value: 28),
+            makeUInt32KV(key: "gemma.embedding_length", value: 3072),
+            makeUInt32KV(key: "gemma.attention.head_count", value: 16),
+            makeUInt32KV(key: "gemma.attention.head_count_kv", value: 8),
+            makeStringKV(key: "tokenizer.chat_template", value: "<|im_start|>{{x}}")
+        ]
+        let v3 = try writeTempFile(named: "golden-v3.gguf", data: makeGGUFV3Header(metadata: kvs))
+        let v2 = try writeTempFile(named: "golden-v2.gguf", data: makeGGUFV2Header(metadata: kvs))
+
+        let m3 = try GGUFMetadataReader.readMetadata(from: v3)
+        let m2 = try GGUFMetadataReader.readMetadata(from: v2)
+
+        // Baseline captured from the same metadata definition.
+        let baseline = GGUFMetadata(
+            generalName: "GoldenModel",
+            generalArchitecture: "gemma",
+            contextLength: 8192,
+            chatTemplate: "<|im_start|>{{x}}",
+            fileType: 15,
+            kvCacheParameters: GGUFKVCacheParameters(
+                blockCount: 28,
+                embeddingLength: 3072,
+                attentionHeadCount: 16,
+                attentionHeadCountKV: 8,
+                attentionKeyLength: nil,
+                attentionValueLength: nil
+            )
+        )
+
+        XCTAssertEqual(m3, baseline, "v3 parse must match the captured baseline")
+        XCTAssertEqual(m2, baseline, "v2 parse must match the captured baseline")
+        XCTAssertEqual(m2, m3, "v2 and v3 envelopes of the same metadata must parse identically")
+    }
+
     func test_isValidGGUF_invalidFile_returnsFalse() throws {
         let data = Data(repeating: 0, count: 64)
         let url = try writeTempFile(named: "invalid.gguf", data: data)
@@ -372,6 +489,53 @@ final class GGUFMetadataReaderTests: XCTestCase {
         appendUInt32(&data, 9)
         appendUInt32(&data, 0)              // element type: uint8
         appendUInt64(&data, count)          // declared count (no actual bytes follow)
+        return data
+    }
+
+    /// Builds a KV pair whose value is a STRING array of `count` identical-prefixed
+    /// elements (`<element>-<i>`). String arrays carry NO array-level byte count, so
+    /// this exercises the per-element `skipString` walk.
+    private func makeStringArrayKV(key: String, count: Int, element: String) -> Data {
+        var data = Data()
+        let keyBytes = Array(key.utf8)
+        appendUInt64(&data, UInt64(keyBytes.count))
+        data.append(contentsOf: keyBytes)
+        appendUInt32(&data, 9)   // ARRAY
+        appendUInt32(&data, 8)   // element type: STRING
+        appendUInt64(&data, UInt64(count))
+        for i in 0..<count {
+            let elementBytes = Array("\(element)-\(i)".utf8)
+            appendUInt64(&data, UInt64(elementBytes.count))
+            data.append(contentsOf: elementBytes)
+        }
+        return data
+    }
+
+    /// Builds a KV pair whose value is a FLOAT32 array of `count` zeroed elements.
+    /// Fixed-width (4 bytes) — exercises the single-seek fast path.
+    private func makeFloat32ArrayKV(key: String, count: Int) -> Data {
+        var data = Data()
+        let keyBytes = Array(key.utf8)
+        appendUInt64(&data, UInt64(keyBytes.count))
+        data.append(contentsOf: keyBytes)
+        appendUInt32(&data, 9)   // ARRAY
+        appendUInt32(&data, 6)   // element type: FLOAT32
+        appendUInt64(&data, UInt64(count))
+        data.append(Data(repeating: 0x00, count: count * 4))
+        return data
+    }
+
+    /// Builds a KV pair whose value is an INT32 array of `count` zeroed elements.
+    /// Fixed-width (4 bytes) — exercises the single-seek fast path.
+    private func makeInt32ArrayKV(key: String, count: Int) -> Data {
+        var data = Data()
+        let keyBytes = Array(key.utf8)
+        appendUInt64(&data, UInt64(keyBytes.count))
+        data.append(contentsOf: keyBytes)
+        appendUInt32(&data, 9)   // ARRAY
+        appendUInt32(&data, 5)   // element type: INT32
+        appendUInt64(&data, UInt64(count))
+        data.append(Data(repeating: 0x00, count: count * 4))
         return data
     }
 

--- a/Tests/ManifoldModelCatalogTests/ModelStorageServiceTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ModelStorageServiceTests.swift
@@ -168,6 +168,60 @@ final class ModelStorageServiceTests: XCTestCase {
         XCTAssertEqual(match?.fileSize, 1024)
     }
 
+    // MARK: - mmproj companion (single enumeration per scan, #1787)
+
+    func test_discoverModels_resolvesMmprojForEveryModel_withSingleEnumeration() throws {
+        // K text GGUFs + one mmproj sibling in the same directory. Every model's
+        // mmprojURL must resolve to the projector, and the parent directory must be
+        // enumerated exactly ONCE for the whole scan (not once per GGUF as the old
+        // O(K²) self-enumeration did).
+        let counter = CountingFileManager()
+        let scratch = makeIsolatedModelsDirectory()
+        // includeUserDocumentsFallback: false so the scan touches ONLY this scratch
+        // directory — otherwise the dev machine's ~/Documents/Models pollutes both
+        // the model count and the enumeration count.
+        let countingService = ModelStorageService(
+            fileManager: counter,
+            baseDirectory: scratch,
+            includeUserDocumentsFallback: false
+        )
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try countingService.ensureModelsDirectory()
+        let dir = countingService.modelsDirectory
+
+        func writeGGUF(_ name: String) throws {
+            var data = Data([0x47, 0x47, 0x55, 0x46])
+            data.append(Data(repeating: 0xAA, count: 1020))
+            try data.write(to: dir.appendingPathComponent(name))
+        }
+
+        let k = 5
+        for i in 0..<k {
+            try writeGGUF("model-\(i).gguf")
+        }
+        try writeGGUF("mmproj-vision.gguf")
+
+        // Reset the counter so only the scan's enumerations are measured.
+        counter.contentsOfDirectoryCallCount = 0
+        let models = countingService.discoverModels()
+
+        let textModels = models.filter { !$0.fileName.lowercased().hasPrefix("mmproj") }
+        XCTAssertEqual(textModels.count, k, "All \(k) text models should be discovered")
+        XCTAssertTrue(
+            textModels.allSatisfy { $0.mmprojURL?.lastPathComponent == "mmproj-vision.gguf" },
+            "Every text model must resolve the mmproj companion"
+        )
+
+        // One enumeration for the models directory. The fallback (~/Documents/Models)
+        // is disabled in the isolated service, so no extra enumeration is expected.
+        // Sabotage proof: reverting ModelInfo.load to self-enumerate per file would
+        // make this K (one per GGUF) + 1 instead of 1.
+        XCTAssertEqual(
+            counter.contentsOfDirectoryCallCount, 1,
+            "The scan must enumerate the directory exactly once, not once per GGUF (#1787)"
+        )
+    }
+
     func test_discoverModels_singleFileCompatibilityIgnoresPackageManifest() throws {
         let ggufURL = try createGgufFile()
         try createDiffusionPackage()
@@ -592,5 +646,22 @@ final class ModelStorageServiceTests: XCTestCase {
         let space = service.availableDiskSpace()
 
         XCTAssertGreaterThan(space, 0, "Available disk space should be non-zero on a real system")
+    }
+}
+
+// MARK: - Counting FileManager
+
+/// A `FileManager` subclass that counts `contentsOfDirectory(at:...)` calls so a
+/// test can assert a directory is enumerated exactly once per scan (#1787).
+private final class CountingFileManager: FileManager {
+    var contentsOfDirectoryCallCount = 0
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        contentsOfDirectoryCallCount += 1
+        return try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
     }
 }

--- a/Tests/ManifoldUIModelManagementTests/ModelManagementSheetLogicTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/ModelManagementSheetLogicTests.swift
@@ -273,6 +273,93 @@ final class ModelManagementSheetLogicTests: XCTestCase {
         XCTAssertFalse(vm.modelsDirectoryPath.isEmpty, "Models directory path should never be empty")
     }
 
+    // MARK: - Cached discovery state (#1787)
+
+    func test_discoveredModels_cachedAndOffMain_noScanOnRead() async throws {
+        let counter = ScanCountingFileManager()
+        let scratch = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let storage = ModelStorageService(
+            fileManager: counter,
+            baseDirectory: scratch,
+            includeUserDocumentsFallback: false
+        )
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try storage.ensureModelsDirectory()
+
+        // Two fixture GGUFs on disk.
+        for i in 0..<2 {
+            var data = Data([0x47, 0x47, 0x55, 0x46])
+            data.append(Data(repeating: 0xAA, count: 1020))
+            try data.write(to: storage.modelsDirectory.appendingPathComponent("m-\(i).gguf"))
+        }
+
+        let vm = ModelManagementViewModel(modelStorage: storage)
+
+        // Pre-refresh: cache is empty, totalStorageUsed derives "0 bytes" without
+        // touching disk, and hasLoadedModelsOnce is false.
+        XCTAssertTrue(vm.discoveredModels.isEmpty, "Cache must be empty before any refresh")
+        XCTAssertFalse(vm.hasLoadedModelsOnce)
+
+        // Reading the render-path properties must NOT trigger a disk scan.
+        counter.scanCount = 0
+        _ = vm.discoveredModels
+        _ = vm.totalStorageUsed
+        _ = vm.discoveredModels
+        _ = vm.totalStorageUsed
+        XCTAssertEqual(counter.scanCount, 0, "Reading discoveredModels/totalStorageUsed must never scan disk (#1787)")
+
+        // After an awaited refresh the cache is populated.
+        vm.refreshDiscoveredModels()
+        try await waitForRefresh(vm)
+
+        XCTAssertEqual(vm.discoveredModels.count, 2, "Refresh must populate the cache from disk")
+        XCTAssertTrue(vm.hasLoadedModelsOnce)
+        XCTAssertFalse(vm.totalStorageUsed.isEmpty)
+
+        // Reading again post-refresh still triggers zero additional scans.
+        let afterRefreshCount = counter.scanCount
+        _ = vm.discoveredModels
+        _ = vm.totalStorageUsed
+        XCTAssertEqual(counter.scanCount, afterRefreshCount, "Post-refresh reads must stay cache-only")
+    }
+
+    func test_refreshDiscoveredModels_isSingleFlight() async throws {
+        let counter = ScanCountingFileManager()
+        let scratch = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let storage = ModelStorageService(
+            fileManager: counter,
+            baseDirectory: scratch,
+            includeUserDocumentsFallback: false
+        )
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        try storage.ensureModelsDirectory()
+        var data = Data([0x47, 0x47, 0x55, 0x46])
+        data.append(Data(repeating: 0xAA, count: 1020))
+        try data.write(to: storage.modelsDirectory.appendingPathComponent("only.gguf"))
+
+        let vm = ModelManagementViewModel(modelStorage: storage)
+        counter.scanCount = 0
+
+        // Fire N concurrent refreshes synchronously on the main actor — the
+        // single-flight guard collapses them into ONE in-flight scan.
+        for _ in 0..<8 {
+            vm.refreshDiscoveredModels()
+        }
+        try await waitForRefresh(vm)
+
+        XCTAssertEqual(counter.scanCount, 1, "Concurrent refresh calls must collapse into a single scan")
+        XCTAssertEqual(vm.discoveredModels.count, 1)
+    }
+
+    /// Polls until the view model's in-flight refresh has settled, with a tight deadline.
+    private func waitForRefresh(_ vm: ModelManagementViewModel) async throws {
+        let deadline = Date().addingTimeInterval(5)
+        while vm.isRefreshingModels && Date() < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        XCTAssertFalse(vm.isRefreshingModels, "Refresh should settle within the deadline")
+    }
+
     // MARK: - Download model grouping
 
     func test_downloadableModelGroup_singleVariant() {
@@ -472,4 +559,26 @@ final class ModelManagementSheetLogicTests: XCTestCase {
         return controller.view.fittingSize
     }
     #endif
+}
+
+// MARK: - Scan-counting FileManager
+
+/// A `FileManager` subclass that counts directory enumerations so a test can
+/// prove the view model scans disk only when it intends to (#1787).
+///
+/// `@unchecked Sendable`: the discovery scan runs on a detached task thread, but
+/// the test only reads `scanCount` after awaiting the refresh to completion, so
+/// the read is ordered after every write via the `@MainActor` hop that publishes
+/// `isRefreshingModels = false`.
+private final class ScanCountingFileManager: FileManager, @unchecked Sendable {
+    var scanCount = 0
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        scanCount += 1
+        return try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
+    }
 }


### PR DESCRIPTION
Closes #1787.

Three independent hot-path fixes in the model-management surface, each verified against the issue's adversarial review.

### 1 — Cached `@Observable` discovery state, no scan on render
`ModelManagementViewModel.discoveredModels` is now stored `@Observable` state (was a computed property that called `ModelStorageService.discoverModels()` on every read). `totalStorageUsed` stays computed but derives **purely** from the cached array (`reduce(fileSize)` → `ByteCountFormatter`) and never touches disk. The scan runs off-main via the existing `discoverModelsOffMain()` (the sanctioned `Task.detached` site) behind a single-flight `refreshDiscoveredModels()` plus a `forceRefreshDiscoveredModels()` for post-mutation/explicit pulls; `invalidateModelCache()` now drives a force-refresh. Views trigger the scan from `.task` (on appear) and a `completedDownloadCount` `onChange`; deletes already route through `invalidateModelCache()`. First render shows `Calculating…` (gated on `isRefreshingModels && !hasLoadedModelsOnce`) instead of a false `0 GB`. Non-UI callers keep the synchronous `discoverModels()` unchanged.

### 2 — GGUF buffered reads + seek past arrays
A 64 KiB forward-only `BufferedFileReader` serves the primitive reads (one chunk read per refill instead of one syscall per primitive). `skipValue`'s `.array` case seeks past **fixed-width** element types in one `count*width` seek. **String arrays cannot be block-seeked** — they have no array-level byte count (`tokenizer.ggml.tokens` / `merges` are the worst case), so they are still walked element-by-element, but via a new `skipString` that reads the 8-byte length then seeks past the bytes (no per-element `Data` alloc / UTF-8 decode). Numeric companions (`scores`=f32, `token_type`=i32) take the single-seek fast path. Peak memory is one chunk + one bounded primitive.

### 3 — mmproj enumerated once per scan
`scanDirectory` resolves the `mmproj*.gguf` candidate once from the `contents` it already has and threads it into `ModelInfo.load(ggufURL:mmprojURL:)`, turning the per-file parent re-enumeration (O(K²)) into O(K). The self-enumerating block stays as the fallback for the standalone `init(ggufURL:)` / drag-and-drop import path.

### Tests
- **GGUF golden-parity** (v2 + v3 envelopes, including a large string `tokens` array + f32/i32 companions) asserted byte-identical to a captured baseline.
- **Seek-correctness** + **buffer-boundary** fixtures (keys parse correctly after a large array / across a 64 KiB refill) — sabotage-verified (corrupt seek arithmetic → assertion fails; restored).
- **mmproj single-enumeration**: counting `FileManager` proves exactly 1 enumeration for K GGUFs + 1 mmproj, and every `mmprojURL` resolves.
- **VM cached-state**: zero scans when reading `discoveredModels`/`totalStorageUsed`; populated only after an awaited refresh; N concurrent refreshes collapse to one scan (single-flight).

Gate: `scripts/test.sh --profile local` → **Failed: 0** (4910 passed). The INCOMPLETE banner is the documented non-deterministic teardown signal-11 in the unrelated `BatchRegistrationTests` suite, which passes 12/12 in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)