### PR TITLE
feat(rag): bundle on-device NLEmbedding default embedder so RAG works zero-config (#1812 Stage 1)

### DIFF
--- a/Sources/ManifoldInference/Services/NLEmbeddingBackend.swift
+++ b/Sources/ManifoldInference/Services/NLEmbeddingBackend.swift
@@ -1,0 +1,78 @@
+#if canImport(NaturalLanguage)
+import Foundation
+import NaturalLanguage
+
+/// Zero-dependency, on-device ``EmbeddingBackend`` backed by Apple's
+/// `NaturalLanguage` framework (`NLEmbedding.sentenceEmbedding`).
+///
+/// This is the **default** embedder wired by ``ManifoldBootstrap`` /
+/// `quickStart()` so RAG retrieval works out of the box with no model download
+/// and no companion package. It produces 512-dimensional sentence embeddings
+/// entirely on-device; semantically related passages score markedly higher
+/// cosine similarity than unrelated ones, which is sufficient for the
+/// `FlatFileVectorStore` nearest-neighbour retrieval path.
+///
+/// For higher-quality embeddings, hosts can still inject their own
+/// ``EmbeddingBackend`` (e.g. `MLXEmbedders` from the manifold-mlx companion
+/// package, or `LlamaEmbeddingBackend`) — the injected backend always wins
+/// over this default.
+///
+/// ## Locale availability
+///
+/// `NLEmbedding.sentenceEmbedding(for:)` returns `nil` for locales Apple does
+/// not ship a model for. ``init(language:)`` is failable and returns `nil`
+/// in that case rather than constructing an unusable backend, so callers can
+/// fail-closed (fall back to keyword search) instead of crashing.
+public final class NLEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+
+    // `NLEmbedding` is immutable after construction and documented as safe to
+    // use concurrently; it is wrapped here only to satisfy `Sendable`.
+    private let embedding: NLEmbedding
+
+    public var isModelLoaded: Bool { true }
+
+    public let dimensions: Int
+
+    /// Creates a backend over the bundled sentence embedding for `language`.
+    ///
+    /// - Parameter language: The natural language to embed in. Defaults to
+    ///   `.english`.
+    /// - Returns: `nil` when no sentence-embedding model is available for the
+    ///   requested language on this OS — callers should treat that as "no
+    ///   embedder" and let RAG fall back to keyword search.
+    public init?(language: NLLanguage = .english) {
+        guard let embedding = NLEmbedding.sentenceEmbedding(for: language) else {
+            Log.inference.warning("NLEmbeddingBackend: no sentence-embedding model available for language \(language.rawValue, privacy: .public); embedder unavailable.")
+            return nil
+        }
+        self.embedding = embedding
+        self.dimensions = embedding.dimension
+    }
+
+    /// No-op: the model is bundled with the OS, so there is no local file to
+    /// load. The backend reports itself loaded from construction.
+    public func loadModel(from url: URL) async throws {}
+
+    public func unloadModel() {}
+
+    public func embed(_ texts: [String]) async throws -> [[Float]] {
+        guard !texts.isEmpty else { return [] }
+
+        var result: [[Float]] = []
+        result.reserveCapacity(texts.count)
+        for text in texts {
+            // `vector(for:)` returns nil for an empty/whitespace input or a
+            // string the model cannot embed. A zero vector is the honest
+            // "no signal" representation — `FlatFileVectorStore` L2-normalizes
+            // it to an empty vector and skips it during cosine search rather
+            // than ranking it spuriously.
+            if let vector = embedding.vector(for: text) {
+                result.append(vector.map { Float($0) })
+            } else {
+                result.append([Float](repeating: 0, count: dimensions))
+            }
+        }
+        return result
+    }
+}
+#endif

--- a/Sources/ManifoldInference/Services/NLEmbeddingBackend.swift
+++ b/Sources/ManifoldInference/Services/NLEmbeddingBackend.swift
@@ -62,10 +62,17 @@ public final class NLEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
         result.reserveCapacity(texts.count)
         for text in texts {
             // `vector(for:)` returns nil for an empty/whitespace input or a
-            // string the model cannot embed. A zero vector is the honest
-            // "no signal" representation — `FlatFileVectorStore` L2-normalizes
-            // it to an empty vector and skips it during cosine search rather
-            // than ranking it spuriously.
+            // string the model cannot embed. The `EmbeddingBackend` contract
+            // requires output count == input count with every vector at
+            // `dimensions` length (see `EmbeddingBackendContract`), and
+            // `FlatFileVectorStore.insert` aligns embeddings to chunks
+            // positionally — so a dropped or short-length entry would
+            // mis-pair vectors with chunks. A zero vector is therefore the
+            // honest, contract-correct "no signal" placeholder that preserves
+            // alignment. Its cosine score against any query is 0, so it never
+            // ranks above a genuine match; it can only surface as a trailing
+            // zero-score hit when the store holds fewer real matches than the
+            // requested limit.
             if let vector = embedding.vector(for: text) {
                 result.append(vector.map { Float($0) })
             } else {

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -220,8 +220,16 @@ public enum ManifoldKit {
             // milestones from the simple facade — `quickStart()` is the
             // "no progress UI" path. Consumers that want a launch
             // progress bar should call `ManifoldBootstrap.build` directly.
+            // Enable RAG by default. With no embedding backend injected,
+            // `ManifoldBootstrap` resolves the bundled on-device
+            // `NLEmbeddingBackend` (Apple NaturalLanguage, zero download), so a
+            // host gets working semantic retrieval out of the box. Hosts that
+            // want a higher-quality embedder (MLXEmbedders / Llama) or to disable
+            // RAG drop down to `ManifoldBootstrap.build` directly with their own
+            // `RAGConfiguration`.
             let (progress, task) = ManifoldBootstrap.build(
                 configuration: configuration,
+                ragConfiguration: RAGConfiguration(),
                 makeModelContainer: makeModelContainer
             )
             for await _ in progress {

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -449,10 +449,31 @@ public final class ManifoldBootstrap {
         return RAGService(
             documentStore: documentStore,
             vectorStore: vectorStore,
-            embeddingBackend: ragConfig.embeddingBackend,
+            embeddingBackend: resolveEmbeddingBackend(ragConfig.embeddingBackend),
             reranker: ragConfig.reranker,
             chunker: chunker
         )
+    }
+
+    /// Resolves the embedding backend RAG will use.
+    ///
+    /// A host-supplied backend always wins. When the host did not inject one,
+    /// this falls back to the bundled on-device ``NLEmbeddingBackend`` so RAG
+    /// performs semantic (vector) retrieval out of the box with zero model
+    /// download. If even that is unavailable (no sentence-embedding model for
+    /// the OS locale), `nil` is returned and ``RAGService`` degrades to
+    /// case-insensitive keyword search — never a crash.
+    static func resolveEmbeddingBackend(
+        _ hostSupplied: (any EmbeddingBackend)?
+    ) -> (any EmbeddingBackend)? {
+        if let hostSupplied { return hostSupplied }
+        #if canImport(NaturalLanguage)
+        if let bundled = NLEmbeddingBackend() {
+            return bundled
+        }
+        Log.persistence.warning("ManifoldBootstrap: bundled NLEmbeddingBackend unavailable for this OS locale — RAG will use keyword-only retrieval until a host backend is supplied.")
+        #endif
+        return nil
     }
 
     public static func build(

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
@@ -146,6 +146,10 @@ The schema and adapters are deliberately split so non-chat use cases can opt in 
 - ``SwiftDataBenchmarkCache`` persists model-capability tier results — useful for any app that benchmarks local models, not just chat.
 - ``SwiftDataDocumentStore`` is the RAG document index; image-generation and agent flows that ingest user files re-use it.
 
+### Zero-dependency RAG out of the box
+
+RAG no longer needs a host-supplied embedder. When ``RAGConfiguration/embeddingBackend`` is `nil`, ``ManifoldBootstrap`` resolves the bundled on-device `NLEmbeddingBackend` (Apple's `NaturalLanguage` framework — 512-dim sentence embeddings, no model download, no heavy dependency), so semantic retrieval works with zero configuration. `quickStart()` enables this by default. A host-supplied ``EmbeddingBackend`` (e.g. MLXEmbedders from the manifold-mlx companion, or a Llama embedder) always overrides the default; if no sentence-embedding model is available for the OS locale, retrieval degrades gracefully to keyword search.
+
 ## Topics
 
 ### Bootstrap

--- a/Tests/ManifoldPersistenceSwiftDataTests/NLEmbeddingRAGIntegrationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/NLEmbeddingRAGIntegrationTests.swift
@@ -1,0 +1,137 @@
+#if canImport(NaturalLanguage)
+import XCTest
+import SwiftData
+import NaturalLanguage
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+
+/// End-to-end integration coverage for the bundled on-device
+/// ``NLEmbeddingBackend`` (issue #1812 Stage 1): embed real text with Apple's
+/// `NaturalLanguage` framework, persist the vectors through the shipped
+/// ``FlatFileVectorStore``, and retrieve through ``RAGService`` driving an
+/// in-memory ``SwiftDataDocumentStore``.
+///
+/// These touch SwiftData and the on-disk flat-file index, so they are
+/// integration tests and live here rather than in a unit suite. No mocks are
+/// used for the embedding or persistence paths — only the real stack.
+@MainActor
+final class NLEmbeddingRAGIntegrationTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var vectorURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Skip on hosts/locales where Apple ships no sentence-embedding model —
+        // the backend is correctly nil there and RAG degrades to keyword search.
+        try XCTSkipIf(
+            NLEmbedding.sentenceEmbedding(for: .english) == nil,
+            "No English sentence-embedding model on this host."
+        )
+        container = try ModelContainerFactory.makeInMemoryContainer()
+        vectorURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".bin")
+    }
+
+    override func tearDown() {
+        if let vectorURL { try? FileManager.default.removeItem(at: vectorURL) }
+        container = nil
+        vectorURL = nil
+        super.tearDown()
+    }
+
+    private func makeRAGService() throws -> RAGService {
+        let backend = try XCTUnwrap(NLEmbeddingBackend(), "NLEmbeddingBackend should construct after the skip guard.")
+        XCTAssertTrue(backend.isModelLoaded)
+        XCTAssertGreaterThan(backend.dimensions, 0)
+
+        let documentStore = SwiftDataDocumentStore(modelContext: container.mainContext)
+        let vectorStore = FlatFileVectorStore(storageURL: vectorURL)
+        return RAGService(
+            documentStore: documentStore,
+            vectorStore: vectorStore,
+            embeddingBackend: backend
+        )
+    }
+
+    /// Embed three semantically distinct documents, store them via the real
+    /// flat-file index, then query with text semantically near one of them.
+    /// The relevant document must rank top — proving NLEmbedding's vectors
+    /// produce a usable nearest-neighbour signal through the shipped store.
+    func test_embedStoreRetrieve_semanticQueryRanksRelevantDocTop() async throws {
+        let rag = try makeRAGService()
+
+        try await ingest(rag, title: "Cooking",
+            text: "Preheat the oven and bake the bread until the crust turns golden brown.")
+        try await ingest(rag, title: "Astronomy",
+            text: "The telescope captured a distant galaxy of countless stars and nebulae.")
+        try await ingest(rag, title: "Finance",
+            text: "The company reported strong quarterly earnings and raised its dividend.")
+
+        // Semantically near the Astronomy passage but shares no salient keyword
+        // (no "telescope"/"galaxy"/"stars"), so a keyword fallback would not
+        // float it — this exercises the vector path.
+        let result = try await rag.retrieve(query: "observing planets and the night sky", limit: 3)
+
+        let topTitle = try XCTUnwrap(result.citations.first?.documentTitle, "Expected at least one hit.")
+        XCTAssertEqual(topTitle, "Astronomy",
+            "Semantic query should rank the astronomy document first via NLEmbedding vectors.")
+    }
+
+    /// Negative assertion: a query semantically far from every stored document
+    /// must NOT rank the astronomy document top. This is the sabotage check kept
+    /// as a genuine negative — if NLEmbedding vectors collapsed to a constant
+    /// (or the wiring fell back to a degenerate path) the semantic ordering
+    /// above would be meaningless, and this would fail.
+    func test_embedStoreRetrieve_unrelatedQueryDoesNotRankAstronomyTop() async throws {
+        let rag = try makeRAGService()
+
+        try await ingest(rag, title: "Cooking",
+            text: "Preheat the oven and bake the bread until the crust turns golden brown.")
+        try await ingest(rag, title: "Astronomy",
+            text: "The telescope captured a distant galaxy of countless stars and nebulae.")
+        try await ingest(rag, title: "Finance",
+            text: "The company reported strong quarterly earnings and raised its dividend.")
+
+        let result = try await rag.retrieve(query: "stir the simmering soup and season the stew", limit: 3)
+
+        let topTitle = try XCTUnwrap(result.citations.first?.documentTitle, "Expected at least one hit.")
+        XCTAssertNotEqual(topTitle, "Astronomy",
+            "A cooking-themed query must not rank the astronomy document first.")
+        XCTAssertEqual(topTitle, "Cooking",
+            "A cooking-themed query should rank the cooking document first.")
+    }
+
+    /// The default-resolution seam used by `quickStart()` / bootstrap returns
+    /// the bundled backend when the host injects nothing, and honours a
+    /// host-supplied backend over the default.
+    func test_resolveEmbeddingBackend_defaultsToBundledAndHonoursOverride() throws {
+        let resolvedDefault = try XCTUnwrap(
+            ManifoldBootstrap.resolveEmbeddingBackend(nil),
+            "Bootstrap should fall back to the bundled NLEmbeddingBackend."
+        )
+        XCTAssertTrue(resolvedDefault is NLEmbeddingBackend)
+
+        let host = try XCTUnwrap(NLEmbeddingBackend())
+        let resolvedOverride = ManifoldBootstrap.resolveEmbeddingBackend(host)
+        XCTAssertTrue(resolvedOverride === host, "Host-supplied backend must win over the default.")
+    }
+
+    // MARK: - Helpers
+
+    private func ingest(_ rag: RAGService, title: String, text: String) async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(title)-\(UUID().uuidString).txt")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+        // The parser derives the title from the file's last path component; we
+        // assert on the human title above, so name the file accordingly.
+        let titledURL = url.deletingLastPathComponent().appendingPathComponent("\(title).txt")
+        try? FileManager.default.removeItem(at: titledURL)
+        try FileManager.default.moveItem(at: url, to: titledURL)
+        defer { try? FileManager.default.removeItem(at: titledURL) }
+        try await rag.ingest(url: titledURL)
+    }
+}
+#endif


### PR DESCRIPTION
Closes #1812 (Stage 1).

## Problem

`EmbeddingBackend` is fully wired through `RAGConfiguration` → `RAGService` → `FlatFileVectorStore` and the server `EmbeddingsAdapter`, but **every concrete conformance was a test mock**. A host literally could not embed without bringing its own backend, so RAG v1 (citations + document library) shipped with no out-of-the-box embedding path.

## What this adds

A zero-dependency, on-device default embedder so RAG works with nothing injected:

- **`NLEmbeddingBackend`** — an `EmbeddingBackend` over Apple's `NaturalLanguage` `NLEmbedding.sentenceEmbedding` (512-dim, on-device, no model download, no heavy dependency). Failable `init?(language:)` returns `nil` when the OS ships no sentence-embedding model for the locale, so RAG **fails closed to keyword search** rather than crashing.
- **`ManifoldBootstrap.resolveEmbeddingBackend(_:)`** — a host-supplied backend always wins; otherwise it falls back to the bundled `NLEmbeddingBackend`.
- **`quickStart()`** now enables RAG by default by passing `RAGConfiguration()` to `ManifoldBootstrap.build`. Previously quickStart wired no RAG service at all.

## Placement decision

`NLEmbeddingBackend` lives in **`ManifoldInference`** (`Sources/ManifoldInference/Services/`), gated behind `#if canImport(NaturalLanguage)`.

Rationale per the CLAUDE.md target table: `EmbeddingBackend` is defined in `ManifoldContract` (the thin kernel), but Contract is deliberately dependency-minimal, and the existing concrete embedding conformances/orchestration (e.g. `OllamaEmbeddingBackend` in test support, the RAG engine consumers) sit at the `ManifoldInference` layer. `NaturalLanguage` is a pure system framework with zero heavy deps, so importing it in `ManifoldInference` drags nothing upward and keeps the kernel clean. `ManifoldPersistenceSwiftData` already imports `ManifoldInference`, so the bootstrap default-resolution sees the type with no new package edge — `Package.resolved` is untouched.

## Quality verification (before committing the surface)

Probed `NLEmbedding` directly: English sentence embeddings are **512-dim** and give a strong relevance signal — semantically related sentences score ~0.50 cosine vs ~0.08 for unrelated — well within what `FlatFileVectorStore`'s cosine NN path needs.

## Tests (in this PR, real stack)

`NLEmbeddingRAGIntegrationTests` (integration — touches in-memory SwiftData `SwiftDataDocumentStore` + on-disk `FlatFileVectorStore`, driven through `RAGService`; no persistence mocks):

- **Relevance:** embed three distinct docs, query with text semantically near the astronomy doc but sharing no salient keyword → astronomy ranks top (exercises the vector path, not keyword fallback).
- **Negative/sabotage (kept):** a cooking-themed query must NOT rank the astronomy doc top, and DOES rank the cooking doc top — a genuine negative assertion that fails if the vectors collapsed or the wiring degraded.
- **Resolution seam:** `resolveEmbeddingBackend(nil)` returns the bundled `NLEmbeddingBackend`; a host-supplied backend is honoured (`===`).

Skipped gracefully on hosts/locales with no English sentence-embedding model.

## DocC

Added a "Zero-dependency RAG out of the box" note to `ManifoldPersistenceSwiftData.md`.

## Gate

`scripts/test.sh --profile local` → **RESULT: PASSED** (0 suites with failures), including the 3 new integration tests.

## Stage 2 (not in this PR)

MLXEmbedders-backed `EmbeddingBackend` is a cross-repo change for `manifold-mlx` (heavy ML deps are exiled to companions) and remains tracked under #1812 — no new issue opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)