### PR TITLE
feat!: harden Contract wire types before 1.0 freeze (integer fidelity, ErrorKind escape hatch, tolerant capability decode)

### DIFF
--- a/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
+++ b/Sources/ManifoldAppIntents/AppIntentToolExecutor.swift
@@ -374,6 +374,17 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
                 return String(n) as? ID
             }
             return nil
+        case .integer(let i):
+            // Whole-number ids arrive here with full int64 precision intact.
+            if ID.self == Int.self { return Int(exactly: i) as? ID }
+            if ID.self == Int32.self { return Int32(exactly: i) as? ID }
+            if ID.self == Int64.self { return i as? ID }
+            if ID.self == UInt.self { return UInt(exactly: i) as? ID }
+            if ID.self == UInt32.self { return UInt32(exactly: i) as? ID }
+            if ID.self == UInt64.self { return UInt64(exactly: i) as? ID }
+            if ID.self == Double.self { return Double(i) as? ID }
+            if ID.self == String.self { return String(i) as? ID }
+            return nil
         default:
             return nil
         }
@@ -384,6 +395,7 @@ public struct AppIntentToolExecutor<Intent: AppIntent & Decodable>: ToolExecutor
         switch idValue {
         case .string(let s): "\"\(s)\""
         case .number(let n): String(n)
+        case .integer(let i): String(i)
         case .bool(let b): String(b)
         case .null: "null"
         case .array, .object: String(describing: idValue)

--- a/Sources/ManifoldContract/Message.swift
+++ b/Sources/ManifoldContract/Message.swift
@@ -3,8 +3,9 @@ import Foundation
 /// A typed conversation message used by `InferenceService.enqueue(messages:...)`
 /// (the typed overload) and `InferenceService.generate(messages:...)`.
 ///
-/// **Not the same as `ChatMessage` / `ChatMessage`.** Those types live
-/// further down the stack:
+/// **Not the same as `ChatMessage` (the SwiftData `@Model`) / `ChatMessage`
+/// (the `ManifoldInference` value type).** Those types live further down the
+/// stack — they share a name but differ by module:
 ///
 /// - `ChatMessage` (a SwiftData `@Model` in `ManifoldPersistenceSwiftData`)
 ///   is the persisted record with a UUID, timestamp, attachments, token-

--- a/Sources/ManifoldHardware/BackendCapabilities.swift
+++ b/Sources/ManifoldHardware/BackendCapabilities.swift
@@ -256,16 +256,19 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportedParameters = try c.decode(Set<GenerationParameter>.self, forKey: .supportedParameters)
         maxContextTokens = try c.decode(Int32.self, forKey: .maxContextTokens)
         maxOutputTokens = try c.decode(Int.self, forKey: .maxOutputTokens)
-        requiresPromptTemplate = try c.decode(Bool.self, forKey: .requiresPromptTemplate)
-        supportsSystemPrompt = try c.decode(Bool.self, forKey: .supportsSystemPrompt)
-        supportsStreaming = try c.decode(Bool.self, forKey: .supportsStreaming)
-        supportsToolCalling = try c.decode(Bool.self, forKey: .supportsToolCalling)
-        supportsStructuredOutput = try c.decode(Bool.self, forKey: .supportsStructuredOutput)
+        // Boolean flags decode tolerantly: an older/partial capabilities blob
+        // missing a now-required flag falls back to the memberwise-init default
+        // rather than throwing keyNotFound. Structural keys below stay required.
+        requiresPromptTemplate = (try c.decodeIfPresent(Bool.self, forKey: .requiresPromptTemplate)) ?? false
+        supportsSystemPrompt = (try c.decodeIfPresent(Bool.self, forKey: .supportsSystemPrompt)) ?? true
+        supportsStreaming = (try c.decodeIfPresent(Bool.self, forKey: .supportsStreaming)) ?? true
+        supportsToolCalling = (try c.decodeIfPresent(Bool.self, forKey: .supportsToolCalling)) ?? false
+        supportsStructuredOutput = (try c.decodeIfPresent(Bool.self, forKey: .supportsStructuredOutput)) ?? false
         supportsNativeJSONMode = (try c.decodeIfPresent(Bool.self, forKey: .supportsNativeJSONMode)) ?? false
         cancellationStyle = try c.decode(CancellationStyle.self, forKey: .cancellationStyle)
-        supportsTokenCounting = try c.decode(Bool.self, forKey: .supportsTokenCounting)
+        supportsTokenCounting = (try c.decodeIfPresent(Bool.self, forKey: .supportsTokenCounting)) ?? false
         memoryStrategy = try c.decode(MemoryStrategy.self, forKey: .memoryStrategy)
-        isRemote = try c.decode(Bool.self, forKey: .isRemote)
+        isRemote = (try c.decodeIfPresent(Bool.self, forKey: .isRemote)) ?? false
         supportsKVCachePersistence = (try c.decodeIfPresent(Bool.self, forKey: .supportsKVCachePersistence)) ?? false
         supportsGrammarConstrainedSampling = (try c.decodeIfPresent(Bool.self, forKey: .supportsGrammarConstrainedSampling)) ?? false
         supportsThinking = (try c.decodeIfPresent(Bool.self, forKey: .supportsThinking)) ?? false

--- a/Sources/ManifoldHardware/ToolTypes.swift
+++ b/Sources/ManifoldHardware/ToolTypes.swift
@@ -68,6 +68,12 @@ public struct ToolDefinition: Sendable, Codable, Equatable, Hashable {
 public indirect enum JSONSchemaValue: Sendable, Codable, Equatable, Hashable {
     /// A JSON string.
     case string(String)
+    /// A whole-number JSON value preserved as `Int64`.
+    ///
+    /// Whole-number JSON literals (e.g. `42`) decode to this case so that
+    /// `int64` magnitudes above 2^53 survive an encode → decode round-trip
+    /// without the precision loss they would suffer going through `Double`.
+    case integer(Int64)
     /// A JSON number (stored as `Double` to cover both int and float cases).
     case number(Double)
     /// A JSON boolean.
@@ -87,6 +93,11 @@ public indirect enum JSONSchemaValue: Sendable, Codable, Equatable, Hashable {
             self = .null
         } else if let b = try? container.decode(Bool.self) {
             self = .bool(b)
+        } else if let i = try? container.decode(Int64.self) {
+            // Whole-number literals decode here BEFORE Double so int64 values
+            // above 2^53 keep full precision. Fractional literals (e.g. 4.2)
+            // fail Int64 decode and fall through to the Double case below.
+            self = .integer(i)
         } else if let n = try? container.decode(Double.self) {
             self = .number(n)
         } else if let s = try? container.decode(String.self) {
@@ -106,6 +117,8 @@ public indirect enum JSONSchemaValue: Sendable, Codable, Equatable, Hashable {
             try container.encodeNil()
         case .bool(let b):
             try container.encode(b)
+        case .integer(let i):
+            try container.encode(i)
         case .number(let n):
             try container.encode(n)
         case .string(let s):
@@ -332,6 +345,23 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
         /// No registered executor matched the call name — dispatch failed before execution.
         /// Distinct from ``notFound``, which fires inside a running executor.
         case unknownTool
+        /// A wire value not recognised by this SDK version.
+        ///
+        /// Forward-compatibility escape hatch: an `errorKind` raw string produced
+        /// by a newer producer that this build doesn't know decodes here instead
+        /// of throwing the whole ``ToolResult`` decode. The raw value `"unknown"`
+        /// is stable; the original unrecognised string is not preserved.
+        case unknown
+
+        /// Forward-compatible tolerant decode.
+        ///
+        /// Unrecognised raw strings map to ``unknown`` rather than throwing, so a
+        /// newer producer's `errorKind` vocabulary never breaks an older reader's
+        /// ``ToolResult`` decode. `encode`/``rawValue`` stay synthesized.
+        public init(from decoder: Decoder) throws {
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            self = ErrorKind(rawValue: raw) ?? .unknown
+        }
 
         /// User-facing, localizable summary for presentation surfaces.
         ///
@@ -357,6 +387,8 @@ public struct ToolResult: Sendable, Codable, Equatable, Hashable {
                 return String(localized: "tool.error.permanent", defaultValue: "The tool couldn't complete this request.")
             case .unknownTool:
                 return String(localized: "tool.error.unknownTool", defaultValue: "This tool isn't available.")
+            case .unknown:
+                return String(localized: "tool.error.unknown", defaultValue: "The tool reported an unrecognized error.")
             }
         }
     }

--- a/Sources/ManifoldInference/Services/JSONSchemaValidator.swift
+++ b/Sources/ManifoldInference/Services/JSONSchemaValidator.swift
@@ -159,6 +159,8 @@ public struct JSONSchemaValidator: Sendable {
             return validateString(value: s, schemaObject: schemaObject, path: path)
         case .number(let n):
             return validateNumber(value: n, schemaObject: schemaObject, path: path)
+        case .integer(let i):
+            return validateNumber(value: Double(i), schemaObject: schemaObject, path: path)
         case .bool, .null:
             return nil
         }
@@ -250,13 +252,22 @@ public struct JSONSchemaValidator: Sendable {
     }
 
     private func isNumber(_ value: JSONSchemaValue) -> Bool {
-        if case .number = value { return true }
-        return false
+        // A whole-number `.integer` satisfies the JSON-Schema "number" type too.
+        switch value {
+        case .number, .integer: return true
+        default: return false
+        }
     }
 
     private func isInteger(_ value: JSONSchemaValue) -> Bool {
-        guard case let .number(n) = value else { return false }
-        return n.isFinite && n.rounded() == n
+        switch value {
+        case .integer:
+            return true
+        case let .number(n):
+            return n.isFinite && n.rounded() == n
+        default:
+            return false
+        }
     }
 
     private func validateObject(
@@ -514,6 +525,8 @@ public struct JSONSchemaValidator: Sendable {
             return "'\(s)'"
         case .number(let n):
             return describeNumber(n)
+        case .integer(let i):
+            return String(i)
         case .bool(let b):
             return b ? "true" : "false"
         case .null:
@@ -527,9 +540,10 @@ public struct JSONSchemaValidator: Sendable {
 
     private static func describeActualType(_ value: JSONSchemaValue) -> String {
         switch value {
-        case .string: return "string"
-        case .number: return "number"
-        case .bool:   return "boolean"
+        case .string:  return "string"
+        case .number:  return "number"
+        case .integer: return "integer"
+        case .bool:    return "boolean"
         case .null:   return "null"
         case .array:  return "array"
         case .object: return "object"

--- a/Sources/ManifoldInference/Services/ToolArgumentCoercer.swift
+++ b/Sources/ManifoldInference/Services/ToolArgumentCoercer.swift
@@ -148,7 +148,7 @@ enum ToolArgumentCoercer {
             // object (homogeneous list) or an array of sub-schemas (tuple
             // form, draft-04 / 2019-09); we handle both.
             return try coerceArray(elements, against: schema, depth: depth)
-        case .number, .bool, .null:
+        case .integer, .number, .bool, .null:
             return value
         }
     }

--- a/Sources/ManifoldMCP/InternalMCPJSONRPC.swift
+++ b/Sources/ManifoldMCP/InternalMCPJSONRPC.swift
@@ -187,6 +187,8 @@ package struct MCPJSONRPCCodec: Sendable {
             return NSNull()
         case .bool(let value):
             return value
+        case .integer(let value):
+            return value
         case .number(let value):
             return value
         case .string(let value):

--- a/Sources/ManifoldMCP/InternalMCPSession.swift
+++ b/Sources/ManifoldMCP/InternalMCPSession.swift
@@ -343,6 +343,8 @@ private func stringify(_ value: JSONSchemaValue) -> String {
         return "null"
     case .bool(let value):
         return value ? "true" : "false"
+    case .integer(let value):
+        return String(value)
     case .number(let value):
         return String(value)
     case .string(let value):

--- a/Sources/ManifoldMCP/MCPToolSource.swift
+++ b/Sources/ManifoldMCP/MCPToolSource.swift
@@ -756,7 +756,7 @@ private func schemaDepthIfCompatible(
             deepest = max(deepest, d)
         }
         return deepest
-    case .string, .number, .bool, .null:
+    case .string, .integer, .number, .bool, .null:
         // Includes `additionalProperties: true`/`false` (the bool form) — a
         // permissive flag, not a nested schema.
         return currentDepth

--- a/Sources/ManifoldMCPHost/MCPHostServer.swift
+++ b/Sources/ManifoldMCPHost/MCPHostServer.swift
@@ -582,6 +582,8 @@ public actor ManifoldMCPHost {
             return "null"
         case .bool(let v):
             return v ? "true" : "false"
+        case .integer(let v):
+            return String(v)
         case .number(let v):
             return String(v)
         case .string(let v):

--- a/Tests/ManifoldAppIntentsTests/AppIntentToolExecutorTests.swift
+++ b/Tests/ManifoldAppIntentsTests/AppIntentToolExecutorTests.swift
@@ -707,12 +707,12 @@ final class AppIntentToolExecutorTests: XCTestCase {
             .string("World"),
             "string defaults must round-trip through the schema as JSON strings"
         )
-        // Number defaults: JSONSchemaValue stores all numbers as Double, so
-        // `5` arrives as `.number(5.0)`. We don't care about the boxing —
-        // only that the value made it through.
+        // Integer defaults: whole-number JSON now decodes to `.integer` (the
+        // int64-fidelity case), so `5` arrives as `.integer(5)` rather than the
+        // pre-freeze `.number(5.0)`. We care only that the value made it through.
         XCTAssertEqual(
             countField["default"],
-            .number(5),
+            .integer(5),
             "integer defaults must surface in the schema"
         )
     }

--- a/Tests/ManifoldInferenceTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/ManifoldInferenceTests/BackendCapabilitiesContractTests.swift
@@ -86,4 +86,41 @@ final class BackendCapabilitiesContractTests: XCTestCase {
         XCTAssertTrue(decoded.supportsThinking)
         XCTAssertTrue(decoded.supportsVision)
     }
+
+    // MARK: - Tolerant decode: structural-only blob, ALL boolean flags absent
+
+    func test_codable_structuralKeysOnly_booleanFlagsDecodeToMemberwiseDefaults() throws {
+        // Only the structural keys are present — none of the boolean flags,
+        // including the ones that were originally required (`requiresPromptTemplate`,
+        // `supportsSystemPrompt`, `supportsStreaming`, `supportsToolCalling`,
+        // `supportsStructuredOutput`, `supportsTokenCounting`, `isRemote`). Decode
+        // must succeed and fall back to the memberwise-init defaults.
+        let json = """
+        {
+            "supportedParameters": ["temperature"],
+            "maxContextTokens": 4096,
+            "maxOutputTokens": 2048,
+            "memoryStrategy": "resident",
+            "cancellationStyle": "cooperative"
+        }
+        """.data(using: .utf8)!
+
+        // Sabotage check: revert any of these flags back to plain `try c.decode`
+        // and this decode throws keyNotFound instead of yielding defaults.
+        let decoded = try JSONDecoder().decode(BackendCapabilities.self, from: json)
+
+        XCTAssertFalse(decoded.requiresPromptTemplate)
+        XCTAssertTrue(decoded.supportsSystemPrompt)
+        XCTAssertTrue(decoded.supportsStreaming)
+        XCTAssertFalse(decoded.supportsToolCalling)
+        XCTAssertFalse(decoded.supportsStructuredOutput)
+        XCTAssertFalse(decoded.supportsTokenCounting)
+        XCTAssertFalse(decoded.isRemote)
+
+        // Structural fields still decoded from the blob.
+        XCTAssertEqual(decoded.maxContextTokens, 4096)
+        XCTAssertEqual(decoded.maxOutputTokens, 2048)
+        XCTAssertEqual(decoded.memoryStrategy, .resident)
+        XCTAssertEqual(decoded.cancellationStyle, .cooperative)
+    }
 }

--- a/Tests/ManifoldInferenceTests/ToolCallContractTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolCallContractTests.swift
@@ -333,4 +333,38 @@ final class ToolCallContractTests: XCTestCase {
         let decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: encoded)
         XCTAssertEqual(decoded, value)
     }
+
+    func test_jsonSchemaValue_int64BeyondDoubleMantissa_roundTripsWithoutPrecisionLoss() throws {
+        // 2^53 + 1 == 9007254740993 cannot survive a Double round-trip: it is the
+        // first integer not exactly representable as a Double. Decoding it as
+        // `.integer(Int64)` is what preserves the exact value.
+        let raw = #"{"id": 9007199254740993}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: raw)
+        guard case .object(let dict) = decoded, case .integer(let i) = dict["id"] else {
+            return XCTFail("Expected .object containing .integer, got \(decoded)")
+        }
+        XCTAssertEqual(i, 9_007_199_254_740_993)
+
+        // Encode → decode again to prove the value survives a full Codable cycle.
+        let reEncoded = try JSONEncoder().encode(decoded)
+        let reDecoded = try JSONDecoder().decode(JSONSchemaValue.self, from: reEncoded)
+        guard case .object(let dict2) = reDecoded, case .integer(let i2) = dict2["id"] else {
+            return XCTFail("Expected .object containing .integer on re-decode, got \(reDecoded)")
+        }
+        // Sabotage check: route whole numbers through Double (drop the Int64
+        // branch in init(from:)) and this becomes 9007199254740992, failing.
+        XCTAssertEqual(i2, 9_007_199_254_740_993)
+    }
+
+    func test_jsonSchemaValue_fractionalNumberStaysNumber() throws {
+        // Guard the decode ordering: a fractional literal must NOT be captured by
+        // the Int64 branch — it stays `.number`.
+        let raw = #"4.2"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: raw)
+        guard case .number(let n) = decoded else {
+            return XCTFail("Expected .number, got \(decoded)")
+        }
+        XCTAssertEqual(n, 4.2, accuracy: 0.0001)
+    }
 }

--- a/Tests/ManifoldInferenceTests/ToolResultErrorKindTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolResultErrorKindTests.swift
@@ -10,11 +10,12 @@ final class ToolResultErrorKindTests: XCTestCase {
     func test_allErrorKinds_roundTripThroughCodable() throws {
         let allKinds: [ToolResult.ErrorKind] = [
             .invalidArguments, .permissionDenied, .notFound, .timeout,
-            .rateLimited, .cancelled, .transient, .permanent, .unknownTool
+            .rateLimited, .cancelled, .transient, .permanent, .unknownTool,
+            .unknown
         ]
         // Guard against someone adding a new case and forgetting to update the
-        // test exhaustively. 9 cases is the wave 1 contract.
-        XCTAssertEqual(allKinds.count, 9)
+        // test exhaustively. 10 cases after the pre-1.0 `.unknown` escape hatch.
+        XCTAssertEqual(allKinds.count, 10)
 
         for kind in allKinds {
             let result = ToolResult(callId: "c-\(kind.rawValue)", content: "x", errorKind: kind)
@@ -36,9 +37,10 @@ final class ToolResultErrorKindTests: XCTestCase {
             .transient: "The tool hit a temporary problem.",
             .permanent: "The tool couldn't complete this request.",
             .unknownTool: "This tool isn't available.",
+            .unknown: "The tool reported an unrecognized error.",
         ]
 
-        XCTAssertEqual(ToolResult.ErrorKind.allCases.count, 9)
+        XCTAssertEqual(ToolResult.ErrorKind.allCases.count, 10)
         for kind in ToolResult.ErrorKind.allCases {
             XCTAssertEqual(kind.localizedDescription, expected[kind], "missing localized description for \(kind.rawValue)")
             XCTAssertNotEqual(kind.localizedDescription, kind.rawValue)
@@ -96,6 +98,22 @@ final class ToolResultErrorKindTests: XCTestCase {
 
         XCTAssertEqual(decoded.errorKind, .timeout)
         XCTAssertTrue(decoded.isError)
+    }
+
+    func test_forwardCompatDecode_unrecognizedErrorKind_mapsToUnknown() throws {
+        // A newer producer emits an errorKind raw string this build doesn't
+        // know. It must decode to `.unknown` rather than throwing the whole
+        // ToolResult decode.
+        let future = #"{"callId":"x","content":"y","errorKind":"quotaExceeded"}"#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(ToolResult.self, from: future)
+
+        // Sabotage check: reverting ErrorKind's tolerant init(from:) makes the
+        // decode throw instead of yielding `.unknown`.
+        XCTAssertEqual(decoded.errorKind, .unknown)
+        XCTAssertTrue(decoded.isError)
+        XCTAssertEqual(decoded.callId, "x")
+        XCTAssertEqual(decoded.content, "y")
     }
 
     // MARK: - Equatable / Hashable


### PR DESCRIPTION
## Summary

Three pre-1.0 API-hardening fixes to the Contract wire surface, landed **intentionally before the 1.0 vocabulary freeze**. These are `feat!:` breaking changes to frozen wire types.

### Fix A — `JSONSchemaValue` integer fidelity (#13)
All JSON numbers previously decoded through `Double`, so int64 values above 2^53 lost precision on round-trip. New `case integer(Int64)`, decoded **before** `Double` in `init(from:)`. A whole-number JSON literal (`42`) now decodes to `.integer`; a fractional literal (`4.2`) stays `.number`. Every exhaustive switch over `JSONSchemaValue` gained a real `.integer` arm (no `@unknown default` hacks). In the validator/coercer an integer satisfies both the `"number"` and `"integer"` JSON-schema types.

**6 switch sites** were fixed across 5 files (beyond `ToolTypes.swift` itself): `ToolArgumentCoercer`, `JSONSchemaValidator` (3 arms: main dispatch, `describeValue`, `describeActualType`, plus `isNumber`/`isInteger` predicates), `AppIntentToolExecutor` (`describeId` + a real `.integer` arm in `coerceID`), `InternalMCPJSONRPC`, `InternalMCPSession`, `MCPToolSource`, `MCPHostServer`.

### Fix B — `ToolResult.ErrorKind` forward-compat escape hatch (#4)
Unknown `errorKind` raw strings on the wire previously threw the whole `ToolResult` decode. Added `case unknown` (rawValue `"unknown"`, keeps `CaseIterable`) plus a tolerant `init(from:)` that maps any unrecognized raw String to `.unknown` instead of throwing — mirroring `ToolResultPart.unknown`. Keeps the `String` raw-value conformance and synthesized `encode`/`rawValue`. `ToolChoice`'s strict throw-on-unknown decode is left unchanged (a config type).

### Fix C — `BackendCapabilities` tolerant decode
The originally-required boolean flags used plain `decode` (throws `keyNotFound`) while later-added flags used `decodeIfPresent ?? default`. An older/partial blob missing a now-required bool threw. Changed the seven boolean flags to `decodeIfPresent ?? <init default>`, matching the memberwise-init defaults exactly. Structural fields (`supportedParameters`, `maxContextTokens`, `maxOutputTokens`, `memoryStrategy`, `cancellationStyle`) stay **required**.

### Fix D — doc typo
`Message.swift` summary repeated `ChatMessage` twice. Both the SwiftData `@Model` and the `ManifoldInference` value type are in fact *named* `ChatMessage` (they differ by module, not by name), so the fix disambiguates by module rather than inventing a wrong distinct name.

## Tests
- `JSONSchemaValue` int64-beyond-2^53 round-trips without precision loss (`9007199254740993`); fractional stays `.number`.
- `ToolResult` with unrecognized `errorKind` (`"quotaExceeded"`) decodes to `.unknown`, not a throw.
- `ErrorKind.allCases.count` 9 → 10 updated; UI `allCases` iteration still green.
- `BackendCapabilities` blob with only structural keys (no boolean flags) decodes with documented defaults.
- Updated one AppIntents test: an integer default now surfaces as `.integer(5)` rather than `.number(5.0)`.

## Validation
- `swift build --build-tests --traits Server,Macros` — **clean** (mandatory trait sweep for switched enums).
- Targeted suites green: `ToolResultErrorKind` (9), `JSONSchema*` (37), `ToolCallContract` (27), `BackendCapabilit*` (58), `ToolArgumentCoercer` (30), `AppIntentToolExecutor` (27).

## ⚠️ CI note for the maintainer/orchestrator
This is a `feat!:` that adds **two new enum cases** (`JSONSchemaValue.integer`, `ToolResult.ErrorKind.unknown`). The **swift-api-digester / API-break CI gate will very likely flag both** as breaking public-API changes. That is **expected and intended** for this pre-freeze breaking change — the digester baseline / allowlist will probably need updating. Flagging here so it can be addressed deliberately; the gate was **not** silently disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)