### PR TITLE
ci: nightly #1709 triage + close #1706 (TrafficBoundaryAudit per-PR)

### DIFF
--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -6,6 +6,10 @@ name: Nightly slow tests
 #  - TrafficBoundaryAuditTest — source-tree boundary audit (~50s); as of
 #    issue #1706 this also runs per-PR in ci.yml's ManifoldInferenceTests
 #    batch — it is kept here for nightly double-coverage, no longer gated.
+#    When this audit fails (e.g. issue #1709: a new file did direct URLSession
+#    I/O), the fix is to route the call through URLSessionProvider or add the
+#    file to TrafficBoundaryAuditTest.networkIOAllowlist with reviewer sign-off
+#    — the audit is doing its job, not flaking.
 #  - ManifoldAuditSabotageSuiteTests — SABOTAGE=1 audit tripwire proof
 #  - ManifoldMCPE2ESmokeTests — explicitly gated MCP streamable-HTTP E2E smoke
 # The perf suites are gated by RUN_SLOW_TESTS=1 in their setUp; the main `ci.yml`


### PR DESCRIPTION
Triage + verification PR closing out two CI-tier issues. One small, comment-only change to the nightly workflow header; no Swift touched.

## #1709 — nightly-slow failure triage (run 27119252332)

**What failed:** the `slow` job's `TrafficBoundaryAuditTest.test_rule1_networkIOOnlyInAllowlistedFiles` (1 failure / 15 tests), at `Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift:342`.

**Why:** `Sources/ManifoldHuggingFace/DiffusionDownloadDelegate.swift` (lines 58/83/112) took direct `URLSession` parameters that were not yet in `TrafficBoundaryAuditTest.networkIOAllowlist`. Rule 1 correctly flagged it — URLSession-family types must live in `URLSessionProvider` or be allowlisted so `LocalOnlyNetworkIsolationTests` can intercept outbound requests.

**Why no code fix now:** already resolved on current `main`. The allowlist entry `"ManifoldHuggingFace/DiffusionDownloadDelegate.swift"` landed via **#1718** (`d4d9ef3d test: fix flaky diffusion-download tests and traffic-boundary allowlist`). The failing nightly (2026-06-08) predated that commit. This was the audit doing its job and self-healing, not a flake or infra issue. **Triage only — close #1709 manually on merge.**

This PR adds a breadcrumb to the nightly workflow header documenting that an audit failure here is a real boundary regression (fix = route through `URLSessionProvider` or allowlist with sign-off), so the next debugger doesn't mistake it for a flake.

## #1706 — Move TrafficBoundaryAuditTest to per-PR CI

**Verified already shipped.** Removed the `RUN_SLOW_TESTS=1` setUp guard in **#1772** (`6673eb9c fix: streaming-wait perf + run traffic-boundary audit per-PR`). The test now runs unconditionally:
- **Per-PR:** `ci.yml:553` runs `--filter ManifoldInferenceTests`, which includes `TrafficBoundaryAuditTest` (XCTest suite in that target).
- **Nightly:** still filtered in `nightly-slow-tests.yml` for double-coverage.
- No `XCTSkip`/`ProcessInfo`/`RUN_SLOW_TESTS` guard remains in the test (only a historical comment at line 75).

No code change needed for #1706. **Closes #1706** on merge.

## Issues to close on merge
- Closes #1706 (verified shipped via #1772)
- #1709 — triage only, close manually (already fixed on main via #1718)

## Gate
Comment-only YAML change, no Swift impact. Validated YAML parses; `swift build`/full gate not warranted.