### PR TITLE
perf: bound RepetitionDetector loop scan to the tail (O(n²)→O(n))

### DIFF
--- a/Sources/ManifoldInference/Services/RepetitionDetector.swift
+++ b/Sources/ManifoldInference/Services/RepetitionDetector.swift
@@ -15,7 +15,15 @@ public enum RepetitionDetector {
     ///
     /// Requires at least 100 characters for 2x detection and 48 for 3x detection.
     public static func looksLikeLooping(_ text: String) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        // The algorithm only ever inspects the tail: 2x detection compares the last
+        // 200-char unit against the preceding 200 (≤400 chars), and 3x detection the
+        // last three 120-char units (≤360 chars). Bounding the input to the final 500
+        // characters keeps each call O(1) in accumulated length instead of O(n) — this
+        // detector is called once per streamed token over the whole accumulated text.
+        // Behaviour is preserved exactly: detection is purely tail-local, and the
+        // `count >= 100` / `count >= 48` thresholds saturate immediately past the bound.
+        let tail = text.suffix(500)
+        let trimmed = tail.trimmingCharacters(in: .whitespacesAndNewlines)
         let characters = Array(trimmed)
 
         // 2x detection for longer units (50+ chars repeated twice).

--- a/Tests/ManifoldInferenceSwiftTestingTests/RepetitionDetectorTests.swift
+++ b/Tests/ManifoldInferenceSwiftTestingTests/RepetitionDetectorTests.swift
@@ -109,6 +109,47 @@ struct RepetitionDetectorTests {
         #expect(!RepetitionDetector.looksLikeLooping(list))
     }
 
+    // MARK: - Tail-bound performance fix
+
+    @Test("Tail 3x-repeat is detected even behind a long non-repeating prefix")
+    func test_tailTripleRepeat_behindLongPrefix_detected() {
+        // A long, non-repeating prefix that exceeds the 500-char tail bound, followed
+        // by a 3x-repeated tail unit. Proves bounding the work to the tail did not
+        // break detection: the loop lives entirely within the final 500 characters.
+        let prefix = (0..<200).map { "word\($0) " }.joined() // ~1200 chars, no repeats
+        #expect(prefix.count > 600)
+        let unit = "the model is stuck here " // 24 chars
+        let tail = String(repeating: unit, count: 3) // 72 chars, 3x repeat
+        #expect(RepetitionDetector.looksLikeLooping(prefix + tail))
+    }
+
+    @Test("Tail 2x-repeat is detected even behind a long non-repeating prefix")
+    func test_tailDoubleRepeat_behindLongPrefix_detected() {
+        let prefix = (0..<200).map { "token\($0) " }.joined()
+        #expect(prefix.count > 600)
+        let unit = "The world was dark and full of ancient forgotten mystery" // 56 chars
+        let tail = unit + unit // 2x repeat of 56-char unit
+        #expect(RepetitionDetector.looksLikeLooping(prefix + tail))
+    }
+
+    @Test("Long unique text with no tail repeat is not detected (no regression)")
+    func test_longUniqueText_noTailRepeat_notDetected() {
+        // Far longer than the 500-char tail bound, but no repeated unit anywhere in
+        // the tail. Confirms bounding introduces no false positives.
+        let text = (0..<400).map { "phrase\($0) " }.joined() // ~3000 unique chars
+        #expect(text.count > 2000)
+        #expect(!RepetitionDetector.looksLikeLooping(text))
+    }
+
+    @Test("Bound matches unbounded behaviour: repeat starting before the bound still fires via tail")
+    func test_boundedResult_matchesFullScan_forRepeatStraddlingBound() {
+        // A long repeated block whose tail (within 500 chars) is itself a clean 3x
+        // repeat. Both the old full-scan and the new tail-bounded path detect it.
+        let unit = "Repeating sentence that keeps going and going. " // 47 chars
+        let text = String(repeating: unit, count: 50) // ~2350 chars, heavily repeated
+        #expect(RepetitionDetector.looksLikeLooping(text))
+    }
+
     // MARK: - Repetition rate metric
 
     @Test("Repetition rate of empty string is 0.0")


### PR DESCRIPTION
## What

`RepetitionDetector.looksLikeLooping(_:)` is invoked once per streamed token over the **entire** accumulated visible text (via `GenerationStreamConsumer.shouldStopForLoop(content:)` from `ConversationTurnExecutor`, passing `accumulator.visibleText`). It did `Array(trimmed)` over the whole string on every call, making the per-generation cost **O(n²)** in output length.

## Fix

The detection algorithm only ever inspects the tail:
- **2x detection** compares the last 200-char unit against the preceding 200 (≤400 chars).
- **3x detection** compares the last three 120-char units (≤360 chars).

Bounding the input to `text.suffix(500)` makes each call **O(1)** in accumulated length, so the per-generation cost drops to O(n).

Behaviour is preserved exactly: detection is purely tail-local, and the `count >= 100` / `count >= 48` thresholds saturate immediately past the bound (any text ≥500 chars yields the same bounded character array regardless of total length).

## Tests

- `test_tailTripleRepeat_behindLongPrefix_detected` / `test_tailDoubleRepeat_behindLongPrefix_detected` — a tail-repeat preceded by a >500-char non-repeating prefix still fires, proving the bound did not break detection.
- `test_longUniqueText_noTailRepeat_notDetected` — long (>2000 char) unique text yields no false positive.
- `test_boundedResult_matchesFullScan_forRepeatStraddlingBound` — a heavily repeated block still detected via the tail.

Gate: `scripts/test.sh --profile local` → RESULT: PASSED.

Refs #1796