### PR TITLE
docs: add DX walkthrough v0.50.0 iter-1 synthesis (chat-cli + swiftui-chat)

### DIFF
--- a/scripts/dx-walkthrough/runs/2026-06-14_v0.50.0_iter1/01-chat-cli/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-06-14_v0.50.0_iter1/01-chat-cli/SUMMARY.md
@@ -1,0 +1,102 @@
+# chat-cli archetype — iteration 1 (v0.50.0)
+
+**Date**: 2026-06-14
+**MK version**: 0.50.0 (git `v0.50.0-6-ge929ca40`)
+**Agent model**: Opus 4.8 (all 4 runs)
+**App outcome**: **3/4 reached working CLIs; 1 partial (MLX)**
+
+First DX walkthrough since the v0.48 packaging split and the pre-1.0 "P-series"
+API cleanup. Four runs deliberately spread across backend surfaces (methodology:
+variation is signal).
+
+## Backend coverage this iteration
+
+| Run | Path | Outcome | Notes |
+|---|---|---|---|
+| 1 | Ollama (`llama3.1:8b`) | ✅ working | ~5 min from docs to multi-turn streaming CLI |
+| 2 | Apple Foundation Models | ✅ working | 2 real cycles, clean EOF |
+| 3 | Local GGUF via `manifold-llama` companion | ✅ working | real on-device Llama-3.1-8B on Metal |
+| 4 | MLX via `manifold-mlx` companion | ⚠️ partial | builds/loads/streams **only** after a manual `default.metallib` workaround |
+
+Overall verdict across runs: the cloud/Ollama/GGUF CLI story is **strong** —
+fast, low-guesswork, gotchas spelled out. Two doc/packaging defects block a
+*verbatim* copy-paste, and the MLX path has an undocumented structural cliff.
+
+## Blockers (must-fix)
+
+### B1 — `ManifoldBackends` SwiftPM product does not exist [4/4, blocker]
+**The unanimous finding.** Every run's `Package.swift`, copied from
+`docs/QUICKSTART-CLI.md`, declares `.product(name: "ManifoldBackends", package:
+"ManifoldKit")` (doc lines 84 / 165 / 404 — all three CLI sections). That product
+was retired in the P-series cleanup (post-v0.50.0 tag; commits `efb0c6f8`,
+`e929ca40`). It is exposed as **neither a `.library` product nor a target** in
+v0.50.0's `Package.swift`. A fresh dev pinning v0.50.0 and copy-pasting the
+"compile-tested" quickstart is **hard-stopped at dependency resolution**:
+`product 'ManifoldBackends' ... not found in package 'ManifoldKit'`.
+
+The examples are internally contradictory: the manifest names the phantom
+umbrella product, while each example's `main.swift` already imports the *real*
+modules (`ManifoldFoundation` / `ManifoldOllama` / `ManifoldCloudSaaS`). CLAUDE.md
+also still describes `ManifoldBackends` as a live umbrella. See ROOT_CAUSES.md RC-1.
+
+**Fix**: either (a) vend a `ManifoldBackends` `.library` product that re-exports
+the families, or (b) rewrite the quickstart manifests to list the three per-family
+products (or just the `ManifoldKit` umbrella). Sweep CLAUDE.md too.
+
+### B2 — MLX cannot generate under plain `swift run` [run-4, blocker]
+mlx-swift hardcodes a relative `default.metallib` path, but a SwiftPM executable
+build never compiles/bundles the Metal kernels — there is no `default.metallib`
+anywhere in `.build/`. MLX aborts at Metal init
+(`mlx-c/mlx/c/stream.cpp:115 — Failed to load the default metallib`). Discovery,
+classification (`[mlx]`), registry wiring and load-plan all worked perfectly up to
+that boundary. The agent only got tokens by hand-compiling the 8 `.metal` kernels
+with `xcrun metal`/`metallib` — out of reach for a docs-only dev. The docs warn
+about the *Simulator* Metal caveat but not the far-more-common macOS-CLI case.
+Cross-confirmed by swiftui/run-4. See ROOT_CAUSES.md RC-2.
+
+## Major
+
+### M1 — QUICKSTART-CLI §1 won't parse: tools-version 6.1 vs `.macOS(.v26)` [run-2, major]
+§1 (the Foundation example) declares `// swift-tools-version: 6.1` but uses
+`.macOS(.v26)`, introduced in PackageDescription 6.2 — SwiftPM rejects the
+manifest before any dependency resolves (`'v26' is unavailable`). A Foundation
+example *must* target macOS 26, so it *must* use 6.2. The README's own
+Requirements section even says so; §1 contradicts it. (§2/§3 correctly use 6.1
+because they target `.macOS(.v15)`.) **Fix**: bump §1 to `6.2`.
+
+### M2 — No MLX CLI recipe [run-4, major]
+`QUICKSTART-CLI.md` has worked recipes for Foundation (§1), GGUF (§2), Cloud (§3)
+but **no MLX section** — MLX appears only as a commented-out `.package(...)` line.
+The one backend with the runtime cliff (B2) is also the one with no end-to-end
+recipe.
+
+### M3 — No documented `ModelInfo` for a local MLX directory [run-4, major]
+Public docs document `ModelInfo(ggufURL:)` only. There is no documented way to
+build a `ModelInfo` for an MLX directory for the headless
+`InferenceService.loadModel(from:plan:)` path — the real route is
+`ModelStorageService().discoverModels()` → registry, undiscoverable from docs.
+Cross-confirmed by swiftui/run-4.
+
+## Minor / papercut
+
+- **Umbrella-product-vs-submodule import mismatch** [run-1, minor] — examples depend on the (phantom) `ManifoldBackends` product but `import` the granular modules; the relationship isn't spelled out. Moot once B1 is fixed.
+- **`provider: .ollama` vs README's `OpenAIBackend` framing** [run-1, minor] — the README "Supported Model Types" table lists Ollama under `OpenAIBackend`, while §3 uses `APIEndpointRecord(provider: .ollama)`. Not contradictory, but the `APIProvider`-case ↔ backend-class mapping isn't documented.
+- **Companion + local-path identity** [run-3, minor] — when evaluating against a local ManifoldKit checkout *and* a companion package, the companion's URL-pinned ManifoldKit dependency must unify with the local-path core. SwiftPM emits `Conflicting identity for manifoldkit ... will be escalated to an error in future versions`. Resolves today; latent forward-compat hazard. Docs only ever show the URL form. See ROOT_CAUSES.md RC-5.
+
+## Harness defect (not a ManifoldKit issue)
+
+**Worktree GC destroyed deliverables** [run-2 logged it; run-1 & run-3 victims].
+Agents ran in isolated git worktrees; Write/Edit pinned to the worktree path; the
+harness pruned worktrees on agent completion. run-3's worktree was GC'd and its
+`FRICTION.md`/`NOTES.md`/`session.log` were lost (only `app/` was harvested in
+time); run-1 likewise lost its friction log. run-2 alone survived intact because
+it detected the trap and wrote deliverables via `Bash` heredoc to the persistent
+main checkout. **Content was recovered from agents' completion reports**, so this
+synthesis is unaffected — but the raw logs are gone. See ROOT_CAUSES.md RC-4 for
+the harness fix.
+
+## Positives (worth preserving)
+
+- Headless CLI DX is genuinely fast once B1 is worked around: ~5 min docs→multi-turn streaming on Ollama; multi-turn history and clean Ctrl-D "just worked."
+- Local on-device GGUF via the companion package produced real Metal-backed inference with near-zero guesswork (run-3).
+- The GGUF/Foundation quickstart *narrative* (gotchas, multi-turn, reasoning) is strong — the defects are packaging/version drift, not pedagogy.

--- a/scripts/dx-walkthrough/runs/2026-06-14_v0.50.0_iter1/02-swiftui-chat/SUMMARY.md
+++ b/scripts/dx-walkthrough/runs/2026-06-14_v0.50.0_iter1/02-swiftui-chat/SUMMARY.md
@@ -1,0 +1,101 @@
+# swiftui-chat archetype — iteration 1 (v0.50.0)
+
+**Date**: 2026-06-14
+**MK version**: 0.50.0 (git `v0.50.0-6-ge929ca40`)
+**Agent model**: Opus 4.8 (all 4 runs)
+**App outcome**: run-3 working (with workaround), run-4 partial (MLX), run-1 & run-2 incomplete (no final verdict — see caveat)
+
+First SwiftUI walkthrough since the v0.48 split + P-series cleanup. Steered across
+the drop-in vs hand-assembled vs MLX axes.
+
+> **Data caveat**: run-1 (Ollama + drop-in ChatView) and run-2 (Foundation) did
+> not return final verdicts within the window — their cold builds finished but no
+> completion report arrived, and their on-disk `FRICTION.md` logs cover only the
+> doc-reading phase (2 and 1 entries respectively). Their early findings are
+> included below and flagged `[partial-log]`. The synthesis-grade signal comes
+> from run-3 and run-4, which completed.
+
+## Backend / path coverage this iteration
+
+| Run | Path | Outcome | Persistence verified? |
+|---|---|---|---|
+| 1 | Ollama + drop-in `ChatView` | ◻️ incomplete | not reported |
+| 2 | Apple Foundation Models | ◻️ incomplete | not reported |
+| 3 | **BYO-assembly** (own views → MK view models) + Ollama | ✅ working (workaround) | yes (manual bootstrap) |
+| 4 | MLX via `manifold-mlx` companion | ⚠️ partial | **yes — verified same-UUID restore** |
+
+## Blockers (must-fix)
+
+### B1 — Canonical multi-session §6 recipe doesn't compile: `DefaultBackends` unreachable [run-3, blocker]
+This is the **SwiftUI-side manifestation of chat-cli's B1** (same root cause,
+RC-1). `docs/SWIFTUI-MULTI-SESSION.md` §6 (the recommended manual-bootstrap path
+"for control") shows `import ManifoldKit` as the only import, then calls
+`DefaultBackends.register(with: bootstrap.inferenceService)` (doc lines 142, 353).
+It does not compile: `cannot find 'DefaultBackends' in scope`. The umbrella's
+`@_exported import ManifoldBackends` does **not** surface `DefaultBackends` to
+consumers, and there is no `ManifoldBackends` `.library` product to depend on
+directly — so `DefaultBackends` is genuinely unreachable from any external
+consumer. The agent confirmed it by inspecting `Package.swift`'s product list (a
+forced-blindness near-miss). `quickStart()` users dodge this (they never name
+`DefaultBackends`); it bites exactly the manual path the doc recommends.
+
+**Fix**: same as chat-cli B1 — vend a product or rewrite the recipe to
+`import ManifoldOllama` + `OllamaBackends.register(with:)` (which the agent
+verified works). Sweep the `DefaultBackends` references at doc lines 142/170/353/482.
+
+### B2 — MLX cannot generate under plain `swift build` [run-4, blocker]
+Cross-confirms chat-cli B2 (RC-2). The SwiftUI app **compiled cleanly, launched,
+rendered the multi-session UI, and persisted/restored sessions** — but MLX
+generation aborted at the same unbuilt-`default.metallib` boundary. `swift build`
+produces an app that cannot load MLX's Metal kernels; MLX generation requires an
+Xcode-built `.app` bundle that **no doc mentions**.
+
+## Major
+
+### M1 — Cold-build FS desync surfaces as a misleading MK-internal error [run-3, major]
+First cold build aborted near the end with
+`error closing '.../ManifoldHardware.build/ModelLoadPlan.swift.o' ... No such
+file or directory` — the `.build`/workspace-state desync class CLAUDE.md documents
+(`scripts/clean-build.sh` territory), likely aggravated by a path-dependency into
+a live, churning checkout. A re-run recovered. But the error names an
+*MK-internal* object file and reads like an MK bug; the recovery isn't
+discoverable from the error text. (Partly an eval-harness artifact of building
+against a live worktree — see RC-4.)
+
+### M2 — MLX model acquisition: zero hand-holding [run-4, major]
+README says MLX = "directory with config.json + .safetensors, auto-discovered from
+`~/Documents/Models`", but no doc names a concrete MLX model id or gives an
+`hf download` command, and `seed: .recommendedSmallModel()` only covers the GGUF
+starter. MLX adopters must already know `mlx-community` exists. (Agent used
+`mlx-community/Qwen2.5-0.5B-Instruct-4bit`.)
+
+### M3 — No headless `ModelInfo` for MLX [run-4, major]
+Same gap as chat-cli M3 (RC-2): `ModelInfo(ggufURL:)` is the only documented
+constructor; the MLX path is discovery-only.
+
+### M4 — Companion + local-path identity warning [run-4, major]
+Same as chat-cli minor (RC-5), rated higher here: `Conflicting identity for
+manifoldkit` between the companion's URL pin and the app's local-path pin —
+"will be escalated to an error in future versions of SwiftPM." Undocumented; a
+real hazard for the local multi-checkout dev setup CLAUDE.md itself calls out.
+
+## Minor / papercut
+
+- **QuickStartResult shape disagreement** [run-4, minor] — multi-session guide reads `kit.sessionManager`; README "Key Types" documents `QuickStartResult` as `{ bootstrap, viewModel }` (no `sessionManager`). Compiler arbitrated in the guide's favor; docs disagree.
+- **`quickStart(backends:configuration:)` arg order** [run-4, minor] — no doc shows the two args used together; `backends` must precede `configuration`, but the guide shows `configuration:` alone first, so a 50/50 guess fails to compile.
+- **MLX wiring scattered across 3–4 docs** [run-4, minor] — correct but no single MLX-quickstart page.
+- **No documented local-path form for companion packages** [run-4, minor] — docs only show the GitHub-URL form.
+- **No "custom views + persistence" recipe** [run-3, minor] — BYO-UI doc explicitly drops SwiftData; multi-session doc assumes MK's `ChatView`. The "bind your own views to the shared view models" path is an inference, not a documented recipe.
+- **No SwiftPM-executable SwiftUI guidance** [run-1, minor, partial-log] — every quickstart routes through Xcode; running a `@main App` from an `executableTarget` (fast for headless/CI eval) is undocumented.
+- **Hardcoded `llama3.2:3b` in §6** [run-1, papercut, partial-log] — doc pre-seeds a model the reader may not have pulled, with no "list your models" hint.
+- **SwiftPM-executable window has no bundle identity** [run-3, papercut] — complicates `screencapture`/automation; a `MinimalExample` shipped as an `.xcodeproj` would smooth this.
+
+## Positives (worth preserving)
+
+- **SwiftUI persistence DX is genuinely polished** — run-4 verified same session UUID restored across quit+relaunch with no duplicate; run-3 kept persistence via the manual bootstrap path. This is a real strength.
+- **BYO view-model binding shines** [run-3] — `chatVM.inputText = …; await chatVM.sendMessage()`, `chatVM.messages` directly `ForEach`-able, `@MainActor @Observable` view models bind idiomatically. ~80 lines for a working multi-session chat.
+- **`docs/SWIFTUI-MULTI-SESSION.md` is otherwise high-quality** [run-2 positive, partial-log] — filename matched the task, covered bootstrap/sidebar/persistence/Foundation wiring; discoverability "effortless." The blocker is the one stale `DefaultBackends` recipe, not the doc's structure.
+
+## Follow-up for next iteration
+
+- Re-run run-1 (Ollama drop-in `ChatView`) and run-2 (Foundation) to completion — the drop-in `ChatView` path (the headline "easy mode") has **no completed data point** this iteration. Whether `ChatView` + `quickStart` compiles and runs end-to-end on v0.50.0 is currently unverified here.

--- a/scripts/dx-walkthrough/runs/2026-06-14_v0.50.0_iter1/ROOT_CAUSES.md
+++ b/scripts/dx-walkthrough/runs/2026-06-14_v0.50.0_iter1/ROOT_CAUSES.md
@@ -1,0 +1,217 @@
+# Root causes — DX walkthrough iteration 1 (v0.50.0)
+
+**Date**: 2026-06-14 · **MK version**: 0.50.0 (`v0.50.0-6-ge929ca40`)
+**Scenarios**: 01-chat-cli (4 runs) + 02-swiftui-chat (4 runs), 8 agents total.
+
+Causal grouping across both scenarios. Most surface-level findings collapse into
+a small number of causes — two of them are the same packaging regression seen
+from the CLI and SwiftUI sides.
+
+---
+
+## RC-1 — `ManifoldBackends` was retired in the P-series cleanup but the docs weren't [HEADLINE]
+
+**Symptoms it explains** (5 of 6 completed runs):
+- chat-cli B1 — `.product(name: "ManifoldBackends", …)` doesn't resolve (runs 1/2/3/4)
+- swiftui B1 — `DefaultBackends.register(…)` doesn't compile (run-3)
+- chat-cli minor — umbrella-product-vs-submodule import confusion (run-1)
+
+**Cause**: The `ManifoldBackends` umbrella was demoted in the pre-1.0 P-series API
+cleanup (commits `efb0c6f8`, `e929ca40`), landing **after the v0.50.0 tag**. In
+v0.50.0's `Package.swift` it is exposed as **neither a `.library` product nor a
+target** (verified: the only backend-ish product is `ManifoldBackendTestKit`).
+`DefaultBackends` lives behind that now-unreachable boundary, and the umbrella's
+`@_exported import ManifoldBackends` does not surface it to external consumers.
+
+The docs and CLAUDE.md still describe `ManifoldBackends` as a live umbrella, so the
+canonical "compile-tested" recipes are stale against the very tag a fresh consumer
+pins. This is exactly the doc↔package drift this harness exists to catch — and
+invisible to in-repo tests, which never resolve the package as an outside consumer.
+
+**Confirmed locations**:
+- `docs/QUICKSTART-CLI.md:84`, `:165`, `:404` — `.product(name: "ManifoldBackends", …)`
+- `docs/SWIFTUI-MULTI-SESSION.md:142`, `:353` — `DefaultBackends.register(…)`; refs at `:170`, `:482`
+- `CLAUDE.md` — describes `ManifoldBackends` as a live umbrella target/product
+
+**Fix (one of):**
+- (a) **Vend a `ManifoldBackends` `.library` product** that re-exports the families + `DefaultBackends`. Lowest doc churn; restores the documented API.
+- (b) **Rewrite the recipes** to the per-family products: `import ManifoldOllama` + `OllamaBackends.register(with:)` (CLI) / drop `DefaultBackends` (SwiftUI). The agents verified this path works and it's arguably cleaner.
+- Either way: sweep CLAUDE.md and any DocC articles.
+
+**Recommendation**: This is a clean, high-value doc/packaging PR. Pick (a) if
+`DefaultBackends`/umbrella-import is meant to remain public API; (b) if the
+per-family split is the intended 1.0 surface. Decide the API intent first, then
+fix docs to match.
+
+---
+
+## RC-2 — The MLX companion path has no SwiftPM runtime story and is under-documented end-to-end
+
+**Symptoms it explains** (both MLX runs, 2/2 partial):
+- chat-cli B2 / swiftui B2 — MLX aborts at unbuilt `default.metallib` under `swift build`/`swift run`
+- chat-cli M2/M3, swiftui M2/M3/M4 + minors — no MLX CLI recipe, no MLX `ModelInfo`, no model-acquisition guidance, scattered wiring, companion local-path identity warning
+
+**Cause**: mlx-swift compiles its Metal kernels into `default.metallib` only through
+its Xcode/CMake build-tool path. A plain SwiftPM executable build never produces or
+bundles the metallib, and MLX loads it relative to the executable at runtime — so
+**MLX generation structurally cannot work from a bare `swift run`**; it needs an
+Xcode-built `.app`. Everything *up to* generation works (discovery, `[mlx]`
+classification, registry wiring, load-plan), which makes the failure especially
+confusing — a cryptic C++ runtime error with no doc pointer. On top of the runtime
+cliff, the MLX surface lacks a quickstart, a headless `ModelInfo` entry point, a
+recommended model id, and a local-path companion form.
+
+**Fix**:
+- Document the metallib/Xcode-bundle requirement prominently in the manifold-mlx README *and* in ManifoldKit's MLX docs — the Simulator caveat exists but the common macOS-CLI case doesn't. State plainly: "MLX requires an Xcode `.app` build; `swift run` cannot load MLX kernels."
+- Add an MLX quickstart (CLI + SwiftUI) parallel to the GGUF one, including a recommended `mlx-community` model id + `hf download` command and a documented headless `ModelInfo` route (or a `ModelInfo(mlxURL:)` factory mirroring `ggufURL:`).
+- Document the local-path companion form (see RC-5).
+
+**Recommendation**: Two tracks — a fast doc PR (the metallib warning is the
+highest-leverage single line; it converts a silent blocker into a known
+constraint), and a follow-up on whether to expose a headless MLX `ModelInfo`
+factory. The metallib cliff likely warrants a tracked issue if it can't be fixed
+in mlx-swift's SwiftPM build.
+
+---
+
+## RC-3 — `QUICKSTART-CLI.md` §1 manifest is internally inconsistent
+
+**Symptom**: chat-cli M1 — §1 declares `swift-tools-version: 6.1` but uses
+`.macOS(.v26)` (needs 6.2); the manifest is rejected before resolution.
+
+**Cause**: A Foundation example must target macOS 26 (the backend's floor) but the
+tools-version line was left at 6.1. Isolated to §1 (§2/§3 correctly use 6.1 for
+`.macOS(.v15)`). **Fix**: bump §1 to `6.2`. Trivial; bundle with the RC-1 doc PR.
+
+---
+
+## RC-4 — [HARNESS, not MK] Worktree isolation + GC destroys agent deliverables
+
+**Symptom**: chat-cli run-1 & run-3 lost their `FRICTION.md`/`NOTES.md`/`session.log`;
+run-3's whole worktree was pruned before harvest. (Content recovered from
+completion reports, so this synthesis is intact — but the raw logs are gone, and a
+silent run could have lost everything.)
+
+**Cause**: Agents were dispatched with `isolation: worktree`. The Write/Edit tools
+pin to the worktree path even when given a main-checkout absolute path, so
+deliverables land *inside* the worktree; the harness then prunes worktrees on
+agent completion. run-2 survived only because it detected this and wrote via `Bash`
+heredoc to the persistent main checkout.
+
+**Fix (harness)** — update `scripts/dx-walkthrough/README.md` and `run.sh`'s
+dispatch prompt:
+- These agents are **read-only against ManifoldKit** (forced-blindness forbids touching `Sources/`/`Tests/`); they only *create a separate consumer app*. They do **not** need worktree isolation. **Drop `isolation: worktree`** for this harness — agents can write straight to the main-checkout run dir, and there's no mutation to isolate.
+- If isolation is kept for build sandboxing, instruct agents to write all deliverables via `Bash` to the absolute main-checkout run dir (not Write/Edit), and have the orchestrator harvest *incrementally* as each agent completes (before GC), not at the end.
+
+**Recommendation**: Adopt "drop worktree isolation" — simplest and removes the
+class entirely. It also dissolves M1 in the SwiftUI scenario (the `.build` desync
+came from building against a live churning worktree).
+
+---
+
+## RC-5 — Local-path companion + URL-pinned core → SwiftPM identity collision
+
+**Symptoms**: chat-cli run-3 minor, swiftui run-4 M4 — `Conflicting identity for
+manifoldkit` warning when an app pins ManifoldKit by local path while a companion
+(manifold-llama / manifold-mlx) pins it by GitHub URL. Resolves today; SwiftPM
+warns it "will be escalated to an error in future versions."
+
+**Cause**: The companion packages pin ManifoldKit by URL; a local-checkout
+evaluator pins by path; SwiftPM unifies on the `manifoldkit` identity but flags the
+divergent coordinates. The docs only ever show the URL form, so the local
+multi-checkout setup (the exact dev workflow CLAUDE.md endorses) is undocumented
+and on a forward-compat clock.
+
+**Fix**: document the local-path companion form and the dual-local-checkout
+override pattern (both core and companion by path so identity unifies). Tie to
+RC-2's MLX docs. Low urgency but a known time bomb.
+
+---
+
+## Priority ranking for PRs
+
+1. **RC-1** — doc/packaging fix (decide API intent, then fix docs + CLAUDE.md). Highest value: unblocks every fresh CLI *and* SwiftUI consumer. Bundle **RC-3** in.
+2. **RC-2 (doc track)** — the MLX metallib warning + an MLX quickstart. Converts a silent structural blocker into a documented constraint.
+3. **RC-4** — harness fix (drop worktree isolation). Cheap; prevents data loss next iteration.
+4. **RC-5** — local-path companion docs. Low urgency.
+
+---
+
+# Deeper repo-wide investigation (2026-06-14, 5-agent sweep)
+
+A follow-up sweep showed RC-1 and RC-3 are not isolated doc typos — they are the
+visible tip of **one code-level retirement (P7 / #1837 "retire deprecated
+ManifoldBackends/ManifoldCloud @_exported shims") that shipped without sweeping
+its docs, examples, and generated artifacts — compounded by a CI gate that
+structurally cannot catch it.** Every finding below is the *same bug class*.
+
+## RC-1-DEEP — the real root cause: retirement without a sweep, + a CI blind spot
+
+**The systemic hole.** The only gate that compiles doc code is
+`readme-snippets.yml` → `scripts/extract-snippets.sh`. It **deliberately skips
+every `Package.swift` manifest fragment** (`extract-snippets.sh:222-233`: any
+fence beginning `.package(`, `.target(`, or `import PackageDescription` is tagged
+`package-manifest-fragment` and not built). So the exact place dead product names
+and wrong tools-versions live is exempt from validation. The gate is **green
+(12/12) while the docs are broken.** And coverage is incomplete:
+`docs/SWIFTUI-MULTI-SESSION.md` (9 swift fences, "complete end-to-end recipe") is
+**not in the INPUTS list at all** — zero coverage. The bundled `Example/` app and
+the generated `affected-suites-graph.json` aren't validated against reality either.
+
+Net: any rename/retirement rots docs + examples + the dep graph, and CI says
+nothing. This will recur on every future API change until the gate is fixed.
+
+## Full blast radius of the ManifoldBackends/ManifoldCloud/DefaultBackends retirement
+
+### Build-breaking for a fresh consumer (or a shipped artifact)
+- `docs/QUICKSTART-CLI.md:84,165,404` — `.product(name: "ManifoldBackends", …)` (phantom product)
+- `docs/QUICKSTART-BRING-YOUR-OWN-UI.md:14` — same phantom product (its own source imports the right families — self-contradicting)
+- `docs/AppStoreSubmission.md:110` — `import ManifoldBackends` (phantom module)
+- `docs/CLOUD-OAUTH.md:33,117,118,149,150` — `import ManifoldCloud` (retired shim)
+- **`Example/Advanced/ManifoldDemoApp.swift:7`** — `import ManifoldBackends`, **plus `Example/Advanced.xcodeproj/project.pbxproj` links the phantom product (5 refs).** A *shipped* example, not just a doc. (`example-ui-smoke.yml` references `Example/` — verify whether it actually builds the `Advanced` target; if so it should be red, if not the example rotted unguarded.)
+- `AGENTS.md:105` — `DefaultBackends.register(with:)` in the file's most-copied bootstrap recipe (`DefaultBackends` type no longer exists)
+- `docs/SWIFTUI-MULTI-SESSION.md:142,353` — `DefaultBackends.register(...)` (the §6 recipe = DX blocker B1; ungated doc)
+
+### `DefaultBackends` type is gone — referenced as live API in
+`docs/QUICKSTART.md:72,166`, `docs/SCOPE_DECISION.md:11`, `CONTRIBUTING.md:144`,
+`AGENTS.md:32,105`, `CLAUDE.md:34`, `SWIFTUI-MULTI-SESSION.md:170,482`.
+
+### Stale architecture prose (misleads, doesn't break builds)
+- `CLAUDE.md` — 7 stale `ManifoldBackends`/`ManifoldCloud`/`DefaultBackends` spots (lines 32,34,81,83,85,87 + table rows 65,67)
+- `README.md:197,236,245`, `CONTRIBUTING.md:64,77,180`, `SECURITY.md:74` (dead path `Sources/ManifoldBackends/Cloud/*`), `FIPS.md:236`, `RELIABILITY.md:15`, `QUICKSTART.md:32`, `QUICKSTART-VOICE.md:41`
+- DocC: `ManifoldInference.docc/ManifoldInference.md:22`, `ManifoldRuntime.docc/ManifoldRuntime.md:15,36` (lists retired `ManifoldCloud` + companion-moved MLX/Llama as in-repo families), `ManifoldUI.docc/.../GenerationComponents.md:94,124`
+- `DefaultWebSearchRuntime` moved `ManifoldCloud` → `ManifoldCloudCore`; DocC still points at the old home.
+
+### Generated artifact stale (CI-affecting)
+- `scripts/affected-suites-graph.json:124,134` (+ edges) — nodes `Sources/ManifoldCloud` and `Sources/ManifoldBackendsUmbrella` point at **deleted** dirs. Regenerate (don't hand-edit).
+
+## RC-6 — a SECOND, independent rot pattern: CLAUDE.md dep claims drifted from Package.swift
+
+Separate from the retirement, CLAUDE.md's dependency descriptions no longer match
+`Package.swift` — architecture docs weren't updated when edges moved in P-series:
+- `ManifoldFoundation` documented as "**Contract only — no engine-state dependency**" but actually depends on **`ManifoldContract` + `ManifoldInference`** (the relocated `FoundationBackends` registrar needs the engine). (CLAUDE.md:29 vs Package.swift:381-385)
+- `ManifoldCloudCore` documented as "Depends on `ManifoldInference`" but now also depends on **`ManifoldRuntime`** (for `DefaultWebSearchRuntime`'s port conformance). (CLAUDE.md:33 vs Package.swift:354-368)
+- `ManifoldFuzzBackends` / `manifold-tools` deps described via the dead umbrella.
+
+No test validates CLAUDE.md/AGENTS.md claims against `Package.swift` — `AgentsMdAuditTest` only aligns the two text files to each other and checks for a few literal substrings, not against package reality. So both files can (and did) drift freely.
+
+## RC-3 status: NARROW (good news)
+The tools-version/platform mismatch is a **single instance** (QUICKSTART-CLI §1,
+line 64). Not a systemic pattern — every other snippet's tools-version matches its
+platforms. One-line fix (6.1 → 6.2).
+
+## Remediation plan (deeper)
+
+1. **Sweep PR** — fix all build-breaking refs above (QUICKSTART-CLI/BYO-UI/AppStore/CLOUD-OAUTH docs + **the Example/Advanced app** + AGENTS.md:105 recipe + SWIFTUI-MULTI-SESSION §6), regenerate `affected-suites-graph.json`, bump QUICKSTART-CLI §1 tools-version. Decide the API intent first (re-vend `ManifoldBackends` product, or commit to per-family + `quickStart(backends:)`).
+2. **Close the CI blind spot (the durable fix)** — in `scripts/extract-snippets.sh`, stop blanket-skipping manifest fragments: text-validate them instead (every `.product(name:)` exists in `Package.swift` `products:`; `swift-tools-version` ≥ repo floor). Strongest form: write full `Package.swift` fragments to a temp dir + trivial `main.swift` and run `swift package resolve`. Add `docs/SWIFTUI-MULTI-SESSION.md` to INPUTS + the `readme-snippets.yml` paths filter. This turns *both* DX blockers into red CI.
+3. **CLAUDE.md + AGENTS.md accuracy PR** — fix the 7 retirement-stale spots + the 3 dep inaccuracies (RC-6). Respect AGENTS.md test landmines (keep literal `"umbrella module"` / `"BackendName.foundation"` substrings). Consider a lightweight audit that checks CLAUDE.md target/dep claims against `Package.swift`.
+4. **MLX docs (RC-2)** and **local-path companion docs (RC-5)** — separate, lower urgency.
+
+---
+
+## Coverage gap to close next iteration
+
+The drop-in `ChatView` + `quickStart` path (SwiftUI run-1) and the Foundation
+SwiftUI path (run-2) have **no completed data point** — both stalled after their
+cold builds. The "easy mode" SwiftUI happy path is therefore unverified on
+v0.50.0. Re-run both to completion before declaring the SwiftUI DX healthy.


### PR DESCRIPTION
Checked-in retrospective from the 2026-06-14 DX walkthrough run (8 agents — chat-cli + swiftui-chat archetypes across Ollama / Foundation / GGUF / MLX surfaces).

Per the harness convention (`scripts/dx-walkthrough/README.md`), the per-run `run-*/` artifacts are gitignored but the per-archetype `SUMMARY.md` and the cross-scenario `ROOT_CAUSES.md` are checked in so historical DX state lives in the repo.

## Files
- `…/01-chat-cli/SUMMARY.md`
- `…/02-swiftui-chat/SUMMARY.md`
- `…/ROOT_CAUSES.md`

## Why it matters
This is the run that surfaced the work already merged in **#1847** (build-breaking `ManifoldBackends`/`ManifoldCloud`/`DefaultBackends` refs + the snippet-gate blind spot) and **#1849** (stale architecture prose + dependency-claim drift + regenerated graph). `ROOT_CAUSES.md` also documents two findings not yet actioned: MLX is structurally blocked under plain `swift run` (unbuilt metallib — RC-2), and the harness's own worktree-GC deliverable-loss gotcha (RC-4), plus a coverage gap (the SwiftUI drop-in `ChatView` happy path never completed this run).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)