### PR TITLE
feat(fuzz): wire memory-growth budget + context-exhaustion guard detectors

### DIFF
--- a/Sources/ManifoldFuzz/Detectors/ContextExhaustionSilentDetector.swift
+++ b/Sources/ManifoldFuzz/Detectors/ContextExhaustionSilentDetector.swift
@@ -5,11 +5,14 @@ import Foundation
 /// window. The detector flags records whose error description indicates a
 /// context-exhaustion refusal.
 ///
-/// The "false trigger" guard (prompt token estimate < contextLimit * 0.5)
-/// is deliberately disabled today. The `RunRecord` does not carry a
-/// per-request prompt-token count. Until that field lands, we flag every
-/// context-exhausted error — false positives are acceptable at `.flaky`
-/// severity and the calibration corpus will filter legitimate exhaustions.
+/// When the capture supplies both `PromptSnapshot.estimatedPromptTokens` and
+/// `ConfigSnapshot.contextLimit`, the detector gates the positive on the
+/// "false trigger" guard: it fires only when the prompt comfortably fits
+/// (`promptTokens < contextLimit / 2`), since a context-exhausted error there
+/// is a misfire rather than a legitimate exhaustion. When either field is
+/// absent the guard is a no-op and every context-exhausted error is flagged —
+/// false positives are acceptable at `.flaky` severity and the calibration
+/// corpus will filter legitimate exhaustions.
 ///
 /// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
 /// calibration corpus + FP/TP gating planned in W2.C phase 2.
@@ -28,10 +31,18 @@ public struct ContextExhaustionSilentDetector: Detector {
         guard let err = r.error else { return [] }
         guard err.lowercased().contains(Self.errorNeedle) else { return [] }
 
-        // TODO: wire prompt-token estimate + contextLimit comparison. Once
-        // `ConfigSnapshot` / `PromptSnapshot` carries a token budget, gate
-        // this positive with `promptTokens < contextLimit / 2` to filter
-        // legitimate exhaustions.
+        // False-trigger guard: when both the prompt-token estimate and the
+        // context limit are present, a context-exhausted error is only a
+        // misfire if the prompt comfortably fit (well under half the window).
+        // If the prompt was actually large the exhaustion is legitimate — skip.
+        // Absent either field, the guard is a no-op and we flag the error.
+        if let promptTokens = r.prompt.estimatedPromptTokens,
+           let contextLimit = r.config.contextLimit,
+           contextLimit > 0,
+           promptTokens >= contextLimit / 2 {
+            return []
+        }
+
         return [Finding(
             detectorId: id,
             subCheck: "context-exhausted-fired",

--- a/Sources/ManifoldFuzz/Detectors/MemoryGrowthDetector.swift
+++ b/Sources/ManifoldFuzz/Detectors/MemoryGrowthDetector.swift
@@ -5,10 +5,10 @@ import Foundation
 ///
 /// 1. A memory-related error string (`memory`, `OOM`, `jetsam`, etc.) fires
 ///    during generation. This path is always enabled.
-/// 2. Peak resident bytes exceed `beforeBytes` by more than a model-declared
-///    budget by a factor of `growthFactor`. This path is behind a TODO —
-///    the record carries `MemorySnapshot.beforeBytes`/`peakBytes` today but
-///    there is no `declaredBudget` field yet.
+/// 2. Peak resident bytes exceed the model-declared budget
+///    (`ModelSnapshot.memoryBudgetBytes`). The record carries
+///    `MemorySnapshot.peakBytes` and, when capture supplies it, the per-model
+///    budget; both must be present for this branch to fire.
 ///
 /// Ships at `.flaky` severity. Promotion to `.confirmed` requires the
 /// calibration corpus + FP/TP gating planned in W2.C phase 2.
@@ -46,13 +46,21 @@ public struct MemoryGrowthDetector: Detector {
             }
         }
 
-        // 2. Growth-budget path.
-        // TODO: wire memory capture in a follow-up. The declared-budget
-        // comparison requires a per-model memory budget field on
-        // `ModelSnapshot` / `ConfigSnapshot` that doesn't exist yet. Until
-        // then, this branch stays disabled to avoid speculative thresholds.
-        _ = r.memory.beforeBytes
-        _ = r.memory.peakBytes
+        // 2. Growth-budget path. Fires only when both the captured peak and the
+        // per-model budget are present — absent data is a no-op, never a
+        // speculative threshold.
+        if let peak = r.memory.peakBytes,
+           let budget = r.model.memoryBudgetBytes,
+           budget > 0,
+           peak > budget {
+            findings.append(.init(
+                detectorId: id,
+                subCheck: "budget-exceeded",
+                severity: .flaky,
+                trigger: "peak>\(budget)",
+                modelId: r.model.id
+            ))
+        }
 
         return findings
     }

--- a/Sources/ManifoldFuzz/RunRecord.swift
+++ b/Sources/ManifoldFuzz/RunRecord.swift
@@ -182,6 +182,27 @@ public struct RunRecord: Codable, Sendable, Equatable {
         public var url: String
         public var fileSHA256: String?
         public var tokenizerHash: String?
+        /// Per-model memory budget in bytes. `MemoryGrowthDetector` compares
+        /// `MemorySnapshot.peakBytes` against this to flag runaway resident
+        /// growth. Optional so capture paths that can't supply a budget leave
+        /// the growth-budget branch a no-op rather than firing on missing data.
+        public var memoryBudgetBytes: UInt64?
+
+        public init(
+            backend: String,
+            id: String,
+            url: String,
+            fileSHA256: String? = nil,
+            tokenizerHash: String? = nil,
+            memoryBudgetBytes: UInt64? = nil
+        ) {
+            self.backend = backend
+            self.id = id
+            self.url = url
+            self.fileSHA256 = fileSHA256
+            self.tokenizerHash = tokenizerHash
+            self.memoryBudgetBytes = memoryBudgetBytes
+        }
     }
 
     public struct ConfigSnapshot: Codable, Sendable, Equatable {
@@ -194,6 +215,11 @@ public struct RunRecord: Codable, Sendable, Equatable {
         /// not configure tools. `ToolCallValidityDetector.toolchoice-violation`
         /// reads this to assert the model honoured the constraint.
         public var toolChoice: String?
+        /// The model's context-window limit in tokens for this run.
+        /// `ContextExhaustionSilentDetector` uses it (with the prompt-token
+        /// estimate) to suppress legitimate exhaustions. Optional so capture
+        /// paths that can't supply a limit leave the guard a no-op.
+        public var contextLimit: Int?
 
         public init(
             seed: UInt64,
@@ -201,7 +227,8 @@ public struct RunRecord: Codable, Sendable, Equatable {
             topP: Float,
             maxTokens: Int?,
             systemPrompt: String?,
-            toolChoice: String? = nil
+            toolChoice: String? = nil,
+            contextLimit: Int? = nil
         ) {
             self.seed = seed
             self.temperature = temperature
@@ -209,10 +236,11 @@ public struct RunRecord: Codable, Sendable, Equatable {
             self.maxTokens = maxTokens
             self.systemPrompt = systemPrompt
             self.toolChoice = toolChoice
+            self.contextLimit = contextLimit
         }
 
         private enum CodingKeys: String, CodingKey {
-            case seed, temperature, topP, maxTokens, systemPrompt, toolChoice
+            case seed, temperature, topP, maxTokens, systemPrompt, toolChoice, contextLimit
         }
 
         public init(from decoder: Decoder) throws {
@@ -223,6 +251,7 @@ public struct RunRecord: Codable, Sendable, Equatable {
             maxTokens = try c.decodeIfPresent(Int.self, forKey: .maxTokens)
             systemPrompt = try c.decodeIfPresent(String.self, forKey: .systemPrompt)
             toolChoice = try c.decodeIfPresent(String.self, forKey: .toolChoice)
+            contextLimit = try c.decodeIfPresent(Int.self, forKey: .contextLimit)
         }
     }
 
@@ -230,10 +259,32 @@ public struct RunRecord: Codable, Sendable, Equatable {
         public var corpusId: String
         public var mutators: [String]
         public var messages: [Message]
+        /// Estimated prompt-token count for this run.
+        /// `ContextExhaustionSilentDetector` compares it against
+        /// `ConfigSnapshot.contextLimit` to suppress legitimate exhaustions.
+        /// Optional so capture paths without a tokenizer leave the guard a no-op.
+        public var estimatedPromptTokens: Int?
+
+        public init(
+            corpusId: String,
+            mutators: [String],
+            messages: [Message],
+            estimatedPromptTokens: Int? = nil
+        ) {
+            self.corpusId = corpusId
+            self.mutators = mutators
+            self.messages = messages
+            self.estimatedPromptTokens = estimatedPromptTokens
+        }
 
         public struct Message: Codable, Sendable, Equatable {
             public var role: String
             public var text: String
+
+            public init(role: String, text: String) {
+                self.role = role
+                self.text = text
+            }
         }
     }
 

--- a/Tests/ManifoldFuzzTests/DetectorTests.swift
+++ b/Tests/ManifoldFuzzTests/DetectorTests.swift
@@ -288,6 +288,65 @@ final class DetectorTests: XCTestCase {
 
     // MARK: - ThinkingClassificationDetector — stopReason gating
 
+    // MARK: - MemoryGrowthDetector — growth-budget branch
+
+    func test_memoryGrowth_budgetExceeded_fires() {
+        var r = makeRecord()
+        r.model.memoryBudgetBytes = 1_000
+        r.memory.peakBytes = 2_000
+        let findings = MemoryGrowthDetector().inspect(r)
+        XCTAssertTrue(findings.contains { $0.subCheck == "budget-exceeded" })
+    }
+
+    func test_memoryGrowth_withinBudget_doesNotFire() {
+        var r = makeRecord()
+        r.model.memoryBudgetBytes = 4_000
+        r.memory.peakBytes = 2_000
+        let findings = MemoryGrowthDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "budget-exceeded" })
+    }
+
+    func test_memoryGrowth_noBudgetData_doesNotFireBudgetBranch() {
+        // Capture path that supplies a peak but no budget must no-op, not fire
+        // on missing data.
+        var r = makeRecord()
+        r.model.memoryBudgetBytes = nil
+        r.memory.peakBytes = 9_999_999
+        let findings = MemoryGrowthDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "budget-exceeded" })
+    }
+
+    // MARK: - ContextExhaustionSilentDetector — false-trigger guard
+
+    private let exhaustedError =
+        "Prompt plus requested output exceeds context window (8192 tokens)."
+
+    func test_contextExhaustion_promptWellUnderLimit_fires() {
+        var r = makeRecord(error: exhaustedError)
+        r.prompt.estimatedPromptTokens = 100
+        r.config.contextLimit = 8_192
+        let findings = ContextExhaustionSilentDetector().inspect(r)
+        XCTAssertTrue(findings.contains { $0.subCheck == "context-exhausted-fired" })
+    }
+
+    func test_contextExhaustion_promptNearLimit_doesNotFire() {
+        // Legitimate exhaustion: prompt is at/above half the window, so the
+        // refusal is expected and must be suppressed.
+        var r = makeRecord(error: exhaustedError)
+        r.prompt.estimatedPromptTokens = 5_000
+        r.config.contextLimit = 8_192
+        let findings = ContextExhaustionSilentDetector().inspect(r)
+        XCTAssertFalse(findings.contains { $0.subCheck == "context-exhausted-fired" })
+    }
+
+    func test_contextExhaustion_noTokenData_stillFires() {
+        // Without the estimate/limit the guard no-ops and every exhaustion is
+        // flagged (acceptable at .flaky severity).
+        let r = makeRecord(error: exhaustedError)
+        let findings = ContextExhaustionSilentDetector().inspect(r)
+        XCTAssertTrue(findings.contains { $0.subCheck == "context-exhausted-fired" })
+    }
+
     func test_thinkingClassification_unbalancedEvents_skipsWhenMaxTokensTruncation() {
         // 64-token cap routinely truncates mid-`<think>` on reasoning models;
         // the lack of a `thinkingCompleted` event is the cap's fault, not a parser bug.


### PR DESCRIPTION
Two fuzz detectors had a disabled branch, both blocked on the same missing primitive — no token/memory budget on the fuzz snapshot types. This wires them up.

## Detectors enabled

- **MemoryGrowthDetector** (`Sources/ManifoldFuzz/Detectors/MemoryGrowthDetector.swift`): the growth-budget branch (was a `TODO` no-op). Now fires `budget-exceeded` (`.flaky`) when `MemorySnapshot.peakBytes` exceeds the per-model `ModelSnapshot.memoryBudgetBytes`. The always-enabled `memory-error` string path is unchanged.
- **ContextExhaustionSilentDetector** (`Sources/ManifoldFuzz/Detectors/ContextExhaustionSilentDetector.swift`): the false-trigger guard (was a `TODO`). When both the prompt-token estimate and context limit are present, suppresses the `context-exhausted-fired` positive if the prompt is at/above half the window (a legitimate exhaustion). When token data is absent the guard no-ops and every exhaustion is flagged, as before.

## Snapshot fields added (`Sources/ManifoldFuzz/RunRecord.swift`)

All **optional** — absent data is a no-op, never a speculative threshold; existing capture paths that don't populate them still compile and the detectors degrade gracefully:

- `ModelSnapshot.memoryBudgetBytes: UInt64?`
- `ConfigSnapshot.contextLimit: Int?` (added to its custom `CodingKeys` + `init(from:)`)
- `PromptSnapshot.estimatedPromptTokens: Int?`

## Tests

Added detector unit tests in `Tests/ManifoldFuzzTests/DetectorTests.swift` — for each detector, a case that should fire (budget exceeded / prompt well under limit) and cases that should not (within budget / prompt near limit / no data). Existing `DetectorContractTests` fixtures (which leave the new fields nil) continue to exercise the error-string / no-guard paths unchanged.

Backend-agnostic; no real model needed. Full `scripts/test.sh --profile local` gate: RESULT PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)