### PR TITLE
docs: redesign layer-cake hero + fix stale pre-companion-split references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The only open-source Swift package that bundles UI, turn-loop runtime, persistence, and multi-backend inference into one drop-in chat product for Apple platforms.
 
-![ManifoldKit assembled full-stack hero — one import gives you the SwiftUI ChatView, the ConversationRuntime turn loop, SwiftData persistence, model-management UI, and every backend; competitors own a single band](docs/images/product/layer-cake-hero.svg)
+![ManifoldKit assembled full-stack hero — one import gives you the SwiftUI ChatView, the ConversationRuntime turn loop, SwiftData persistence, model-management UI, and the in-core backends, with the manifold-mlx and manifold-llama companion packages adding on-device MLX and llama.cpp/GGUF](docs/images/product/layer-cake-hero.svg)
 
 **New here?** Start with **[Why ManifoldKit — and how it's built to last](docs/WHY-MANIFOLDKIT.md)** for the honest "what it solves and why trust it" narrative, or jump to the [docs index](docs/README.md) for the full guided path from install to first token. Prefer rendered API reference? The full **[DocC documentation site](https://roryford.github.io/ManifoldKit/documentation/manifoldkit/)** ties every module's reference together under one navigable root.
 

--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -19,11 +19,12 @@ layers:
 - `ManifoldRuntime` adds persistence-agnostic ports and use cases.
 - `ManifoldPersistenceSwiftData` adds the shipped SwiftData schema and
   ``ManifoldBootstrap`` entry point.
-- `ManifoldBackends` re-exports the concrete MLX, llama.cpp, Foundation, and
-  cloud backends. The MLX and llama.cpp families depend on `ManifoldInference`
-  directly; the Foundation and cloud families were repointed to `ManifoldContract`
-  (the thin protocol kernel) in v0.40+ so they stay free of engine internals and
-  SwiftData.
+- `ManifoldBackends` re-exports the concrete Foundation and cloud backends
+  (always compiled into core since v0.48). The MLX and llama.cpp families live in
+  the `manifold-mlx` / `manifold-llama` companion packages since v0.48 and depend
+  on `ManifoldInference` directly; the Foundation and cloud families were
+  repointed to `ManifoldContract` (the thin protocol kernel) in v0.40+ so they
+  stay free of engine internals and SwiftData.
 
 Apps that bring their own persistence and UI can depend on this target alone
 to integrate a custom backend or drive a custom chat surface.

--- a/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
+++ b/Sources/ManifoldKit/ManifoldKit.docc/ManifoldKit.md
@@ -112,3 +112,34 @@ inline — follow each home-module catalog for the full reference:
 - ``ManifoldKit/quickStart(backends:configuration:seed:)``
 - ``QuickStartResult``
 - ``QuickStartSeed``
+- ``ManifoldConfiguration``
+- ``ManifoldKitError``
+
+### Build a Chat UI
+
+- ``ChatView``
+- ``ChatViewModel``
+
+### Bring Your Own UI
+
+- ``InferenceService``
+- ``ConversationRuntime``
+- ``ModelRegistry``
+
+### Backends
+
+Every engine sits behind one ``InferenceBackend`` protocol; ``DefaultBackends``
+registers the Foundation and cloud backends compiled into core. Cloud backends
+(OpenAI, Anthropic, Ollama, LAN) live in `ManifoldOllama` / `ManifoldCloudSaaS`
+and are always compiled in since v0.48 (the `CloudSaaS` / `Ollama` traits were
+retired). The local MLX and llama.cpp families ship in the `manifold-mlx` /
+`manifold-llama` companion packages since v0.48 — add the package and pass its
+registrar to `quickStart(backends:)`.
+
+- ``InferenceBackend``
+- ``DefaultBackends``
+- ``FoundationBackend``
+
+### Persistence & Bootstrap
+
+- ``ManifoldBootstrap``

--- a/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/BackgroundTaskSupport.md
+++ b/Sources/ManifoldRuntime/ManifoldRuntime.docc/Articles/BackgroundTaskSupport.md
@@ -40,14 +40,15 @@ func applicationDidEnterBackground() {
 
 ### 3. Backend selection
 
-Background GPU access is iPad-only. Check availability before relying on ``MLXBackend``:
+Background GPU access is iPad-only. Check availability before relying on the MLX
+backend (from the `manifold-mlx` companion package):
 
 ```swift,no-build
 if #available(iOS 26, *), ConversationRuntimeBackgroundBridge.backgroundGPUAvailable {
-    // GPU available — MLXBackend will run at full speed
+    // GPU available — the MLX backend (manifold-mlx companion package) runs at full speed
 } else {
     // iPhone or unsupported iPad: GPU unavailable.
-    // ManifoldLlama (CPU) degrades ~4–5× vs. foreground MLX.
+    // The llama.cpp backend (manifold-llama companion package, CPU) degrades ~4–5× vs. foreground MLX.
     // Consider not submitting the task on iPhone if speed is critical.
 }
 ```

--- a/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
+++ b/Sources/ManifoldRuntime/Services/ResumableRunDriver.swift
@@ -351,6 +351,22 @@ public final class ResumableRunDriver: TurnDriver, @unchecked Sendable {
     /// point counts only *completed* steps, so the dangling index is always
     /// re-executed.
     ///
+    /// ## Future work: cross-process auto-resume (deferred — no consumer yet)
+    ///
+    /// Today `resume(runID:…)` is host-driven: an interrupted run leaves a
+    /// durable checkpoint (#1784) but nothing detects it on next launch. The
+    /// natural extension is a bootstrap-time scan of ``RunStore`` for runs with a
+    /// dangling-incomplete final step, surfaced for auto- or host-prompted
+    /// resume (app-kill recovery, background-generation continuation). It is
+    /// **intentionally not built**: no host pulls on it, and it must clear two
+    /// bars first — (1) decide replay-from-provider (current M1 design) vs.
+    /// durable content persistence, whose hard half is moving generated
+    /// `GenerationEvent`s across the detached-task / `@Model` (MainActor)
+    /// boundary via JSON columns rather than passing `@Model` instances; and
+    /// (2) honour `RELIABILITY.md` — resume stays an explicit, observable action,
+    /// never a silent mid-stream reconnect. Pick this up only when a concrete
+    /// host need lands.
+    ///
     /// - Parameters:
     ///   - runID:        The id of the persisted run to resume.
     ///   - provider:     Supplies the ``TurnInput`` for each remaining step.

--- a/Sources/ManifoldUI/ManifoldUI.docc/Extensions/ChatViewModel.md
+++ b/Sources/ManifoldUI/ManifoldUI.docc/Extensions/ChatViewModel.md
@@ -27,7 +27,7 @@
 
 ### Model Selection
 
-Local backends (MLX, Llama, Foundation) surface choices through ``availableModels`` / ``selectedModel``. Cloud and LAN backends (Ollama, OpenAI-compatible providers, Anthropic, and similar) surface saved endpoint records through ``availableEndpoints`` / ``selectedEndpoint``. Setting either property records the user's selection; call ``dispatchSelectedLoad()`` (or the explicit ``loadSelectedModel()`` / ``loadSelectedEndpoint()`` / ``loadCloudEndpoint(_:)`` entry points) to actually load it.
+On-device backends surface choices through ``availableModels`` / ``selectedModel``: the Foundation Models backend (iOS/macOS 26+) ships in core, while the MLX and llama.cpp backends come from the `manifold-mlx` / `manifold-llama` companion packages (v0.48) once registered. Cloud and LAN backends (Ollama, OpenAI-compatible providers, Anthropic, and similar) surface saved endpoint records through ``availableEndpoints`` / ``selectedEndpoint``. Setting either property records the user's selection; call ``dispatchSelectedLoad()`` (or the explicit ``loadSelectedModel()`` / ``loadSelectedEndpoint()`` / ``loadCloudEndpoint(_:)`` entry points) to actually load it.
 
 - ``selectedModel``
 - ``selectedEndpoint``

--- a/docs/PROVIDER-BRIDGE.md
+++ b/docs/PROVIDER-BRIDGE.md
@@ -1,6 +1,6 @@
 # Provider bridge (AnyLanguageModel)
 
-ManifoldKit ships native backends for MLX, llama.cpp/GGUF, Apple Foundation Models, OpenAI (Chat + Responses), Anthropic, and Ollama. Providers without a native backend are reached through the **AnyLanguageModel bridge** — a single `InferenceBackend` adapter over HuggingFace's [AnyLanguageModel](https://github.com/huggingface/AnyLanguageModel) package.
+ManifoldKit ships native backends for Apple Foundation Models, OpenAI (Chat + Responses), Anthropic, and Ollama; the local MLX and llama.cpp/GGUF families come from the [manifold-mlx](https://github.com/roryford/manifold-mlx) / [manifold-llama](https://github.com/roryford/manifold-llama) companion packages (v0.48). Providers without a native backend are reached through the **AnyLanguageModel bridge** — a single `InferenceBackend` adapter over HuggingFace's [AnyLanguageModel](https://github.com/huggingface/AnyLanguageModel) package.
 
 AnyLanguageModel operates at the model-access altitude (one protocol, many providers). ManifoldKit operates at the application-framework altitude and consumes it as one more backend, so a bridged provider plugs into the same `ChatViewModel`, conversation runtime, and persistence path as a native backend.
 

--- a/docs/images/product/layer-cake-hero.svg
+++ b/docs/images/product/layer-cake-hero.svg
@@ -1,186 +1,186 @@
 <svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1600 900">
   <title id="title">ManifoldKit assembled full-stack hero diagram</title>
-  <desc id="desc">An isometric four-layer ManifoldKit stack showing UI, runtime, persistence, and backends as one assembled product, while other categories own only one layer.</desc>
+  <desc id="desc">A four-layer ManifoldKit stack — UI, runtime, persistence, and backends — shipped as one assembled package from a single import. The backends layer shows in-core backends (Apple Foundation, OpenAI/Anthropic, Ollama/LAN, AnyLanguageModel bridge) alongside the opt-in companion packages manifold-mlx and manifold-llama for on-device MLX and llama.cpp/GGUF.</desc>
   <defs>
     <style>
-      :root {
-        --ink: #111b2d;
-        --muted: #607083;
-        --paper: #f6f8f3;
-        --blue: #1868b7;
-        --blue-side: #0d477f;
-        --teal: #087b78;
-        --teal-side: #075753;
-        --green: #29845d;
-        --green-side: #1f5f44;
-        --amber: #cb7326;
-        --amber-side: #935018;
-        --line: #d8dfd4;
-      }
-      .bg { fill: url(#background); }
-      .halo { fill: url(#halo); opacity: .9; }
-      .brand { fill: var(--ink); font: 900 72px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .headline { fill: var(--ink); font: 850 38px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .subhead { fill: var(--muted); font: 600 23px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .micro { fill: var(--muted); font: 700 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .code-pill { fill: #111b2d; }
-      .code-text { fill: #dff4ea; font: 800 22px ui-monospace, "SF Mono", Menlo, monospace; letter-spacing: 0; }
-      .spark { fill: #f3a43b; }
-      .layer-title { fill: white; font: 900 32px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .layer-sub { fill: rgba(255,255,255,.88); font: 700 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .chip { fill: rgba(255,255,255,.2); stroke: rgba(255,255,255,.38); stroke-width: 1.2; }
-      .chip-text { fill: white; font: 800 15px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .brace { fill: none; stroke: #111b2d; stroke-width: 7; stroke-linecap: round; opacity: .92; }
-      .brace-text { fill: #111b2d; font: 900 22px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .ghost-top { fill: #eef2eb; stroke: #d5ddd2; stroke-width: 2; }
-      .ghost-side { fill: #dfe7dd; }
-      .ghost-label { fill: #6d796e; font: 900 18px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .ghost-note { fill: #7b8679; font: 700 15px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .callout { fill: white; stroke: #d8dfd4; stroke-width: 2; }
-      .callout-title { fill: var(--ink); font: 900 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .callout-sub { fill: var(--muted); font: 700 16px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .caption { fill: var(--ink); font: 850 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
-      .caption-sub { fill: var(--muted); font: 650 20px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 0; }
+      .brand { font: 900 60px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .lede { fill: #16223b; font: 800 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .sub { fill: #5b6b80; font: 600 21px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .code-text { fill: #d8f7ea; font: 800 21px ui-monospace, "SF Mono", Menlo, monospace; }
+      .note-h { fill: #6b5cc9; font: 800 16px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: .5px; }
+      .note { fill: #6c7a8d; font: 600 16px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .spine-label { fill: #8190a3; font: 800 17px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 1.5px; }
+      .layer-title { fill: #16223b; font: 900 30px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .layer-sub { fill: #65748a; font: 650 17px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .chip { fill: #eef2f7; }
+      .chip-text { fill: #495a70; font: 700 15px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .row-label { fill: #93a0b2; font: 800 13px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; letter-spacing: 1.4px; }
+      .comp-pill { fill: #f1edff; stroke: #b9a8f0; stroke-width: 1.4; stroke-dasharray: 5 4; }
+      .comp-text { fill: #4b3ba0; font: 800 15px ui-monospace, "SF Mono", Menlo, monospace; }
+      .caption { fill: #16223b; font: 800 24px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
+      .caption-sub { fill: #5b6b80; font: 600 19px ui-rounded, "SF Pro Rounded", "Avenir Next", sans-serif; }
     </style>
-    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#fbfbf7"/>
-      <stop offset=".52" stop-color="#edf4f0"/>
-      <stop offset="1" stop-color="#f6f0e4"/>
+
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbfcff"/>
+      <stop offset=".55" stop-color="#eef3fb"/>
+      <stop offset="1" stop-color="#f4f1fb"/>
     </linearGradient>
-    <radialGradient id="halo" cx=".56" cy=".42" r=".55">
-      <stop offset="0" stop-color="#cbe9df"/>
-      <stop offset=".5" stop-color="#e7f0e9"/>
-      <stop offset="1" stop-color="#f6f8f3" stop-opacity="0"/>
+    <radialGradient id="blobA" cx=".5" cy=".5" r=".5">
+      <stop offset="0" stop-color="#dbe2fb"/>
+      <stop offset="1" stop-color="#dbe2fb" stop-opacity="0"/>
     </radialGradient>
-    <filter id="stackShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="34" stdDeviation="30" flood-color="#172033" flood-opacity=".22"/>
+    <radialGradient id="blobB" cx=".5" cy=".5" r=".5">
+      <stop offset="0" stop-color="#cdeede"/>
+      <stop offset="1" stop-color="#cdeede" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="brandGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#8b3df0"/>
+    </linearGradient>
+    <linearGradient id="spineGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2f80ed"/>
+      <stop offset=".36" stop-color="#16b8a6"/>
+      <stop offset=".68" stop-color="#23a06b"/>
+      <stop offset="1" stop-color="#ef9a3c"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#f7fafc"/>
+    </linearGradient>
+    <linearGradient id="discUI" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2f80ed"/><stop offset="1" stop-color="#5aa6f6"/>
+    </linearGradient>
+    <linearGradient id="discRuntime" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#12b3a4"/><stop offset="1" stop-color="#34d6c4"/>
+    </linearGradient>
+    <linearGradient id="discData" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1f9d63"/><stop offset="1" stop-color="#46c886"/>
+    </linearGradient>
+    <linearGradient id="discBackend" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ef9a3c"/><stop offset="1" stop-color="#f7ba5d"/>
+    </linearGradient>
+
+    <filter id="cardShadow" x="-12%" y="-30%" width="124%" height="170%">
+      <feDropShadow dx="0" dy="13" stdDeviation="20" flood-color="#1a2740" flood-opacity=".13"/>
     </filter>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#172033" flood-opacity=".13"/>
+    <filter id="pillShadow" x="-20%" y="-40%" width="140%" height="200%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#1a2740" flood-opacity=".10"/>
     </filter>
-    <linearGradient id="uiTop" x1="0" x2="1">
-      <stop offset="0" stop-color="#1f7fcb"/>
-      <stop offset="1" stop-color="#39a1df"/>
-    </linearGradient>
-    <linearGradient id="runtimeTop" x1="0" x2="1">
-      <stop offset="0" stop-color="#0b8f89"/>
-      <stop offset="1" stop-color="#23b3a7"/>
-    </linearGradient>
-    <linearGradient id="dataTop" x1="0" x2="1">
-      <stop offset="0" stop-color="#319164"/>
-      <stop offset="1" stop-color="#62b979"/>
-    </linearGradient>
-    <linearGradient id="backendTop" x1="0" x2="1">
-      <stop offset="0" stop-color="#d17825"/>
-      <stop offset="1" stop-color="#ee9b3d"/>
-    </linearGradient>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b6c1b8"/>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#c3cad6"/>
     </marker>
   </defs>
 
-  <rect class="bg" width="1600" height="900"/>
-  <ellipse class="halo" cx="930" cy="430" rx="620" ry="420"/>
-  <circle cx="1465" cy="105" r="210" fill="#e5ece6" opacity=".75"/>
-  <circle cx="95" cy="812" r="260" fill="#ece3d5" opacity=".72"/>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <ellipse cx="1340" cy="150" rx="430" ry="360" fill="url(#blobA)"/>
+  <ellipse cx="180" cy="820" rx="420" ry="340" fill="url(#blobB)"/>
 
+  <!-- left brand block -->
   <g>
-    <text class="brand" x="92" y="116">ManifoldKit</text>
-    <text class="headline" x="98" y="168">One import that ships the stack.</text>
-    <text class="subhead" x="100" y="208">UI, runtime, data, and backends.</text>
-    <text class="subhead" x="100" y="238">Already wired. Ready to ship.</text>
-    <rect class="code-pill" x="100" y="282" width="314" height="58" rx="29"/>
-    <text class="code-text" x="130" y="319">import ManifoldKit</text>
-    <circle class="spark" cx="446" cy="311" r="6"/>
-    <circle class="spark" cx="470" cy="292" r="4"/>
-    <circle class="spark" cx="476" cy="332" r="3"/>
+    <text class="brand" x="94" y="150" fill="url(#brandGrad)">ManifoldKit</text>
+    <text class="lede" x="98" y="198">One import ships the stack.</text>
+    <text class="sub" x="100" y="232">UI · runtime · data · backends.</text>
+    <text class="sub" x="100" y="262">Already wired. Ready to ship.</text>
+
+    <rect x="100" y="300" width="292" height="54" rx="27" fill="#141f33"/>
+    <text class="code-text" x="126" y="334">import ManifoldKit</text>
+    <circle cx="421" cy="327" r="5" fill="#f3a43b"/>
+    <circle cx="442" cy="310" r="3.5" fill="#f3a43b"/>
+    <circle cx="447" cy="345" r="3" fill="#f3a43b"/>
+
+    <text class="note-h" x="100" y="430">＋ COMPANION PACKAGES</text>
+    <text class="note" x="100" y="458">manifold-mlx · manifold-llama</text>
+    <text class="note" x="100" y="482">add on-device MLX &amp; llama.cpp, opt-in</text>
   </g>
 
-  <g filter="url(#stackShadow)">
-    <!-- UI slab -->
-    <path d="M 500 230 L 1030 164 L 1244 238 L 713 316 Z" fill="url(#uiTop)"/>
-    <path d="M 713 316 L 1244 238 L 1244 302 L 713 382 Z" fill="var(--blue-side)"/>
-    <path d="M 500 230 L 713 316 L 713 382 L 500 294 Z" fill="#135a9b"/>
+  <!-- flow from import into the stack -->
+  <path d="M 398 318 C 470 296 502 224 548 178" fill="none" stroke="#c3cad6" stroke-width="2.5" stroke-dasharray="2 7" stroke-linecap="round" marker-end="url(#arrow)" opacity=".8"/>
 
-    <!-- Runtime slab -->
-    <path d="M 500 342 L 1030 276 L 1244 350 L 713 428 Z" fill="url(#runtimeTop)"/>
-    <path d="M 713 428 L 1244 350 L 1244 414 L 713 494 Z" fill="var(--teal-side)"/>
-    <path d="M 500 342 L 713 428 L 713 494 L 500 406 Z" fill="#086b66"/>
+  <!-- assembled spine -->
+  <rect x="546" y="120" width="10" height="660" rx="5" fill="url(#spineGrad)"/>
+  <text class="spine-label" transform="translate(523 450) rotate(-90)" text-anchor="middle">ONE ASSEMBLED PACKAGE</text>
 
-    <!-- Persistence slab -->
-    <path d="M 500 454 L 1030 388 L 1244 462 L 713 540 Z" fill="url(#dataTop)"/>
-    <path d="M 713 540 L 1244 462 L 1244 526 L 713 606 Z" fill="var(--green-side)"/>
-    <path d="M 500 454 L 713 540 L 713 606 L 500 518 Z" fill="#28764f"/>
+  <!-- UI card -->
+  <g filter="url(#cardShadow)">
+    <rect x="560" y="120" width="950" height="132" rx="26" fill="url(#card)" stroke="#e7ecf3"/>
+  </g>
+  <circle cx="636" cy="186" r="27" fill="url(#discUI)"/>
+  <rect x="623" y="175" width="26" height="22" rx="4" fill="#fff" opacity=".96"/>
+  <rect x="623" y="175" width="26" height="7" rx="4" fill="#cfe2fb"/>
+  <text class="layer-title" x="688" y="182">UI</text>
+  <text class="layer-sub" x="688" y="210">ChatView · sessions · model management</text>
+  <rect class="chip" x="1238" y="169" width="116" height="34" rx="17"/>
+  <text class="chip-text" x="1256" y="191">ChatView</text>
+  <rect class="chip" x="1370" y="169" width="116" height="34" rx="17"/>
+  <text class="chip-text" x="1390" y="191">Model UI</text>
 
-    <!-- Backends slab -->
-    <path d="M 500 566 L 1030 500 L 1244 574 L 713 652 Z" fill="url(#backendTop)"/>
-    <path d="M 713 652 L 1244 574 L 1244 638 L 713 718 Z" fill="var(--amber-side)"/>
-    <path d="M 500 566 L 713 652 L 713 718 L 500 630 Z" fill="#af641f"/>
+  <!-- Runtime card -->
+  <g filter="url(#cardShadow)">
+    <rect x="560" y="276" width="950" height="132" rx="26" fill="url(#card)" stroke="#e7ecf3"/>
+  </g>
+  <circle cx="636" cy="342" r="27" fill="url(#discRuntime)"/>
+  <circle cx="636" cy="342" r="11" fill="none" stroke="#fff" stroke-width="3.4" opacity=".96"/>
+  <circle cx="636" cy="331" r="3.4" fill="#fff"/>
+  <text class="layer-title" x="688" y="338">Runtime</text>
+  <text class="layer-sub" x="688" y="366">send · regenerate · edit · cancel · branch</text>
+  <rect class="chip" x="1170" y="325" width="160" height="34" rx="17"/>
+  <text class="chip-text" x="1188" y="347">metrics + cost</text>
+  <rect class="chip" x="1346" y="325" width="140" height="34" rx="17"/>
+  <text class="chip-text" x="1364" y="347">tool approval</text>
+
+  <!-- Persistence card -->
+  <g filter="url(#cardShadow)">
+    <rect x="560" y="432" width="950" height="132" rx="26" fill="url(#card)" stroke="#e7ecf3"/>
+  </g>
+  <circle cx="636" cy="498" r="27" fill="url(#discData)"/>
+  <ellipse cx="636" cy="489" rx="12" ry="4.4" fill="#fff"/>
+  <rect x="624" y="489" width="24" height="18" fill="#fff"/>
+  <ellipse cx="636" cy="507" rx="12" ry="4.4" fill="#fff"/>
+  <ellipse cx="636" cy="498" rx="12" ry="4.4" fill="none" stroke="#1f9d63" stroke-width="1.2" opacity=".5"/>
+  <text class="layer-title" x="688" y="494">Persistence</text>
+  <text class="layer-sub" x="688" y="522">SwiftData stores · schema migrations</text>
+  <rect class="chip" x="1174" y="481" width="150" height="34" rx="17"/>
+  <text class="chip-text" x="1192" y="503">SessionStore</text>
+  <rect class="chip" x="1340" y="481" width="146" height="34" rx="17"/>
+  <text class="chip-text" x="1358" y="503">MessageStore</text>
+
+  <!-- Backends card -->
+  <g filter="url(#cardShadow)">
+    <rect x="560" y="580" width="950" height="200" rx="26" fill="url(#card)" stroke="#e7ecf3"/>
+  </g>
+  <circle cx="636" cy="628" r="27" fill="url(#discBackend)"/>
+  <rect x="623" y="617" width="26" height="6" rx="3" fill="#fff"/>
+  <rect x="623" y="626" width="26" height="6" rx="3" fill="#fff" opacity=".85"/>
+  <rect x="623" y="635" width="26" height="6" rx="3" fill="#fff" opacity=".7"/>
+  <text class="layer-title" x="688" y="624">Backends</text>
+  <text class="layer-sub" x="688" y="652">one InferenceBackend protocol — swap engines, not code</text>
+
+  <text class="row-label" x="600" y="711">IN THE BOX</text>
+  <rect class="chip" x="760" y="689" width="158" height="34" rx="17"/>
+  <text class="chip-text" x="778" y="711">Apple Foundation</text>
+  <rect class="chip" x="934" y="689" width="182" height="34" rx="17"/>
+  <text class="chip-text" x="952" y="711">OpenAI · Anthropic</text>
+  <rect class="chip" x="1132" y="689" width="132" height="34" rx="17"/>
+  <text class="chip-text" x="1150" y="711">Ollama / LAN</text>
+  <rect class="chip" x="1280" y="689" width="172" height="34" rx="17"/>
+  <text class="chip-text" x="1298" y="711">AnyLanguageModel</text>
+
+  <text class="row-label" x="600" y="757">COMPANIONS</text>
+  <g filter="url(#pillShadow)">
+    <rect class="comp-pill" x="760" y="734" width="322" height="36" rx="18"/>
+    <rect x="774" y="743" width="18" height="18" rx="4" fill="#6d5cd6"/>
+    <path d="M783 747 v8 M779 751 h8" stroke="#fff" stroke-width="1.8" stroke-linecap="round"/>
+    <text class="comp-text" x="802" y="757">manifold-mlx · MLX · image/video</text>
+  </g>
+  <g filter="url(#pillShadow)">
+    <rect class="comp-pill" x="1098" y="734" width="330" height="36" rx="18"/>
+    <rect x="1112" y="743" width="18" height="18" rx="4" fill="#6d5cd6"/>
+    <path d="M1121 747 v8 M1117 751 h8" stroke="#fff" stroke-width="1.8" stroke-linecap="round"/>
+    <text class="comp-text" x="1140" y="757">manifold-llama · llama.cpp / GGUF</text>
   </g>
 
-  <g>
-    <text class="layer-title" x="645" y="246">UI</text>
-    <text class="layer-sub" x="645" y="274">ChatView + sessions + model UI</text>
-    <rect class="chip" x="904" y="210" width="96" height="30" rx="15"/>
-    <text class="chip-text" x="925" y="230">ChatView</text>
-    <rect class="chip" x="1014" y="238" width="146" height="30" rx="15"/>
-    <text class="chip-text" x="1034" y="258">Model UI</text>
-
-    <text class="layer-title" x="632" y="360">Runtime</text>
-    <text class="layer-sub" x="632" y="388">send / regenerate / edit / cancel / branch</text>
-    <rect class="chip" x="936" y="324" width="130" height="30" rx="15"/>
-    <text class="chip-text" x="956" y="344">tool approval</text>
-    <rect class="chip" x="1078" y="344" width="138" height="30" rx="15"/>
-    <text class="chip-text" x="1098" y="364">metrics + cost</text>
-
-    <text class="layer-title" x="620" y="472">Persistence</text>
-    <text class="layer-sub" x="620" y="500">SwiftData stores + migrations</text>
-    <rect class="chip" x="956" y="434" width="132" height="30" rx="15"/>
-    <text class="chip-text" x="976" y="454">MessageStore</text>
-
-    <text class="layer-title" x="617" y="585">Backends</text>
-    <text class="layer-sub" x="617" y="613">MLX, GGUF, Apple, cloud, bridge</text>
-    <rect class="chip" x="918" y="544" width="66" height="30" rx="15"/>
-    <text class="chip-text" x="940" y="564">MLX</text>
-    <rect class="chip" x="998" y="526" width="120" height="30" rx="15"/>
-    <text class="chip-text" x="1020" y="546">OpenAI</text>
-    <rect class="chip" x="1034" y="588" width="100" height="30" rx="15"/>
-    <text class="chip-text" x="1055" y="608">Ollama</text>
-  </g>
-
-  <g>
-    <path class="brace" d="M 430 232 C 388 245 388 292 424 307 L 424 641 C 388 655 388 704 430 716"/>
-    <text class="brace-text" transform="translate(374 650) rotate(-90)">owned end to end</text>
-  </g>
-
-  <g filter="url(#softShadow)" opacity=".92">
-    <path class="ghost-top" d="M 1288 220 L 1436 202 L 1490 222 L 1342 244 Z"/>
-    <path class="ghost-side" d="M 1342 244 L 1490 222 L 1490 258 L 1342 282 Z"/>
-    <text class="ghost-label" x="1322" y="226">UI kits</text>
-    <text class="ghost-note" x="1322" y="249">one layer</text>
-
-    <path class="ghost-top" d="M 1290 555 L 1438 537 L 1492 557 L 1344 579 Z"/>
-    <path class="ghost-side" d="M 1344 579 L 1492 557 L 1492 593 L 1344 617 Z"/>
-    <text class="ghost-label" x="1315" y="562">engines</text>
-    <text class="ghost-note" x="1315" y="585">tokens only</text>
-
-    <path class="ghost-top" d="M 1286 645 L 1434 627 L 1488 647 L 1340 669 Z"/>
-    <path class="ghost-side" d="M 1340 669 L 1488 647 L 1488 683 L 1340 707 Z"/>
-    <text class="ghost-label" x="1309" y="652">cloud SDKs</text>
-    <text class="ghost-note" x="1309" y="675">one API</text>
-  </g>
-
-  <g>
-    <path d="M 1248 282 C 1290 276 1298 262 1322 244" fill="none" stroke="#b6c1b8" stroke-width="3" marker-end="url(#arrow)" opacity=".55"/>
-    <path d="M 1248 608 C 1290 598 1300 590 1324 579" fill="none" stroke="#b6c1b8" stroke-width="3" marker-end="url(#arrow)" opacity=".55"/>
-  </g>
-
-  <g filter="url(#softShadow)">
-    <rect class="callout" x="112" y="682" width="360" height="98" rx="26"/>
-    <text class="callout-title" x="142" y="724">Competitors sell a layer.</text>
-    <text class="callout-sub" x="142" y="754">ManifoldKit sells the assembled product.</text>
-  </g>
-
-  <text class="caption" x="100" y="830">ChatView + ConversationRuntime + SwiftData + model-management UI + every backend.</text>
-  <text class="caption-sub" x="100" y="864">Competitors hand you one layer and a wiring diagram. ManifoldKit hands you the product.</text>
+  <!-- caption -->
+  <text class="caption" x="96" y="840">One package ships the assembled product.</text>
+  <text class="caption-sub" x="96" y="872">ChatView · ConversationRuntime · SwiftData · model management · every backend — companions add on-device MLX &amp; GGUF.</text>
 </svg>


### PR DESCRIPTION
## What

Documentation-only refresh, split out of the `fix/download-tab-runtime-backends` branch onto its own.

### 1. Redesigned README hero image
Replaces the old isometric "layer cake" SVG with a cleaner design — color-coded spine, polished rounded layer cards (UI / Runtime / Persistence / Backends) with layer icons. Crucially, the **backends layer now reflects the v0.48 companion-package split**: it separates **"In the box"** (Apple Foundation, OpenAI · Anthropic, Ollama / LAN, AnyLanguageModel bridge) from **"Companions"** (`manifold-mlx`, `manifold-llama` shown as distinct opt-in pills). The old "Competitors sell a layer" callout is removed and the README alt-text drops the competitor framing in favour of naming the companions.

### 2. Stale companion-reference sweep
Fixes docs/DocC references that predated the v0.48 split and still implied MLX / llama.cpp ship inside core:

- `docs/PROVIDER-BRIDGE.md` — core-native backend list + companion packages for MLX/llama.
- `ManifoldKit.docc/ManifoldKit.md` — reworded backend registration; **removed broken `` ``MLXBackend`` `` / `` ``LlamaBackend`` `` DocC symbol links** (types no longer compiled into this package).
- `ManifoldInference.docc/ManifoldInference.md` — `ManifoldBackends` re-exports Foundation + cloud only; MLX/llama live in companions.
- `BackgroundTaskSupport.md` — removed broken `` ``MLXBackend`` `` link; comments name the companion packages.
- `ChatViewModel.md` — clarified Foundation ships in core, MLX/llama come from companions once registered.

### 3. Deferred-resume note
Adds a future-work doc comment to `ResumableRunDriver` capturing the cross-process auto-resume design (closed #1813 into code instead of a tracked issue — no host pulls on it yet).

## Why
The README hero and several DocC catalogs still described the pre-v0.48 world where MLX/llama.cpp shipped in core. Two of the fixes also removed **dead DocC symbol links** that would fail to resolve.

## Notes
- Docs/comment-only — no code, no release bump.
- Deliberately left alone: `MIGRATION-0.48.md`, CHANGELOG history, and positioning docs that correctly list MLX/llama as protocol implementers without claiming in-repo shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
