### PR TITLE
chore(mcp-host): repoint HTTP/SSE transport TODOs from closed #874 to #1842

### DIFF
--- a/Sources/ManifoldMCPHost/MCPHostServer.swift
+++ b/Sources/ManifoldMCPHost/MCPHostServer.swift
@@ -45,7 +45,7 @@ import os
 /// ## HTTP/SSE transport
 ///
 /// HTTP/SSE server-side transport (for Claude Desktop's streamable-HTTP
-/// configuration) is not yet implemented. Track progress in issue #874.
+/// configuration) is not yet implemented. Track progress in issue #1842.
 ///
 /// ## Concurrency
 ///
@@ -661,7 +661,7 @@ public enum MCPHostError: Error, LocalizedError, Sendable {
 /// The server reads incoming JSON-RPC frames from `incomingMessages` and
 /// writes response frames via `send(_:)`. The built-in implementation is
 /// ``MCPHostStdioTransport`` (macOS only). HTTP/SSE support is tracked in
-/// issue #874.
+/// issue #1842.
 public protocol MCPHostTransport: Sendable {
     /// Inbound frames from the remote MCP client.
     var incomingMessages: AsyncThrowingStream<Data, Error> { get }

--- a/Sources/ManifoldMCPHost/MCPHostStdioTransport.swift
+++ b/Sources/ManifoldMCPHost/MCPHostStdioTransport.swift
@@ -19,7 +19,7 @@ import os
 ///
 /// - macOS only (not available on iOS or Catalyst).
 /// - Single-connection by design — a new process is expected per client.
-/// - HTTP/SSE server-side transport is not yet implemented (see issue #874).
+/// - HTTP/SSE server-side transport is not yet implemented (see issue #1842).
 public actor MCPHostStdioTransport: MCPHostTransport {
 
     // MARK: MCPHostTransport

--- a/Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md
+++ b/Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md
@@ -39,7 +39,7 @@ let transport = MCPHostStdioTransport()
 #endif
 ```
 
-HTTP/SSE server-side transport is not yet implemented. It is tracked in issue #874.
+HTTP/SSE server-side transport is not yet implemented. It is tracked in issue #1842.
 
 ### 3. Start serving
 


### PR DESCRIPTION
## What
Four doc-comment/article sites in `ManifoldMCPHost` pointed at **#874** for the not-yet-implemented HTTP/SSE server-side transport. #874 (the MCPHost feature) shipped its stdio transport and was **closed**, leaving those references dangling and the deferred work effectively untracked.

This repoints all four to the fresh tracking issue **#1842**:
- `Sources/ManifoldMCPHost/MCPHostServer.swift:48` and `:663-664`
- `Sources/ManifoldMCPHost/MCPHostStdioTransport.swift:22`
- `Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md:42`

## Why
Surfaced during an open-issue / TODO audit: closed-issue references in shipped source read as "tracked" when they aren't. The actual HTTP/SSE transport work now lives in #1842.

Comment/doc-only — no behavior or API change.

Closes nothing; refs #1842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)