### PR TITLE
docs: capture recon findings (SwiftData WONTFIX, companion boundary, perf)

### DIFF
--- a/Sources/ManifoldInference/Services/RepetitionDetector.swift
+++ b/Sources/ManifoldInference/Services/RepetitionDetector.swift
@@ -5,6 +5,10 @@ import Foundation
 /// Useful for catching model "looping" during streaming generation, where the model
 /// repeats the same phrase or sentence indefinitely. ``ChatViewModel`` uses this
 /// automatically when ``ChatViewModel/loopDetectionEnabled`` is `true`.
+///
+/// Perf note (#1796): the tail-bounding fix below was the one high-value §A item from the
+/// perf-grounding pass — it shipped (#1802, O(n²)→O(n) per streamed token). The remaining
+/// §A candidates were judged marginal or contested and were not pursued.
 public enum RepetitionDetector {
 
     /// Returns `true` when the tail of `text` appears to be a contiguous repeated chunk.

--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -418,6 +418,8 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         // save (proven by SwiftDataTransactionalMutationTests'
         // rollback cases, which fail under a transaction-based rewrite). The
         // manual rollback is what gives the batch its all-or-nothing semantics.
+        // This is a documented WONTFIX (#1682): the transaction-based rewrite
+        // has been evaluated and rejected on those grounds — do not re-litigate.
         var writtenRecords: [ManifoldInference.ChatMessage] = []
         do {
             for mutation in mutations {

--- a/docs/plans/target-architecture.md
+++ b/docs/plans/target-architecture.md
@@ -63,6 +63,18 @@ plan from reality at a glance. Where the prose below still reads as future tense
 > unchanged (`import ManifoldMLX` / `import ManifoldLlama` still compile). The RING 2 prose
 > below lists them as adapter products — they remain so, just sourced from companion packages.
 
+### Companion-boundary audit (2026-06)
+
+A grounded recon pass over the v0.48 split confirms the boundary is **clean** — no
+duplication or shadowing crossed it. The companion packages reuse this repo's shared test
+products (`ManifoldTestSupport`, `ManifoldBackendTestKit`) for their mocks and contract
+checks rather than forking copies, so there is a single source of truth for `MockInferenceBackend`,
+the contract mixins, and `FixtureComparator`. GGUF parsing is **not** duplicated: core
+(`ManifoldHardware`) parses GGUF headers only for capability/load planning, while
+`manifold-llama` does the runtime model load — distinct concerns over the same file format,
+not a forked parser. No cross-boundary type shadowing was found (no duplicate `ManifoldMLX` /
+`ManifoldLlama` symbol definitions split across repos).
+
 This is a **planning artifact**, not user-facing documentation and not an implementation
 plan. It captures the agreed *end state* for ManifoldKit's module architecture so a
 subsequent migration plan can be argued against a fixed target. When the structure


### PR DESCRIPTION
Captures three grounded-recon findings in repo docs/comments. Per repo hygiene, these are recorded in-tree rather than as follow-up GitHub issues. Docs/comments only — no behavior change.

## Notes

1. **#1682 SwiftData truth-up.** Extends the existing defending comment at `performMessageMutations` (`SwiftDataPersistenceProvider.swift`) to mark the `transaction {}` rewrite as a documented WONTFIX: `transaction(block:)` does not discard staged in-memory changes on throw (a staged `.update` leaks on the next save), proven by `SwiftDataTransactionalMutationTests`. The manual `rollback()` is what gives the batch all-or-nothing semantics. Stops future readers re-litigating it.

2. **Companion-boundary audit (2026-06).** New subsection in `docs/plans/target-architecture.md` recording that the v0.48 split is clean: manifold-mlx / manifold-llama reuse the shared `ManifoldTestSupport` / `ManifoldBackendTestKit` products (no test-mock duplication), GGUF parsing is not duplicated (core parses for capability/load planning; llama loads at runtime), and no cross-boundary type shadowing was found.

3. **#1796 perf grounding.** One-line pointer in `RepetitionDetector` doc comment noting it was the one high-value §A perf item (shipped via #1802, O(n²)→O(n)); the rest are marginal/contested.

## Verification

`swift build --build-tests` passes (two touched files are `.swift`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)