### PR TITLE
feat!: GenerationEvent — usage(TokenUsage) struct payload + 1.0 vocabulary freeze

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -89,3 +89,7 @@ API breakage: func InferenceService.enqueue(structuredMessages:systemPrompt:temp
 API breakage: var CloudImageEncoding.encodeHook has been removed
 API breakage: enumelement ImageRuntimeEvent.preview has been added as a new enum case
 API breakage: enumelement ImageGenerationEvent.preview has been added as a new enum case
+# GenerationEvent 1.0 vocabulary freeze: usage(prompt:completion:) → usage(TokenUsage)
+# so future token-accounting fields (cached/reasoning tokens) can grow as defaulted
+# struct fields without breaking exhaustive consumers. Intentional feat!: breaking change.
+API breakage: enumelement GenerationEvent.usage has declared type change from (ManifoldContract.GenerationEvent.Type) -> (Swift.Int, Swift.Int) -> ManifoldContract.GenerationEvent to (ManifoldContract.GenerationEvent.Type) -> (ManifoldContract.TokenUsage) -> ManifoldContract.GenerationEvent

--- a/Sources/ManifoldBackendTestKit/FixtureComparator.swift
+++ b/Sources/ManifoldBackendTestKit/FixtureComparator.swift
@@ -109,10 +109,10 @@ public struct FixtureComparator {
             switch event {
             case .token(let text):
                 return .init(event: "token", fields: ["text": text])
-            case .usage(let prompt, let completion):
+            case .usage(let usage):
                 return .init(event: "usage", fields: [
-                    "prompt": String(prompt),
-                    "completion": String(completion),
+                    "prompt": String(usage.promptTokens),
+                    "completion": String(usage.completionTokens),
                 ])
             case .toolCall(let call):
                 return .init(event: "toolCall", fields: [
@@ -146,6 +146,14 @@ public struct FixtureComparator {
             case .handoffRequested:
                 // Runtime-synthesised handoff event — never emitted by the
                 // backend wire path the fixture comparator validates.
+                return nil
+            @unknown default:
+                // `GenerationEvent`'s vocabulary is frozen at 1.0, but this
+                // comparator ships as a `.library` reused by the companion
+                // backend packages (manifold-mlx / manifold-llama). A future
+                // major that adds a case should not break their fixture
+                // projection — drop unrecognised events from the wire
+                // contract rather than failing to compile downstream.
                 return nil
             }
         }

--- a/Sources/ManifoldCloudCore/CloudRoutedStreamParser.swift
+++ b/Sources/ManifoldCloudCore/CloudRoutedStreamParser.swift
@@ -75,7 +75,7 @@ package struct CloudRoutedStreamParser: Sendable {
                        let prompt = usage.promptTokens,
                        let completion = usage.completionTokens {
                         handleUsage((promptTokens: prompt, completionTokens: completion))
-                        continuation.yield(.usage(prompt: prompt, completion: completion))
+                        continuation.yield(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
                     }
                     break
                 }
@@ -108,8 +108,8 @@ package struct CloudRoutedStreamParser: Sendable {
     ) throws {
         for event in consumer.consume(frame: frame) {
             if Task.isCancelled { break }
-            if case .usage(let prompt, let completion) = event {
-                handleUsage((promptTokens: prompt, completionTokens: completion))
+            if case .usage(let usage) = event {
+                handleUsage((promptTokens: usage.promptTokens, completionTokens: usage.completionTokens))
             }
             try limitTracker.noteEventYielded()
             continuation.yield(event)
@@ -145,7 +145,7 @@ package struct CloudRoutedStreamParser: Sendable {
             handleUsage(usage)
             if let prompt = usage.promptTokens,
                let completion = usage.completionTokens {
-                continuation.yield(.usage(prompt: prompt, completion: completion))
+                continuation.yield(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
             }
         }
     }

--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -724,7 +724,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
                 handleUsage(usage)
                 if let prompt = usage.promptTokens,
                    let completion = usage.completionTokens {
-                    continuation.yield(.usage(prompt: prompt, completion: completion))
+                    continuation.yield(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
                 }
             }
 

--- a/Sources/ManifoldCloudSaaS/ClaudeStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeStreamEventExtractor.swift
@@ -474,7 +474,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
             if let completion = usage.completionTokens,
                let prompt = pendingPromptTokens,
                !emittedUsage {
-                out.append(.usage(prompt: prompt, completion: completion))
+                out.append(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
                 emittedUsage = true
             }
         }

--- a/Sources/ManifoldCloudSaaS/OpenAIResponsesStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIResponsesStreamEventExtractor.swift
@@ -198,7 +198,7 @@ public final class OpenAIResponsesStreamEventExtractor: CloudStreamEventConsumer
             if let usage = OpenAIResponsesBackend.parseUsage(from: data) {
                 if let prompt = usage.promptTokens,
                    let completion = usage.completionTokens {
-                    out.append(.usage(prompt: prompt, completion: completion))
+                    out.append(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
                 }
             }
             appendFinalisedToolCalls(into: &out)

--- a/Sources/ManifoldCloudSaaS/OpenAIStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIStreamEventExtractor.swift
@@ -149,7 +149,7 @@ public final class OpenAIStreamEventExtractor: CloudStreamEventConsumer, @unchec
         if let usage = OpenAIChatCompletionsPayloadParsing.extractUsage(from: payload),
            let prompt = usage.promptTokens,
            let completion = usage.completionTokens {
-            out.append(.usage(prompt: prompt, completion: completion))
+            out.append(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
         }
 
         if let reason = OpenAIChatCompletionsPayloadParsing.parseFinishReason(from: payload) {

--- a/Sources/ManifoldContract/GenerationEvent.swift
+++ b/Sources/ManifoldContract/GenerationEvent.swift
@@ -6,8 +6,25 @@
 ///
 /// ## Vocabulary freeze (1.0)
 ///
-/// The tool-call event vocabulary is locked as of the 1.0 release. Key design
-/// decisions recorded here for Wave 3 consumers:
+/// **The entire `GenerationEvent` vocabulary is frozen as of the 1.0 release** —
+/// not just the tool-call sub-vocabulary. The set of cases is the stable cross-
+/// module contract every backend emits and every consumer switches over; adding
+/// a case is source-breaking for exhaustive `switch` statements (see "Source
+/// compatibility for pattern-match consumers" below), so new cases land only in
+/// a major (`feat!:`) release. Public-facing / cross-module consumers should add
+/// an `@unknown default:` arm to stay resilient to a future major.
+///
+/// Payloads that are expected to grow are modelled as **associated structs**
+/// rather than bare enum parameters so their fields can grow non-breakingly
+/// after the freeze:
+///
+/// - ``ToolProgressEvent`` — payload of ``toolProgress(_:)``.
+/// - ``TokenUsage`` — payload of ``usage(_:)``. Carried as a struct precisely so
+///   future token-accounting fields (cached-prompt tokens, reasoning tokens,
+///   tool-overhead tokens) can arrive as defaulted init parameters without
+///   forcing every `.usage(let usage)` consumer to rewrite its pattern.
+///
+/// Key design decisions recorded here for Wave 3 consumers:
 ///
 /// ### Queue-emitted lifecycle events
 ///
@@ -50,7 +67,11 @@ public enum GenerationEvent: Sendable, Equatable {
     case token(String)
 
     /// Token usage reported by the backend (cloud backends only today).
-    case usage(prompt: Int, completion: Int)
+    ///
+    /// Carries a ``TokenUsage`` struct rather than bare `prompt`/`completion`
+    /// parameters so future token-accounting fields can grow without breaking
+    /// exhaustive consumers — see the "Vocabulary freeze (1.0)" note above.
+    case usage(TokenUsage)
 
     /// A tool invocation requested by the model.
     ///

--- a/Sources/ManifoldContract/SSEStreamParser.swift
+++ b/Sources/ManifoldContract/SSEStreamParser.swift
@@ -425,7 +425,7 @@ package struct SSEStreamParser {
                         if let usage = handler.extractUsage(from: payload),
                            let prompt = usage.promptTokens,
                            let completion = usage.completionTokens {
-                            continuation.yield(.usage(prompt: prompt, completion: completion))
+                            continuation.yield(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
                         }
 
                         if handler.isStreamEnd(payload) {

--- a/Sources/ManifoldContract/TokenUsage.swift
+++ b/Sources/ManifoldContract/TokenUsage.swift
@@ -1,0 +1,31 @@
+/// Token-usage accounting reported by an inference backend, carried by
+/// ``GenerationEvent/usage(_:)``.
+///
+/// ## Growth point for future token accounting
+///
+/// This is deliberately a `struct` payload rather than bare enum associated
+/// values (the way ``ToolProgressEvent`` is). The `GenerationEvent` enum is
+/// frozen as of the 1.0 release, but token accounting is a near-certain growth
+/// area: providers are beginning to report cached-prompt tokens, reasoning
+/// (thinking) tokens, and tool-overhead tokens separately. Modelling usage as a
+/// struct lets those fields arrive later as **defaulted** initializer
+/// parameters — additive, source-compatible, and invisible to any consumer that
+/// already pattern-matches `.usage(let usage)`. A bare-parameter case
+/// (`case usage(prompt:completion:)`) could not grow that way without breaking
+/// every exhaustive `switch`.
+///
+/// When adding a field, give it a default in the memberwise init so existing
+/// `TokenUsage(promptTokens:completionTokens:)` call sites keep compiling.
+public struct TokenUsage: Sendable, Equatable, Hashable {
+    /// Number of prompt (input) tokens the backend reported for this request.
+    public let promptTokens: Int
+
+    /// Number of completion (output) tokens the backend reported for this
+    /// request.
+    public let completionTokens: Int
+
+    public init(promptTokens: Int, completionTokens: Int) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+    }
+}

--- a/Sources/ManifoldFuzz/EventRecorder.swift
+++ b/Sources/ManifoldFuzz/EventRecorder.swift
@@ -115,10 +115,10 @@ public struct EventRecorder: Sendable {
                         thinkingBuffer = ""
                     }
                     events.append(.init(t: t, kind: "thinkingCompleted", v: nil))
-                case .usage(let p, let c):
-                    promptTokens = p
-                    completionTokens = c
-                    events.append(.init(t: t, kind: "usage", v: "\(p)/\(c)"))
+                case .usage(let usage):
+                    promptTokens = usage.promptTokens
+                    completionTokens = usage.completionTokens
+                    events.append(.init(t: t, kind: "usage", v: "\(usage.promptTokens)/\(usage.completionTokens)"))
                 case .toolCall(let call):
                     toolCalls.append(call)
                     events.append(.init(t: t, kind: "toolCall", v: call.toolName))

--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -174,8 +174,8 @@ for try await event in stream {
     case .toolCall(let call):
         let result = try await myToolRegistry.dispatch(call)
         // The queue re-prompts automatically; you only need to observe.
-    case .usage(let prompt, let completion):
-        updateTokenCounter(prompt: prompt, completion: completion)
+    case .usage(let usage):
+        updateTokenCounter(prompt: usage.promptTokens, completion: usage.completionTokens)
     default:
         break
     }

--- a/Sources/ManifoldInference/Services/GenerationStreamConsumer.swift
+++ b/Sources/ManifoldInference/Services/GenerationStreamConsumer.swift
@@ -22,8 +22,8 @@ public struct GenerationStreamConsumer: Sendable {
         case .token(let text):
             return .appendText(text)
 
-        case .usage(let prompt, let completion):
-            return .recordUsage(prompt: prompt, completion: completion)
+        case .usage(let usage):
+            return .recordUsage(prompt: usage.promptTokens, completion: usage.completionTokens)
 
         case .toolCall(let call):
             return .dispatchToolCall(call)

--- a/Sources/ManifoldOllama/OllamaStreamEventExtractor.swift
+++ b/Sources/ManifoldOllama/OllamaStreamEventExtractor.swift
@@ -467,7 +467,7 @@ public final class OllamaStreamEventExtractor: CloudStreamEventConsumer, @unchec
         guard let prompt = parsed.promptEvalCount, let completion = parsed.evalCount else {
             return
         }
-        out.append(.usage(prompt: prompt, completion: completion))
+        out.append(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
     }
 
     // MARK: - Cap-aware emit helper

--- a/Sources/ManifoldServer/ChatCompletionsAdapter.swift
+++ b/Sources/ManifoldServer/ChatCompletionsAdapter.swift
@@ -756,8 +756,8 @@ internal struct ChatCompletionEventMapper: Sendable {
                 content += text
             case .thinkingToken(let text):
                 reasoningContent += text
-            case .usage(let prompt, let completion):
-                usage = ChatCompletionUsage(promptTokens: prompt, completionTokens: completion)
+            case .usage(let tokenUsage):
+                usage = ChatCompletionUsage(promptTokens: tokenUsage.promptTokens, completionTokens: tokenUsage.completionTokens)
             case .toolCallStart(let callID, let name):
                 _ = index(for: callID)
                 sawToolCall = true

--- a/Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift
+++ b/Sources/ManifoldTestSupport/ScriptedGenerationBackend.swift
@@ -63,7 +63,7 @@ public final class ScriptedGenerationBackend: InferenceBackend, @unchecked Senda
 
         /// Emits a `usage` event followed by text tokens.
         public static func withUsage(prompt: Int, completion: Int, tokens: [String]) -> TurnScript {
-            var events: [ScriptedEvent] = [.emit(.usage(prompt: prompt, completion: completion))]
+            var events: [ScriptedEvent] = [.emit(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))]
             events += tokens.map { .emit(.token($0)) }
             return TurnScript(events)
         }

--- a/Tests/APIFreezeTests/Fixtures/BackendSeamConsumer.swift
+++ b/Tests/APIFreezeTests/Fixtures/BackendSeamConsumer.swift
@@ -124,8 +124,8 @@ enum BackendSeamConsumer {
             _ = (tokensProcessed, tokensTotal, tokensPerSecond)
         case .token(let text):
             _ = text
-        case .usage(prompt: let prompt, completion: let completion):
-            _ = (prompt, completion)
+        case .usage(let usage):
+            _ = (usage.promptTokens, usage.completionTokens)
         case .toolCall(let call):
             _ = call
         case .toolCallStart(callId: let callId, name: let name):

--- a/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
@@ -130,7 +130,7 @@ final class ClaudeStreamEventExtractorTests: XCTestCase {
     func test_extractor_usageBasic_emitsMergedUsageOnce() throws {
         let events = try driveExtractor(scenario: "usage/basic")
         let usages: [(Int, Int)] = events.compactMap { event in
-            if case .usage(let p, let c) = event { return (p, c) } else { return nil }
+            if case .usage(let u) = event { return (u.promptTokens, u.completionTokens) } else { return nil }
         }
         XCTAssertEqual(usages.count, 1, "expected exactly one merged .usage event, saw \(usages)")
         XCTAssertEqual(usages.first?.0, 12, "prompt tokens from message_start")
@@ -316,7 +316,7 @@ final class ClaudeStreamEventExtractorParityTests: XCTestCase {
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
-        case .usage(let p, let c): return "usage(\(p),\(c))"
+        case .usage(let u): return "usage(\(u.promptTokens),\(u.completionTokens))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
         case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"

--- a/Tests/ManifoldBackendsTests/CloudBackendSSETests.swift
+++ b/Tests/ManifoldBackendsTests/CloudBackendSSETests.swift
@@ -765,9 +765,9 @@ struct SSEHazardTests {
         // Must contain exactly one .usage event, and it must precede termination.
         var sawUsage = false
         for event in events {
-            if case .usage(let prompt, let completion) = event {
-                #expect(prompt == 10)
-                #expect(completion == 5)
+            if case .usage(let u) = event {
+                #expect(u.promptTokens == 10)
+                #expect(u.completionTokens == 5)
                 sawUsage = true
             }
         }

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -717,8 +717,8 @@ struct OllamaBackendTests {
         let stream = try backend.generate(prompt: "hi", systemPrompt: nil, config: .init())
         var usageEvents: [(prompt: Int, completion: Int)] = []
         for try await event in stream.events {
-            if case .usage(let p, let c) = event {
-                usageEvents.append((prompt: p, completion: c))
+            if case .usage(let u) = event {
+                usageEvents.append((prompt: u.promptTokens, completion: u.completionTokens))
             }
         }
 

--- a/Tests/ManifoldBackendsTests/OllamaStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaStreamEventExtractorTests.swift
@@ -30,7 +30,7 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
         XCTAssertEqual(tokens, ["Hello", " world"],
                        "extractor must replay the same token sequence as the legacy OllamaStreamProcessor")
         let usage: (prompt: Int, completion: Int)? = events.lazy.compactMap {
-            if case .usage(let p, let c) = $0 { return (p, c) } else { return nil }
+            if case .usage(let u) = $0 { return (u.promptTokens, u.completionTokens) } else { return nil }
         }.first
         XCTAssertEqual(usage?.prompt, 7)
         XCTAssertEqual(usage?.completion, 2)
@@ -70,9 +70,9 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
             XCTAssertTrue(call.arguments.contains("Paris"))
         } else { XCTFail("expected .toolCall, got \(filtered[2])") }
 
-        if case .usage(let p, let c) = filtered[3] {
-            XCTAssertEqual(p, 42)
-            XCTAssertEqual(c, 18)
+        if case .usage(let u) = filtered[3] {
+            XCTAssertEqual(u.promptTokens, 42)
+            XCTAssertEqual(u.completionTokens, 18)
         } else { XCTFail("expected .usage, got \(filtered[3])") }
     }
 
@@ -81,7 +81,7 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
     func test_extractor_usageBasic_emitsUsageEvent() throws {
         let events = try driveExtractor(scenario: "usage/basic", config: GenerationConfig())
         let usage: (prompt: Int, completion: Int)? = events.lazy.compactMap {
-            if case .usage(let p, let c) = $0 { return (p, c) } else { return nil }
+            if case .usage(let u) = $0 { return (u.promptTokens, u.completionTokens) } else { return nil }
         }.first
         XCTAssertEqual(usage?.prompt, 12)
         XCTAssertEqual(usage?.completion, 48)
@@ -110,9 +110,9 @@ final class OllamaStreamEventExtractorTests: XCTestCase {
         if case .token(let visible) = events[3] { XCTAssertEqual(visible, "Answer.") }
         else { XCTFail("event[3] expected .token, got \(events[3])") }
 
-        if case .usage(let p, let c) = events[4] {
-            XCTAssertEqual(p, 5)
-            XCTAssertEqual(c, 12)
+        if case .usage(let u) = events[4] {
+            XCTAssertEqual(u.promptTokens, 5)
+            XCTAssertEqual(u.completionTokens, 12)
         } else { XCTFail("event[4] expected .usage, got \(events[4])") }
     }
 
@@ -249,7 +249,7 @@ final class OllamaStreamEventExtractorParityTests: XCTestCase {
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
-        case .usage(let p, let c): return "usage(\(p),\(c))"
+        case .usage(let u): return "usage(\(u.promptTokens),\(u.completionTokens))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
         case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"

--- a/Tests/ManifoldBackendsTests/OllamaToolCallLiveReplayTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaToolCallLiveReplayTests.swift
@@ -157,7 +157,7 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
         XCTAssertEqual(tokens, ["The", " capital", " of France", " is Paris."])
 
         let usage = events.compactMap { event -> (Int, Int)? in
-            if case .usage(let p, let c) = event { return (p, c) } else { return nil }
+            if case .usage(let u) = event { return (u.promptTokens, u.completionTokens) } else { return nil }
         }
         XCTAssertEqual(usage.count, 1, "expected exactly one .usage event from the done-line")
         XCTAssertEqual(usage.first?.0, 30)
@@ -185,8 +185,8 @@ final class OllamaToolCallLiveReplayTests: XCTestCase {
                     projected.append(ExpectedEvent(event: "token", text: t, tool_name: nil, arguments_contains: nil, prompt: nil, completion: nil))
                 case .toolCall(let call):
                     projected.append(ExpectedEvent(event: "toolCall", text: nil, tool_name: call.toolName, arguments_contains: nil, prompt: nil, completion: nil))
-                case .usage(let p, let c):
-                    projected.append(ExpectedEvent(event: "usage", text: nil, tool_name: nil, arguments_contains: nil, prompt: p, completion: c))
+                case .usage(let u):
+                    projected.append(ExpectedEvent(event: "usage", text: nil, tool_name: nil, arguments_contains: nil, prompt: u.promptTokens, completion: u.completionTokens))
                 case .thinkingToken, .thinkingCompleted, .thinkingSignature:
                     // Not exercised by tool-call fixtures; ignore for
                     // forward-compat with future thinking-in-tool-call

--- a/Tests/ManifoldBackendsTests/OpenAIResponsesStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIResponsesStreamEventExtractorTests.swift
@@ -32,7 +32,7 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
         XCTAssertEqual(tokens, ["Hello", " world"])
 
         let usage: (prompt: Int, completion: Int)? = events.lazy.compactMap {
-            if case .usage(let p, let c) = $0 { return (p, c) } else { return nil }
+            if case .usage(let u) = $0 { return (u.promptTokens, u.completionTokens) } else { return nil }
         }.first
         XCTAssertEqual(usage?.prompt, 4)
         XCTAssertEqual(usage?.completion, 2)
@@ -60,9 +60,9 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
             XCTFail("expected .toolCallArgumentsDelta second, got \(events[1])")
         }
 
-        if case .usage(let prompt, let completion) = events[2] {
-            XCTAssertEqual(prompt, 12)
-            XCTAssertEqual(completion, 7)
+        if case .usage(let u) = events[2] {
+            XCTAssertEqual(u.promptTokens, 12)
+            XCTAssertEqual(u.completionTokens, 7)
         } else {
             XCTFail("expected .usage third, got \(events[2])")
         }
@@ -101,7 +101,7 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
     func test_extractor_usageBasic_emitsUsageEvent() throws {
         let events = try driveExtractor(scenario: "usage/basic")
         let usage: (prompt: Int, completion: Int)? = events.lazy.compactMap {
-            if case .usage(let p, let c) = $0 { return (p, c) } else { return nil }
+            if case .usage(let u) = $0 { return (u.promptTokens, u.completionTokens) } else { return nil }
         }.first
         XCTAssertEqual(usage?.prompt, 11)
         XCTAssertEqual(usage?.completion, 1)
@@ -199,7 +199,7 @@ final class OpenAIResponsesStreamEventExtractorTests: XCTestCase {
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName))"
-        case .usage(let p, let c): return "usage(\(p),\(c))"
+        case .usage(let u): return "usage(\(u.promptTokens),\(u.completionTokens))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
         case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"
@@ -323,7 +323,7 @@ final class OpenAIResponsesStreamEventExtractorParityTests: XCTestCase {
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
-        case .usage(let p, let c): return "usage(\(p),\(c))"
+        case .usage(let u): return "usage(\(u.promptTokens),\(u.completionTokens))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
         case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"

--- a/Tests/ManifoldBackendsTests/OpenAIStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/OpenAIStreamEventExtractorTests.swift
@@ -83,7 +83,7 @@ final class OpenAIStreamEventExtractorTests: XCTestCase {
     func test_extractor_usageBasic_emitsUsageEvent() throws {
         let events = try driveExtractor(scenario: "usage/basic")
         let usage: (prompt: Int, completion: Int)? = events.lazy.compactMap {
-            if case .usage(let p, let c) = $0 { return (p, c) } else { return nil }
+            if case .usage(let u) = $0 { return (u.promptTokens, u.completionTokens) } else { return nil }
         }.first
         XCTAssertEqual(usage?.prompt, 12)
         XCTAssertEqual(usage?.completion, 48)
@@ -127,7 +127,7 @@ final class OpenAIStreamEventExtractorTests: XCTestCase {
         XCTAssertEqual(tokens, ["Once", " upon"])
 
         let usage: (prompt: Int, completion: Int)? = events.lazy.compactMap {
-            if case .usage(let p, let c) = $0 { return (p, c) } else { return nil }
+            if case .usage(let u) = $0 { return (u.promptTokens, u.completionTokens) } else { return nil }
         }.first
         XCTAssertEqual(usage?.prompt, 7)
         XCTAssertEqual(usage?.completion, 2)
@@ -304,7 +304,7 @@ final class OpenAIStreamEventExtractorParityTests: XCTestCase {
         case .toolCallStart(let id, let name): return "toolCallStart(\(id),\(name))"
         case .toolCallArgumentsDelta(let id, let d): return "toolCallArgumentsDelta(\(id),\(d))"
         case .toolCall(let c): return "toolCall(\(c.id),\(c.toolName),\(c.arguments))"
-        case .usage(let p, let c): return "usage(\(p),\(c))"
+        case .usage(let u): return "usage(\(u.promptTokens),\(u.completionTokens))"
         case .prefillProgress(let n, let t, _): return "prefillProgress(\(n)/\(t))"
         case .toolIterationLimitExceeded(let n): return "toolIterationLimitExceeded(\(n))"
         case .toolResult: return "toolResult"

--- a/Tests/ManifoldBackendsTests/SSECloudBackendAdapterRoutingTests.swift
+++ b/Tests/ManifoldBackendsTests/SSECloudBackendAdapterRoutingTests.swift
@@ -207,9 +207,9 @@ struct SSECloudBackendAdapterRoutingTests {
         for try await event in stream.events {
             switch event {
             case .token(let t): tokens.append(t)
-            case .usage(let p, let c):
-                usagePrompt = p
-                usageCompletion = c
+            case .usage(let u):
+                usagePrompt = u.promptTokens
+                usageCompletion = u.completionTokens
             default: break
             }
         }
@@ -279,7 +279,7 @@ struct SSECloudBackendAdapterRoutingTests {
             case .thinkingToken(let text): events.append("thinking:\(text)")
             case .thinkingCompleted: events.append("thinkingCompleted")
             case .token(let text): events.append("token:\(text)")
-            case .usage(let prompt, let completion): events.append("usage:\(prompt)/\(completion)")
+            case .usage(let u): events.append("usage:\(u.promptTokens)/\(u.completionTokens)")
             default: break
             }
         }

--- a/Tests/ManifoldInferenceTests/GenerationStreamConsumerTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationStreamConsumerTests.swift
@@ -22,7 +22,7 @@ final class GenerationStreamConsumerTests: XCTestCase {
 
     func test_usageEvent_returnsRecordUsage() {
         var consumer = GenerationStreamConsumer()
-        let action = consumer.handle(.usage(prompt: 10, completion: 5))
+        let action = consumer.handle(.usage(TokenUsage(promptTokens: 10, completionTokens: 5)))
         // Sabotage check: swapping prompt/completion in the .usage case causes this to fail
         XCTAssertEqual(action, .recordUsage(prompt: 10, completion: 5))
     }

--- a/Tests/ManifoldInferenceTests/GenerationStreamTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationStreamTests.swift
@@ -26,15 +26,15 @@ final class GenerationStreamTests: XCTestCase {
 
     func test_eventsDeliversUsage() async throws {
         let inner = AsyncThrowingStream<GenerationEvent, Error> { continuation in
-            continuation.yield(.usage(prompt: 10, completion: 5))
+            continuation.yield(.usage(TokenUsage(promptTokens: 10, completionTokens: 5)))
             continuation.finish()
         }
         let stream = GenerationStream(inner)
 
         var usages: [(Int, Int)] = []
         for try await event in stream.events {
-            if case .usage(let p, let c) = event {
-                usages.append((p, c))
+            if case .usage(let usage) = event {
+                usages.append((usage.promptTokens, usage.completionTokens))
             }
         }
         // Sabotage check: removing the .usage yield from the inner stream causes count to be 0

--- a/Tests/ManifoldRuntimeTests/CompressionEventInsertedRecordsTests.swift
+++ b/Tests/ManifoldRuntimeTests/CompressionEventInsertedRecordsTests.swift
@@ -83,7 +83,7 @@ final class CompressionEventInsertedRecordsTests: XCTestCase {
                         for try await event in innerStream.events {
                             continuation.yield(event)
                         }
-                        continuation.yield(.usage(prompt: 50, completion: 10))
+                        continuation.yield(.usage(TokenUsage(promptTokens: 50, completionTokens: 10)))
                         continuation.finish()
                     } catch {
                         continuation.finish(throwing: error)

--- a/Tests/ManifoldRuntimeTests/CompressionPolicyTests.swift
+++ b/Tests/ManifoldRuntimeTests/CompressionPolicyTests.swift
@@ -99,7 +99,7 @@ final class CompressionPolicyTests: XCTestCase {
                         for try await event in innerStream.events {
                             continuation.yield(event)
                         }
-                        continuation.yield(.usage(prompt: 50, completion: 10))
+                        continuation.yield(.usage(TokenUsage(promptTokens: 50, completionTokens: 10)))
                         continuation.finish()
                     } catch {
                         continuation.finish(throwing: error)

--- a/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationRuntimeTests.swift
@@ -54,7 +54,7 @@ private final class RuntimeUsageBackend: InferenceBackend, TokenUsageProvider, @
                     continuation.yield(.token(token))
                 }
                 if let usage = turn.usage, !Task.isCancelled {
-                    continuation.yield(.usage(prompt: usage.promptTokens, completion: usage.completionTokens))
+                    continuation.yield(.usage(TokenUsage(promptTokens: usage.promptTokens, completionTokens: usage.completionTokens)))
                     self.lastUsage = usage
                 }
                 self.isGenerating = false

--- a/Tests/ManifoldRuntimeTests/GlassBoxEventWiringTests.swift
+++ b/Tests/ManifoldRuntimeTests/GlassBoxEventWiringTests.swift
@@ -50,7 +50,7 @@ private final class UsageReportingBackend: InferenceBackend, @unchecked Sendable
                     for try await event in innerStream.events {
                         continuation.yield(event)
                     }
-                    continuation.yield(.usage(prompt: prompt, completion: completion))
+                    continuation.yield(.usage(TokenUsage(promptTokens: prompt, completionTokens: completion)))
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -86,7 +86,7 @@ private final class FakeEndpointBackend: InferenceBackend, EndpointBackendURLMod
     func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
         GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { continuation in
             continuation.yield(.token("hi"))
-            continuation.yield(.usage(prompt: 12, completion: 3))
+            continuation.yield(.usage(TokenUsage(promptTokens: 12, completionTokens: 3)))
             continuation.finish()
         })
     }

--- a/Tests/ManifoldRuntimeTests/PreCompactWiringTests.swift
+++ b/Tests/ManifoldRuntimeTests/PreCompactWiringTests.swift
@@ -63,7 +63,7 @@ final class PreCompactWiringTests: XCTestCase {
                         for try await event in innerStream.events {
                             continuation.yield(event)
                         }
-                        continuation.yield(.usage(prompt: 50, completion: 10))
+                        continuation.yield(.usage(TokenUsage(promptTokens: 50, completionTokens: 10)))
                         continuation.finish()
                     } catch {
                         continuation.finish(throwing: error)

--- a/Tests/ManifoldRuntimeTests/SummarisationHookTests.swift
+++ b/Tests/ManifoldRuntimeTests/SummarisationHookTests.swift
@@ -142,7 +142,7 @@ final class SummarisationHookTests: XCTestCase {
                         for try await event in innerStream.events {
                             continuation.yield(event)
                         }
-                        continuation.yield(.usage(prompt: promptTokens, completion: 10))
+                        continuation.yield(.usage(TokenUsage(promptTokens: promptTokens, completionTokens: 10)))
                         continuation.finish()
                     } catch {
                         continuation.finish(throwing: error)

--- a/Tests/ManifoldServerTests/ChatCompletionsAdapterTests.swift
+++ b/Tests/ManifoldServerTests/ChatCompletionsAdapterTests.swift
@@ -112,7 +112,7 @@ final class ChatCompletionsAdapterTests: XCTestCase {
     }
 
     func testUsageEventMapsToFinalUsageChunkWhenRequested() async throws {
-        let backend = EventSequenceBackend(events: [.token("ok"), .usage(prompt: 3, completion: 2)])
+        let backend = EventSequenceBackend(events: [.token("ok"), .usage(TokenUsage(promptTokens: 3, completionTokens: 2))])
         let request = ChatCompletionRequest(
             model: "m",
             messages: [ChatCompletionMessage(role: .user, content: "hi")],
@@ -176,7 +176,7 @@ final class ChatCompletionsAdapterTests: XCTestCase {
         ]
 
         for request in requests {
-            let backend = EventSequenceBackend(events: [.token("ok"), .usage(prompt: 3, completion: 2)])
+            let backend = EventSequenceBackend(events: [.token("ok"), .usage(TokenUsage(promptTokens: 3, completionTokens: 2))])
             let chunks = try await collect(try DefaultChatCompletionsAdapter().chunks(for: request, using: backend))
 
             XCTAssertTrue(chunks.allSatisfy { $0.usage == nil })
@@ -224,7 +224,7 @@ final class ChatCompletionsAdapterTests: XCTestCase {
             .toolCallStart(callId: "call_1", name: "lookup"),
             .toolCallArgumentsDelta(callId: "call_1", textDelta: "{\"q\":"),
             .toolCallArgumentsDelta(callId: "call_1", textDelta: "\"swift\"}"),
-            .usage(prompt: 5, completion: 7)
+            .usage(TokenUsage(promptTokens: 5, completionTokens: 7))
         ])
         let request = ChatCompletionRequest(model: "m", messages: [ChatCompletionMessage(role: .user, content: "hi")])
 


### PR DESCRIPTION
## Summary

Unit B2 — **GenerationEvent vocabulary freeze**.

- Adds `public struct TokenUsage: Sendable, Equatable, Hashable` to `ManifoldContract` (new `Sources/ManifoldContract/TokenUsage.swift`) with `promptTokens` / `completionTokens` + memberwise init. Doc comments mark it the growth point for future token accounting (cached / reasoning / tool-overhead tokens) — additive fields land as defaulted init params, source-compatibly.
- Changes `GenerationEvent.usage(prompt: Int, completion: Int)` → `usage(TokenUsage)`. Same struct-payload precedent as `ToolProgressEvent`.
- Declares the **whole** `GenerationEvent` enum frozen at 1.0 in its doc block (previously only the tool-call sub-vocabulary was noted) and documents the `TokenUsage` rationale.
- Adds `@unknown default:` to `FixtureComparator.project` (shipped as a `.library` reused by the companion `manifold-mlx` / `manifold-llama` packages) so a future major adding a case does not break downstream fixture projection. Core-internal exhaustive switches intentionally keep no default.
- Updates every emit + consumer site across `ManifoldContract`, `ManifoldCloudCore`, `ManifoldCloudSaaS`, `ManifoldOllama`, `ManifoldInference`, `ManifoldServer`, `ManifoldFuzz`, `ManifoldTestSupport`, `ManifoldBackendTestKit`, the DocC article, and all affected test suites.
- Allowlists the enum-element signature change in `.github/api-breakage-allowlist.txt` (intentional breaking change).

## Breaking change + migration

`GenerationEvent.usage` no longer carries bare `prompt` / `completion` parameters; it carries a `TokenUsage`.

```swift
// Construction
- .usage(prompt: p, completion: c)
+ .usage(TokenUsage(promptTokens: p, completionTokens: c))

// Pattern match
- case .usage(let p, let c):
+ case .usage(let usage):  // usage.promptTokens, usage.completionTokens
```

## Gate results

`scripts/test.sh --profile local` (two-invocation shape):

```
Invocation 1 (XCTest + Swift Testing): Passed 4960  Failed 0  (4779 XCTest + 181 Swift Testing)
Invocation 2 (Swift Testing):          Passed 32    Failed 0
RESULT: PASSED  (both invocations)
```

`swift build --build-tests --traits Server,Macros` → Build complete! (no new warnings)

API-breakage diagnoser confirmed the single expected message, now allowlisted:
`enumelement GenerationEvent.usage has declared type change ... -> (TokenUsage) -> GenerationEvent`.

Refs #1605 (GenerationEvent freeze)

BREAKING CHANGE: `GenerationEvent.usage(prompt:completion:)` is now `usage(TokenUsage)`.