### PR TITLE
feat!: rename persistence ChatSession/ChatMessage typealiases to Persisted* (resolves #1717 ambiguity)

### DIFF
--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SettingsService+ChatSession.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SettingsService+ChatSession.swift
@@ -1,23 +1,24 @@
 import ManifoldInference
 
-// Source-compatibility shims so callers can pass an @Model `ChatSession` to the
-// `SettingsService` resolution helpers, even though those helpers now operate
-// on the storage-agnostic `ManifoldInference.ChatSession` after the ManifoldInference split.
+// Source-compatibility shims so callers can pass an @Model `PersistedChatSession`
+// to the `SettingsService` resolution helpers, even though those helpers now
+// operate on the storage-agnostic `ManifoldInference.ChatSession` after the
+// ManifoldInference split.
 extension SettingsService {
 
     /// Returns the effective temperature, using session override if available.
     @MainActor
-    public func effectiveTemperature(session: ChatSession?) -> Float {
+    public func effectiveTemperature(session: PersistedChatSession?) -> Float {
         effectiveTemperature(session: session?.record)
     }
 
     @MainActor
-    public func effectiveTopP(session: ChatSession?) -> Float {
+    public func effectiveTopP(session: PersistedChatSession?) -> Float {
         effectiveTopP(session: session?.record)
     }
 
     @MainActor
-    public func effectiveRepeatPenalty(session: ChatSession?) -> Float {
+    public func effectiveRepeatPenalty(session: PersistedChatSession?) -> Float {
         effectiveRepeatPenalty(session: session?.record)
     }
 }

--- a/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Adapters/SwiftDataPersistenceProvider.swift
@@ -44,7 +44,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     // MARK: - Sessions
 
     public func insertSession(_ record: ManifoldInference.ChatSession) async throws {
-        let session = ChatSession(title: record.title)
+        let session = PersistedChatSession(title: record.title)
         session.id = record.id
         session.createdAt = record.createdAt
         session.updatedAt = record.updatedAt
@@ -106,7 +106,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     /// `activeAgentID` is written separately on the parent row (and via
     /// ``setActiveAgent(sessionID:agentID:)``), so handoff state is untouched
     /// here — this only owns the agent registry membership.
-    private func reconcileAgents(on session: ChatSession, with agents: [ManifoldInference.Agent]) {
+    private func reconcileAgents(on session: PersistedChatSession, with agents: [ManifoldInference.Agent]) {
         let desiredByID = Dictionary(agents.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
         var existingByID: [UUID: PersistedAgent] = [:]
 
@@ -172,7 +172,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         // one save closes that window: if the save throws, neither delete
         // reaches the store.
         let messages = try modelContext.fetch(
-            FetchDescriptor<ChatMessage>(predicate: #Predicate { $0.sessionID == sessionID })
+            FetchDescriptor<PersistedChatMessage>(predicate: #Predicate { $0.sessionID == sessionID })
         )
         for message in messages {
             modelContext.delete(message)
@@ -194,11 +194,11 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         // no orphaned ChatMessage rows can survive — `sessionID` is a UUID
         // foreign key (no SwiftData relationship), so an implicit cascade is
         // not available today.
-        let messages = try modelContext.fetch(FetchDescriptor<ChatMessage>())
+        let messages = try modelContext.fetch(FetchDescriptor<PersistedChatMessage>())
         for message in messages {
             modelContext.delete(message)
         }
-        let sessions = try modelContext.fetch(FetchDescriptor<ChatSession>())
+        let sessions = try modelContext.fetch(FetchDescriptor<PersistedChatSession>())
         for session in sessions {
             modelContext.delete(session)
         }
@@ -213,7 +213,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         // desc — the pre-V8 order. SwiftData applies the secondary keys only
         // when the primary one ties, so within each bucket the intended
         // ordering holds.
-        let descriptor = FetchDescriptor<ChatSession>(
+        let descriptor = FetchDescriptor<PersistedChatSession>(
             sortBy: [
                 SortDescriptor(\.pinnedSortKey, order: .reverse),
                 SortDescriptor(\.updatedAt, order: .reverse),
@@ -223,7 +223,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     }
 
     public func fetchSessions(offset: Int, limit: Int) async throws -> [ManifoldInference.ChatSession] {
-        var descriptor = FetchDescriptor<ChatSession>(
+        var descriptor = FetchDescriptor<PersistedChatSession>(
             sortBy: [
                 SortDescriptor(\.pinnedSortKey, order: .reverse),
                 SortDescriptor(\.updatedAt, order: .reverse),
@@ -318,11 +318,11 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     /// limits. Bulk-delete paths deliberately do not route through here: capping
     /// a delete would leave orphaned rows, so they own their unbounded fetch.
     private func boundedMessageFetch(
-        predicate: Predicate<ChatMessage>,
-        sortBy: [SortDescriptor<ChatMessage>],
+        predicate: Predicate<PersistedChatMessage>,
+        sortBy: [SortDescriptor<PersistedChatMessage>],
         limit: Int
-    ) -> FetchDescriptor<ChatMessage> {
-        var descriptor = FetchDescriptor<ChatMessage>(predicate: predicate, sortBy: sortBy)
+    ) -> FetchDescriptor<PersistedChatMessage> {
+        var descriptor = FetchDescriptor<PersistedChatMessage>(predicate: predicate, sortBy: sortBy)
         descriptor.fetchLimit = limit
         return descriptor
     }
@@ -395,7 +395,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
     }
 
     public func deleteMessages(for sessionID: UUID) async throws {
-        let descriptor = FetchDescriptor<ChatMessage>(
+        let descriptor = FetchDescriptor<PersistedChatMessage>(
             predicate: #Predicate { $0.sessionID == sessionID }
         )
         for message in try modelContext.fetch(descriptor) {
@@ -439,7 +439,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
                     }
                     modelContext.delete(message)
                 case let .deleteMessages(sessionID):
-                    let descriptor = FetchDescriptor<ChatMessage>(
+                    let descriptor = FetchDescriptor<PersistedChatMessage>(
                         predicate: #Predicate { $0.sessionID == sessionID }
                     )
                     for message in try modelContext.fetch(descriptor) {
@@ -488,22 +488,22 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
 
     // MARK: - Private
 
-    private func fetchSwiftDataSession(id: UUID) throws -> ChatSession? {
-        let descriptor = FetchDescriptor<ChatSession>(
+    private func fetchSwiftDataSession(id: UUID) throws -> PersistedChatSession? {
+        let descriptor = FetchDescriptor<PersistedChatSession>(
             predicate: #Predicate { $0.id == id }
         )
         return try modelContext.fetch(descriptor).first
     }
 
-    private func fetchSwiftDataMessage(id: UUID) throws -> ChatMessage? {
-        let descriptor = FetchDescriptor<ChatMessage>(
+    private func fetchSwiftDataMessage(id: UUID) throws -> PersistedChatMessage? {
+        let descriptor = FetchDescriptor<PersistedChatMessage>(
             predicate: #Predicate { $0.id == id }
         )
         return try modelContext.fetch(descriptor).first
     }
 
-    private func makeSwiftDataMessage(from record: ManifoldInference.ChatMessage) -> ChatMessage {
-        let message = ChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
+    private func makeSwiftDataMessage(from record: ManifoldInference.ChatMessage) -> PersistedChatMessage {
+        let message = PersistedChatMessage(role: record.role, contentParts: record.contentParts, sessionID: record.sessionID)
         message.id = record.id
         message.timestamp = record.timestamp
         message.promptTokens = record.promptTokens
@@ -514,7 +514,7 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
         return message
     }
 
-    private func applyMutableMessageFields(from record: ManifoldInference.ChatMessage, to message: ChatMessage) {
+    private func applyMutableMessageFields(from record: ManifoldInference.ChatMessage, to message: PersistedChatMessage) {
         message.contentParts = record.contentParts
         message.promptTokens = record.promptTokens
         message.completionTokens = record.completionTokens
@@ -526,14 +526,14 @@ public final class SwiftDataPersistenceProvider: SessionStore, MessageStore, Tra
 
 // MARK: - Model <-> Record conversions
 
-extension ChatSession {
+extension PersistedChatSession {
     /// Converts a SwiftData model to a plain record.
     func toRecord() -> ManifoldInference.ChatSession {
         record
     }
 }
 
-extension ChatMessage {
+extension PersistedChatMessage {
     /// Converts a SwiftData model to a plain record.
     func toRecord() -> ManifoldInference.ChatMessage {
         ManifoldInference.ChatMessage(

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldPersistenceSwiftData.docc/ManifoldPersistenceSwiftData.md
@@ -108,7 +108,7 @@ let bootstrap = try ManifoldBootstrap(
         // includes both your app's models and ManifoldKit's.
         try ModelContainer(
             for: Schema([
-                ChatSession.self, ChatMessage.self, APIEndpoint.self,
+                PersistedChatSession.self, PersistedChatMessage.self, APIEndpoint.self,
                 SamplerPreset.self, PersistedAgent.self,
                 MyAppModel.self
             ]),

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ChatMessage.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ChatMessage.swift
@@ -1,6 +1,26 @@
-/// Public alias for the current SwiftData chat message model.
+/// The SwiftData persistence model for a chat message. Renamed at the
+/// module-public layer to ``PersistedChatMessage`` to avoid shadowing
+/// ``ManifoldInference/ChatMessage`` (the value type that flows through the
+/// runtime and ports). The underlying `@Model` class remains
+/// ``ManifoldSchemaV9/ChatMessage`` so existing SwiftData stores stay valid.
 ///
 /// SchemaV9 adds `agentID: UUID?` for multi-agent attribution. Intentionally
 /// not a `@Relationship` so deleting an agent doesn't cascade-delete its
 /// authored history (see the field doc in ``ManifoldSchemaV9/ChatMessage``).
+///
+/// Use ``PersistedChatMessage`` in new code. Host apps that import both
+/// ``ManifoldInference`` and ``ManifoldPersistenceSwiftData`` can refer to
+/// the value type as `ChatMessage` and the SwiftData row as
+/// `PersistedChatMessage` without disambiguation.
+public typealias PersistedChatMessage = ManifoldSchemaV9.ChatMessage
+
+/// Back-compat alias for code that referenced ``ChatMessage`` directly before
+/// the #1717 disambiguation. Prefer ``PersistedChatMessage`` in new code.
+///
+/// > Deprecated: Renamed to ``PersistedChatMessage``. The bare name shadows
+/// > ``ManifoldInference/ChatMessage`` when both modules are imported (e.g.
+/// > under `import ManifoldKit`). Migrate to `PersistedChatMessage` now — this
+/// > alias will be removed in the 1.0-adjacent major release (≥2 minors after
+/// > this annotation was added, 0.x-era).
+@available(*, deprecated, renamed: "PersistedChatMessage", message: "Use PersistedChatMessage to avoid shadowing ManifoldInference.ChatMessage. This alias will be removed in the 1.0-adjacent major release.")
 public typealias ChatMessage = ManifoldSchemaV9.ChatMessage

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession+Record.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession+Record.swift
@@ -2,9 +2,9 @@ import Foundation
 import ManifoldInference
 
 // Source-compatibility shim: lets callers convert the SwiftData `@Model`
-// `ChatSession` into the storage-agnostic `ManifoldInference.ChatSession` used by
-// ManifoldInference APIs.
-extension ChatSession {
+// `PersistedChatSession` into the storage-agnostic `ManifoldInference.ChatSession`
+// used by ManifoldInference APIs.
+extension PersistedChatSession {
 
     /// Returns a storage-agnostic snapshot of this session suitable for
     /// passing to inference services that don't depend on SwiftData.

--- a/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Schema/ChatSession.swift
@@ -1,6 +1,26 @@
-/// Public alias for the current SwiftData chat session model.
+/// The SwiftData persistence model for a chat session. Renamed at the
+/// module-public layer to ``PersistedChatSession`` to avoid shadowing
+/// ``ManifoldInference/ChatSession`` (the value type that flows through the
+/// runtime and ports). The underlying `@Model` class remains
+/// ``ManifoldSchemaV9/ChatSession`` so existing SwiftData stores stay valid.
 ///
 /// SchemaV9 adds `activeAgentID: UUID?`, `activeSkillName: String?`, and a
 /// cascade `agents: [Agent]` relationship for the multi-agent / skills
 /// foundation. Lightweight migration; all new fields default to nil/empty.
+///
+/// Use ``PersistedChatSession`` in new code. Host apps that import both
+/// ``ManifoldInference`` and ``ManifoldPersistenceSwiftData`` can refer to
+/// the value type as `ChatSession` and the SwiftData row as
+/// `PersistedChatSession` without disambiguation.
+public typealias PersistedChatSession = ManifoldSchemaV9.ChatSession
+
+/// Back-compat alias for code that referenced ``ChatSession`` directly before
+/// the #1717 disambiguation. Prefer ``PersistedChatSession`` in new code.
+///
+/// > Deprecated: Renamed to ``PersistedChatSession``. The bare name shadows
+/// > ``ManifoldInference/ChatSession`` when both modules are imported (e.g.
+/// > under `import ManifoldKit`). Migrate to `PersistedChatSession` now — this
+/// > alias will be removed in the 1.0-adjacent major release (≥2 minors after
+/// > this annotation was added, 0.x-era).
+@available(*, deprecated, renamed: "PersistedChatSession", message: "Use PersistedChatSession to avoid shadowing ManifoldInference.ChatSession. This alias will be removed in the 1.0-adjacent major release.")
 public typealias ChatSession = ManifoldSchemaV9.ChatSession

--- a/Sources/ManifoldPersistenceSwiftData/Services/ConversationExporter.swift
+++ b/Sources/ManifoldPersistenceSwiftData/Services/ConversationExporter.swift
@@ -5,7 +5,7 @@ import ManifoldRuntime
 extension ConversationExporter {
     /// Loads the session's messages via `provider`, then writes the export.
     ///
-    /// Uses the SwiftData ``ChatSession`` directly — `provider.fetchMessages`
+    /// Uses the SwiftData ``PersistedChatSession`` directly — `provider.fetchMessages`
     /// returns the linear chronological history. Apps modelling branches
     /// should call ``ManifoldRuntime/ConversationExporter/export(session:messages:format:directory:)``
     /// with the active path they have already materialised.
@@ -13,7 +13,7 @@ extension ConversationExporter {
     /// `@MainActor` because ``MessageStore`` is `@MainActor`-isolated.
     @MainActor
     public static func export(
-        session: ChatSession,
+        session: PersistedChatSession,
         format: ConversationExportFormat,
         provider: any MessageStore,
         directory: URL? = nil

--- a/Tests/ManifoldPersistenceSwiftDataTests/ChatSessionTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ChatSessionTests.swift
@@ -5,19 +5,19 @@ import ManifoldInference
 final class ChatSessionTests: XCTestCase {
 
     func test_init_setsDefaults() {
-        let session = ChatSession()
+        let session = PersistedChatSession()
 
         XCTAssertEqual(session.title, "New Chat")
         XCTAssertEqual(session.systemPrompt, "")
     }
 
     func test_init_customTitle() {
-        let session = ChatSession(title: "My Chat")
+        let session = PersistedChatSession(title: "My Chat")
         XCTAssertEqual(session.title, "My Chat")
     }
 
     func test_optionalOverrides_nilByDefault() {
-        let session = ChatSession()
+        let session = PersistedChatSession()
 
         XCTAssertNil(session.temperature)
         XCTAssertNil(session.topP)
@@ -29,7 +29,7 @@ final class ChatSessionTests: XCTestCase {
     }
 
     func test_promptTemplate_roundTrip() {
-        let session = ChatSession()
+        let session = PersistedChatSession()
 
         session.promptTemplate = .llama3
         XCTAssertEqual(session.promptTemplate, .llama3)
@@ -41,7 +41,7 @@ final class ChatSessionTests: XCTestCase {
     }
 
     func test_promptTemplate_allCases() {
-        let session = ChatSession()
+        let session = PersistedChatSession()
 
         for template in PromptTemplate.allCases {
             session.promptTemplate = template
@@ -51,7 +51,7 @@ final class ChatSessionTests: XCTestCase {
     }
 
     func test_generationOverrides_setAndRead() {
-        let session = ChatSession()
+        let session = PersistedChatSession()
 
         session.temperature = 1.5
         session.topP = 0.8
@@ -63,7 +63,7 @@ final class ChatSessionTests: XCTestCase {
     }
 
     func test_record_mapsSessionState() {
-        let session = ChatSession(title: "Bridge")
+        let session = PersistedChatSession(title: "Bridge")
         let selectedModelID = UUID()
         let selectedEndpointID = UUID()
         let firstPinnedID = UUID()

--- a/Tests/ManifoldPersistenceSwiftDataTests/ImageAttachmentInflationTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/ImageAttachmentInflationTests.swift
@@ -68,7 +68,7 @@ final class ImageAttachmentInflationTests: XCTestCase {
         imageBytes: Int
     ) throws -> UInt64 {
         let sessionID = UUID()
-        let session = ChatSession(title: "Vision Inflation")
+        let session = PersistedChatSession(title: "Vision Inflation")
         // ChatSession's id is generated in init; force the field to match the
         // sessionID we use on the messages so the foreign-key relationship
         // mirrors production usage.
@@ -82,7 +82,7 @@ final class ImageAttachmentInflationTests: XCTestCase {
                 .text("attachment-\(index)"),
                 .image(data: imageData, mimeType: "image/jpeg"),
             ]
-            let message = ChatMessage(role: .user, contentParts: parts, sessionID: sessionID)
+            let message = PersistedChatMessage(role: .user, contentParts: parts, sessionID: sessionID)
             context.insert(message)
             rawTotal += UInt64(imageData.count)
         }

--- a/Tests/ManifoldPersistenceSwiftDataTests/MessagePartTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/MessagePartTests.swift
@@ -136,7 +136,7 @@ final class MessagePartTests: XCTestCase {
         let container = try ModelContainerFactory.makeInMemoryContainer()
         let context = ModelContext(container)
         let sessionID = UUID()
-        let message = ChatMessage(role: .user, content: "original", sessionID: sessionID)
+        let message = PersistedChatMessage(role: .user, content: "original", sessionID: sessionID)
         context.insert(message)
         try context.save()
 
@@ -170,7 +170,7 @@ final class MessagePartTests: XCTestCase {
         let container = try ModelContainerFactory.makeInMemoryContainer()
         let context = ModelContext(container)
         let sessionID = UUID()
-        let message = ChatMessage(
+        let message = PersistedChatMessage(
             role: .assistant,
             contentParts: [
                 .text("hello "),
@@ -210,7 +210,7 @@ final class MessagePartTests: XCTestCase {
         let container = try ModelContainerFactory.makeInMemoryContainer()
         let context = ModelContext(container)
         let sessionID = UUID()
-        let message = ChatMessage(role: .user, content: "migrated text", sessionID: sessionID)
+        let message = PersistedChatMessage(role: .user, content: "migrated text", sessionID: sessionID)
         context.insert(message)
         try context.save()
 

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataPersistenceProviderTests.swift
@@ -367,7 +367,7 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
         // Bypass the provider to write a raw CSV value that a buggy migration
         // or corrupt store could produce, then verify the model's getter is
         // tolerant — empty set, no crash.
-        let session = ChatSession(title: "Malformed")
+        let session = PersistedChatSession(title: "Malformed")
         session.pinnedMessageIDsRaw = "not-a-uuid,also-not,@@@"
         context.insert(session)
         try context.save()
@@ -379,7 +379,7 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
 
     func test_pinnedMessageIDs_parsesTrailingCommaWithoutThrowing() async throws {
         let valid = UUID()
-        let session = ChatSession(title: "Trailing Comma")
+        let session = PersistedChatSession(title: "Trailing Comma")
         session.pinnedMessageIDsRaw = "\(valid.uuidString),"
         context.insert(session)
         try context.save()
@@ -390,7 +390,7 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
 
     func test_pinnedMessageIDs_filtersNonUUIDTokensMixedWithValid() async throws {
         let valid = UUID()
-        let session = ChatSession(title: "Mixed")
+        let session = PersistedChatSession(title: "Mixed")
         session.pinnedMessageIDsRaw = "garbage,\(valid.uuidString),more-garbage"
         context.insert(session)
         try context.save()
@@ -400,7 +400,7 @@ final class SwiftDataPersistenceProviderTests: XCTestCase {
     }
 
     func test_pinnedMessageIDs_emptyStringProducesEmptySet() async throws {
-        let session = ChatSession(title: "Empty Raw")
+        let session = PersistedChatSession(title: "Empty Raw")
         session.pinnedMessageIDsRaw = ""
         context.insert(session)
         try context.save()

--- a/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataUsageStoreTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/SwiftDataUsageStoreTests.swift
@@ -195,9 +195,9 @@ final class SwiftDataUsageStoreTests: XCTestCase {
         // Insert a V5-era ChatSession and ChatMessage into the current schema
         // container (all V5 types are carried forward in V6).
         let context = container.mainContext
-        let session = ChatSession(title: "Migration test session")
+        let session = PersistedChatSession(title: "Migration test session")
         context.insert(session)
-        let message = ChatMessage(role: .user, content: "Hello", sessionID: session.id)
+        let message = PersistedChatMessage(role: .user, content: "Hello", sessionID: session.id)
         context.insert(message)
         try context.save()
 
@@ -206,11 +206,11 @@ final class SwiftDataUsageStoreTests: XCTestCase {
         try await sut.record(usageRecord)
 
         // Both old and new rows should be retrievable.
-        let sessions = try context.fetch(FetchDescriptor<ChatSession>())
+        let sessions = try context.fetch(FetchDescriptor<PersistedChatSession>())
         XCTAssertEqual(sessions.count, 1)
         XCTAssertEqual(sessions[0].title, "Migration test session")
 
-        let messages = try context.fetch(FetchDescriptor<ChatMessage>())
+        let messages = try context.fetch(FetchDescriptor<PersistedChatMessage>())
         XCTAssertEqual(messages.count, 1)
 
         let usageRows = try context.fetch(FetchDescriptor<TurnUsageModel>())

--- a/Tests/ManifoldPersistenceSwiftDataTests/VisionSessionResidentMemoryTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/VisionSessionResidentMemoryTests.swift
@@ -68,7 +68,7 @@ final class VisionSessionResidentMemoryTests: XCTestCase {
         imageBytes: Int
     ) throws -> UUID {
         let sessionID = UUID()
-        let session = ChatSession(title: withImage ? "vision" : "text-only")
+        let session = PersistedChatSession(title: withImage ? "vision" : "text-only")
         session.id = sessionID
         stack.context.insert(session)
 
@@ -86,7 +86,7 @@ final class VisionSessionResidentMemoryTests: XCTestCase {
             } else {
                 parts = [.text("message-\(index) lorem ipsum")]
             }
-            let message = ChatMessage(role: role, contentParts: parts, sessionID: sessionID)
+            let message = PersistedChatMessage(role: role, contentParts: parts, sessionID: sessionID)
             stack.context.insert(message)
         }
         try stack.context.save()

--- a/Tests/ManifoldUITests/ChatViewModelCacheLifecycleTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelCacheLifecycleTests.swift
@@ -48,7 +48,7 @@ final class ChatViewModelCacheLifecycleTests: XCTestCase {
             memoryPressure: handler
         )
         vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
-        let session = ChatSession(title: "Cache Lifecycle")
+        let session = PersistedChatSession(title: "Cache Lifecycle")
         context.insert(session)
         try? context.save()
         await vm.switchToSession(session.toRecord())

--- a/Tests/ManifoldUITests/GenerationViewModelTests.swift
+++ b/Tests/ManifoldUITests/GenerationViewModelTests.swift
@@ -510,7 +510,7 @@ final class ChatViewModelTests: XCTestCase {
         await vm.sendMessage()
 
         let originalCount = vm.messages.count
-        let fakeMessage = ChatMessage(role: .user, content: "Fake", sessionID: UUID())
+        let fakeMessage = PersistedChatMessage(role: .user, content: "Fake", sessionID: UUID())
 
         await vm.editMessage(fakeMessage.id, newContent: "Edited")
 


### PR DESCRIPTION
## Summary

Resolves the **#1717** name collision between the public value-type structs `ManifoldInference.ChatSession` / `ChatMessage` (the domain types ports and protocols traffic in) and the SwiftData `@Model` typealiases of the same bare names in `ManifoldPersistenceSwiftData`. Under `import ManifoldKit` (which re-exports both modules) the bare names were ambiguous.

## The rename

Follows the established `PersistedAgent` precedent exactly:

- `Schema/ChatSession.swift`: `public typealias ChatSession = ManifoldSchemaV9.ChatSession` → **`PersistedChatSession`**
- `Schema/ChatMessage.swift`: same → **`PersistedChatMessage`**

The underlying `@Model` class names (`ManifoldSchemaV9.ChatSession` / `ChatMessage`) are unchanged, so **existing SwiftData stores stay valid**.

## What this means

- **Bare `ChatSession` / `ChatMessage` now unambiguously resolve to the value-type structs.** Verified against `Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift` (imports both modules non-`@testable` and uses the bare value-type initializers) — still compiles.
- **Deprecated back-compat aliases at the old bare names are retained** (`@available(*, deprecated, renamed: "Persisted*")`) for the deprecation window, mirroring how `Agent.swift` keeps a deprecated `Agent` alias. Soft break — existing source keeps compiling.
- The load-bearing **`ChatSessionRecord` / `ChatMessageRecord`** aliases in `ConversationRecords.swift` are **untouched**.

## In-repo migration

Adapter / provider / exporter references that meant the persistence `@Model` row were migrated to `Persisted*` (`SwiftDataPersistenceProvider`, `SettingsService+ChatSession`, `ChatSession+Record`, `ConversationExporter`, the DocC container-merge snippet). In-repo test sites that construct the `@Model` directly were also migrated, eliminating the new deprecation warnings.

## API-break gate

`swift package diagnose-api-breaking-changes origin/main --targets ManifoldPersistenceSwiftData` reports **"No breaking changes detected"** — because the deprecated aliases keep the old public symbols present, no allowlist entry is required.

## Gate result

`scripts/test.sh --profile local` → **RESULT: PASSED** (4975 XCTest + 87 Swift Testing; 0 errors; 0 deprecation warnings).

Closes #1717. Refs #1605 (P6).

---

**BREAKING CHANGE:** `ManifoldPersistenceSwiftData.ChatSession` and `.ChatMessage` are renamed to `PersistedChatSession` / `PersistedChatMessage`. Deprecated aliases at the old names are retained for one deprecation window, so this is a soft break — migrate to the `Persisted*` names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)