### PR TITLE
ci: document Package.resolved plain-resolve invariant + trait-build landmine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,11 +342,30 @@ jobs:
         # Gated on the deps-changed filter: Package.resolved can only go stale
         # when Package.swift is edited, so skipping when neither file changed
         # avoids ~47s of wasted resolve work on the typical PR (~15% of total CI).
+        #
+        # The committed Package.resolved is intentionally the PLAIN (no-trait)
+        # resolution, so this gate runs a plain `swift package resolve` and the
+        # two match by construction. Trait-gated deps (hummingbird + the Server
+        # stack via `--traits Server`; swift-syntax is already pinned for Macros)
+        # resolve on demand during trait builds and are NOT committed.
+        #
+        # LANDMINE: `swift build/test --traits Server,Macros` (the optional-traits
+        # sweep CLAUDE.md mandates) MUTATES Package.resolved in your working tree
+        # in place, appending ~163 lines of Server deps. If this gate trips on a
+        # PR, you almost certainly committed that trait-bloated lockfile by
+        # accident. Do NOT "fix" it by stripping lines by hand — just regenerate
+        # with a plain resolve and re-commit:
+        #     git checkout Package.resolved && swift package resolve
         if: steps.deps-changed.outputs.deps == 'true'
         run: |
           swift package resolve
-          git diff --exit-code Package.resolved || \
-            (echo "Package.resolved is stale — run 'swift package resolve' and commit the result." && exit 1)
+          git diff --exit-code Package.resolved || {
+            echo "::error::Package.resolved is stale or carries trait-only deps."
+            echo "The committed lockfile must be the PLAIN resolution. Regenerate with:"
+            echo "    git checkout Package.resolved && swift package resolve"
+            echo "Do NOT commit the lockfile produced by a '--traits Server' build/test."
+            exit 1
+          }
 
       - name: Verify Tier 0 affected-suites graph snapshot is up to date
         # The Tier 0 resolver (scripts/affected-suites.sh, issue #1588) reads a


### PR DESCRIPTION
## Investigation finding

The brief flagged a suspected inconsistency: that `main`'s committed `Package.resolved` carries Server-trait deps which the CI "Verify Package.resolved is up to date" step (plain `swift package resolve`, no traits) would strip — forcing any `Package.swift`-touching PR to drop ~163 lines.

On inspection of current `main`, **the repo is already self-consistent**:

- The committed `Package.resolved` is exactly the **plain (no-trait) resolution**. It contains only `swift-syntax` (Macros) and `swift-argument-parser` — **no** hummingbird / async-http-client / swift-numerics / swift-service-context / swift-lifecycle / swift-certificates.
- A plain `swift package resolve` produces **zero diff** against the committed file (verified idempotent).
- So both a no-`Package.swift` PR and a `Package.swift`-touching PR pass the gate today, with no lockfile churn.

## The real, durable landmine

`swift build/test --traits Server,Macros` — the optional-traits sweep **CLAUDE.md mandates** for many changes — **mutates `Package.resolved` in place**, appending exactly ~163 lines of Server-stack deps. A developer who runs that sweep then has a dirty lockfile; if they accidentally `git add` it alongside a `Package.swift` change, the plain-resolve gate trips and the generic "run resolve and commit" message tempts a hand-strip.

## Chosen reconciliation: option (a), hardened

Keep the committed lockfile as the **plain** resolution (already the state of `main`) — trait-gated deps resolve on demand during trait builds and are intentionally not committed. This matches the verify gate by construction, so there is no surprise churn for either PR shape.

The change here makes that invariant **explicit and self-remediating**:

- Document in the step's comments that the committed lockfile is the plain resolution and that trait builds dirty it locally.
- Rewrite the failure message to name the real cause (trait-build leak) and give the one-line fix: `git checkout Package.resolved && swift package resolve`.

No `Package.resolved` change was needed — it was already canonical.

## Verification

- `swift package resolve` (the way CI runs it) → `git diff --exit-code Package.resolved` is **clean** (idempotent).
- `swift build` (default) succeeds.
- `swift build --traits Server,Macros` succeeds (and dirties the lockfile locally, as documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)