### PR TITLE
perf: parse each cloud stream frame once instead of 8-12 times

### DIFF
--- a/Sources/ManifoldCloudCore/CloudRoutedStreamParser.swift
+++ b/Sources/ManifoldCloudCore/CloudRoutedStreamParser.swift
@@ -41,11 +41,17 @@ package struct CloudRoutedStreamParser: Sendable {
 
                 let payload = String(data: frame, encoding: .utf8) ?? ""
 
+                // Parse the frame exactly once. Every downstream consumer
+                // (the stateful extractor, the stateless handler fallback,
+                // and the finalizer) reads off this single parsed structure
+                // instead of re-running `JSONSerialization` 8–12× per frame.
+                let parsedFrame = ParsedFrame.make(from: payload)
+
                 if !payload.isEmpty {
                     if let consumer {
                         try emitConsumerEvents(
                             from: consumer,
-                            payload: payload,
+                            frame: parsedFrame,
                             limitTracker: &limitTracker,
                             continuation: continuation
                         )
@@ -63,7 +69,7 @@ package struct CloudRoutedStreamParser: Sendable {
                     }
                 }
 
-                if case .streamComplete(let usage, _) = finalizer.finalize(frame: frame) {
+                if case .streamComplete(let usage, _) = finalizer.finalize(frame: parsedFrame) {
                     if consumer == nil,
                        let usage,
                        let prompt = usage.promptTokens,
@@ -96,11 +102,11 @@ package struct CloudRoutedStreamParser: Sendable {
 
     private func emitConsumerEvents(
         from consumer: any CloudStreamEventConsumer,
-        payload: String,
+        frame: ParsedFrame,
         limitTracker: inout RoutedStreamLimitTracker,
         continuation: AsyncThrowingStream<GenerationEvent, Error>.Continuation
     ) throws {
-        for event in consumer.consume(payload: payload) {
+        for event in consumer.consume(frame: frame) {
             if Task.isCancelled { break }
             if case .usage(let prompt, let completion) = event {
                 handleUsage((promptTokens: prompt, completionTokens: completion))

--- a/Sources/ManifoldCloudCore/CloudStreamEventConsumer.swift
+++ b/Sources/ManifoldCloudCore/CloudStreamEventConsumer.swift
@@ -26,10 +26,26 @@ public protocol CloudStreamEventConsumer: AnyObject, Sendable {
     /// chunks).
     func consume(payload: String) -> [GenerationEvent]
 
+    /// Returns the event sequence to emit for one already-parsed frame.
+    ///
+    /// Real extractors override this to read off `frame.json` /
+    /// `frame.namedEvent` instead of re-parsing the payload string 8–12×.
+    /// The default delegates to ``consume(payload:)`` so conformers that
+    /// haven't migrated keep working.
+    func consume(frame: ParsedFrame) -> [GenerationEvent]
+
     /// Flushes pending state at stream end. Implementations yield any
     /// open-thinking close (`.thinkingCompleted`) and any buffered tool
     /// calls the upstream never accompanied with an explicit
     /// `finish_reason`. Pass `cancelled: true` to suppress phantom tool
     /// emissions when the consumer is being dropped mid-stream.
     func finish(cancelled: Bool) -> [GenerationEvent]
+}
+
+public extension CloudStreamEventConsumer {
+    /// Default: delegate to the string surface so un-migrated consumers
+    /// keep compiling. The three real cloud extractors override this.
+    func consume(frame: ParsedFrame) -> [GenerationEvent] {
+        consume(payload: frame.raw)
+    }
 }

--- a/Sources/ManifoldCloudCore/OpenAIChatCompletionsPayloadParsing.swift
+++ b/Sources/ManifoldCloudCore/OpenAIChatCompletionsPayloadParsing.swift
@@ -22,6 +22,10 @@ package enum OpenAIChatCompletionsPayloadParsing {
         parseToken(from: payload)
     }
 
+    package static func extractToken(from json: JSONValue) -> String? {
+        parseToken(from: json)
+    }
+
     /// Stateless event extraction. The full event vocabulary
     /// (tool calls, reasoning handoff, usage, prefill progress) lives on
     /// ``OpenAIStreamEventExtractor`` because it requires cross-frame state.
@@ -39,6 +43,11 @@ package enum OpenAIChatCompletionsPayloadParsing {
         return (promptTokens: usage.promptTokens, completionTokens: usage.completionTokens)
     }
 
+    package static func extractUsage(from json: JSONValue) -> (promptTokens: Int?, completionTokens: Int?)? {
+        guard let usage = parseUsage(from: json) else { return nil }
+        return (promptTokens: usage.promptTokens, completionTokens: usage.completionTokens)
+    }
+
     // MARK: - Field-level parsers
 
     /// Extracts the content token from an OpenAI streaming response chunk.
@@ -48,12 +57,15 @@ package enum OpenAIChatCompletionsPayloadParsing {
     /// {"choices":[{"delta":{"content":"token"}}]}
     /// ```
     package static func parseToken(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = parsed["choices"] as? [[String: Any]],
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseToken(from: parsed)
+    }
+
+    package static func parseToken(from json: JSONValue) -> String? {
+        guard let choices = json["choices"]?.objectArrayValue,
               let firstChoice = choices.first,
-              let delta = firstChoice["delta"] as? [String: Any],
-              let content = delta["content"] as? String else {
+              let delta = firstChoice["delta"]?.objectValue,
+              let content = delta["content"]?.stringValue else {
             return nil
         }
         return content
@@ -72,17 +84,20 @@ package enum OpenAIChatCompletionsPayloadParsing {
     /// `content` — returns `nil` so the caller can fall back to the standard
     /// token extractor.
     package static func parseReasoningDelta(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = parsed["choices"] as? [[String: Any]],
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseReasoningDelta(from: parsed)
+    }
+
+    package static func parseReasoningDelta(from json: JSONValue) -> String? {
+        guard let choices = json["choices"]?.objectArrayValue,
               let firstChoice = choices.first,
-              let delta = firstChoice["delta"] as? [String: Any] else {
+              let delta = firstChoice["delta"]?.objectValue else {
             return nil
         }
-        if let content = delta["reasoning_content"] as? String, !content.isEmpty {
+        if let content = delta["reasoning_content"]?.stringValue, !content.isEmpty {
             return content
         }
-        if let content = delta["reasoning"] as? String, !content.isEmpty {
+        if let content = delta["reasoning"]?.stringValue, !content.isEmpty {
             return content
         }
         return nil
@@ -114,22 +129,25 @@ package enum OpenAIChatCompletionsPayloadParsing {
     /// Compat servers vary on whether `id` is repeated; the accumulator
     /// handles that by stickying the first non-empty value seen per index.
     package static func parseToolCallDeltas(from json: String) -> [ToolCallDelta] {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = parsed["choices"] as? [[String: Any]],
+        guard let parsed = JSONValue.parse(string: json) else { return [] }
+        return parseToolCallDeltas(from: parsed)
+    }
+
+    package static func parseToolCallDeltas(from json: JSONValue) -> [ToolCallDelta] {
+        guard let choices = json["choices"]?.objectArrayValue,
               let firstChoice = choices.first,
-              let delta = firstChoice["delta"] as? [String: Any],
-              let rawCalls = delta["tool_calls"] as? [[String: Any]] else {
+              let delta = firstChoice["delta"]?.objectValue,
+              let rawCalls = delta["tool_calls"]?.objectArrayValue else {
             return []
         }
 
         var result: [ToolCallDelta] = []
         for raw in rawCalls {
-            guard let index = raw["index"] as? Int else { continue }
-            let id = raw["id"] as? String
-            let function = raw["function"] as? [String: Any]
-            let name = function?["name"] as? String
-            let argumentsDelta = function?["arguments"] as? String
+            guard let index = raw["index"]?.intValue else { continue }
+            let id = raw["id"]?.stringValue
+            let function = raw["function"]?.objectValue
+            let name = function?["name"]?.stringValue
+            let argumentsDelta = function?["arguments"]?.stringValue
             result.append(ToolCallDelta(
                 index: index,
                 id: id,
@@ -143,23 +161,26 @@ package enum OpenAIChatCompletionsPayloadParsing {
     /// Parses a whole `choices[0].message.tool_calls[]` array from a
     /// non-streaming response chunk.
     package static func parseWholeToolCalls(from json: String) -> [WholeToolCall] {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = parsed["choices"] as? [[String: Any]],
+        guard let parsed = JSONValue.parse(string: json) else { return [] }
+        return parseWholeToolCalls(from: parsed)
+    }
+
+    package static func parseWholeToolCalls(from json: JSONValue) -> [WholeToolCall] {
+        guard let choices = json["choices"]?.objectArrayValue,
               let firstChoice = choices.first,
-              let message = firstChoice["message"] as? [String: Any],
-              let rawCalls = message["tool_calls"] as? [[String: Any]] else {
+              let message = firstChoice["message"]?.objectValue,
+              let rawCalls = message["tool_calls"]?.objectArrayValue else {
             return []
         }
         var result: [WholeToolCall] = []
         for raw in rawCalls {
-            guard let function = raw["function"] as? [String: Any],
-                  let name = function["name"] as? String,
+            guard let function = raw["function"]?.objectValue,
+                  let name = function["name"]?.stringValue,
                   !name.isEmpty else {
                 continue
             }
-            let id = (raw["id"] as? String) ?? ""
-            let arguments = (function["arguments"] as? String) ?? "{}"
+            let id = raw["id"]?.stringValue ?? ""
+            let arguments = function["arguments"]?.stringValue ?? "{}"
             result.append(WholeToolCall(id: id, name: name, arguments: arguments))
         }
         return result
@@ -167,11 +188,14 @@ package enum OpenAIChatCompletionsPayloadParsing {
 
     /// Parses `choices[0].finish_reason` (e.g. `"stop"`, `"tool_calls"`).
     package static func parseFinishReason(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = parsed["choices"] as? [[String: Any]],
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseFinishReason(from: parsed)
+    }
+
+    package static func parseFinishReason(from json: JSONValue) -> String? {
+        guard let choices = json["choices"]?.objectArrayValue,
               let firstChoice = choices.first,
-              let reason = firstChoice["finish_reason"] as? String,
+              let reason = firstChoice["finish_reason"]?.stringValue,
               !reason.isEmpty else {
             return nil
         }
@@ -185,11 +209,14 @@ package enum OpenAIChatCompletionsPayloadParsing {
     /// {"choices":[...],"usage":{"prompt_tokens":25,"completion_tokens":100,"total_tokens":125}}
     /// ```
     package static func parseUsage(from json: String) -> (promptTokens: Int, completionTokens: Int)? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let usage = parsed["usage"] as? [String: Any],
-              let prompt = usage["prompt_tokens"] as? Int,
-              let completion = usage["completion_tokens"] as? Int else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseUsage(from: parsed)
+    }
+
+    package static func parseUsage(from json: JSONValue) -> (promptTokens: Int, completionTokens: Int)? {
+        guard let usage = json["usage"]?.objectValue,
+              let prompt = usage["prompt_tokens"]?.intValue,
+              let completion = usage["completion_tokens"]?.intValue else {
             return nil
         }
         return (prompt, completion)
@@ -204,28 +231,16 @@ package enum OpenAIChatCompletionsPayloadParsing {
     }
 
     package static func parsePrefillProgress(from json: String) -> PrefillProgress? {
-        guard let data = json.data(using: .utf8) else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parsePrefillProgress(from: parsed)
+    }
+
+    package static func parsePrefillProgress(from json: JSONValue) -> PrefillProgress? {
+        guard let nPast = json["n_past"]?.intValue,
+              let nTotal = json["n_total"]?.intValue else {
             return nil
         }
-        let parsed: [String: Any]
-        do {
-            guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return nil
-            }
-            parsed = object
-        } catch {
-            return nil
-        }
-        guard let nPast = parsed["n_past"] as? Int,
-              let nTotal = parsed["n_total"] as? Int else {
-            return nil
-        }
-        let tokensPerSecond: Double
-        if let value = parsed["tokens_per_second"] as? Double {
-            tokensPerSecond = value
-        } else if let value = parsed["tokens_per_second"] as? Int {
-            tokensPerSecond = Double(value)
-        } else {
+        guard let tokensPerSecond = json["tokens_per_second"]?.doubleValue else {
             return nil
         }
         return PrefillProgress(

--- a/Sources/ManifoldCloudCore/ParsedFrame.swift
+++ b/Sources/ManifoldCloudCore/ParsedFrame.swift
@@ -1,0 +1,277 @@
+import Foundation
+import ManifoldInference
+
+/// A `Sendable` JSON value tree.
+///
+/// Cloud stream extractors historically re-parsed every SSE / NDJSON frame
+/// 8–12× — each field extractor independently did `String → Data →
+/// JSONSerialization.jsonObject`, and `StreamFinalizer.finalize` re-parsed
+/// the same bytes once more. `ParsedFrame` parses each frame **once** and
+/// hands the parsed tree to every consumer.
+///
+/// `[String: Any]` (the natural `JSONSerialization` output) is **not**
+/// `Sendable`, so it cannot cross the `AsyncStream`/continuation boundary in
+/// the routed stream loop under Swift 6 region isolation. `@unchecked
+/// Sendable` is not an option (it would hide a real race — see the
+/// concurrency gotchas in CLAUDE.md). This enum is a fully-`Sendable`,
+/// value-typed stand-in.
+///
+/// ### NSNumber Int-vs-Double fidelity
+///
+/// The legacy code casts numbers with `as? Int` (e.g. `usage["prompt_tokens"]
+/// as? Int`). On a `JSONSerialization` `NSNumber`, `as? Int` succeeds for any
+/// integral value — including one the wire encoded as a whole float
+/// (`100.0 as? Int == 100`) — and `true as? Int == 1`, while `3.5 as? Int ==
+/// nil`. The accessors below (`intValue`, `doubleValue`, `boolValue`)
+/// reproduce that exactly so usage counts never silently drop. This is the
+/// single highest-risk behaviour in the parse-once migration; it is covered
+/// directly by the differential extractor tests.
+public enum JSONValue: Sendable, Hashable {
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case string(String)
+    case number(Double)
+    case int(Int)
+    case bool(Bool)
+    case null
+}
+
+public extension JSONValue {
+    /// Builds a `JSONValue` from `JSONSerialization` output, reproducing the
+    /// `NSNumber` Int-vs-Double-vs-Bool discrimination the legacy `as?` casts
+    /// relied on.
+    init(jsonObject: Any) {
+        switch jsonObject {
+        case let dict as [String: Any]:
+            var out: [String: JSONValue] = [:]
+            out.reserveCapacity(dict.count)
+            for (key, value) in dict {
+                out[key] = JSONValue(jsonObject: value)
+            }
+            self = .object(out)
+        case let arr as [Any]:
+            self = .array(arr.map { JSONValue(jsonObject: $0) })
+        case let str as String:
+            self = .string(str)
+        case let number as NSNumber:
+            // Order matters: a JSON `true`/`false` bridges to an NSNumber
+            // backed by CFBoolean, so check that *before* the numeric paths
+            // (otherwise `true` would decode as `.int(1)`).
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else if CFNumberIsFloatType(number) {
+                // Wire encoded a float. Preserve it as `.number`; the
+                // `intValue` accessor still recovers a whole value via
+                // `Int(exactly:)`, matching `100.0 as? Int == 100`.
+                self = .number(number.doubleValue)
+            } else if let intValue = Int(exactly: number.int64Value) {
+                self = .int(intValue)
+            } else {
+                self = .number(number.doubleValue)
+            }
+        case is NSNull:
+            self = .null
+        default:
+            self = .null
+        }
+    }
+
+    /// Parses a JSON payload string into a `JSONValue`, or `nil` on
+    /// malformed input. Used by the thin `String` wrappers on the parser
+    /// namespaces so legacy callers (single-shot) keep working while the
+    /// routed path uses the once-parsed `ParsedFrame.json`.
+    static func parse(string: String) -> JSONValue? {
+        guard let data = string.data(using: .utf8) else { return nil }
+        do {
+            let object = try JSONSerialization.jsonObject(with: data)
+            return JSONValue(jsonObject: object)
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Accessors mirroring the legacy `as?` casts
+
+    /// Mirrors `value as? [String: Any]` for an object node.
+    var objectValue: [String: JSONValue]? {
+        if case .object(let dict) = self { return dict }
+        return nil
+    }
+
+    /// Mirrors `value as? [[String: Any]]` for an array-of-objects node.
+    var objectArrayValue: [[String: JSONValue]]? {
+        guard case .array(let arr) = self else { return nil }
+        var out: [[String: JSONValue]] = []
+        out.reserveCapacity(arr.count)
+        for element in arr {
+            guard case .object(let dict) = element else { return nil }
+            out.append(dict)
+        }
+        return out
+    }
+
+    /// Mirrors `value as? String`.
+    var stringValue: String? {
+        if case .string(let str) = self { return str }
+        return nil
+    }
+
+    /// Mirrors `value as? Int` on a `JSONSerialization` `NSNumber`:
+    /// integral numbers (including whole floats such as `100.0`) and booleans
+    /// (`true → 1`, `false → 0`) succeed; non-integral floats return `nil`.
+    var intValue: Int? {
+        switch self {
+        case .int(let value):
+            return value
+        case .number(let value):
+            return Int(exactly: value)
+        case .bool(let value):
+            return value ? 1 : 0
+        default:
+            return nil
+        }
+    }
+
+    /// Mirrors `value as? Double`.
+    var doubleValue: Double? {
+        switch self {
+        case .number(let value):
+            return value
+        case .int(let value):
+            return Double(value)
+        case .bool(let value):
+            return value ? 1 : 0
+        default:
+            return nil
+        }
+    }
+
+    /// Mirrors `value as? Bool` (only a JSON boolean qualifies — a numeric
+    /// `1` is not a bool, matching `1 as? Bool == nil`).
+    var boolValue: Bool? {
+        if case .bool(let value) = self { return value }
+        return nil
+    }
+
+    /// Converts back to a `JSONSerialization`-compatible Foundation object
+    /// (`[String: Any]` / `[Any]` / `String` / `NSNumber` / `NSNull`). Used
+    /// when a parsed sub-tree must be re-serialised to a JSON string (e.g.
+    /// Claude `tool_use.input`).
+    var foundationObject: Any {
+        switch self {
+        case .object(let dict):
+            var out: [String: Any] = [:]
+            out.reserveCapacity(dict.count)
+            for (key, value) in dict {
+                out[key] = value.foundationObject
+            }
+            return out
+        case .array(let arr):
+            return arr.map { $0.foundationObject }
+        case .string(let str):
+            return str
+        case .number(let value):
+            return value
+        case .int(let value):
+            return value
+        case .bool(let value):
+            return value
+        case .null:
+            return NSNull()
+        }
+    }
+
+    /// Convenience object-member subscript. Returns `nil` for non-objects or
+    /// absent keys.
+    subscript(_ key: String) -> JSONValue? {
+        guard case .object(let dict) = self else { return nil }
+        return dict[key]
+    }
+}
+
+/// One cloud SSE / NDJSON frame, parsed exactly once.
+///
+/// Built at the single parse site in ``CloudRoutedStreamParser`` and passed
+/// to every consumer (`CloudStreamEventConsumer.consume(frame:)`,
+/// `StreamFinalizer.finalize(frame:)`) so no downstream code re-parses the
+/// payload string.
+public struct ParsedFrame: Sendable {
+    /// The original payload string. Some paths (error sanitisation, the
+    /// stateless `SSEPayloadHandler` fallback) still consume the raw string.
+    public let raw: String
+
+    /// The parsed JSON tree, or `nil` for frames that aren't JSON objects
+    /// (`[DONE]`, keepalive/heartbeat lines, malformed frames).
+    public let json: JSONValue?
+
+    /// For `NamedSSETransport` envelopes (`{"__event":..,"__data":".."}`):
+    /// the unwrapped event name plus its inner `__data` payload, parsed in
+    /// the same pass. `nil` for plain (non-envelope) frames.
+    public let namedEvent: (name: String, dataJSON: JSONValue?, dataRaw: String)?
+
+    public init(
+        raw: String,
+        json: JSONValue?,
+        namedEvent: (name: String, dataJSON: JSONValue?, dataRaw: String)?
+    ) {
+        self.raw = raw
+        self.json = json
+        self.namedEvent = namedEvent
+    }
+
+    /// Parses `payload` into a `ParsedFrame` exactly once.
+    ///
+    /// Detects the `NamedSSETransport` envelope shape structurally and
+    /// unwraps `__data` in the same pass. Malformed frames log at debug (no
+    /// `try?` — production code) and yield `json == nil`.
+    public static func make(from payload: String) -> ParsedFrame {
+        guard let data = payload.data(using: .utf8) else {
+            return ParsedFrame(raw: payload, json: nil, namedEvent: nil)
+        }
+
+        let object: Any?
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            Log.network.debug(
+                "ParsedFrame: non-JSON frame skipped (\(error.localizedDescription, privacy: .public))"
+            )
+            return ParsedFrame(raw: payload, json: nil, namedEvent: nil)
+        }
+
+        guard let object else {
+            return ParsedFrame(raw: payload, json: nil, namedEvent: nil)
+        }
+
+        let json = JSONValue(jsonObject: object)
+
+        // Structurally detect the NamedSSETransport envelope:
+        //   {"__event":"<name>","__data":"<json string>"}
+        // and unwrap `__data` in this same pass so the Responses consumer
+        // never re-parses the wrapper.
+        if let name = json[NamedSSETransport.eventNameKey]?.stringValue,
+           let inner = json[NamedSSETransport.eventDataKey]?.stringValue {
+            let dataJSON: JSONValue?
+            if let innerData = inner.data(using: .utf8) {
+                do {
+                    let innerObject = try JSONSerialization.jsonObject(with: innerData)
+                    dataJSON = JSONValue(jsonObject: innerObject)
+                } catch {
+                    Log.network.debug(
+                        "ParsedFrame: NamedSSE __data not JSON (\(error.localizedDescription, privacy: .public))"
+                    )
+                    dataJSON = nil
+                }
+            } else {
+                dataJSON = nil
+            }
+            return ParsedFrame(
+                raw: payload,
+                json: json,
+                namedEvent: (name: name, dataJSON: dataJSON, dataRaw: inner)
+            )
+        }
+
+        return ParsedFrame(raw: payload, json: json, namedEvent: nil)
+    }
+}

--- a/Sources/ManifoldCloudCore/StreamFinalizer.swift
+++ b/Sources/ManifoldCloudCore/StreamFinalizer.swift
@@ -39,6 +39,22 @@ public protocol StreamFinalizer: Sendable {
     ///     shape). Callers treat `nil` as "no termination signal" and let
     ///     framing decide whether to surface the frame.
     func finalize(frame: Data) -> StreamTermination?
+
+    /// Inspect one already-parsed frame and report whether it terminates the
+    /// stream. Real finalizers override this to read off `frame.json`
+    /// instead of re-parsing the payload bytes (the parse-once path). The
+    /// default re-encodes and delegates to ``finalize(frame:)-(Data)`` so
+    /// un-migrated finalizers keep working.
+    func finalize(frame: ParsedFrame) -> StreamTermination?
+}
+
+public extension StreamFinalizer {
+    /// Default: fall back to the `Data` surface. Only hit by finalizers that
+    /// haven't migrated to the parsed shape.
+    func finalize(frame: ParsedFrame) -> StreamTermination? {
+        guard let data = frame.raw.data(using: .utf8) else { return nil }
+        return finalize(frame: data)
+    }
 }
 
 /// Result type returned by ``StreamFinalizer/finalize(frame:)``.
@@ -91,6 +107,34 @@ public struct OpenAIDoneSentinelFinalizer: StreamFinalizer {
             return .streamComplete(usage: usage, stopReason: stopReason)
         }
         return .streamContinue
+    }
+
+    public func finalize(frame: ParsedFrame) -> StreamTermination? {
+        guard let parsed = frame.json else { return nil }
+        let usage = Self.extractUsage(parsed)
+        let stopReason = Self.extractStopReason(parsed)
+        if usage != nil || stopReason != nil {
+            return .streamComplete(usage: usage, stopReason: stopReason)
+        }
+        return .streamContinue
+    }
+
+    private static func extractUsage(_ parsed: JSONValue) -> StreamTermination.TokenUsage? {
+        guard let usage = parsed["usage"]?.objectValue else { return nil }
+        let prompt = usage["prompt_tokens"]?.intValue
+        let completion = usage["completion_tokens"]?.intValue
+        guard prompt != nil || completion != nil else { return nil }
+        return .init(promptTokens: prompt, completionTokens: completion)
+    }
+
+    private static func extractStopReason(_ parsed: JSONValue) -> String? {
+        guard let choices = parsed["choices"]?.objectArrayValue,
+              let first = choices.first,
+              let reason = first["finish_reason"]?.stringValue,
+              !reason.isEmpty else {
+            return nil
+        }
+        return reason
     }
 
     private static func extractUsage(_ parsed: [String: Any]) -> StreamTermination.TokenUsage? {
@@ -171,6 +215,47 @@ public struct OpenAIResponsesEventFinalizer: StreamFinalizer {
 
         return .streamContinue
     }
+
+    public func finalize(frame: ParsedFrame) -> StreamTermination? {
+        // On the wrapped path require the event name to be the terminal one,
+        // otherwise an intermediate event whose body happens to embed a
+        // `response` object would spuriously terminate the stream. Plain
+        // (un-wrapped) callers fall through to the structural usage check.
+        let body: JSONValue
+        if let named = frame.namedEvent {
+            if named.name != "response.completed" {
+                return .streamContinue
+            }
+            guard let dataJSON = named.dataJSON else { return nil }
+            body = dataJSON
+        } else {
+            guard let json = frame.json else { return nil }
+            body = json
+        }
+
+        if let response = body["response"]?.objectValue,
+           let usage = response["usage"]?.objectValue {
+            let prompt = usage["input_tokens"]?.intValue
+            let completion = usage["output_tokens"]?.intValue
+            return .streamComplete(
+                usage: .init(promptTokens: prompt, completionTokens: completion),
+                stopReason: response["status"]?.stringValue
+            )
+        }
+
+        if let usage = body["usage"]?.objectValue {
+            let prompt = usage["input_tokens"]?.intValue ?? usage["prompt_tokens"]?.intValue
+            let completion = usage["output_tokens"]?.intValue ?? usage["completion_tokens"]?.intValue
+            if prompt != nil || completion != nil {
+                return .streamComplete(
+                    usage: .init(promptTokens: prompt, completionTokens: completion),
+                    stopReason: nil
+                )
+            }
+        }
+
+        return .streamContinue
+    }
 }
 
 /// Finalizer for Anthropic Claude Messages API streams.
@@ -206,6 +291,22 @@ public struct ClaudeMessageStopFinalizer: StreamFinalizer {
             return .streamContinue
         }
     }
+
+    public func finalize(frame: ParsedFrame) -> StreamTermination? {
+        guard let parsed = frame.json,
+              let type = parsed["type"]?.stringValue else {
+            return nil
+        }
+        switch type {
+        case "message_stop":
+            let stopReason = parsed["message"]?.objectValue?["stop_reason"]?.stringValue
+            return .streamComplete(usage: nil, stopReason: stopReason)
+        case "message_delta":
+            return .streamContinue
+        default:
+            return .streamContinue
+        }
+    }
 }
 
 /// Finalizer for Ollama `/api/chat` and `/api/generate` NDJSON streams.
@@ -226,6 +327,19 @@ public struct OllamaDoneFlagFinalizer: StreamFinalizer {
         let prompt = parsed["prompt_eval_count"] as? Int
         let completion = parsed["eval_count"] as? Int
         let stopReason = parsed["done_reason"] as? String
+        return .streamComplete(
+            usage: .init(promptTokens: prompt, completionTokens: completion),
+            stopReason: stopReason
+        )
+    }
+
+    public func finalize(frame: ParsedFrame) -> StreamTermination? {
+        guard let parsed = frame.json else { return nil }
+        let done = parsed["done"]?.boolValue ?? false
+        guard done else { return .streamContinue }
+        let prompt = parsed["prompt_eval_count"]?.intValue
+        let completion = parsed["eval_count"]?.intValue
+        let stopReason = parsed["done_reason"]?.stringValue
         return .streamComplete(
             usage: .init(promptTokens: prompt, completionTokens: completion),
             stopReason: stopReason

--- a/Sources/ManifoldCloudSaaS/ClaudeStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeStreamEventExtractor.swift
@@ -31,64 +31,89 @@ enum ClaudePayloadParser {
     }
 
     static func parseEventType(from json: String) -> String? {
-        guard let parsed = parseObject(json) else { return nil }
-        return parsed["type"] as? String
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseEventType(from: parsed)
+    }
+
+    static func parseEventType(from json: JSONValue) -> String? {
+        json["type"]?.stringValue
     }
 
     static func parseToolUseBlockStart(from json: String) -> ToolUseBlockStart? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "content_block_start",
-              let index = parsed["index"] as? Int,
-              let block = parsed["content_block"] as? [String: Any],
-              block["type"] as? String == "tool_use",
-              let id = block["id"] as? String, !id.isEmpty,
-              let name = block["name"] as? String, !name.isEmpty else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseToolUseBlockStart(from: parsed)
+    }
+
+    static func parseToolUseBlockStart(from json: JSONValue) -> ToolUseBlockStart? {
+        guard json["type"]?.stringValue == "content_block_start",
+              let index = json["index"]?.intValue,
+              let block = json["content_block"]?.objectValue,
+              block["type"]?.stringValue == "tool_use",
+              let id = block["id"]?.stringValue, !id.isEmpty,
+              let name = block["name"]?.stringValue, !name.isEmpty else {
             return nil
         }
         return ToolUseBlockStart(index: index, id: id, name: name)
     }
 
     static func parseInputJSONDelta(from json: String) -> InputJSONDelta? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "content_block_delta",
-              let index = parsed["index"] as? Int,
-              let delta = parsed["delta"] as? [String: Any],
-              delta["type"] as? String == "input_json_delta",
-              let partial = delta["partial_json"] as? String else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseInputJSONDelta(from: parsed)
+    }
+
+    static func parseInputJSONDelta(from json: JSONValue) -> InputJSONDelta? {
+        guard json["type"]?.stringValue == "content_block_delta",
+              let index = json["index"]?.intValue,
+              let delta = json["delta"]?.objectValue,
+              delta["type"]?.stringValue == "input_json_delta",
+              let partial = delta["partial_json"]?.stringValue else {
             return nil
         }
         return InputJSONDelta(index: index, partialJSON: partial)
     }
 
     static func parseContentBlockIndex(from json: String) -> Int? {
-        parseObject(json)?["index"] as? Int
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseContentBlockIndex(from: parsed)
+    }
+
+    static func parseContentBlockIndex(from json: JSONValue) -> Int? {
+        json["index"]?.intValue
     }
 
     static func parseWholeMessageToolUseBlocks(from json: String) -> [WholeToolUseBlock]? {
-        guard let parsed = parseObject(json) else { return nil }
-        guard parsed["type"] as? String == "message",
-              let content = parsed["content"] as? [[String: Any]] else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseWholeMessageToolUseBlocks(from: parsed)
+    }
+
+    static func parseWholeMessageToolUseBlocks(from json: JSONValue) -> [WholeToolUseBlock]? {
+        guard json["type"]?.stringValue == "message",
+              let content = json["content"]?.objectArrayValue else {
             return nil
         }
         var result: [WholeToolUseBlock] = []
         for block in content {
-            guard block["type"] as? String == "tool_use",
-                  let id = block["id"] as? String, !id.isEmpty,
-                  let name = block["name"] as? String, !name.isEmpty else {
+            guard block["type"]?.stringValue == "tool_use",
+                  let id = block["id"]?.stringValue, !id.isEmpty,
+                  let name = block["name"]?.stringValue, !name.isEmpty else {
                 continue
             }
-            let input = block["input"] ?? [String: Any]()
+            let input = block["input"] ?? .object([:])
             result.append(WholeToolUseBlock(id: id, name: name, serializedInput: serializeInputObject(input)))
         }
         return result
     }
 
     static func parseThinkingBlockStartSignature(from json: String) -> String? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "content_block_start",
-              let block = parsed["content_block"] as? [String: Any],
-              block["type"] as? String == "thinking",
-              let signature = block["signature"] as? String,
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseThinkingBlockStartSignature(from: parsed)
+    }
+
+    static func parseThinkingBlockStartSignature(from json: JSONValue) -> String? {
+        guard json["type"]?.stringValue == "content_block_start",
+              let block = json["content_block"]?.objectValue,
+              block["type"]?.stringValue == "thinking",
+              let signature = block["signature"]?.stringValue,
               !signature.isEmpty else {
             return nil
         }
@@ -96,11 +121,15 @@ enum ClaudePayloadParser {
     }
 
     static func parseSignatureDelta(from json: String) -> String? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "content_block_delta",
-              let delta = parsed["delta"] as? [String: Any],
-              delta["type"] as? String == "signature_delta",
-              let signature = delta["signature"] as? String,
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseSignatureDelta(from: parsed)
+    }
+
+    static func parseSignatureDelta(from json: JSONValue) -> String? {
+        guard json["type"]?.stringValue == "content_block_delta",
+              let delta = json["delta"]?.objectValue,
+              delta["type"]?.stringValue == "signature_delta",
+              let signature = delta["signature"]?.stringValue,
               !signature.isEmpty else {
             return nil
         }
@@ -108,29 +137,37 @@ enum ClaudePayloadParser {
     }
 
     static func parseThinkingDelta(from json: String) -> String? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "content_block_delta",
-              let delta = parsed["delta"] as? [String: Any],
-              delta["type"] as? String == "thinking_delta",
-              let thinking = delta["thinking"] as? String else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseThinkingDelta(from: parsed)
+    }
+
+    static func parseThinkingDelta(from json: JSONValue) -> String? {
+        guard json["type"]?.stringValue == "content_block_delta",
+              let delta = json["delta"]?.objectValue,
+              delta["type"]?.stringValue == "thinking_delta",
+              let thinking = delta["thinking"]?.stringValue else {
             return nil
         }
         return thinking
     }
 
     static func parseToken(from json: String) -> String? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "content_block_delta",
-              let delta = parsed["delta"] as? [String: Any],
-              let text = delta["text"] as? String else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseToken(from: parsed)
+    }
+
+    static func parseToken(from json: JSONValue) -> String? {
+        guard json["type"]?.stringValue == "content_block_delta",
+              let delta = json["delta"]?.objectValue,
+              let text = delta["text"]?.stringValue else {
             return nil
         }
         return text
     }
 
     static func parseIsStreamEnd(_ json: String) -> Bool {
-        guard let type = parseObject(json)?["type"] as? String else { return false }
-        return type == "message_stop"
+        guard let parsed = JSONValue.parse(string: json) else { return false }
+        return parsed["type"]?.stringValue == "message_stop"
     }
 
     struct CacheUsage {
@@ -139,22 +176,24 @@ enum ClaudePayloadParser {
     }
 
     static func parseUsage(from json: String) -> (promptTokens: Int?, completionTokens: Int?)? {
-        guard let parsed = parseObject(json),
-              let type = parsed["type"] as? String else {
-            return nil
-        }
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseUsage(from: parsed)
+    }
+
+    static func parseUsage(from json: JSONValue) -> (promptTokens: Int?, completionTokens: Int?)? {
+        guard let type = json["type"]?.stringValue else { return nil }
 
         switch type {
         case "message_start":
-            guard let message = parsed["message"] as? [String: Any],
-                  let usage = message["usage"] as? [String: Any],
-                  let inputTokens = usage["input_tokens"] as? Int else {
+            guard let message = json["message"]?.objectValue,
+                  let usage = message["usage"]?.objectValue,
+                  let inputTokens = usage["input_tokens"]?.intValue else {
                 return nil
             }
             return (promptTokens: inputTokens, completionTokens: nil)
         case "message_delta":
-            guard let usage = parsed["usage"] as? [String: Any],
-                  let outputTokens = usage["output_tokens"] as? Int else {
+            guard let usage = json["usage"]?.objectValue,
+                  let outputTokens = usage["output_tokens"]?.intValue else {
                 return nil
             }
             return (promptTokens: nil, completionTokens: outputTokens)
@@ -169,14 +208,18 @@ enum ClaudePayloadParser {
     /// activity occurred, not a parse failure, so we treat them as optional
     /// with a zero fallback rather than nil-gating the whole result.
     static func parseCacheUsage(from json: String) -> CacheUsage? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "message_start",
-              let message = parsed["message"] as? [String: Any],
-              let usage = message["usage"] as? [String: Any] else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseCacheUsage(from: parsed)
+    }
+
+    static func parseCacheUsage(from json: JSONValue) -> CacheUsage? {
+        guard json["type"]?.stringValue == "message_start",
+              let message = json["message"]?.objectValue,
+              let usage = message["usage"]?.objectValue else {
             return nil
         }
-        let creation = usage["cache_creation_input_tokens"] as? Int ?? 0
-        let read = usage["cache_read_input_tokens"] as? Int ?? 0
+        let creation = usage["cache_creation_input_tokens"]?.intValue ?? 0
+        let read = usage["cache_read_input_tokens"]?.intValue ?? 0
         // Only materialise a CacheUsage when there is actual cache activity to
         // report — avoids a debug log on every non-cached turn.
         guard creation > 0 || read > 0 else { return nil }
@@ -184,30 +227,26 @@ enum ClaudePayloadParser {
     }
 
     static func parseStreamError(from json: String) -> CloudBackendError? {
-        guard let parsed = parseObject(json),
-              parsed["type"] as? String == "error",
-              let error = parsed["error"] as? [String: Any],
-              let message = error["message"] as? String else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseStreamError(from: parsed)
+    }
+
+    static func parseStreamError(from json: JSONValue) -> CloudBackendError? {
+        guard json["type"]?.stringValue == "error",
+              let error = json["error"]?.objectValue,
+              let message = error["message"]?.stringValue else {
             return nil
         }
         return .sanitizedParseError(message)
     }
 
-    private static func parseObject(_ json: String) -> [String: Any]? {
-        guard let data = json.data(using: .utf8) else { return nil }
-        do {
-            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        } catch {
-            return nil
-        }
-    }
-
-    private static func serializeInputObject(_ value: Any) -> String {
-        guard JSONSerialization.isValidJSONObject(value) else {
+    private static func serializeInputObject(_ value: JSONValue) -> String {
+        let foundationValue = value.foundationObject
+        guard JSONSerialization.isValidJSONObject(foundationValue) else {
             return "{}"
         }
         do {
-            let data = try JSONSerialization.data(withJSONObject: value, options: [])
+            let data = try JSONSerialization.data(withJSONObject: foundationValue, options: [])
             return String(data: data, encoding: .utf8) ?? "{}"
         } catch {
             Log.inference.warning(
@@ -318,6 +357,19 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
     ///      tool_use blocks → flush + uniform start/delta/call triples
     ///   8. usage on `message_start` / `message_delta` → `.usage`
     public func consume(payload: String) -> [GenerationEvent] {
+        guard let json = JSONValue.parse(string: payload) else { return [] }
+        return consume(json: json)
+    }
+
+    /// Parse-once entry point. Reads the already-parsed frame; the
+    /// stringly-typed ``consume(payload:)`` is a thin wrapper retained for
+    /// legacy callers and per-payload tests.
+    public func consume(frame: ParsedFrame) -> [GenerationEvent] {
+        guard let json = frame.json else { return [] }
+        return consume(json: json)
+    }
+
+    private func consume(json payload: JSONValue) -> [GenerationEvent] {
         var out: [GenerationEvent] = []
 
         let eventType = ClaudePayloadParser.parseEventType(from: payload)
@@ -374,7 +426,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
         // 6. Thinking + plain text deltas — route via the stateless handler
         //    surface (it classifies thinking_delta vs. text_delta in one
         //    place) and gate the thinking-handoff transition here.
-        let handlerEvents = CloudPayloadHandler.claude.extractEvents(from: payload)
+        let handlerEvents = Self.claudeHandlerEvents(from: payload)
         for event in handlerEvents {
             switch event {
             case .thinkingToken:
@@ -415,7 +467,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
         //    `ClaudeBackend.parseResponseStream` semantics (which got the
         //    same merge for free via `SSECloudBackend.handleUsage`'s
         //    bookkeeping).
-        if let usage = CloudPayloadHandler.claude.extractUsage(from: payload) {
+        if let usage = ClaudePayloadParser.parseUsage(from: payload) {
             if let prompt = usage.promptTokens {
                 pendingPromptTokens = prompt
             }
@@ -460,6 +512,20 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
     }
 
     // MARK: - Internal helpers
+
+    /// Parse-once mirror of ``ClaudeMessagesPayloadHandler/extractEvents(from:)``
+    /// — thinking_delta → `.thinkingToken`, text_delta → `.token`. Kept here
+    /// so the extractor reads off the already-parsed frame instead of
+    /// round-tripping through the stringly-typed handler surface.
+    private static func claudeHandlerEvents(from json: JSONValue) -> [GenerationEvent] {
+        if let thinking = ClaudePayloadParser.parseThinkingDelta(from: json) {
+            return [.thinkingToken(thinking)]
+        }
+        if let token = ClaudePayloadParser.parseToken(from: json) {
+            return [.token(token)]
+        }
+        return []
+    }
 
     private func flushThinking(into out: inout [GenerationEvent]) {
         guard thinking.isOpen else { return }

--- a/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
@@ -361,11 +361,12 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
 
     /// Extracts a `delta` string from a Responses-API event payload.
     static func parseDelta(from json: String) -> String? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
-        return parsed["delta"] as? String
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseDelta(from: parsed)
+    }
+
+    static func parseDelta(from json: JSONValue) -> String? {
+        json["delta"]?.stringValue
     }
 
     /// Extracts a usage tuple from a `response.completed` payload.
@@ -375,24 +376,24 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
     /// {"response":{"usage":{"input_tokens":12,"output_tokens":8}}}
     /// ```
     static func parseUsage(from json: String) -> (promptTokens: Int?, completionTokens: Int?)? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseUsage(from: parsed)
+    }
+
+    static func parseUsage(from json: JSONValue) -> (promptTokens: Int?, completionTokens: Int?)? {
         // The usage block can sit at the top level (`{"usage":{...}}`) or
         // nested under `response` — accept either.
-        let usage: [String: Any]?
-        if let top = parsed["usage"] as? [String: Any] {
+        let usage: [String: JSONValue]?
+        if let top = json["usage"]?.objectValue {
             usage = top
-        } else if let response = parsed["response"] as? [String: Any],
-                  let nested = response["usage"] as? [String: Any] {
+        } else if let nested = json["response"]?.objectValue?["usage"]?.objectValue {
             usage = nested
         } else {
             usage = nil
         }
         guard let usage else { return nil }
-        let prompt = usage["input_tokens"] as? Int ?? usage["prompt_tokens"] as? Int
-        let completion = usage["output_tokens"] as? Int ?? usage["completion_tokens"] as? Int
+        let prompt = usage["input_tokens"]?.intValue ?? usage["prompt_tokens"]?.intValue
+        let completion = usage["output_tokens"]?.intValue ?? usage["completion_tokens"]?.intValue
         if prompt == nil && completion == nil { return nil }
         return (prompt, completion)
     }
@@ -412,20 +413,21 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
     /// `type == "function_call"`. Returns `nil` for unrelated items
     /// (e.g. reasoning, message).
     static func parseFunctionCallItem(from json: String) -> FunctionCallItemInfo? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let item = parsed["item"] as? [String: Any] else {
-            return nil
-        }
-        guard (item["type"] as? String) == "function_call" else { return nil }
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseFunctionCallItem(from: parsed)
+    }
+
+    static func parseFunctionCallItem(from json: JSONValue) -> FunctionCallItemInfo? {
+        guard let item = json["item"]?.objectValue else { return nil }
+        guard item["type"]?.stringValue == "function_call" else { return nil }
         // item.id is the streaming-internal handle; call_id is the value the
         // model used to refer to this call (and what we feed back to the
         // server in `function_call_output.call_id`). Both are required.
-        guard let itemId = item["id"] as? String, !itemId.isEmpty,
-              let callId = item["call_id"] as? String, !callId.isEmpty else {
+        guard let itemId = item["id"]?.stringValue, !itemId.isEmpty,
+              let callId = item["call_id"]?.stringValue, !callId.isEmpty else {
             return nil
         }
-        let name = (item["name"] as? String) ?? ""
+        let name = item["name"]?.stringValue ?? ""
         return FunctionCallItemInfo(itemId: itemId, callId: callId, name: name)
     }
 
@@ -436,14 +438,15 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
     }
 
     static func parseFunctionCallArgumentsDelta(from json: String) -> FunctionCallArgumentsDelta? {
-        guard let data = json.data(using: .utf8),
-              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard let parsed = JSONValue.parse(string: json) else { return nil }
+        return parseFunctionCallArgumentsDelta(from: parsed)
+    }
+
+    static func parseFunctionCallArgumentsDelta(from json: JSONValue) -> FunctionCallArgumentsDelta? {
+        guard let itemId = json["item_id"]?.stringValue, !itemId.isEmpty else {
             return nil
         }
-        guard let itemId = parsed["item_id"] as? String, !itemId.isEmpty else {
-            return nil
-        }
-        let delta = (parsed["delta"] as? String) ?? ""
+        let delta = json["delta"]?.stringValue ?? ""
         return FunctionCallArgumentsDelta(itemId: itemId, delta: delta)
     }
 
@@ -500,9 +503,19 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
         return [.thinkingToken(delta)]
     }
 
+    static func eventsForReasoningDelta(data: JSONValue) -> [GenerationEvent] {
+        guard let delta = parseDelta(from: data), !delta.isEmpty else { return [] }
+        return [.thinkingToken(delta)]
+    }
+
     /// Maps a `response.output_text.delta` payload to the events the
     /// dispatcher should yield.
     static func eventsForOutputTextDelta(data: String) -> [GenerationEvent] {
+        guard let delta = parseDelta(from: data), !delta.isEmpty else { return [] }
+        return [.token(delta)]
+    }
+
+    static func eventsForOutputTextDelta(data: JSONValue) -> [GenerationEvent] {
         guard let delta = parseDelta(from: data), !delta.isEmpty else { return [] }
         return [.token(delta)]
     }

--- a/Sources/ManifoldCloudSaaS/OpenAIResponsesStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIResponsesStreamEventExtractor.swift
@@ -99,6 +99,20 @@ public final class OpenAIResponsesStreamEventExtractor: CloudStreamEventConsumer
         return events(forEvent: envelope.name, data: envelope.data)
     }
 
+    /// Parse-once entry point. The envelope (`__event` + `__data`) was
+    /// unwrapped and `__data` parsed in a single pass at the
+    /// ``ParsedFrame`` build site, so this reads `frame.namedEvent` without
+    /// re-parsing.
+    public func consume(frame: ParsedFrame) -> [GenerationEvent] {
+        guard let named = frame.namedEvent else { return [] }
+        guard let dataJSON = named.dataJSON else {
+            // Inner `__data` wasn't JSON — fall back to the string surface so
+            // behaviour matches the legacy path exactly.
+            return events(forEvent: named.name, data: named.dataRaw)
+        }
+        return events(forEvent: named.name, dataJSON: dataJSON)
+    }
+
     /// Flushes pending state at stream end. Yields a trailing
     /// `.thinkingCompleted` if a thinking block is still open and finalises
     /// any buffered tool calls the upstream didn't accompany with a
@@ -119,6 +133,17 @@ public final class OpenAIResponsesStreamEventExtractor: CloudStreamEventConsumer
     // MARK: - Per-event dispatch
 
     func events(forEvent name: String, data: String) -> [GenerationEvent] {
+        guard let json = JSONValue.parse(string: data) else {
+            // Non-JSON data body — only the (no-op) structural / error /
+            // unknown arms can run, and they don't read the body. Route
+            // through the JSONValue path with a null body to keep dispatch
+            // in one place.
+            return events(forEvent: name, dataJSON: .null)
+        }
+        return events(forEvent: name, dataJSON: json)
+    }
+
+    func events(forEvent name: String, dataJSON data: JSONValue) -> [GenerationEvent] {
         var out: [GenerationEvent] = []
         switch OpenAIResponsesBackend.ResponsesEventKind(name: name) {
         case .reasoningDelta:

--- a/Sources/ManifoldCloudSaaS/OpenAIStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIStreamEventExtractor.swift
@@ -64,6 +64,19 @@ public final class OpenAIStreamEventExtractor: CloudStreamEventConsumer, @unchec
     ///   6. `usage` → `.usage`
     ///   7. `finish_reason` → finalise buffered tool calls (`.toolCall` × N)
     public func consume(payload: String) -> [GenerationEvent] {
+        guard let json = JSONValue.parse(string: payload) else { return [] }
+        return consume(json: json)
+    }
+
+    /// Parse-once entry point. Reads the already-parsed frame; the
+    /// stringly-typed ``consume(payload:)`` is a thin wrapper retained for
+    /// legacy callers and per-payload tests.
+    public func consume(frame: ParsedFrame) -> [GenerationEvent] {
+        guard let json = frame.json else { return [] }
+        return consume(json: json)
+    }
+
+    private func consume(json payload: JSONValue) -> [GenerationEvent] {
         var out: [GenerationEvent] = []
 
         if let progress = OpenAIChatCompletionsPayloadParsing.parsePrefillProgress(from: payload) {

--- a/Tests/ManifoldBackendsTests/ParsedFrameParseOnceTests.swift
+++ b/Tests/ManifoldBackendsTests/ParsedFrameParseOnceTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+import Foundation
+@testable import ManifoldOllama
+@testable import ManifoldCloudSaaS
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+
+/// Proves the parse-once migration (`ParsedFrame` / `JSONValue`) produces
+/// **provably unchanged** output versus the legacy per-field re-parse path.
+///
+/// Coverage:
+/// - `JSONValue` reproduces `NSNumber`'s Int-vs-Double-vs-Bool casts exactly
+///   (the #1 risk: a coercion regression would silently drop usage counts).
+/// - Differential: every fixture through both `consume(payload:)` and
+///   `consume(frame:)` yields identical event arrays per frame.
+/// - Finalizer equivalence: `finalize(frame: ParsedFrame)` ==
+///   `finalize(frame: Data)` on terminal + non-terminal frames.
+/// - Non-JSON frames (`[DONE]`, keepalive, malformed, empty) → `json == nil`
+///   and zero events.
+final class ParsedFrameParseOnceTests: XCTestCase {
+
+    // MARK: - JSONValue number coercion fidelity (the #1 risk)
+
+    func test_jsonValue_reproducesNSNumberIntDoubleBoolCasts() {
+        // Mirrors the legacy `as? Int` / `as? Double` / `as? Bool` semantics
+        // on a JSONSerialization NSNumber tree.
+        let json = """
+        {"intVal":25,"wholeFloat":100.0,"frac":3.5,"boolTrue":true,"boolFalse":false,"one":1}
+        """
+        guard let v = JSONValue.parse(string: json) else {
+            return XCTFail("parse failed")
+        }
+
+        // Plain integers.
+        XCTAssertEqual(v["intVal"]?.intValue, 25)
+        XCTAssertEqual(v["intVal"]?.doubleValue, 25.0)
+        XCTAssertNil(v["intVal"]?.boolValue, "a numeric int is not a bool")
+
+        // Whole float decodes as .number but still recovers as Int (100.0 → 100),
+        // exactly matching `100.0 as? Int == 100`.
+        XCTAssertEqual(v["wholeFloat"]?.intValue, 100)
+        XCTAssertEqual(v["wholeFloat"]?.doubleValue, 100.0)
+
+        // Fractional float: Int recovery fails (3.5 as? Int == nil).
+        XCTAssertNil(v["frac"]?.intValue)
+        XCTAssertEqual(v["frac"]?.doubleValue, 3.5)
+
+        // Booleans: boolValue succeeds; intValue mirrors `true as? Int == 1`.
+        XCTAssertEqual(v["boolTrue"]?.boolValue, true)
+        XCTAssertEqual(v["boolTrue"]?.intValue, 1)
+        XCTAssertEqual(v["boolFalse"]?.boolValue, false)
+        XCTAssertEqual(v["boolFalse"]?.intValue, 0)
+
+        // A numeric 1 must NOT read as a bool (1 as? Bool == nil).
+        XCTAssertNil(v["one"]?.boolValue)
+        XCTAssertEqual(v["one"]?.intValue, 1)
+    }
+
+    func test_jsonValue_usageCounts_survive_wholeFloatEncoding() {
+        // A compat server that emits usage as floats (25.0 / 100.0) must not
+        // drop the counts — this is the exact silent-drop failure mode.
+        let payload = """
+        {"choices":[],"usage":{"prompt_tokens":25.0,"completion_tokens":100.0}}
+        """
+        let usage = OpenAIChatCompletionsPayloadParsing.parseUsage(from: payload)
+        XCTAssertEqual(usage?.promptTokens, 25)
+        XCTAssertEqual(usage?.completionTokens, 100)
+    }
+
+    // MARK: - Non-JSON frames
+
+    func test_parsedFrame_nonJSONFrames_haveNilJSON() {
+        for payload in ["[DONE]", "", ": keepalive", "{not json", "  "] {
+            let frame = ParsedFrame.make(from: payload)
+            XCTAssertNil(frame.json, "non-JSON frame \"\(payload)\" must have json == nil")
+            XCTAssertNil(frame.namedEvent)
+            XCTAssertEqual(frame.raw, payload)
+        }
+    }
+
+    func test_extractors_nonJSONFrames_emitZeroEvents() {
+        let openAI = OpenAIStreamEventExtractor()
+        let claude = ClaudeStreamEventExtractor()
+        let responses = OpenAIResponsesStreamEventExtractor()
+        for payload in ["[DONE]", "", ": keepalive", "{not json"] {
+            let frame = ParsedFrame.make(from: payload)
+            XCTAssertTrue(openAI.consume(frame: frame).isEmpty)
+            XCTAssertTrue(claude.consume(frame: frame).isEmpty)
+            XCTAssertTrue(responses.consume(frame: frame).isEmpty)
+        }
+    }
+
+    // MARK: - Differential: consume(payload:) == consume(frame:)
+
+    private func assertDifferential(
+        _ payloads: [String],
+        makeConsumerA: () -> any CloudStreamEventConsumer,
+        makeConsumerB: () -> any CloudStreamEventConsumer,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        // Two fresh consumers (each carries per-stream state) so the string
+        // path and the frame path see identical history.
+        let a = makeConsumerA()
+        let b = makeConsumerB()
+        for payload in payloads {
+            let viaString = a.consume(payload: payload)
+            let viaFrame = b.consume(frame: ParsedFrame.make(from: payload))
+            XCTAssertEqual(
+                viaString, viaFrame,
+                "differential drift on frame: \(payload)",
+                file: file, line: line
+            )
+        }
+        XCTAssertEqual(a.finish(cancelled: false), b.finish(cancelled: false),
+                       "finish() drift", file: file, line: line)
+    }
+
+    func test_differential_openAI_tokensReasoningToolCallsUsage() {
+        let payloads = [
+            #"{"choices":[{"delta":{"role":"assistant","content":""}}]}"#,
+            #"{"choices":[{"delta":{"reasoning_content":"thinking…"}}]}"#,
+            #"{"choices":[{"delta":{"content":"Hello"}}]}"#,
+            #"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":""}}]}}]}"#,
+            #"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"SF\"}"}}]}}]}"#,
+            #"{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+            #"{"choices":[],"usage":{"prompt_tokens":25,"completion_tokens":100}}"#,
+        ]
+        assertDifferential(payloads,
+                           makeConsumerA: { OpenAIStreamEventExtractor() },
+                           makeConsumerB: { OpenAIStreamEventExtractor() })
+    }
+
+    func test_differential_claude_thinkingTextToolUseUsage() {
+        let payloads = [
+            #"{"type":"message_start","message":{"id":"m","type":"message","role":"assistant","content":[],"usage":{"input_tokens":12,"output_tokens":0}}}"#,
+            #"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
+            #"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}"#,
+            #"{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig123"}}"#,
+            #"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+            #"{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu_1","name":"lookup"}}"#,
+            #"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"q\":1}"}}"#,
+            #"{"type":"content_block_stop","index":1}"#,
+            #"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":48}}"#,
+            #"{"type":"message_stop"}"#,
+        ]
+        assertDifferential(payloads,
+                           makeConsumerA: { ClaudeStreamEventExtractor() },
+                           makeConsumerB: { ClaudeStreamEventExtractor() })
+    }
+
+    func test_differential_responses_reasoningTextToolCallUsage() {
+        // The Responses extractor consumes NamedSSETransport envelopes.
+        let payloads: [String] = [
+            envelope("response.reasoning_summary_text.delta", #"{"delta":"think"}"#),
+            envelope("response.reasoning_summary_text.done", #"{}"#),
+            envelope("response.output_text.delta", #"{"delta":"Hello"}"#),
+            envelope("response.output_item.added", #"{"item":{"type":"function_call","id":"item_1","call_id":"call_1","name":"do_thing"}}"#),
+            envelope("response.function_call_arguments.delta", #"{"item_id":"item_1","delta":"{\"a\":1}"}"#),
+            envelope("response.completed", #"{"response":{"status":"completed","usage":{"input_tokens":12,"output_tokens":8}}}"#),
+        ]
+        assertDifferential(payloads,
+                           makeConsumerA: { OpenAIResponsesStreamEventExtractor() },
+                           makeConsumerB: { OpenAIResponsesStreamEventExtractor() })
+    }
+
+    // MARK: - Finalizer equivalence (Data vs ParsedFrame)
+
+    private func assertFinalizerEquivalent(
+        _ finalizer: any StreamFinalizer,
+        _ payloads: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for payload in payloads {
+            let viaData = finalizer.finalize(frame: Data(payload.utf8))
+            let viaFrame = finalizer.finalize(frame: ParsedFrame.make(from: payload))
+            XCTAssertEqual(viaData, viaFrame, "finalizer drift on: \(payload)",
+                           file: file, line: line)
+        }
+    }
+
+    func test_finalizer_openAI_terminalAndNonTerminal() {
+        assertFinalizerEquivalent(OpenAIDoneSentinelFinalizer(), [
+            #"{"choices":[{"delta":{"content":"x"}}]}"#,                    // continue
+            #"{"choices":[{"delta":{},"finish_reason":"stop"}]}"#,         // complete (stop)
+            #"{"choices":[],"usage":{"prompt_tokens":25,"completion_tokens":100}}"#, // trailing usage
+            #"{"choices":[],"usage":{"prompt_tokens":25.0,"completion_tokens":100.0}}"#, // float usage
+        ])
+    }
+
+    func test_finalizer_claude_messageDeltaContinues_messageStopCompletes() {
+        assertFinalizerEquivalent(ClaudeMessageStopFinalizer(), [
+            #"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}"#,
+            #"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":48}}"#,
+            #"{"type":"message_stop","message":{"stop_reason":"end_turn"}}"#,
+        ])
+    }
+
+    func test_finalizer_ollama_doneFlag() {
+        assertFinalizerEquivalent(OllamaDoneFlagFinalizer(), [
+            #"{"message":{"content":"x"},"done":false}"#,
+            #"{"done":true,"done_reason":"stop","prompt_eval_count":25,"eval_count":100}"#,
+        ])
+    }
+
+    func test_finalizer_responses_envelopeTerminalAndIntermediate() {
+        let finalizer = OpenAIResponsesEventFinalizer()
+        // Intermediate event with the wrapper must NOT terminate even if it
+        // embeds a response object.
+        let intermediate = envelope("response.output_item.added", #"{"response":{"usage":{"input_tokens":1,"output_tokens":2}}}"#)
+        let terminal = envelope("response.completed", #"{"response":{"status":"completed","usage":{"input_tokens":12,"output_tokens":8}}}"#)
+        assertFinalizerEquivalent(finalizer, [intermediate, terminal])
+    }
+
+    // MARK: - Helpers
+
+    /// Encodes a NamedSSETransport envelope the way the transport does at
+    /// runtime (`{"__event":..,"__data":"<json string>"}`).
+    private func envelope(_ name: String, _ data: String) -> String {
+        let obj: [String: Any] = [
+            NamedSSETransport.eventNameKey: name,
+            NamedSSETransport.eventDataKey: data,
+        ]
+        let bytes = try! JSONSerialization.data(withJSONObject: obj)
+        return String(data: bytes, encoding: .utf8)!
+    }
+}


### PR DESCRIPTION
## Problem

Every cloud SSE/NDJSON frame (~1 per streamed token) was fully JSON-parsed **8×** (OpenAI Chat Completions) to **8–12×** (Claude): each field-extractor independently ran `String → Data → JSONSerialization.jsonObject`, and `StreamFinalizer.finalize` re-parsed every frame on top.

## Fix: parse once

- **`ParsedFrame` + `JSONValue`** (`Sources/ManifoldCloudCore/ParsedFrame.swift`) — a fully `Sendable` JSON value tree. No `[String: Any]` (not `Sendable` — would fail Swift 6 region isolation across the `AsyncStream` boundary) and no `@unchecked Sendable`.
  - `JSONValue` reproduces `NSNumber`'s Int-vs-Double-vs-Bool cast semantics **exactly**: `100.0 as? Int == 100`, `true as? Int == 1`, `3.5 as? Int == nil`, `1 as? Bool == nil`. This is the #1 risk — a regression would silently drop usage counts; it has a direct test.
- **Single parse site** in `CloudRoutedStreamParser.parse`: builds one `ParsedFrame` right after decoding the payload string. The Responses `__event`/`__data` envelope is detected structurally and `__data` unwrapped in the same pass. Malformed frames `do/catch` + `Log.network.debug` (no `try?`); `json == nil`.
- **Additive protocol methods** (no contract-suite breakage):
  - `CloudStreamEventConsumer.consume(frame: ParsedFrame)` with a default delegating to `consume(payload: frame.raw)`; overridden in the three real extractors to read `frame.json` / `frame.namedEvent`.
  - `StreamFinalizer.finalize(frame: ParsedFrame)` with a default delegating to `finalize(frame: Data)`; overridden in all four concrete finalizers.
  - `JSONValue` overloads of every `parse*` helper on `OpenAIChatCompletionsPayloadParsing`, `ClaudePayloadParser`, and the Responses backend helpers. The existing `String` overloads stay as thin parse-once-then-delegate wrappers, so legacy `SSEPayloadHandler` callers and per-payload tests keep working.
- The finalizer still **runs on every frame** to detect the terminal one — it just reads `frame.json` instead of re-parsing. No termination/usage behavior change.

`CloudAdapterRouting` / `streamConsumerFactory` signatures unchanged.

### Parse counts per frame (before → after)

| Provider | Before | After |
|----------|--------|-------|
| OpenAI Chat Completions | 8 | 1 |
| Claude | 8–12 | 1 |
| OpenAI Responses | ~6–9 | 2 (envelope + inner `__data`) |

The `NamedSSETransport` envelope **encode** stays (out of scope); only the consumer-side re-parse is removed.

## Tests (output provably unchanged)

- **Existing parity/replay suites pass unchanged** against the new path (`OpenAIStreamEventExtractorTests`, `ClaudeStreamEventExtractorTests`, `OpenAIResponsesStreamEventExtractorTests`, `SSEPayloadReplayTests`, `ClaudeStructuredReplayTests`, `CrossBackendReplayParityTests`) — equal `GenerationEvent` sequences = no drift. Primary proof.
- **New `ParsedFrameParseOnceTests`**:
  - Differential: same fixtures through both `consume(payload:)` and `consume(frame:)` → identical event arrays per frame, across all three extractors (directly guards the Int/Double coercion corner).
  - Finalizer equivalence: `finalize(frame: ParsedFrame)` == `finalize(frame: Data)` across all four finalizers on terminal + non-terminal frames (Claude `message_delta` → `.streamContinue`, OpenAI trailing usage chunk, Responses intermediate envelope).
  - Malformed / empty / `[DONE]` / keepalive → `json == nil` and zero events.
  - Direct NSNumber-coercion fidelity test, including float-encoded usage (`25.0`/`100.0`). Sabotage-verified (broke `.number → Int(exactly:)`, confirmed 4 failures, reverted).

## Gate

`scripts/test.sh --profile local`: **Passed: 4994, Failed: 0**. `RESULT: INCOMPLETE` due to the known non-deterministic teardown signal-11 in an unrelated suite cluster (no failing assertion; documented local-env artifact, CI runs clean). Optional-traits sweep `swift build --build-tests --traits Server,Macros` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
