### PR TITLE
feat(voice,ui): spoken-range progress callback + Reduce Motion gating

### DIFF
--- a/Sources/ManifoldUI/Views/Chat/StreamingCursorView.swift
+++ b/Sources/ManifoldUI/Views/Chat/StreamingCursorView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Pulsing cursor appended to the end of a streaming message to indicate ongoing generation.
 public struct StreamingCursorView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isVisible = true
 
     public init() {}
@@ -10,9 +11,20 @@ public struct StreamingCursorView: View {
         Rectangle()
             .fill(Color.primary)
             .frame(width: 2, height: 16)
-            .opacity(isVisible ? 1.0 : 0.0)
-            .animation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true), value: isVisible)
-            .onAppear { isVisible = false }
+            .opacity(Self.cursorOpacity(reduceMotion: reduceMotion, isVisible: isVisible))
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.5).repeatForever(autoreverses: true), value: isVisible)
+            .onAppear {
+                // Honour Reduce Motion: leave the cursor solid (no pulsing).
+                guard !reduceMotion else { return }
+                isVisible = false
+            }
+    }
+
+    /// Cursor opacity. Under Reduce Motion the cursor stays solid (no pulsing);
+    /// otherwise it follows the pulsing `isVisible` toggle. Extracted for testing.
+    static func cursorOpacity(reduceMotion: Bool, isVisible: Bool) -> Double {
+        if reduceMotion { return 1.0 }
+        return isVisible ? 1.0 : 0.0
     }
 }
 

--- a/Sources/ManifoldUI/Views/Chat/TypingIndicatorView.swift
+++ b/Sources/ManifoldUI/Views/Chat/TypingIndicatorView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Animated typing indicator shown while waiting for the first token from the backend.
 public struct TypingIndicatorView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var animationPhase: Int = 0
 
     public init() {}
@@ -9,21 +10,35 @@ public struct TypingIndicatorView: View {
     public var body: some View {
         HStack(spacing: 4) {
             ForEach(0..<3, id: \.self) { index in
+                let appearance = Self.dotAppearance(reduceMotion: reduceMotion, isActive: animationPhase == index)
                 Circle()
                     .fill(Color.secondary)
                     .frame(width: 8, height: 8)
-                    .scaleEffect(animationPhase == index ? 1.3 : 0.7)
-                    .opacity(animationPhase == index ? 1.0 : 0.4)
-                    .animation(.easeInOut(duration: 0.4), value: animationPhase)
+                    .scaleEffect(appearance.scale)
+                    .opacity(appearance.opacity)
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: animationPhase)
             }
         }
-        .task {
+        // Honour Reduce Motion: skip the pulsing cycle entirely and render a
+        // static three-dot glyph. Keyed on `reduceMotion` so toggling the
+        // setting starts/stops the loop without recreating the view.
+        .task(id: reduceMotion) {
+            guard !reduceMotion else { return }
             while !Task.isCancelled {
                 try? await Task.sleep(for: .milliseconds(400))
                 animationPhase = (animationPhase + 1) % 3
             }
         }
         .accessibilityLabel("Generating response")
+    }
+
+    /// Per-dot scale/opacity. Under Reduce Motion every dot is uniform (a static
+    /// three-dot glyph, no implied movement); otherwise the active dot is enlarged
+    /// and fully opaque. Extracted so the reduce-motion fallback is unit-tested
+    /// without standing up a SwiftUI host.
+    static func dotAppearance(reduceMotion: Bool, isActive: Bool) -> (scale: CGFloat, opacity: Double) {
+        if reduceMotion { return (scale: 1.0, opacity: 0.7) }
+        return isActive ? (scale: 1.3, opacity: 1.0) : (scale: 0.7, opacity: 0.4)
     }
 }
 

--- a/Sources/ManifoldVoice/Services/AppleSpeechSynthesizer.swift
+++ b/Sources/ManifoldVoice/Services/AppleSpeechSynthesizer.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @MainActor
-public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, AVSpeechSynthesizerDelegate {
+public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, SpeechProgressReporting, AVSpeechSynthesizerDelegate {
     private let synthesizer: AVSpeechSynthesizer
 
     // One continuation per in-flight utterance. AVSpeechSynthesizer can queue
@@ -10,6 +10,12 @@ public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, AVSpeec
     // utterance, so we key continuations by utterance identity rather than
     // holding a single shared one.
     private var continuations: [ObjectIdentifier: CheckedContinuation<Void, Error>] = [:]
+
+    // A stable id per queued utterance, surfaced through `SpeechProgress` so a
+    // host can correlate range callbacks with the utterance being spoken.
+    private var utteranceIDs: [ObjectIdentifier: UUID] = [:]
+
+    public var onSpeechProgress: (@MainActor (SpeechProgress) -> Void)?
 
     public init(synthesizer: AVSpeechSynthesizer = AVSpeechSynthesizer()) {
         self.synthesizer = synthesizer
@@ -32,8 +38,10 @@ public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, AVSpeec
 
         let utterance = Self.makeUtterance(string: trimmed, options: options)
 
+        let key = ObjectIdentifier(utterance)
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            self.continuations[ObjectIdentifier(utterance)] = continuation
+            self.continuations[key] = continuation
+            self.utteranceIDs[key] = UUID()
             synthesizer.speak(utterance)
         }
     }
@@ -64,8 +72,20 @@ public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, AVSpeec
         // utterance currently being spoken.
         let pending = continuations
         continuations.removeAll()
+        utteranceIDs.removeAll()
         for continuation in pending.values {
             continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    nonisolated public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, willSpeakRangeOfSpeechString characterRange: NSRange, utterance: AVSpeechUtterance) {
+        let key = ObjectIdentifier(utterance)
+        // Read the utterance text synchronously in the delegate callback and hop
+        // to the main actor with only Sendable values (String + NSRange), never
+        // the non-Sendable AVSpeechUtterance.
+        let text = utterance.speechString
+        Task { @MainActor in
+            self.emitProgress(key: key, nsRange: characterRange, text: text)
         }
     }
 
@@ -84,7 +104,23 @@ public final class AppleSpeechSynthesizer: NSObject, SpeechSynthesizing, AVSpeec
     }
 
     private func resumeContinuation(for key: ObjectIdentifier, with result: Result<Void, Error>) {
+        utteranceIDs.removeValue(forKey: key)
         guard let continuation = continuations.removeValue(forKey: key) else { return }
         continuation.resume(with: result)
+    }
+
+    private func emitProgress(key: ObjectIdentifier, nsRange: NSRange, text: String) {
+        guard let handler = onSpeechProgress, let id = utteranceIDs[key],
+              let progress = Self.makeProgress(utteranceID: id, nsRange: nsRange, text: text) else { return }
+        handler(progress)
+    }
+
+    /// Maps a delegate `(NSRange, text)` callback into a ``SpeechProgress``,
+    /// converting the UTF-16 `NSRange` into Swift `String.Index` range. Returns
+    /// `nil` when the range cannot be located in `text` (e.g. out of bounds).
+    /// Extracted so the conversion is exercised in isolation by tests.
+    static func makeProgress(utteranceID: UUID, nsRange: NSRange, text: String) -> SpeechProgress? {
+        guard let range = Range(nsRange, in: text) else { return nil }
+        return SpeechProgress(utteranceID: utteranceID, text: text, spokenRange: range)
     }
 }

--- a/Sources/ManifoldVoice/VoiceTypes.swift
+++ b/Sources/ManifoldVoice/VoiceTypes.swift
@@ -158,6 +158,46 @@ public extension SpeechSynthesizing {
     }
 }
 
+/// A "now speaking this range" progress update, emitted as an utterance is
+/// spoken so hosts can do read-along highlighting or resume from a known
+/// position.
+public struct SpeechProgress: Sendable, Equatable {
+    /// Identifies the utterance this update belongs to. The synthesizer can hold
+    /// several queued utterances; the id is stable for one `speak(...)` call and
+    /// changes when the next utterance begins, letting a host tell read-along of
+    /// one item apart from the next.
+    public let utteranceID: UUID
+
+    /// The full text of the utterance currently being spoken.
+    public let text: String
+
+    /// The range within ``text`` currently being spoken. It indexes into the
+    /// `text` carried on this same value, so the pair is always self-consistent
+    /// — safe to use directly for highlighting `Text(text)`.
+    public let spokenRange: Range<String.Index>
+
+    /// The substring currently being spoken — `text[spokenRange]`.
+    public var spokenText: String { String(text[spokenRange]) }
+
+    public init(utteranceID: UUID, text: String, spokenRange: Range<String.Index>) {
+        self.utteranceID = utteranceID
+        self.text = text
+        self.spokenRange = spokenRange
+    }
+}
+
+/// Optional capability for synthesizers that report spoken-range progress as
+/// they speak (Apple's `willSpeakRangeOfSpeechString`). Hosts that want
+/// read-along highlighting or resume-from-position check `as? SpeechProgressReporting`
+/// and set ``onSpeechProgress``. Engines without range reporting simply don't
+/// conform — callers degrade to no highlighting rather than breaking.
+public protocol SpeechProgressReporting: AnyObject {
+    /// Invoked on the main actor for each spoken range as the current utterance
+    /// progresses. `nil` (the default) disables reporting.
+    @MainActor
+    var onSpeechProgress: (@MainActor (SpeechProgress) -> Void)? { get set }
+}
+
 public protocol WakeWordDetector: AnyObject {
     @MainActor
     func ingest(_ update: SpeechTranscriptionUpdate) -> WakeWordDetection?

--- a/Tests/ManifoldUITests/StreamingIndicatorReduceMotionTests.swift
+++ b/Tests/ManifoldUITests/StreamingIndicatorReduceMotionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import ManifoldUI
+
+/// Covers the Reduce Motion gating of the shared streaming indicators (#1833).
+/// SwiftUI animation can't be inspected directly under XCTest, so each view
+/// exposes the reduce-motion-dependent appearance decision as a pure static
+/// helper; these tests assert the static fallback is genuinely static (no
+/// per-element variation that would imply movement) while the animated path
+/// still varies.
+final class StreamingIndicatorReduceMotionTests: XCTestCase {
+
+    // MARK: - TypingIndicatorView
+
+    func test_typingDots_areUniform_whenReduceMotionOn() {
+        let active = TypingIndicatorView.dotAppearance(reduceMotion: true, isActive: true)
+        let inactive = TypingIndicatorView.dotAppearance(reduceMotion: true, isActive: false)
+        // Active and inactive dots must be identical — a static three-dot glyph
+        // with no scale/opacity pulse.
+        XCTAssertEqual(active.scale, inactive.scale)
+        XCTAssertEqual(active.opacity, inactive.opacity)
+        XCTAssertEqual(active.scale, 1.0)
+    }
+
+    func test_typingDots_varyByActiveState_whenReduceMotionOff() {
+        let active = TypingIndicatorView.dotAppearance(reduceMotion: false, isActive: true)
+        let inactive = TypingIndicatorView.dotAppearance(reduceMotion: false, isActive: false)
+        XCTAssertNotEqual(active.scale, inactive.scale)
+        XCTAssertGreaterThan(active.scale, inactive.scale)
+        XCTAssertGreaterThan(active.opacity, inactive.opacity)
+    }
+
+    // MARK: - StreamingCursorView
+
+    func test_cursor_staysSolid_whenReduceMotionOn() {
+        // Opacity is independent of the pulsing `isVisible` toggle.
+        XCTAssertEqual(StreamingCursorView.cursorOpacity(reduceMotion: true, isVisible: true), 1.0)
+        XCTAssertEqual(StreamingCursorView.cursorOpacity(reduceMotion: true, isVisible: false), 1.0)
+    }
+
+    func test_cursor_pulses_whenReduceMotionOff() {
+        XCTAssertEqual(StreamingCursorView.cursorOpacity(reduceMotion: false, isVisible: true), 1.0)
+        XCTAssertEqual(StreamingCursorView.cursorOpacity(reduceMotion: false, isVisible: false), 0.0)
+    }
+}

--- a/Tests/ManifoldVoiceTests/SpeechProgressTests.swift
+++ b/Tests/ManifoldVoiceTests/SpeechProgressTests.swift
@@ -1,0 +1,63 @@
+import AVFoundation
+import XCTest
+@testable import ManifoldVoice
+
+/// Covers the spoken-range progress surface (#1831): the `NSRange` → Swift range
+/// conversion, the `SpeechProgress` value semantics, and that
+/// `AppleSpeechSynthesizer` exposes the optional `SpeechProgressReporting` hook.
+/// The live `willSpeakRangeOfSpeechString` delegate is not driven here — that
+/// requires real audio playback — so the conversion is tested through the
+/// extracted `makeProgress` seam, mirroring `makeUtterance`.
+@MainActor
+final class SpeechProgressTests: XCTestCase {
+
+    func test_makeProgress_mapsUTF16RangeToSpokenSubstring() {
+        let id = UUID()
+        let progress = AppleSpeechSynthesizer.makeProgress(
+            utteranceID: id,
+            nsRange: NSRange(location: 6, length: 5),
+            text: "Hello world"
+        )
+        XCTAssertEqual(progress?.utteranceID, id)
+        XCTAssertEqual(progress?.text, "Hello world")
+        XCTAssertEqual(progress?.spokenText, "world")
+    }
+
+    func test_makeProgress_handlesNonASCIIViaUTF16Offsets() {
+        // "café" is 4 Characters but the word after the space starts at UTF-16
+        // offset 5. The conversion must land on the Swift substring "déjà".
+        let text = "café déjà"
+        let progress = AppleSpeechSynthesizer.makeProgress(
+            utteranceID: UUID(),
+            nsRange: NSRange(location: 5, length: 4),
+            text: text
+        )
+        XCTAssertEqual(progress?.spokenText, "déjà")
+    }
+
+    func test_makeProgress_returnsNilForOutOfBoundsRange() {
+        let progress = AppleSpeechSynthesizer.makeProgress(
+            utteranceID: UUID(),
+            nsRange: NSRange(location: 50, length: 5),
+            text: "short"
+        )
+        XCTAssertNil(progress)
+    }
+
+    func test_speechProgress_spokenTextDerivesFromCarriedTextAndRange() {
+        let text = "read along"
+        let range = text.range(of: "along")!
+        let progress = SpeechProgress(utteranceID: UUID(), text: text, spokenRange: range)
+        XCTAssertEqual(progress.spokenText, "along")
+    }
+
+    func test_appleSynthesizer_exposesProgressReportingHook() {
+        let synth = AppleSpeechSynthesizer()
+        // The capability is opt-in: nil until a host installs a handler.
+        XCTAssertNil(synth.onSpeechProgress)
+        synth.onSpeechProgress = { _ in }
+        XCTAssertNotNil(synth.onSpeechProgress)
+        // And it is reachable through the optional-capability protocol.
+        XCTAssertNotNil(synth as? SpeechProgressReporting)
+    }
+}


### PR DESCRIPTION
Small accessibility-polish pair. **Closes #1831, closes #1833.**

## #1831 — spoken-range progress callback
`AVSpeechSynthesizerDelegate.willSpeakRangeOfSpeechString` was not surfaced, so hosts couldn't do read-along highlighting or resume-from-position.

- New `SpeechProgress` value (`utteranceID` + full `text` + `spokenRange`, with a `spokenText` convenience) and an **opt-in** `SpeechProgressReporting` capability protocol exposing an `onSpeechProgress` handler.
- Additive — the existing `SpeechSynthesizing` protocol and all its conformers (mocks/spies) are untouched. Hosts opt in via `as? SpeechProgressReporting`; engines without range reporting simply don't conform.
- `AppleSpeechSynthesizer` conforms: assigns a stable id per queued utterance, wires the delegate, and maps the UTF-16 `NSRange` → Swift `String.Index` range via the extracted `makeProgress` seam (cleaned up alongside continuations on finish/cancel/stop).

```swift
let synth = AppleSpeechSynthesizer()
synth.onSpeechProgress = { progress in
    // highlight progress.spokenRange within progress.text
    highlight(progress.spokenText)
}
try await synth.speak("Read this aloud.")
```

## #1833 — honour Reduce Motion in streaming indicators
The typing and streaming-cursor indicators animated unconditionally.

- `TypingIndicatorView` renders a **static three-dot glyph** (phase loop skipped, no scale/opacity pulse) and `StreamingCursorView` stays **solid** (no `repeatForever`) when `accessibilityReduceMotion` is set.
- Both read `@Environment(\.accessibilityReduceMotion)` and drop the animation; the appearance decisions are extracted to pure static helpers so the fallback is unit-testable. Accessibility labels are unchanged, so VoiceOver still conveys progress.

## Tests
- `SpeechProgressTests` — NSRange→range mapping (incl. non-ASCII UTF-16 offsets and out-of-bounds → `nil`), value semantics, and the opt-in hook.
- `StreamingIndicatorReduceMotionTests` — reduce-motion fallback is uniform/solid; animated path still varies.
- `swift build --build-tests` clean; full \`scripts/test.sh --profile local\` gate **RESULT: PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)