### PR TITLE
docs: fix unresolved DocC symbol links in ManifoldContract + ManifoldUI

### DIFF
--- a/Sources/ManifoldContract/BackendOptInProtocols.swift
+++ b/Sources/ManifoldContract/BackendOptInProtocols.swift
@@ -19,7 +19,7 @@ public protocol ConversationHistoryReceiver: AnyObject {
 /// One turn in a structured conversation history — a role plus an ordered
 /// list of ``MessagePart`` values.
 ///
-/// This is the inference-layer companion to ``ChatMessage``: it strips
+/// This is the inference-layer companion to `ChatMessage`: it strips
 /// persistence-only fields (timestamp, sessionID, token counts) and exposes
 /// just what the generation pipeline needs to format prompts and serialize
 /// provider-specific request bodies. Crucially, ``parts`` retains
@@ -30,7 +30,7 @@ public protocol ConversationHistoryReceiver: AnyObject {
 ///
 /// Text-only backends collapse a ``StructuredMessage`` back to
 /// `(role, content)` at their boundary — see
-/// ``GenerationQueue`` for the flattening rule (text parts joined,
+/// `GenerationQueue` for the flattening rule (text parts joined,
 /// thinking parts dropped from the prompt).
 public struct StructuredMessage: Sendable, Hashable {
 
@@ -69,7 +69,7 @@ public struct StructuredMessage: Sendable, Hashable {
 /// history — including thinking blocks with their provider signatures and
 /// tool call / result parts.
 ///
-/// ``GenerationQueue`` calls this in addition to (not instead of)
+/// `GenerationQueue` calls this in addition to (not instead of)
 /// ``ConversationHistoryReceiver`` so backends can pick whichever shape
 /// matches their wire format. The Anthropic backend reads the structured
 /// form so it can serialize prior `thinking` content blocks with their
@@ -175,7 +175,7 @@ public protocol LoadProgressReporting: AnyObject {
 /// backends where KV cache overflow is a real concern.
 ///
 /// - Note: `countTokens` must only be called after the model is loaded.
-///   Implementations throw ``InferenceError/modelNotLoaded`` when invoked
+///   Implementations throw ``InferenceError/modelNotFound(path:)`` when invoked
 ///   on an unloaded backend.
 public protocol TokenCountingBackend: AnyObject {
     /// Returns the exact token count for `text` using the loaded model's vocabulary.
@@ -187,14 +187,14 @@ public protocol TokenCountingBackend: AnyObject {
 
 /// Adopted by local backends that support a multimodal projector (mmproj) companion file.
 ///
-/// ``ModelLifecycleCoordinator`` calls ``setMmprojURL(_:)`` with the URL from
+/// `ModelLifecycleCoordinator` calls ``setMmprojURL(_:)`` with the URL from
 /// ``ModelInfo/mmprojURL`` before each ``InferenceBackend/loadModel(from:plan:)`` call.
 /// Conformers should set ``BackendCapabilities/supportsVision`` to `true` only
-/// once they can translate ``MessagePart/image(data:mimeType:)`` into backend
+/// once they can translate ``MessagePart/image(data:mimeType:placeholderHash:)`` into backend
 /// image embeddings, not merely because a projector URL is present.
 ///
 /// - Note: Passing `nil` clears the projector, returning the backend to text-only mode.
-///   ``ModelLifecycleCoordinator`` always calls this before load so the projector state
+///   `ModelLifecycleCoordinator` always calls this before load so the projector state
 ///   stays in sync with the loaded model file.
 public protocol MultimodalProjectorConfigurable: AnyObject {
     /// Sets (or clears) the mmproj companion file URL for the next ``InferenceBackend/loadModel(from:plan:)`` call.

--- a/Sources/ManifoldContract/BackendVisionCapability.swift
+++ b/Sources/ManifoldContract/BackendVisionCapability.swift
@@ -6,7 +6,7 @@
 /// `ManifoldFoundation`, `ManifoldCloud`) share a single source of truth.
 /// Returning `true` means the backend has both a model family known to
 /// accept images and an implemented request/generation path that preserves
-/// ``MessagePart/image`` payloads.
+/// `MessagePart.image(data:mimeType:placeholderHash:)` payloads.
 public enum BackendVisionCapability {
     public static var llamaSupportsImageInput: Bool { false }
 

--- a/Sources/ManifoldContract/DocumentChunk.swift
+++ b/Sources/ManifoldContract/DocumentChunk.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A contiguous passage of text extracted from a ``DocumentRecord``.
+/// A contiguous passage of text extracted from a `DocumentRecord`.
 ///
 /// The `text` is the retrieval unit — what gets embedded and what gets injected
 /// into the context window when retrieved. `chunkIndex` is zero-based within the

--- a/Sources/ManifoldContract/GenerationEvent.swift
+++ b/Sources/ManifoldContract/GenerationEvent.swift
@@ -90,7 +90,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// the signature verbatim on multi-turn replay.
     ///
     /// Fired between the block's `content_block_start` and the first
-    /// `content_block_delta`, before any ``thinkingToken`` events for the
+    /// `content_block_delta`, before any `thinkingToken` events for the
     /// same block. Consumers attach the signature to the in-flight
     /// reasoning accumulator so it lands on the persisted
     /// ``MessagePart/thinking(_:signature:)`` part once
@@ -111,7 +111,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// ``toolCall(_:)`` event.
     ///
     /// Emitted after the coordinator has routed a ``ToolCall`` through the
-    /// registered ``ToolRegistry`` and produced a ``ToolResult``. Downstream
+    /// registered `ToolRegistry` and produced a ``ToolResult``. Downstream
     /// consumers (chat UIs, transcripts) use this to append the tool result to
     /// the assistant turn before the next generation round begins.
     case toolResult(ToolResult)
@@ -155,7 +155,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// boundary they can pin a spinner / start timer to without scraping
     /// logs. This lifecycle covers the coordinator's full handling path for
     /// the call, not only successful routing through the registered
-    /// ``ToolRegistry``: approval gating, registry execution, and synthesized
+    /// `ToolRegistry`: approval gating, registry execution, and synthesized
     /// non-dispatch outcomes (for example approval denial, identical-call
     /// short-circuiting, or byte-budget exhaustion) are all included.
     /// `callId` matches ``ToolCall/id``; `name` is the tool name; `attempt`
@@ -169,7 +169,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// Fires after ``toolDispatchStarted(callId:name:attempt:)`` and before the
     /// matching ``toolResult(_:)``, but ONLY on paths where the call is
     /// genuinely approved: auto-approval (the tool does not require approval)
-    /// or an explicit `.approved` verdict from the ``ToolApprovalGate``. It is
+    /// or an explicit `.approved` verdict from the `ToolApprovalGate`. It is
     /// deliberately NOT emitted for non-approval outcomes —
     /// approval-gate denial, pre-tool-use-hook block, identical-call
     /// short-circuiting, or byte-budget exhaustion — so consumers can treat
@@ -187,7 +187,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// monotonic clock so wall-clock adjustments (NTP, user time changes) do
     /// not skew the value. It covers the full orchestrator-managed lifecycle
     /// for the call, including any approval-gate wait time and paths that do
-    /// not invoke the registered ``ToolRegistry`` because the coordinator
+    /// not invoke the registered `ToolRegistry` because the coordinator
     /// synthesized the result. `errorKind` carries the failure classification
     /// when handling produced an error result and `nil` on success — its
     /// value matches the ``ToolResult/errorKind`` of the `.toolResult` event
@@ -200,7 +200,7 @@ public enum GenerationEvent: Sendable, Equatable {
     /// short-circuits regular tool dispatch and lets the runtime swap the
     /// active agent and inject a boundary message into the next turn.
     ///
-    /// Only emitted by ``GenerationToolDispatchLoop`` when it has been
+    /// Only emitted by `GenerationToolDispatchLoop` when it has been
     /// configured with a session-aware handoff detector; backends never emit
     /// this case directly.
     case handoffRequested(AgentHandoff)

--- a/Sources/ManifoldContract/HeuristicTokenizer.swift
+++ b/Sources/ManifoldContract/HeuristicTokenizer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A ``TokenizerProvider`` that estimates token count using ~4 characters per token.
 ///
-/// This matches the heuristic already used by ``ContextWindowManager`` and is suitable
+/// This matches the heuristic already used by `ContextWindowManager` and is suitable
 /// as a fallback when no model-specific tokenizer is available.
 // @_spi(BackendInternals): published for the backend family packages
 // (manifold-mlx / manifold-llama, #1749). `LlamaBackend` falls back to the

--- a/Sources/ManifoldContract/ImageGenerationBackend.swift
+++ b/Sources/ManifoldContract/ImageGenerationBackend.swift
@@ -14,7 +14,7 @@ import Foundation
 /// protocol as an `Actor` would hold isolation across that 6–10s loop and
 /// block ``isLoaded`` / ``stopGeneration()`` / ``unloadModel()`` from the
 /// UI. ``InferenceBackend`` solved this with reference semantics + fine-
-/// grained ``NSLock``; this protocol follows the same pattern so both
+/// grained `NSLock`; this protocol follows the same pattern so both
 /// backend protocols share one isolation strategy.
 ///
 /// Conformers protect mutable state with `NSLock` (or `@unchecked Sendable`

--- a/Sources/ManifoldContract/InferenceBackend.swift
+++ b/Sources/ManifoldContract/InferenceBackend.swift
@@ -99,8 +99,8 @@ public struct GenerationConfig: Sendable, Codable {
     ///
     /// An alternative to top-p that filters tokens by probability ratio rather than
     /// cumulative mass. `nil` (the default) lets each backend apply its own value.
-    /// Mirrors `GenerateParameters.minP` in `mlx-swift-lm`. Honoured by ``MLXBackend``
-    /// and ``LlamaBackend``; backends that do not expose a min-p sampler ignore it.
+    /// Mirrors `GenerateParameters.minP` in `mlx-swift-lm`. Honoured by `MLXBackend`
+    /// and `LlamaBackend`; backends that do not expose a min-p sampler ignore it.
     public var minP: Float?
 
     /// Repetition penalty applied to recently-generated tokens (1.0 = no penalty).
@@ -109,13 +109,13 @@ public struct GenerationConfig: Sendable, Codable {
     /// callers can leave it `nil` and inherit the backend's default behaviour. When
     /// non-`nil` this value takes precedence over ``repeatPenalty`` for backends that
     /// support an explicit knob (MLX, llama.cpp). Backends that do not expose a
-    /// repetition penalty (e.g. ``FoundationBackend``) ignore it.
+    /// repetition penalty (e.g. `FoundationBackend`) ignore it.
     public var repetitionPenalty: Float?
 
     /// Window size (in recent tokens) over which ``repetitionPenalty`` applies.
     ///
     /// `nil` lets each backend use its own default — llama.cpp uses 64, mlx-swift-lm
-    /// uses 20. Honoured by ``MLXBackend`` and ``LlamaBackend``; other backends ignore.
+    /// uses 20. Honoured by `MLXBackend` and `LlamaBackend`; other backends ignore.
     public var repetitionContextSize: Int?
 
     /// Additive penalty for tokens that already appeared in the recent window
@@ -123,8 +123,8 @@ public struct GenerationConfig: Sendable, Codable {
     /// ``repetitionPenalty``).
     ///
     /// `nil` (the default) lets each backend apply no presence penalty. Honoured by
-    /// ``MLXBackend`` (mapped to `GenerateParameters.presencePenalty`) and
-    /// ``LlamaBackend`` (mapped to the third arg of `llama_sampler_init_penalties`).
+    /// `MLXBackend` (mapped to `GenerateParameters.presencePenalty`) and
+    /// `LlamaBackend` (mapped to the third arg of `llama_sampler_init_penalties`).
     /// Other backends ignore it.
     public var presencePenalty: Float?
 
@@ -140,7 +140,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// appeared in the recent window (OpenAI-style "frequency" penalty).
     ///
     /// `nil` (the default) lets each backend apply no frequency penalty. Honoured by
-    /// ``MLXBackend`` and ``LlamaBackend``; other backends ignore.
+    /// `MLXBackend` and `LlamaBackend`; other backends ignore.
     public var frequencyPenalty: Float?
 
     /// Window size (in recent tokens) over which ``frequencyPenalty`` applies.
@@ -152,30 +152,30 @@ public struct GenerationConfig: Sendable, Codable {
     /// llama.cpp DRY repetition sampler options.
     ///
     /// `nil` (the default) preserves the backend's existing sampler chain. When
-    /// set, ``LlamaBackend`` inserts `llama_sampler_init_dry` after penalties
+    /// set, `LlamaBackend` inserts `llama_sampler_init_dry` after penalties
     /// and grammar, before probability filters. Other backends ignore it.
     public var llamaDRY: LlamaDRYSamplerOptions?
 
     /// llama.cpp XTC sampler options.
     ///
     /// `nil` (the default) preserves the backend's existing sampler chain. When
-    /// set, ``LlamaBackend`` inserts `llama_sampler_init_xtc` immediately after
+    /// set, `LlamaBackend` inserts `llama_sampler_init_xtc` immediately after
     /// the temperature step. Other backends ignore it.
     public var llamaXTC: LlamaXTCSamplerOptions?
 
     /// llama.cpp Mirostat v2 sampler options.
     ///
     /// `nil` (the default) preserves the backend's existing sampler chain. When
-    /// set, ``LlamaBackend`` **replaces** the temperature + dist sampler tail
+    /// set, `LlamaBackend` **replaces** the temperature + dist sampler tail
     /// with `llama_sampler_init_mirostat_v2`. Other backends ignore it.
     public var llamaMirostatV2: LlamaMirostatV2SamplerOptions?
 
     /// Deterministic sampling seed.
     ///
-    /// When set, backends that expose a sampler seed (``MLXBackend``,
-    /// ``LlamaBackend``) initialise their RNG from this value so two runs with the
+    /// When set, backends that expose a sampler seed (`MLXBackend`,
+    /// `LlamaBackend`) initialise their RNG from this value so two runs with the
     /// same prompt and config produce the same token stream. Backends that do not
-    /// expose a seed (``FoundationBackend``, cloud backends without a `seed` API
+    /// expose a seed (`FoundationBackend`, cloud backends without a `seed` API
     /// parameter) silently ignore it — a missing seed is never an error.
     /// Stored as `UInt64` for parity with mlx-swift-lm; backends with smaller seed
     /// types (e.g. llama.cpp's `uint32_t`) truncate.
@@ -298,7 +298,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// Number of tokens between brief cooperative yields during MLX generation.
     ///
     /// Sustained MLX inference on Mac can starve WindowServer's GPU command
-    /// queue and cause hitches in other apps. To mitigate this, ``MLXBackend``
+    /// queue and cause hitches in other apps. To mitigate this, `MLXBackend`
     /// inserts a cooperative `Task.yield()` every `yieldEveryNTokens` tokens.
     ///
     /// - Defaults to `8` (one yield per ~8 tokens).
@@ -309,7 +309,7 @@ public struct GenerationConfig: Sendable, Codable {
     /// Capabilities the backend serving this request must provide.
     ///
     /// Empty (the default) means any wired backend may serve the request —
-    /// preserves the existing zero-config behaviour. When non-empty, ``RouterBackend``
+    /// preserves the existing zero-config behaviour. When non-empty, `RouterBackend`
     /// dispatches to the first child whose ``BackendCapabilities`` satisfy every
     /// requirement; backends used directly may use this for fail-fast validation.
     /// Independent of ``tools`` / ``grammar`` / ``jsonMode`` — those are
@@ -505,7 +505,7 @@ public struct GenerationConfig: Sendable, Codable {
 /// Custom conformers should follow the same pattern.
 ///
 /// New backends adopt this protocol; conformance is verified by the
-/// contract harness in ``BackendContractChecks`` and the per-capability
+/// contract harness in `BackendContractChecks` and the per-capability
 /// meta-contract. See `Tests/README.md` for the conformance walkthrough.
 public protocol InferenceBackend: AnyObject, Sendable {
     var isModelLoaded: Bool { get }
@@ -524,7 +524,7 @@ public protocol InferenceBackend: AnyObject, Sendable {
     ///
     /// The default implementation returns `nil`. Backends that have not yet
     /// adopted the manifest source-of-truth pattern compile against this
-    /// default; consumers (``ContextWindowManager``, request builders) fall
+    /// default; consumers (`ContextWindowManager`, request builders) fall
     /// back to ``BackendCapabilities`` when the manifest is absent. This
     /// keeps the addition non-breaking for adopters of `InferenceBackend`.
     var manifest: ModelManifest? { get }
@@ -587,7 +587,7 @@ public protocol InferenceBackend: AnyObject, Sendable {
     /// calls on this backend.
     ///
     /// The default implementation is a no-op. Backends that hold hot KV state
-    /// between turns (``LlamaBackend``, ``MLXBackend``) override this to
+    /// between turns (`LlamaBackend`, `MLXBackend`) override this to
     /// scrub the residue as best the underlying runtime allows.
     ///
     /// Call this:

--- a/Sources/ManifoldContract/Message.swift
+++ b/Sources/ManifoldContract/Message.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// A typed conversation message used by ``InferenceService/enqueue(messages:...)``
-/// (the typed overload) and ``InferenceService/generate(messages:...)``.
+/// A typed conversation message used by `InferenceService.enqueue(messages:...)`
+/// (the typed overload) and `InferenceService.generate(messages:...)`.
 ///
 /// **Not the same as `ChatMessage` / `ChatMessage`.** Those types live
 /// further down the stack:

--- a/Sources/ManifoldContract/MessagePart.swift
+++ b/Sources/ManifoldContract/MessagePart.swift
@@ -3,19 +3,19 @@ import Foundation
 /// A discrete piece of content within a chat message.
 ///
 /// Messages can contain multiple parts to support multimodal input (images
-/// and audio) alongside plain text, model reasoning (``thinking``), and tool
-/// calling (``toolCall`` / ``toolResult``). Each part is independently typed
+/// and audio) alongside plain text, model reasoning (``thinking(_:signature:)``), and tool
+/// calling (``toolCall(_:)`` / ``toolResult(_:)``). Each part is independently typed
 /// so the UI can render appropriate controls (e.g., inline images, playable
 /// audio, collapsible reasoning blocks) and backends can map parts to their
 /// native message formats.
 ///
 /// ## Persistence compatibility
 ///
-/// ``ManifoldSchemaV4/ChatMessage/decode(_:)`` falls back to a `.text` part
+/// `ManifoldSchemaV4.ChatMessage.decode(_:)` falls back to a `.text` part
 /// when JSON decoding fails. Historically this meant pre-removal rows that
-/// contained ``toolCall`` / ``toolResult`` discriminators degraded gracefully
+/// contained ``toolCall(_:)`` / ``toolResult(_:)`` discriminators degraded gracefully
 /// to text bubbles.  Those discriminators are now first-class cases again
-/// (see ``ManifoldSchemaV4``), so such rows decode correctly as their actual
+/// (see `ManifoldSchemaV4`), so such rows decode correctly as their actual
 /// cases. The `.text` fallback remains as a safety net for genuinely
 /// malformed JSON until V5.
 public enum MessagePart: Hashable, Sendable {
@@ -24,19 +24,19 @@ public enum MessagePart: Hashable, Sendable {
     ///
     /// Distinct from ``generatedImage(_:)`` — this case carries inline
     /// bytes the model is asked to look at; that case carries a file URL
-    /// pointing at an image the model produced. ``placeholderHash`` is optional
+    /// pointing at an image the model produced. The `placeholderHash` is optional
     /// so legacy persisted images and callers that do not need placeholder
     /// rendering can continue to omit it.
     case image(data: Data, mimeType: String, placeholderHash: ImagePlaceholderHash? = nil)
     /// A sandbox-local audio file rendered as an inline player.
     ///
-    /// ``url`` should point at a file inside the host app's container.
-    /// ``waveform`` stores precomputed normalized amplitude buckets so chat
+    /// The `url` should point at a file inside the host app's container.
+    /// The `waveform` stores precomputed normalized amplitude buckets so chat
     /// history can render without re-reading the audio file.
     case audio(url: URL, duration: TimeInterval, waveform: [Float]?)
     /// Accumulated model reasoning. Excluded from context window (textContent returns nil).
     ///
-    /// ``signature`` carries the provider-supplied opaque token that some
+    /// The `signature` carries the provider-supplied opaque token that some
     /// reasoning APIs (notably Anthropic's extended thinking) require verbatim
     /// when the block is replayed in a multi-turn request. It is `nil` for
     /// providers that don't issue one or for legacy persisted rows that
@@ -61,7 +61,7 @@ public enum MessagePart: Hashable, Sendable {
     /// from ``textContent`` (the payload's prompt is metadata, not visible chat
     /// text).
     case generatedImage(ImageMessagePayload)
-    /// A video produced by a ``VideoGenerationBackend`` and attached to
+    /// A video produced by a `VideoGenerationBackend` and attached to
     /// a saved message.
     ///
     /// References a local file URL whose binary is the backend's *output*.

--- a/Sources/ManifoldContract/ThinkingTransform.swift
+++ b/Sources/ManifoldContract/ThinkingTransform.swift
@@ -4,7 +4,7 @@
 /// open/close marker pair (`ThinkingMarkers`) and re-routes text inside a
 /// thinking block to `.thinkingToken`, firing `.thinkingCompleted` exactly on
 /// the depth 1→0 transition. Partial markers straddling a chunk boundary are
-/// held back via the shared ``overlap(_:_:)`` primitive.
+/// held back via the shared `overlap(_:_:)` primitive.
 ///
 /// As a ``StreamTransform`` it re-scans only `.token` payloads; `.thinkingToken`,
 /// `.thinkingCompleted`, `.toolCall`, and every other event case pass through

--- a/Sources/ManifoldContract/TokenizerProvider.swift
+++ b/Sources/ManifoldContract/TokenizerProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Abstraction for counting tokens in a string.
 ///
 /// Backends can vend a model-specific tokenizer conforming to this protocol.
-/// When no real tokenizer is available, ``HeuristicTokenizer`` provides a
+/// When no real tokenizer is available, `HeuristicTokenizer` provides a
 /// character-count estimate (~4 chars per token).
 public protocol TokenizerProvider: Sendable {
     /// Returns the number of tokens in the given text.

--- a/Sources/ManifoldContract/ToolCallTransform.swift
+++ b/Sources/ManifoldContract/ToolCallTransform.swift
@@ -43,7 +43,7 @@ public struct ToolCallMarker: Sendable {
 ///   emits `.toolCall`, and `nil` silently drops the call (matching both
 ///   legacy parsers).
 /// - Partial open/close markers straddling a chunk boundary are held back via
-///   the shared ``overlap`` primitives — the open-tag holdback is the max
+///   the shared `overlap` primitives — the open-tag holdback is the max
 ///   overlap across *all* candidate opens.
 ///
 /// As a ``StreamTransform`` it re-scans only `.token` payloads; all other event

--- a/Sources/ManifoldContract/ToolExecutor.swift
+++ b/Sources/ManifoldContract/ToolExecutor.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// Conformers pair a ``ToolDefinition`` (the JSON-Schema contract the model
 /// sees) with an `execute(arguments:)` hook that runs the tool and returns a
-/// ``ToolResult``. Executors are stored in a ``ToolRegistry`` and dispatched
+/// ``ToolResult``. Executors are stored in a `ToolRegistry` and dispatched
 /// by the orchestration loop when the model emits a ``ToolCall``.
 ///
 /// ## Arguments type
@@ -14,7 +14,7 @@ import Foundation
 /// The protocol intentionally takes ``JSONSchemaValue`` — not a raw `String`
 /// — so adapter layers (MCP bridges, AppIntents, macro-generated tools) can
 /// hand a structured, already-parsed argument tree to the executor without
-/// re-serialising through a string. ``ToolRegistry/dispatch(_:)`` handles the
+/// re-serialising through a string. `ToolRegistry.dispatch(_:)` handles the
 /// `String`→`JSONSchemaValue` parse at the registry boundary.
 ///
 /// ## Typed adapter
@@ -37,7 +37,7 @@ import Foundation
 /// ``executeStreaming(arguments:)`` progress events, but the terminal
 /// ``ToolResult`` remains atomic transcript content.
 ///
-/// When an executor throws mid-work, ``ToolRegistry/dispatch(_:)`` records a
+/// When an executor throws mid-work, `ToolRegistry.dispatch(_:)` records a
 /// ``ToolResult`` with ``ToolResult/ErrorKind/permanent`` and
 /// `String(describing: error)` as the content. Any in-flight state the
 /// executor had accumulated — bytes read, chunks processed, rows fetched — is
@@ -51,7 +51,7 @@ import Foundation
 /// labelling it retry-safe would push agents into loops on permanent
 /// failures (logic bugs, schema mismatches, auth denials) that no amount of
 /// retrying will fix. Executors that *know* a failure is retriable must
-/// return an explicit ``ToolResult/init(callId:content:errorKind:)`` with
+/// return an explicit ``ToolResult/init(callId:content:errorKind:dialog:structuredContent:)`` with
 /// ``ToolResult/ErrorKind/transient`` instead of throwing — same rule for
 /// ``ToolResult/ErrorKind/timeout``, ``ToolResult/ErrorKind/rateLimited``,
 /// ``ToolResult/ErrorKind/cancelled``, and the other specific kinds.
@@ -78,7 +78,7 @@ import Foundation
 /// ## Cooperative cancellation
 ///
 /// `execute(arguments:)` runs inside a `Task` owned by the orchestrator
-/// (``ToolRegistry/dispatch(_:)`` is invoked from a child task in
+/// (`ToolRegistry.dispatch(_:)` is invoked from a child task in
 /// `GenerationQueue`). When the user hits stop mid-generation, the
 /// orchestrator calls `Task.cancel()` on its active generation task and the
 /// cancellation propagates into this executor through structured concurrency.
@@ -96,7 +96,7 @@ import Foundation
 ///   that calls the underlying `cancel()` so the in-flight request is torn
 ///   down. Otherwise the request leaks past the user's stop.
 ///
-/// When the executor cooperates, ``ToolRegistry/dispatch(_:)`` synthesises
+/// When the executor cooperates, `ToolRegistry.dispatch(_:)` synthesises
 /// a ``ToolResult`` with ``ToolResult/ErrorKind/cancelled`` and the fixed
 /// content `"cancelled by user"`. The orchestrator records it in the
 /// transcript and **stops the dispatch loop** — no further backend turn
@@ -109,7 +109,7 @@ import Foundation
 /// handles, in-flight HTTP requests). Cooperate.
 public protocol ToolExecutor: Sendable {
 
-    /// The JSON-Schema contract exposed to the model and the ``ToolRegistry``
+    /// The JSON-Schema contract exposed to the model and the `ToolRegistry`
     /// lookup key. ``ToolDefinition/name`` must be unique within a registry
     /// (case-insensitive).
     var definition: ToolDefinition { get }
@@ -132,17 +132,17 @@ public protocol ToolExecutor: Sendable {
     /// orchestrator dispatches it.
     ///
     /// Side-effecting tools (writes a file, sends a message, calls a paid
-    /// API) should set this to `true` so a UI-layer ``ToolApprovalGate`` is
+    /// API) should set this to `true` so a UI-layer `ToolApprovalGate` is
     /// consulted before execution. Pure-read tools should leave the default
     /// of `false` so they auto-approve regardless of the host's policy. The
     /// generation coordinator queries this flag via
-    /// ``ToolRegistry/requiresApproval(toolName:)`` and skips the gate hop
+    /// `ToolRegistry.requiresApproval(toolName:)` and skips the gate hop
     /// entirely when false — read-only tools never block on a user prompt.
     var requiresApproval: Bool { get }
 
     /// Executes the tool with already-parsed JSON arguments.
     ///
-    /// The returned ``ToolResult/callId`` may be empty — ``ToolRegistry``
+    /// The returned ``ToolResult/callId`` may be empty — `ToolRegistry`
     /// stamps the correct id from the incoming ``ToolCall`` before returning
     /// the result to the caller. Thrown errors are caught by the registry and
     /// turned into ``ToolResult/ErrorKind/permanent`` results; to signal a
@@ -233,7 +233,7 @@ extension ToolExecutor {
 /// registry.register(weather)
 /// ```
 ///
-/// Decode or encode failures throw — ``ToolRegistry/dispatch(_:)`` catches them
+/// Decode or encode failures throw — `ToolRegistry.dispatch(_:)` catches them
 /// and returns a ``ToolResult/ErrorKind/permanent`` result. Malformed JSON in
 /// the raw ``ToolCall/arguments`` string is classified as
 /// ``ToolResult/ErrorKind/invalidArguments`` at the registry boundary before
@@ -244,7 +244,7 @@ extension ToolExecutor {
 /// The adapter is inherently atomic: the handler's `Result` is JSON-encoded
 /// exactly once **after** the handler returns normally. If the handler throws,
 /// nothing is encoded and no ``ToolResult`` is produced — the error bubbles to
-/// ``ToolRegistry/dispatch(_:)`` which records a
+/// `ToolRegistry.dispatch(_:)` which records a
 /// ``ToolResult/ErrorKind/permanent`` result with the error description and
 /// discards any work the handler had performed. See the ``ToolExecutor``
 /// protocol's Atomicity section for the full contract; handlers that perform
@@ -263,7 +263,7 @@ public struct TypedToolExecutor<Arguments: Decodable & Sendable, Result: Encodab
     ///   - definition: The tool contract exposed to the model. ``ToolDefinition/parameters``
     ///     should describe the JSON shape of `Arguments`.
     ///   - requiresApproval: When `true`, the orchestrator routes calls to
-    ///     this tool through a ``ToolApprovalGate`` before execution. Defaults
+    ///     this tool through a `ToolApprovalGate` before execution. Defaults
     ///     to `false` (auto-approve, suitable for pure-read tools).
     ///   - handler: Runs the tool. Thrown errors become ``ToolResult/ErrorKind/permanent``
     ///     results at the registry layer.

--- a/Sources/ManifoldContract/VectorSearchHit.swift
+++ b/Sources/ManifoldContract/VectorSearchHit.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// A retrieved chunk with its relevance score and source document title.
 ///
-/// Returned by ``VectorStore/search(embedding:limit:)`` and
-/// ``VectorStore/keywordSearch(query:limit:)``. The `documentTitle` is stored
+/// Returned by `VectorStore.search(embedding:limit:)` and
+/// `VectorStore.keywordSearch(query:limit:)`. The `documentTitle` is stored
 /// alongside the chunk record so context formatters can attribute retrieved
-/// passages without an extra round-trip to ``DocumentStore``.
+/// passages without an extra round-trip to `DocumentStore`.
 public struct VectorSearchHit: Sendable {
     public let chunk: DocumentChunk
     /// Human-readable source label (typically the document file name).

--- a/Sources/ManifoldKit/ManifoldBootstrap+GenerationToolSources.swift
+++ b/Sources/ManifoldKit/ManifoldBootstrap+GenerationToolSources.swift
@@ -10,11 +10,11 @@ import ManifoldUI
 
 extension ManifoldBootstrap {
 
-    /// Registers ``ImageGenerationToolSource`` and ``VideoGenerationToolSource``
+    /// Registers `ImageGenerationToolSource` and `VideoGenerationToolSource`
     /// on the bootstrap's runtime so the active language model can invoke
-    /// ``generate_image`` and ``generate_video`` tools.
+    /// the `generate_image` and `generate_video` tools.
     ///
-    /// Call after wiring the ``ChatViewModel`` and after the bootstrap has been
+    /// Call after wiring the `ChatViewModel` and after the bootstrap has been
     /// fully configured:
     ///
     /// ```swift
@@ -22,12 +22,12 @@ extension ManifoldBootstrap {
     /// ```
     ///
     /// Each source is only active when the bootstrap has the corresponding
-    /// surface wired: ``ImageGenerationToolSource`` requires
-    /// ``ManifoldBootstrap/imageGenerationService`` to be non-nil;
-    /// ``VideoGenerationToolSource`` requires
-    /// ``ManifoldBootstrap/videoGenerationService`` to be non-nil;
-    /// ``WebSearchToolSource`` requires
-    /// ``ManifoldBootstrap/webSearchRuntime`` to be non-nil. Sources for
+    /// surface wired: `ImageGenerationToolSource` requires
+    /// `imageGenerationService` to be non-nil;
+    /// `VideoGenerationToolSource` requires
+    /// `videoGenerationService` to be non-nil;
+    /// `WebSearchToolSource` requires
+    /// `webSearchRuntime` to be non-nil. Sources for
     /// unwired surfaces are silently skipped so the call is safe to issue
     /// unconditionally regardless of which generation surfaces your app enables.
     ///

--- a/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
+++ b/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
@@ -8,15 +8,15 @@ platforms.
 
 Most AI-chat libraries hand you a single layer — a UI kit, an engine wrapper, or
 a thin cloud client — and leave the rest as an exercise. `ManifoldKit` ships the
-assembled product: import one umbrella module and you get a SwiftUI ``ChatView``,
-the ``ConversationRuntime`` turn loop (send / regenerate / edit / cancel /
+assembled product: import one umbrella module and you get a SwiftUI `ChatView`,
+the `ConversationRuntime` turn loop (send / regenerate / edit / cancel /
 branch), SwiftData persistence, model download & management UI, and inference
 backends spanning on-device (MLX, llama.cpp, Apple Foundation Models) and cloud
-(OpenAI, Anthropic, Ollama, LAN) — all behind one ``InferenceBackend`` protocol.
+(OpenAI, Anthropic, Ollama, LAN) — all behind one `InferenceBackend` protocol.
 Swapping engines is a config change, not a rewrite.
 
 `import ManifoldKit` re-exports the 80%-case modules — the inference surface,
-``ConversationRuntime``, persistence, the backends, and the chat UI. Specialised
+`ConversationRuntime`, persistence, the backends, and the chat UI. Specialised
 modules stay explicit imports: `ManifoldMCP` (Model Context Protocol),
 `ManifoldVoice` (speech I/O), `ManifoldUIModelManagement` (the model browser),
 and `ManifoldAppIntents`.
@@ -25,8 +25,8 @@ and `ManifoldAppIntents`.
 
 Add the package, then drop this into your app entry point.
 ``ManifoldKit/quickStart(configuration:)`` builds the SwiftData container,
-registers the compiled-in backends, and wires up a ``ChatViewModel`` in one call.
-Errors surface as ``ManifoldKitError``.
+registers the compiled-in backends, and wires up a `ChatViewModel` in one call.
+Errors surface as `ManifoldKitError`.
 
 ```swift
 import SwiftUI
@@ -68,7 +68,7 @@ struct MyChatApp: App {
 > Warning: **The no-backend cliff.** With no backend registered — no companion
 > backend package linked (`manifold-mlx`, `manifold-llama`, …) and no registrar
 > passed via `quickStart(backends:)` — `quickStart()` compiles but throws
-> ``ManifoldKitError`` `.noBackendsRegistered` at runtime: there is nothing to
+> `ManifoldKitError` `.noBackendsRegistered` at runtime: there is nothing to
 > generate with. Add a companion package and inject its registrar (e.g.
 > `quickStart(backends: [LlamaBackends.self])`). The cloud and Foundation
 > families compile in unconditionally, so a cloud-only setup with no configured
@@ -84,40 +84,31 @@ install to first token, follow the loose-markdown front door:
 - **Branch points:** [CLI / server](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-CLI.md) · [Bring your own UI](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-BRING-YOUR-OWN-UI.md)
 - **Add a capability:** [Tools](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-TOOLS.md) · [App Intents](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-APPINTENTS.md) · [RAG](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-RAG.md) · [Voice](https://github.com/roryford/ManifoldKit/blob/main/docs/QUICKSTART-VOICE.md) · [Image & video gen (manifold-mlx)](https://github.com/roryford/manifold-mlx)
 
+### The assembled surface
+
+`import ManifoldKit` re-exports these types from their home modules. DocC
+resolves symbol links only within the target it builds, so this umbrella page
+links the entry points it *owns* (see Topics below) and names the re-exports
+inline — follow each home-module catalog for the full reference:
+
+- **Chat UI** (`ManifoldUI`): `ChatView`, `ChatViewModel`.
+- **Bring your own UI** (`ManifoldInference` / `ManifoldRuntime`):
+  `InferenceService`, `ConversationRuntime`, `ModelRegistry`.
+- **Backends** (`ManifoldContract` + families): every engine sits behind one
+  `InferenceBackend` protocol. The cloud (OpenAI, Anthropic, Ollama, LAN) and
+  Apple `FoundationBackend` families compile in unconditionally; the on-device
+  MLX and llama.cpp families ship as companion packages (`manifold-mlx`,
+  `manifold-llama`) since v0.48 and are wired in by passing their registrars to
+  ``ManifoldKit/quickStart(backends:configuration:seed:)``.
+- **Persistence & bootstrap** (`ManifoldPersistenceSwiftData`):
+  `ManifoldBootstrap`, configured by `ManifoldConfiguration`.
+
 ## Topics
 
 ### Get Started
 
 - ``ManifoldKit/quickStart(configuration:)``
+- ``ManifoldKit/quickStart(configuration:seed:)``
+- ``ManifoldKit/quickStart(backends:configuration:seed:)``
 - ``QuickStartResult``
-- ``ManifoldConfiguration``
-- ``ManifoldKitError``
-
-### Build a Chat UI
-
-- ``ChatView``
-- ``ChatViewModel``
-
-### Bring Your Own UI
-
-- ``InferenceService``
-- ``ConversationRuntime``
-- ``ModelRegistry``
-
-### Backends
-
-Every engine sits behind one ``InferenceBackend`` protocol; ``DefaultBackends``
-registers the ones compiled in for the active traits. The on-device families are
-re-exported here. Cloud backends (OpenAI, Anthropic, Ollama, LAN) live in
-`ManifoldOllama` / `ManifoldCloudSaaS` and are always compiled in since v0.48
-(the `CloudSaaS` / `Ollama` traits were retired).
-
-- ``InferenceBackend``
-- ``DefaultBackends``
-- ``MLXBackend``
-- ``LlamaBackend``
-- ``FoundationBackend``
-
-### Persistence & Bootstrap
-
-- ``ManifoldBootstrap``
+- ``QuickStartSeed``

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -37,7 +37,7 @@ import ManifoldHuggingFace
 
 /// The umbrella namespace for ManifoldKit's high-level entry points.
 ///
-/// Today this hosts ``ManifoldKit/ManifoldKit/quickStart(configuration:)``;
+/// Today this hosts ``quickStart(configuration:)``;
 /// future top-level conveniences will land here so adopters have one
 /// well-known place to look.
 @MainActor
@@ -46,14 +46,13 @@ public enum ManifoldKit {
     /// Bootstraps a working chat runtime with sensible defaults in one call.
     ///
     /// Internally this:
-    /// 1. Drives ``ManifoldBootstrap/build(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)``
-    ///    to completion (consuming its progress milestones).
-    /// 2. Registers the compiled-in default backends via
-    ///    ``DefaultBackends/register(with:)``.
-    /// 3. Constructs a ``ChatViewModel`` wired to the bootstrap's shared
-    ///    ``InferenceService``, persistence stores, and ``ConversationRuntime``.
+    /// 1. Drives `ManifoldBootstrap.build(...)` to completion (consuming its
+    ///    progress milestones).
+    /// 2. Registers the compiled-in default backends.
+    /// 3. Constructs a `ChatViewModel` wired to the bootstrap's shared
+    ///    `InferenceService`, persistence stores, and `ConversationRuntime`.
     ///
-    /// Errors thrown by any step are reduced through ``ManifoldKitError/from(_:)``
+    /// Errors thrown by any step are reduced through `ManifoldKitError.from(_:)`
     /// so callers always see the unified error rim instead of raw
     /// `URLError` / SwiftData errors.
     ///
@@ -65,7 +64,7 @@ public enum ManifoldKit {
     /// ```
     ///
     /// - Parameter configuration: The framework configuration. Defaults to
-    ///   ``ManifoldInference/ManifoldConfiguration/default`` — fine for
+    ///   `ManifoldConfiguration.default` — fine for
     ///   demos and tests, but production apps should pass an explicit
     ///   configuration with their own bundle identifier.
     /// - Returns: A ``QuickStartResult`` carrying the bootstrap, the chat view
@@ -100,7 +99,7 @@ public enum ManifoldKit {
     /// of the following is true:
     /// - A model is already available (Foundation or local disk).
     /// - No *registered* backend can load the seed's model type — checked
-    ///   against the live ``InferenceService`` registration state, so backends
+    ///   against the live `InferenceService` registration state, so backends
     ///   injected via ``quickStart(backends:configuration:seed:)`` count.
     ///   The curated GGUF seed therefore requires the manifold-llama companion
     ///   package's `LlamaBackends` registrar (see ``QuickStartSeed``).
@@ -119,7 +118,7 @@ public enum ManifoldKit {
     ///
     /// - Parameters:
     ///   - configuration: Framework configuration. Defaults to
-    ///     ``ManifoldInference/ManifoldConfiguration/default``.
+    ///     `ManifoldConfiguration.default`.
     ///   - seed: Opt-in seed configuration. Use
     ///     ``QuickStartSeed/recommendedSmallModel(onProgress:)`` for the
     ///     curated default. Pass `nil` for the original behavior.
@@ -140,7 +139,7 @@ public enum ManifoldKit {
     ///
     /// This is the migration path for backends that live outside this package
     /// (the `manifold-mlx` / `manifold-llama` companion packages, #1749).
-    /// The compiled-in defaults (``DefaultBackends/registrars``) are registered
+    /// The compiled-in defaults are registered
     /// first, then every entry in `backends` — **before** the model registry
     /// refresh, the optional starter-model seed, and the model-selection
     /// policy run. Registering a backend only after `quickStart` returns is
@@ -160,7 +159,7 @@ public enum ManifoldKit {
     ///     defaults. Order follows array order; registering the same family
     ///     twice is harmless (last registration wins per model type).
     ///   - configuration: Framework configuration. Defaults to
-    ///     ``ManifoldInference/ManifoldConfiguration/default``.
+    ///     `ManifoldConfiguration.default`.
     ///   - seed: Optional starter-model seed, as in
     ///     ``quickStart(configuration:seed:)``. The seed sees the injected
     ///     backends: a GGUF seed downloads when any registered backend —
@@ -424,7 +423,7 @@ public enum ManifoldKit {
     /// decision table without driving a full bootstrap.
     enum BackendAvailabilityDiagnostic: Equatable {
         /// Nothing is registered at all — the service can never generate.
-        /// `quickStart` throws ``ManifoldKitError/noBackendsRegistered``.
+        /// `quickStart` throws `ManifoldKitError.noBackendsRegistered`.
         case noBackends
         /// Cloud providers are registered but no local backend is, and no
         /// endpoint has been configured — the service is degraded until the
@@ -507,17 +506,17 @@ public enum ManifoldKit {
     }
 }
 
-/// The result returned by ``ManifoldKit/ManifoldKit/quickStart(configuration:)``.
+/// The result returned by ``ManifoldKit/quickStart(configuration:)``.
 ///
 /// `bootstrap` owns the inference service, SwiftData container, persistence
-/// adapters, and ``ConversationRuntime``. Retain it for the lifetime of the
+/// adapters, and `ConversationRuntime`. Retain it for the lifetime of the
 /// chat runtime — releasing it tears down the underlying services.
 ///
-/// `viewModel` is the ``ChatViewModel`` wired against `bootstrap`. Pass it to
+/// `viewModel` is the `ChatViewModel` wired against `bootstrap`. Pass it to
 /// `ChatView` (or your own SwiftUI surface) as you would a manually
 /// constructed view model.
 ///
-/// `sessionManager` is a ``SessionManagerViewModel`` configured against the
+/// `sessionManager` is a `SessionManagerViewModel` configured against the
 /// same bootstrap and with its initial session page already loaded (#1425).
 /// Pass it to a sidebar or session-list surface alongside `viewModel` — no
 /// additional `configure` or `loadSessions` call is required.

--- a/Sources/ManifoldKit/QuickStartSeed.swift
+++ b/Sources/ManifoldKit/QuickStartSeed.swift
@@ -27,7 +27,7 @@ import ManifoldInference
 
 // MARK: - QuickStartSeed
 
-/// Configures an opt-in model seed for ``ManifoldKit/ManifoldKit/quickStart(seed:)``.
+/// Configures an opt-in model seed for ``ManifoldKit/quickStart(configuration:seed:)``.
 ///
 /// When a ``QuickStartSeed`` is supplied, `quickStart` downloads a curated
 /// small model **before** the selection policy runs — so on first launch the
@@ -37,9 +37,9 @@ import ManifoldInference
 ///
 /// Seeding requires a *registered* backend capable of loading the seed's
 /// model type. The check is made against the live
-/// ``ManifoldInference/InferenceService`` registration state — not compile-time
+/// `InferenceService` registration state — not compile-time
 /// traits — so a Llama-capable backend injected at runtime via
-/// ``ManifoldKit/ManifoldKit/quickStart(backends:configuration:seed:)``
+/// ``ManifoldKit/quickStart(backends:configuration:seed:)``
 /// (from the manifold-llama companion package) enables the GGUF seed.
 ///
 /// ### Skip conditions

--- a/Sources/ManifoldUI/Views/Chat/ToolInvocationView.swift
+++ b/Sources/ManifoldUI/Views/Chat/ToolInvocationView.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 import ManifoldInference
 
-/// Renders a single ``MessagePart/toolCall`` or ``MessagePart/toolResult``
+/// Renders a single `MessagePart.toolCall` or `MessagePart.toolResult`
 /// within a message bubble.
 ///
 /// Four visual states are branched off the `MessagePart` case and the presence
-/// of a completed ``ToolResult``:
+/// of a completed `ToolResult`:
 /// - ``State/pendingApproval`` — tool-name chip + argument preview + Approve/Deny.
 /// - ``State/running`` — spinner while the tool executes.
 /// - ``State/completed`` — collapsed disclosure showing args + content.
-/// - ``State/failed`` — collapsed disclosure with the ``ToolResult/ErrorKind``
+/// - ``State/failed`` — collapsed disclosure with the `ToolResult.ErrorKind`
 ///   chip.
 ///
 /// This view is intentionally "dumb" — it takes the part and optional
@@ -28,8 +28,8 @@ public struct ToolInvocationView: View {
     /// Visual state the view should render.
     ///
     /// The caller decides which state applies based on whether the part is a
-    /// ``MessagePart/toolCall`` that still needs approval, is currently
-    /// running, or already has a matching ``MessagePart/toolResult`` paired
+    /// `MessagePart.toolCall` that still needs approval, is currently
+    /// running, or already has a matching `MessagePart.toolResult` paired
     /// with it. Keeping the state explicit in the API makes the view unit
     /// testable without having to fabricate the whole messages array.
     public enum State: Sendable, Equatable {
@@ -39,13 +39,13 @@ public struct ToolInvocationView: View {
         case failed
     }
 
-    /// The part being rendered. Must be either ``MessagePart/toolCall`` or
-    /// ``MessagePart/toolResult`` — any other case renders as an empty view
+    /// The part being rendered. Must be either `MessagePart.toolCall` or
+    /// `MessagePart.toolResult` — any other case renders as an empty view
     /// so mixed-content bubbles degrade gracefully.
     public let part: MessagePart
 
-    /// Optional paired ``ToolResult`` for ``State/completed`` / ``State/failed``
-    /// renders driven off a ``MessagePart/toolCall`` primary part. Supplying
+    /// Optional paired `ToolResult` for ``State/completed`` / ``State/failed``
+    /// renders driven off a `MessagePart.toolCall` primary part. Supplying
     /// the result alongside the call lets the disclosure group label with
     /// the tool name while still surfacing the result body underneath.
     public let pairedResult: ToolResult?
@@ -59,7 +59,7 @@ public struct ToolInvocationView: View {
 
     /// Invoked when the user taps Deny on a pending approval. The optional
     /// `String` carries an opt-in reason surfaced back to the model via the
-    /// synthesised ``ToolResult/ErrorKind/permissionDenied``.
+    /// synthesised `ToolResult.ErrorKind.permissionDenied`.
     /// Only read when ``state`` is ``State/pendingApproval``.
     public var onDeny: ((String?) -> Void)?
 

--- a/Sources/ManifoldUI/Views/Composer/VisionInputButton.swift
+++ b/Sources/ManifoldUI/Views/Composer/VisionInputButton.swift
@@ -9,10 +9,10 @@ import ManifoldInference
 /// On iOS presents the Photos picker; on macOS opens a file-chooser panel
 /// restricted to image UTTypes. Stages the selected image via
 /// ``ChatViewModel/stageAttachment(_:)`` as a
-/// ``MessagePart/image(data:mimeType:placeholderHash:)`` part.
+/// `MessagePart.image(data:mimeType:placeholderHash:)` part.
 ///
-/// Only shown when the active backend's ``BackendCapabilities`` indicate
-/// vision support (``BackendCapabilities/supportsVision``). When vision is
+/// Only shown when the active backend's `BackendCapabilities` indicate
+/// vision support (`BackendCapabilities.supportsVision`). When vision is
 /// unsupported the button is hidden.
 ///
 /// ```swift
@@ -21,7 +21,8 @@ import ManifoldInference
 /// })
 /// ```
 ///
-/// Combine with ``VoiceComposerAccessory`` when your app supports both modalities:
+/// Combine with `VoiceComposerAccessory` (from `ManifoldVoice`) when your app
+/// supports both modalities:
 ///
 /// ```swift
 /// ChatView(showModelManagement: $show, composerAccessory: {
@@ -32,7 +33,7 @@ import ManifoldInference
 /// })
 /// ```
 ///
-/// > Note: On iOS, ``PhotoAttachmentButton`` provides equivalent functionality
+/// > Note: On iOS, `PhotoAttachmentButton` provides equivalent functionality
 /// > but is restricted to that platform. Prefer ``VisionInputButton`` for
 /// > cross-platform codebases.
 public struct VisionInputButton: View {

--- a/Sources/ManifoldUI/Views/Settings/SamplerPresetPickerView.swift
+++ b/Sources/ManifoldUI/Views/Settings/SamplerPresetPickerView.swift
@@ -4,7 +4,7 @@ import ManifoldInference
 
 /// Picker and management UI for sampler presets within `GenerationSettingsView`.
 ///
-/// Reads and writes presets through a ``SamplerPresetStore`` injected via the
+/// Reads and writes presets through a `SamplerPresetStore` injected via the
 /// SwiftUI environment (typically from `ManifoldBootstrap.samplerPresetStore`).
 /// The view does not import SwiftData — the store is the only persistence
 /// surface visible to the UI.
@@ -143,7 +143,7 @@ private struct SamplerPresetStoreKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
-    /// Injection point for the ``SamplerPresetStore`` consumed by
+    /// Injection point for the `SamplerPresetStore` consumed by
     /// ``SamplerPresetPickerView``.
     public var samplerPresetStore: (any SamplerPresetStore)? {
         get { self[SamplerPresetStoreKey.self] }


### PR DESCRIPTION
DocC review + fix for the core modules. Part of the overnight DocC pass; the companion-package landing pages shipped separately in manifold-mlx#6 and manifold-llama#7.

## Method

Built the docs the way the publish pipeline does — `xcodebuild docbuild -scheme ManifoldKit` (the combined-scheme build `docs.yml` uses), not per-target `swift package generate-documentation`. Per-target builds report ~436 false cross-module breakages because each `@_exported import` re-export looks unresolved in isolation; the combined scheme resolves them. Working from the combined build's warning set isolates the links that are *genuinely* broken in the published site.

## Fixed (17 files, doc-comment only, no behavior change)

All broken `` ``Symbol`` `` links in the two most consumer-facing surfaces:

- **`ManifoldContract`** (the protocol kernel every consumer imports) — 14 files. Cross-module / companion-package / SPI symbols (`MLXBackend`, `LlamaBackend`, `FoundationBackend`, `ToolRegistry`, `ToolApprovalGate`, `GenerationQueue`, `InferenceService`, `ContextWindowManager`, `HeuristicTokenizer`, `VectorStore`, `NSLock`, …) demoted to single-backtick code spans (they can't resolve from the kernel's module scope). Renamed/typo enum-case and initializer links corrected to DocC's disambiguated form and kept as links where the type resolves via `@_exported` (`MessagePart/image(data:mimeType:placeholderHash:)`, `toolCall(_:)`, `thinking(_:signature:)`, `InferenceError/modelNotFound(path:)`, `ToolResult/init(callId:content:errorKind:dialog:structuredContent:)`).
- **`ManifoldUI`** — 3 files (`ToolInvocationView`, `VisionInputButton`, `SamplerPresetPickerView`). Cross-module `MessagePart` / `ToolResult` / `BackendCapabilities` / `SamplerPresetStore` refs and the platform-gated `VoiceComposerAccessory` / `PhotoAttachmentButton` refs demoted to code spans.

## Verification

- `swift build --build-tests` clean (exit 0).
- Re-ran the combined `xcodebuild docbuild`: **0 remaining** `doesn't exist at` warnings in `ManifoldContract` and in the 3 `ManifoldUI` files (down from ~70 + 12).

## Bounded follow-up (out of scope here)

The combined build still reports ~706 `doesn't exist at` warnings in lower-traffic internal modules — `ManifoldCloudCore`, `ManifoldCloudSaaS`, `ManifoldFoundation`, `ManifoldBackendsUmbrella`, `ManifoldCloud`. These are pre-existing debt (the `docs.yml` publish is best-effort and explicitly does not gate on them — see its comment). Same mechanical pattern (demote cross-module links, apply DocC-suggested renames); deferred to keep this PR scoped to the consumer-facing kernel + chat UI. Tracked as a comment here rather than a new issue per repo hygiene.

---

## Follow-up commit: ManifoldKit umbrella landing page (489769f6)

The umbrella's own DocC catalog + `QuickStart` doc comments had genuinely broken links. Verified against the **combined `xcodebuild docbuild -scheme ManifoldKit`** publish pipeline (not per-target): the original tree emitted **20 real `/ManifoldKit` `doesn't exist at` warnings**; the fix brings that to **0** while the rest of the combined build is unchanged.

Fixed (4 files, doc-comment / catalog only, no behavior change):

- **Dead / companion-package symbols** — `MLXBackend`, `LlamaBackend`, `DefaultBackends` (moved to the manifold-mlx / manifold-llama companion packages or deprecated since v0.48) demoted from broken `` ``Symbol`` `` links to code spans; the landing-page Backends section rewritten to describe the companion-package wiring (`quickStart(backends:)`).
- **Stale / typo'd link paths** — the out-of-date `ManifoldBootstrap/build(configuration:inferenceService:imageGenerationService:diagnostics:makeModelContainer:)` signature, doubled `ManifoldKit/ManifoldKit/quickStart(...)` paths, and the non-existent `quickStart(seed:)` label corrected (the real overloads are `quickStart(configuration:)`, `quickStart(configuration:seed:)`, `quickStart(backends:configuration:seed:)`).
- **Non-symbol references** — the tool-name strings `generate_image` / `generate_video` and cross-module re-exports (`ChatView`, `ChatViewModel`, `InferenceService`, `ConversationRuntime`, …) demoted to inline code spans, consistent with the ManifoldContract/ManifoldUI commit's pattern.
- **Topics curation** — the landing page's task groups previously listed re-exported symbols as bullet items, which DocC rejects as non-link task-group items. Restructured so Topics contains only the symbols the umbrella *defines* (the `quickStart` overloads, `QuickStartResult`, `QuickStartSeed`); re-exports are named in a new prose "assembled surface" section that points at each home module.

Verification: `swift build --build-tests` clean; combined `xcodebuild docbuild` reports 0 remaining `/ManifoldKit` warnings (was 20). The pre-existing 16 `nil-coalescing` *compiler* warnings in `ManifoldUI/ViewModels/ArchitectViewModel.swift` are unrelated to DocC and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
