### PR TITLE
chore: post-train cleanup (stale .usage comments + TrafficBoundary deny-list prune)

### DIFF
--- a/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
@@ -438,7 +438,7 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
     /// Claude reports usage split across `message_start` (prompt) and
     /// `message_delta` (completion). Two arrival shapes are possible:
     ///   - Routed-consumer path: `ClaudeStreamEventExtractor` merges the
-    ///     two halves and yields a single `.usage(prompt, completion)`
+    ///     two halves and yields a single `.usage(TokenUsage)`
     ///     event, which the envelope mirrors here with BOTH halves
     ///     populated.
     ///   - Legacy non-consumer paths (no streamConsumerFactory installed):

--- a/Sources/ManifoldCloudSaaS/ClaudeStreamEventExtractor.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeStreamEventExtractor.swift
@@ -333,7 +333,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
     // stateless `extractUsage` surface returns one half at a time
     // (`(12, nil)` then `(nil, 48)`), so a per-frame gate that requires
     // both halves would never fire. The extractor merges them so it can
-    // emit a single `.usage(prompt, completion)` event on the
+    // emit a single `.usage(TokenUsage)` event on the
     // message_delta frame, matching the inline `parseResponseStream`
     // behaviour the routed path replaces.
     private var pendingPromptTokens: Int?
@@ -462,7 +462,7 @@ public final class ClaudeStreamEventExtractor: CloudStreamEventConsumer, @unchec
         //    `message_start` carries `input_tokens` (the prompt half) and
         //    `message_delta` carries `output_tokens` (the completion half).
         //    `extractUsage` returns each half independently; we merge them
-        //    so consumers see a single `.usage(prompt, completion)` event
+        //    so consumers see a single `.usage(TokenUsage)` event
         //    once both halves have arrived. This mirrors the inline
         //    `ClaudeBackend.parseResponseStream` semantics (which got the
         //    same merge for free via `SSECloudBackend.handleUsage`'s

--- a/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
+++ b/Tests/ManifoldBackendsTests/ClaudeStreamEventExtractorTests.swift
@@ -121,8 +121,7 @@ final class ClaudeStreamEventExtractorTests: XCTestCase {
     // contract.
     //
     // The extractor merges split usage internally: it stashes the prompt
-    // half from `message_start` and emits a single `.usage(prompt,
-    // completion)` event when the completion half lands on
+    // half from `message_start` and emits a single `.usage(TokenUsage)` event when the completion half lands on
     // `message_delta`. This matches what the inline parser used to do via
     // `SSECloudBackend.handleUsage`'s bookkeeping — the merged value now
     // reaches consumers as an event, not just as `lastUsage` state.

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -695,7 +695,7 @@ struct OllamaBackendTests {
     }
 
     /// End-to-end: the done-line's `eval_count` / `prompt_eval_count` must
-    /// surface both as a `.usage(prompt:completion:)` event on the stream and
+    /// surface both as a `.usage(TokenUsage)` event on the stream and
     /// as `lastUsage` on the backend — mirroring `SSECloudBackend`'s SSE path.
     /// This is what actually reaches the UI.
     ///

--- a/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
+++ b/Tests/ManifoldInferenceTests/TrafficBoundaryAuditTest.swift
@@ -500,12 +500,10 @@ final class TrafficBoundaryAuditTest: XCTestCase {
         // forbidden list — `import ManifoldMLX` from ManifoldUI is just as
         // bad as `import ManifoldBackends` was pre-split.
         let backendFamilyModules = [
-            "ManifoldBackends",
             "ManifoldCloudCore",
             "ManifoldMLX",
             "ManifoldLlama",
             "ManifoldFoundation",
-            "ManifoldCloud",
         ]
         let rules: [(prefix: String, forbidden: [String], why: String)] = [
             ("ManifoldUI/",

--- a/Tests/ManifoldTurnLoopCharacterizationTests/TurnLoopCharacterizationTests.swift
+++ b/Tests/ManifoldTurnLoopCharacterizationTests/TurnLoopCharacterizationTests.swift
@@ -578,7 +578,7 @@ final class TurnLoopCharacterizationTests: XCTestCase {
 
     /// Token-usage golden.
     ///
-    /// The backend yields a `.usage(prompt:completion:)` event before its
+    /// The backend yields a `.usage(TokenUsage)` event before its
     /// tokens; the executor records it on the assistant message and emits
     /// `.tokenUsageRecorded`. This pins the token-count fields the happy-path
     /// skeleton drops — a lost token-pinning in the engine de-tangle now diffs.


### PR DESCRIPTION
Batched cosmetic cleanup of two discovered-issues from the pre-1.0 wave run:
- **Stale prose (#2):** 6 comments still said `.usage(prompt, completion)`/`.usage(prompt:completion:)` — refreshed to `.usage(TokenUsage)` (post #1826).
- **TrafficBoundary prune:** removed retired `ManifoldBackends`/`ManifoldCloud` (gone in #1837) from the `backendFamilyModules` UI/Runtime/Persistence/Inference import deny-list; kept the live guards (CloudCore/MLX/Llama/Foundation).

Comments + one test array literal only — no behavior change. (Dropped the MessagePartTests item: its V4/V9/value-type/Persisted spellings are intentional cross-version disambiguation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)