### PR TITLE
docs: fix QuickStartResult shape + document quickStart(backends:configuration:) arg order

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Discovery additionally surfaces any `.gguf` files (or MLX model directories) in 
 
 | Type | Purpose |
 |------|---------|
-| `ManifoldKit.quickStart` | One-call bootstrap — returns `QuickStartResult { bootstrap, viewModel }`. |
+| `ManifoldKit.quickStart` | One-call bootstrap — returns `QuickStartResult { bootstrap, viewModel, sessionManager }`. |
 | `ManifoldBootstrap` | SwiftData-backed bootstrap — installs configuration, builds persistence adapters, holds shared services. Drop down to this when you need a custom inference service or model container. |
 | `ChatViewModel` | Central chat controller — messages, generation, model loading, settings. |
 | `SessionManagerViewModel` | Chat session CRUD and selection. |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -335,6 +335,8 @@ result = try await ManifoldKit.quickStart(
 )
 ```
 
+> **Argument order:** the combined overload is `quickStart(backends:configuration:seed:)` — `backends:` comes **first**, then the optional `configuration:`. So to pass both, write `quickStart(backends: [...], configuration: myConfig)`. (The no-arg and `configuration:`-only forms shown elsewhere in this guide are separate overloads.)
+
 (Xcode consumers: File ▸ Add Package Dependencies… ▸ enter the companion URL ▸ tick the product for your app target — no manifest editing.)
 
 > [!IMPORTANT]


### PR DESCRIPTION
Two minor doc nits surfaced by the DX walkthrough (iter-1 `SUMMARY.md`), both verified against `Sources/ManifoldKit/QuickStart.swift`:

- **`QuickStartResult` shape** — README "Key Types" documented it as `{ bootstrap, viewModel }`, but it also exposes **`sessionManager`** (`SessionManagerViewModel`) — which `docs/SWIFTUI-MULTI-SESSION.md` already reads as `kit.sessionManager`. The two docs disagreed; README now matches the type.
- **`quickStart` arg order** — no doc showed `backends:` and `configuration:` together, so a consumer combining a companion backend with a custom config had to guess the order (it failed to compile for the walkthrough agent). The combined overload is `quickStart(backends:configuration:seed:)` — **`backends:` first**. Added a note in QUICKSTART.md "Customizing backends".

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)