### PR TITLE
feat: wire model recommender into device-aware first-launch seed + UI highlight

### DIFF
--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -121,8 +121,12 @@ public enum ManifoldKit {
     ///   - configuration: Framework configuration. Defaults to
     ///     ``ManifoldInference/ManifoldConfiguration/default``.
     ///   - seed: Opt-in seed configuration. Use
-    ///     ``QuickStartSeed/recommendedSmallModel(onProgress:)`` for the
-    ///     curated default. Pass `nil` for the original behavior.
+    ///     ``QuickStartSeed/recommended(useCase:device:foundationAvailable:onProgress:)``
+    ///     to seed a *device-aware* starter model — a 64 GB M-series machine gets a
+    ///     larger, more capable model than a base iPhone, with the Qwen3-0.6B floor
+    ///     as the guaranteed fallback. Use
+    ///     ``QuickStartSeed/recommendedSmallModel(onProgress:)`` to always seed the
+    ///     fixed 0.6B floor. Pass `nil` for the original (no-seed) behavior.
     /// - Returns: A ``QuickStartResult`` as in ``quickStart(configuration:)``.
     public static func quickStart(
         configuration: ManifoldConfiguration = .default,

--- a/Sources/ManifoldKit/QuickStartSeed.swift
+++ b/Sources/ManifoldKit/QuickStartSeed.swift
@@ -113,6 +113,157 @@ public struct QuickStartSeed: Sendable {
             onProgress: onProgress
         )
     }
+
+    // MARK: - Device-aware seed selection
+
+    /// Curated GGUF starter candidates the device-aware seed picker ranks over.
+    ///
+    /// These are widely-used `bartowski` Q4_K_M quantizations spanning the small →
+    /// mid size range so a 64 GB M-series machine and a base iPhone land on
+    /// different seeds. `recommendedSmallModel()`'s Qwen3-0.6B is the floor and is
+    /// *always* in this set, so the picker can never return nothing runnable.
+    ///
+    /// Sizes are approximate download bytes (Q4_K_M). They feed the scorer's
+    /// `ModelLoadPlan`-backed fit dimension, so an over-budget candidate is
+    /// collapsed below every runnable one and the floor wins by construction.
+    static let seedCandidates: [QuickStartSeed] = [
+        // Floor — the existing recommendedSmallModel(). ~0.4 GB, runs anywhere.
+        QuickStartSeed(
+            modelID: "bartowski/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf",
+            repoID: "bartowski/Qwen3-0.6B-GGUF",
+            fileName: "Qwen3-0.6B-Q4_K_M.gguf",
+            displayName: "Qwen3 0.6B (Q4_K_M)",
+            modelType: .gguf,
+            sizeBytes: 416_000_000,
+            promptTemplate: .chatML,
+            onProgress: nil
+        ),
+        // ~2.0 GB — comfortable on a modern phone / base Mac.
+        QuickStartSeed(
+            modelID: "bartowski/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf",
+            repoID: "bartowski/Qwen3-4B-GGUF",
+            fileName: "Qwen3-4B-Q4_K_M.gguf",
+            displayName: "Qwen3 4B (Q4_K_M)",
+            modelType: .gguf,
+            sizeBytes: 2_500_000_000,
+            promptTemplate: .chatML,
+            onProgress: nil
+        ),
+        // ~4.7 GB — a capable 8B for machines with headroom.
+        QuickStartSeed(
+            modelID: "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+            repoID: "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+            fileName: "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+            displayName: "Llama 3.1 8B (Q4_K_M)",
+            modelType: .gguf,
+            sizeBytes: 4_900_000_000,
+            promptTemplate: .llama3,
+            onProgress: nil
+        ),
+        // ~9.0 GB — frontier-ish local pick for high-memory M-series.
+        QuickStartSeed(
+            modelID: "bartowski/Qwen2.5-14B-Instruct-GGUF/Qwen2.5-14B-Instruct-Q4_K_M.gguf",
+            repoID: "bartowski/Qwen2.5-14B-Instruct-GGUF",
+            fileName: "Qwen2.5-14B-Instruct-Q4_K_M.gguf",
+            displayName: "Qwen2.5 14B (Q4_K_M)",
+            modelType: .gguf,
+            sizeBytes: 9_000_000_000,
+            promptTemplate: .chatML,
+            onProgress: nil
+        ),
+    ]
+
+    /// The Qwen3-0.6B floor — the seed returned when no larger candidate fits the
+    /// device. Always the first entry in ``seedCandidates``.
+    static var floorSeed: QuickStartSeed { seedCandidates[0] }
+
+    /// Picks a first-launch seed model tailored to the host device.
+    ///
+    /// Ranks ``seedCandidates`` with ``ModelFitScorer`` under the host's
+    /// ``DeviceProfile`` (memory + memory bandwidth) for the given use case, then
+    /// returns the best-ranked candidate that will actually run. A 64 GB M-series
+    /// machine lands on a larger, more capable model than a base iPhone; when no
+    /// candidate larger than the floor fits, the Qwen3-0.6B floor is returned — so
+    /// the call never yields a model the device can't load.
+    ///
+    /// This is *additive*: ``recommendedSmallModel(onProgress:)`` still returns the
+    /// fixed 0.6B floor for callers that want the historical behaviour.
+    ///
+    /// - Parameters:
+    ///   - useCase: Biases the scorer's dimension weights. Defaults to `.general`.
+    ///   - device: The device profile to rank against. Defaults to the real host
+    ///     (`.current`); tests inject a fixed profile for determinism.
+    ///   - foundationAvailable: Whether Apple Foundation Models is usable. When
+    ///     `true` the caller already has a zero-download Tier-0 model and would
+    ///     normally skip seeding entirely; the seed picker still returns the floor
+    ///     so a forced seed is well-defined. Defaults to `false` (no FM).
+    ///   - onProgress: Optional main-actor progress closure forwarded to the
+    ///     chosen seed (see ``recommendedSmallModel(onProgress:)``).
+    /// - Returns: A device-appropriate ``QuickStartSeed``.
+    public static func recommended(
+        useCase: ModelUseCase = .general,
+        device: DeviceProfile = .current,
+        foundationAvailable: Bool = false,
+        onProgress: (@Sendable @MainActor (Double) -> Void)? = nil
+    ) -> QuickStartSeed {
+        let scorer = ModelFitScorer()
+        let candidates: [ModelSelectionCandidate] = seedCandidates.map {
+            .downloadable($0.asDownloadableModel())
+        }
+        let ranked = scorer.rank(
+            candidates: candidates,
+            useCase: useCase,
+            device: device,
+            foundationAvailable: foundationAvailable
+        )
+
+        // Find the best-ranked candidate that will actually run on this device.
+        // `rank` already sinks `.deny`/over-budget candidates to the bottom, but we
+        // also gate on `willRun` so a device that can run *nothing but* the floor
+        // (or, hypothetically, not even that) deterministically gets the floor.
+        let chosen = ranked.first(where: { $0.1.willRun })?.0
+
+        let seed: QuickStartSeed
+        if case .downloadable(let model) = chosen,
+           let match = seedCandidates.first(where: { $0.modelID == model.id }) {
+            seed = match
+        } else {
+            seed = floorSeed
+        }
+
+        return seed.withProgress(onProgress)
+    }
+
+    // MARK: - Conversions
+
+    /// Materialises this seed as a ``DownloadableModel`` for scoring / download.
+    func asDownloadableModel() -> DownloadableModel {
+        DownloadableModel(
+            repoID: repoID,
+            fileName: fileName,
+            displayName: displayName,
+            modelType: modelType,
+            sizeBytes: sizeBytes,
+            promptTemplate: promptTemplate
+        )
+    }
+
+    /// Returns a copy of this seed with `onProgress` replaced (no-op when `nil`
+    /// and the seed already has no callback). Used by ``recommended(...)`` so the
+    /// caller's progress closure rides the device-chosen candidate.
+    func withProgress(_ onProgress: (@Sendable @MainActor (Double) -> Void)?) -> QuickStartSeed {
+        guard onProgress != nil else { return self }
+        return QuickStartSeed(
+            modelID: modelID,
+            repoID: repoID,
+            fileName: fileName,
+            displayName: displayName,
+            modelType: modelType,
+            sizeBytes: sizeBytes,
+            promptTemplate: promptTemplate,
+            onProgress: onProgress
+        )
+    }
 }
 
 // MARK: - SeedModelError

--- a/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
+++ b/Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift
@@ -738,6 +738,41 @@ public final class ModelManagementViewModel {
         return ModelFitScorer().rank(searchResults, useCase: useCase ?? selectedUseCase, device: resolvedDevice)
     }
 
+    /// The single highest-fit model for this device under the current selection,
+    /// or `nil` when there is nothing to rank yet.
+    ///
+    /// Highlights one model in the browser as "recommended for your device": it is
+    /// the top of ``rankedVariants(useCase:device:)`` restricted to candidates that
+    /// will actually run (`willRun`). Additive and read-only — it does not reorder
+    /// or filter `searchResults`; the row UI simply badges the returned model.
+    ///
+    /// Ranks `searchResults` when a search is active, otherwise the device-tier
+    /// `recommendedModels` (curated) list, so a fresh browser with no query still
+    /// surfaces a pick. Returns `nil` if neither list has a runnable candidate.
+    ///
+    /// - Parameters:
+    ///   - useCase: Use case to weight dimensions for. Defaults to `selectedUseCase`.
+    ///   - device: Device profile for scoring. Defaults to the real host profile;
+    ///     tests inject a fixed profile for deterministic ranking.
+    public func recommendedModel(
+        useCase: ModelUseCase? = nil,
+        device: DeviceProfile? = nil
+    ) -> DownloadableModel? {
+        let resolvedDevice = device ?? DeviceProfile(
+            physicalMemoryBytes: deviceCapability.physicalMemory,
+            usableMemoryBytes: DeviceCapabilityService.queryAvailableMemory(),
+            memoryBandwidthGBs: AppleSiliconBandwidth.estimatedBandwidthGBs()
+        )
+        let pool = searchResults.isEmpty ? recommendedModels : searchResults
+        guard !pool.isEmpty else { return nil }
+        let ranked = ModelFitScorer().rank(
+            pool,
+            useCase: useCase ?? selectedUseCase,
+            device: resolvedDevice
+        )
+        return ranked.first(where: { $0.1.willRun })?.0
+    }
+
     /// The fit score for a single downloadable model under the current selection.
     ///
     /// Lets the row UI show a `SpeedClass` badge / `rationale` without re-ranking the

--- a/Tests/ManifoldKitTests/QuickStartSeedRecommendationTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartSeedRecommendationTests.swift
@@ -1,0 +1,127 @@
+// QuickStartSeedRecommendationTests.swift
+//
+// Exercises the device-aware first-launch seed picker
+// `QuickStartSeed.recommended(useCase:device:foundationAvailable:onProgress:)`.
+//
+// The seed picker ranks a curated GGUF candidate set with `ModelFitScorer` under
+// an injected `DeviceProfile`, so these tests pass a fixed profile and never read
+// the host machine's RAM/bandwidth. They prove:
+//   1. A high-memory M-series machine seeds a *larger* model than a base phone.
+//   2. The Qwen3-0.6B floor holds when no larger candidate fits.
+//   3. The progress closure rides whatever candidate the device chooses.
+
+import XCTest
+@testable import ManifoldKit
+import ManifoldInference
+
+final class QuickStartSeedRecommendationTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    /// A fixed device profile so memory + bandwidth are not read from the host.
+    private func device(ramGB: UInt64, bandwidthGBs: Double) -> DeviceProfile {
+        let bytes = ramGB * oneGB
+        return DeviceProfile(
+            physicalMemoryBytes: bytes,
+            usableMemoryBytes: bytes,
+            memoryBandwidthGBs: bandwidthGBs
+        )
+    }
+
+    private let floorModelID = "bartowski/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf"
+
+    // MARK: - Seed differs by device profile
+
+    func test_highMemoryDevice_seedsLargerModelThanFloor() {
+        // A 64 GB M-Max-class machine: every curated candidate fits comfortably, so
+        // the picker should choose something larger/more capable than the 0.6B floor.
+        let dev = device(ramGB: 64, bandwidthGBs: 400)
+
+        let seed = QuickStartSeed.recommended(useCase: .general, device: dev)
+
+        XCTAssertNotEqual(
+            seed.modelID, floorModelID,
+            "A 64 GB machine should seed a larger model than the Qwen3-0.6B floor"
+        )
+        XCTAssertGreaterThan(
+            seed.sizeBytes, QuickStartSeed.floorSeed.sizeBytes,
+            "High-memory seed must be larger than the floor"
+        )
+    }
+
+    func test_lowMemoryDevice_seedDiffersFromHighMemoryDevice() {
+        // Prove the seed is device-dependent: a base phone (~3 GB usable) and a
+        // 64 GB Mac must not land on the same model.
+        let phone = device(ramGB: 3, bandwidthGBs: 60)
+        let mac = device(ramGB: 64, bandwidthGBs: 400)
+
+        let phoneSeed = QuickStartSeed.recommended(useCase: .general, device: phone)
+        let macSeed = QuickStartSeed.recommended(useCase: .general, device: mac)
+
+        XCTAssertNotEqual(
+            phoneSeed.modelID, macSeed.modelID,
+            "A base phone and a 64 GB Mac should get different device-aware seeds"
+        )
+        // The phone's pick must not exceed the Mac's pick.
+        XCTAssertLessThanOrEqual(
+            phoneSeed.sizeBytes, macSeed.sizeBytes,
+            "The lower-memory device should never seed a larger model than the high-memory one"
+        )
+    }
+
+    // MARK: - Floor / fallback
+
+    func test_tinyMemoryDevice_fallsBackToFloor() {
+        // A device with ~1.5 GB usable can only run the 0.6B floor; every larger
+        // candidate is over-budget (collapsed by the scorer), so the floor holds.
+        let tiny = device(ramGB: 1, bandwidthGBs: 34)
+
+        let seed = QuickStartSeed.recommended(useCase: .general, device: tiny)
+
+        XCTAssertEqual(
+            seed.modelID, floorModelID,
+            "When no larger candidate fits, the picker must return the Qwen3-0.6B floor"
+        )
+        XCTAssertEqual(seed.modelType, .gguf)
+        XCTAssertGreaterThan(seed.sizeBytes, 0)
+    }
+
+    // MARK: - Floor is always a candidate
+
+    func test_floorSeed_isFirstCandidate_andRunsEverywhere() {
+        XCTAssertEqual(
+            QuickStartSeed.floorSeed.modelID, floorModelID,
+            "floorSeed must be the Qwen3-0.6B entry"
+        )
+        // The floor must be present in the curated candidate set.
+        XCTAssertTrue(
+            QuickStartSeed.seedCandidates.contains { $0.modelID == floorModelID },
+            "The floor must always be in the ranked candidate set so the picker can never return nothing"
+        )
+    }
+
+    // MARK: - Progress closure rides the chosen candidate
+
+    @MainActor
+    func test_recommended_forwardsProgressToChosenSeed() {
+        var received: Double?
+        let dev = device(ramGB: 64, bandwidthGBs: 400)
+
+        let seed = QuickStartSeed.recommended(useCase: .general, device: dev) { p in
+            received = p
+        }
+
+        XCTAssertNotNil(seed.onProgress, "onProgress must ride the device-chosen seed")
+        seed.onProgress?(0.42)
+        XCTAssertEqual(received, 0.42, "Progress closure must forward the value")
+    }
+
+    // MARK: - Use case sensitivity (smoke)
+
+    func test_recommended_isStableForSameInputs() {
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let a = QuickStartSeed.recommended(useCase: .reasoning, device: dev)
+        let b = QuickStartSeed.recommended(useCase: .reasoning, device: dev)
+        XCTAssertEqual(a.modelID, b.modelID, "The picker must be deterministic for identical inputs")
+    }
+}

--- a/Tests/ManifoldUIModelManagementTests/ModelRecommendationRankingTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/ModelRecommendationRankingTests.swift
@@ -121,6 +121,50 @@ final class ModelRecommendationRankingTests: XCTestCase {
         XCTAssertEqual(ranked.first?.0.fileName, fastSmall.fileName)
     }
 
+    // MARK: - recommendedModel highlight
+
+    func test_recommendedModel_picksTopRunnableForUseCase() async {
+        let dev = device(ramGB: 32, bandwidthGBs: 200)
+        let fastSmall = ggufModel(sizeGB: 2.0, quant: "Q4_K_M", name: "Small")
+        let capableBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "Big")
+
+        let vm = await makeViewModel(results: [fastSmall, capableBig])
+
+        vm.selectedUseCase = .chat
+        XCTAssertEqual(
+            vm.recommendedModel(device: dev)?.fileName, fastSmall.fileName,
+            "recommendedModel should mirror the top of the chat-weighted ranking"
+        )
+
+        vm.selectedUseCase = .reasoning
+        XCTAssertEqual(
+            vm.recommendedModel(device: dev)?.fileName, capableBig.fileName,
+            "recommendedModel should track the use case like rankedVariants"
+        )
+    }
+
+    func test_recommendedModel_excludesUnrunnableModels() async {
+        // A 4 GB phone can't run a 14 GB model; the recommendation must fall to the
+        // only runnable candidate rather than highlighting something that won't load.
+        let phone = device(ramGB: 4, bandwidthGBs: 60)
+        let fits = ggufModel(sizeGB: 1.5, quant: "Q4_K_M", name: "Fits")
+        let tooBig = ggufModel(sizeGB: 14.0, quant: "Q5_K_M", name: "TooBig")
+
+        let vm = await makeViewModel(results: [tooBig, fits])
+        XCTAssertEqual(
+            vm.recommendedModel(device: phone)?.fileName, fits.fileName,
+            "recommendedModel must skip over-budget models and highlight a runnable one"
+        )
+    }
+
+    func test_recommendedModel_nilWhenNothingToRank() async {
+        let vm = await makeViewModel(results: [])
+        XCTAssertNil(
+            vm.recommendedModel(device: device(ramGB: 32, bandwidthGBs: 200)),
+            "with no search results and no curated recommendations there is nothing to recommend"
+        )
+    }
+
     // MARK: - Persistence (injected UserDefaults only)
 
     func test_selectedUseCase_persistsToInjectedDefaults() async {


### PR DESCRIPTION
## Summary

The model-fit recommender shipped in #1783 as a scoring library only — nothing called it. This wires it into the actual first-launch path so the seed a device downloads depends on the device.

### Seed wiring (`Sources/ManifoldKit/QuickStartSeed.swift`)
- New `QuickStartSeed.recommended(useCase:device:foundationAvailable:onProgress:)` ranks a curated GGUF candidate set (Qwen3-0.6B → Qwen2.5-14B, all Q4_K_M) with `ModelFitScorer.rank(candidates:useCase:device:foundationAvailable:)` under the host `DeviceProfile` (memory + memory bandwidth).
- A 64 GB M-series machine seeds a larger, more capable model; a base iPhone seeds a smaller one.
- The Qwen3-0.6B floor is **always** in the candidate set and is returned whenever no larger candidate fits (`willRun`-gated) — the picker can never yield a model the device can't load.
- `recommendedSmallModel()` is unchanged (the fixed 0.6B floor), so existing callers and the existing test contract are preserved. `quickStart(seed:)` docs now surface `.recommended(...)` as the device-aware option.

### UI highlight (`Sources/ManifoldUIModelManagement/ViewModels/ModelManagementViewModel.swift`)
- New `recommendedModel(useCase:device:)` returns the single top runnable model (from `searchResults`, falling back to the device-tier `recommendedModels`) so the browser can badge a "recommended for your device" pick. Additive and read-only — it does **not** reorder or filter the list; `ModelLoadPlan` remains the authoritative will-it-run gate.

### Tests
- `QuickStartSeedRecommendationTests` (new): seed differs between high- and low-memory profiles, floor holds on a tiny device, floor is always a candidate, progress closure rides the chosen candidate, deterministic for identical inputs.
- `ModelRecommendationRankingTests` (extended): `recommendedModel` tracks the use case, skips over-budget models, and is `nil` when there is nothing to rank.

All device/memory inputs are injected via `DeviceProfile`, so ranking is deterministic regardless of the runner.

Gate: `scripts/test.sh --profile local` → **RESULT: PASSED** (4950 passed, 0 failed, 15 skipped).

Refs v0.49 Workstream A, #1783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)