### PR TITLE
fix(testsupport): findGGUFModel/findMLXModelDirectory skip on non-matching nameContains instead of returning wrong model

### DIFF
--- a/Sources/ManifoldTestSupport/HardwareRequirements.swift
+++ b/Sources/ManifoldTestSupport/HardwareRequirements.swift
@@ -186,8 +186,11 @@ public enum HardwareRequirements {
     ///
     /// When `MLX_TEST_MODEL` is set to a bare name or substring (no `/`),
     /// discovery runs and the first candidate whose path contains the value wins.
-    /// Falls back to `nameContains`, then to the first discovered candidate in
-    /// deterministic path order.
+    /// If that name fragment matches nothing the function returns `nil` (the
+    /// caller skips) rather than falling back to an unrelated model. Falls back
+    /// to `nameContains` only when the env key is absent; if neither name
+    /// selector is supplied and `MANIFOLD_DISCOVER_LOCAL_MODELS=1`, the first
+    /// discovered candidate in deterministic path order wins.
     public static func findMLXModelDirectory(
         nameContains substring: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
@@ -286,8 +289,11 @@ public enum HardwareRequirements {
     ///
     /// When `LLAMA_TEST_MODEL` is set to a bare name or substring (no `/`),
     /// discovery runs and the first candidate whose path contains the value wins.
-    /// Falls back to `nameContains`, then to the smallest discovered candidate
-    /// that satisfies the size bounds.
+    /// If that name fragment matches nothing the function returns `nil` (the
+    /// caller skips) rather than falling back to an unrelated model. Falls back
+    /// to `nameContains` only when the env key is absent; if neither name
+    /// selector is supplied and `MANIFOLD_DISCOVER_LOCAL_MODELS=1`, the smallest
+    /// discovered candidate that satisfies the size bounds wins.
     public static func findGGUFModel(
         nameContains substring: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -455,14 +461,21 @@ public enum HardwareRequirements {
         let ordered = sortedUniqueURLs(candidates)
         guard !ordered.isEmpty else { return nil }
 
-        if let override = normalizedModelSelector(environment[environmentKey]),
-           let matched = matchingFilesystemModel(override, in: ordered) {
-            return matched
+        // An explicit name selector — supplied via the env key or the
+        // `nameContains` argument — is a request for a *specific* model. If it
+        // matches nothing, return nil so the caller skips rather than silently
+        // running against an unrelated model. Only when no name selector was
+        // provided at all do we fall back to the first candidate (the legit
+        // "any model" discovery path). Mirrors `findOllamaModel(nameContains:)`.
+        let envSelector = normalizedModelSelector(environment[environmentKey])
+        let argSelector = normalizedModelSelector(substring)
+
+        if let envSelector {
+            return matchingFilesystemModel(envSelector, in: ordered)
         }
 
-        if let substring = normalizedModelSelector(substring),
-           let matched = matchingFilesystemModel(substring, in: ordered) {
-            return matched
+        if let argSelector {
+            return matchingFilesystemModel(argSelector, in: ordered)
         }
 
         return ordered.first
@@ -536,14 +549,22 @@ public enum HardwareRequirements {
         let ordered = sortedUniqueGGUFCandidates(candidates).map(\.url)
         guard !ordered.isEmpty else { return nil }
 
-        if let override = normalizedModelSelector(environment[environmentKey]),
-           let matched = matchingFilesystemModel(override, in: ordered) {
-            return matched
+        // An explicit name selector — supplied via the env key or the
+        // `nameContains` argument — is a request for a *specific* model. If it
+        // matches nothing, return nil so the caller skips rather than silently
+        // running against an unrelated (smaller) model. Only when no name
+        // selector was provided at all do we fall back to the smallest
+        // candidate (the legit "any model" discovery path). Mirrors
+        // `findOllamaModel(nameContains:)`.
+        let envSelector = normalizedModelSelector(environment[environmentKey])
+        let argSelector = normalizedModelSelector(substring)
+
+        if let envSelector {
+            return matchingFilesystemModel(envSelector, in: ordered)
         }
 
-        if let substring = normalizedModelSelector(substring),
-           let matched = matchingFilesystemModel(substring, in: ordered) {
-            return matched
+        if let argSelector {
+            return matchingFilesystemModel(argSelector, in: ordered)
         }
 
         return ordered.first

--- a/Tests/ManifoldInferenceTests/HardwareRequirementsGGUFTests.swift
+++ b/Tests/ManifoldInferenceTests/HardwareRequirementsGGUFTests.swift
@@ -49,14 +49,59 @@ final class HardwareRequirementsGGUFTests: XCTestCase {
         XCTAssertEqual(result?.standardizedFileURL.path, nested.standardizedFileURL.path)
     }
 
-    func test_findGGUFModel_missingOverrideFallsBackToSmallestValidCandidate() {
+    func test_findGGUFModel_missingEnvOverride_returnsNilRatherThanSmallestCandidate() {
+        // An explicit env name-fragment that matches no candidate is a request
+        // for a specific model. The function must return nil (caller skips)
+        // rather than silently running against an unrelated smaller model.
         _ = createGGUFFile("alpha.gguf", size: 12)
-        let smallest = createGGUFFile("zeta.gguf", size: 4)
+        _ = createGGUFFile("zeta.gguf", size: 4)
         _ = createGGUFFile("tiny.gguf", size: 1)
 
         let result = HardwareRequirements.findGGUFModel(
             in: [tempDirectory],
             environment: ["LLAMA_TEST_MODEL": "missing"],
+            minimumModelSize: 2
+        )
+
+        XCTAssertNil(result, "Env name-fragment matching nothing must not fall back to another model")
+    }
+
+    func test_findGGUFModel_nameContainsMatchingNothing_returnsNil() {
+        // The reported false positive: a family-targeted selector with no match
+        // must yield nil, not the smallest other GGUF.
+        _ = createGGUFFile("alpha.gguf", size: 12)
+        _ = createGGUFFile("zeta.gguf", size: 4)
+
+        let result = HardwareRequirements.findGGUFModel(
+            in: [tempDirectory],
+            nameContains: "mistral",
+            minimumModelSize: 1
+        )
+
+        XCTAssertNil(result, "nameContains matching nothing must not fall back to another model")
+    }
+
+    func test_findGGUFModel_nameContainsMatching_returnsThatModel() {
+        _ = createGGUFFile("alpha.gguf", size: 12)
+        let mistral = createGGUFFile("mistral-7b.gguf", size: 4)
+
+        let result = HardwareRequirements.findGGUFModel(
+            in: [tempDirectory],
+            nameContains: "mistral",
+            minimumModelSize: 1
+        )
+
+        XCTAssertEqual(result?.standardizedFileURL.path, mistral.standardizedFileURL.path)
+    }
+
+    func test_findGGUFModel_noSelector_returnsSmallestCandidate() {
+        // No env override and no nameContains: the "any model" path is
+        // unchanged — the smallest valid candidate wins.
+        _ = createGGUFFile("alpha.gguf", size: 12)
+        let smallest = createGGUFFile("zeta.gguf", size: 4)
+
+        let result = HardwareRequirements.findGGUFModel(
+            in: [tempDirectory],
             minimumModelSize: 2
         )
 

--- a/Tests/ManifoldInferenceTests/HardwareRequirementsGGUFTests.swift
+++ b/Tests/ManifoldInferenceTests/HardwareRequirementsGGUFTests.swift
@@ -81,6 +81,28 @@ final class HardwareRequirementsGGUFTests: XCTestCase {
         XCTAssertNil(result, "nameContains matching nothing must not fall back to another model")
     }
 
+    func test_findGGUFModel_envOverrideMissingWins_evenWhenNameContainsWouldMatch() {
+        // Precedence lock: when the env key is present it pins the model. An
+        // env miss must return nil even if the `nameContains` argument would
+        // have matched — the env override is the higher-priority "pin a
+        // specific model" request, so a miss skips rather than running the
+        // arg-selected model.
+        _ = createGGUFFile("alpha.gguf", size: 12)
+        _ = createGGUFFile("mistral-7b.gguf", size: 4)
+
+        let result = HardwareRequirements.findGGUFModel(
+            in: [tempDirectory],
+            nameContains: "mistral",
+            environment: ["LLAMA_TEST_MODEL": "missing"],
+            minimumModelSize: 1
+        )
+
+        XCTAssertNil(
+            result,
+            "Env override miss must win over a matching nameContains arg (env pins the model)"
+        )
+    }
+
     func test_findGGUFModel_nameContainsMatching_returnsThatModel() {
         _ = createGGUFFile("alpha.gguf", size: 12)
         let mistral = createGGUFFile("mistral-7b.gguf", size: 4)

--- a/Tests/ManifoldInferenceTests/HardwareRequirementsMLXTests.swift
+++ b/Tests/ManifoldInferenceTests/HardwareRequirementsMLXTests.swift
@@ -95,7 +95,10 @@ final class HardwareRequirementsMLXTests: XCTestCase {
         XCTAssertEqual(result?.standardizedFileURL.path, nested.standardizedFileURL.path)
     }
 
-    func test_findMLXModelDirectory_overrideFallsBackToFirstSortedCandidate() {
+    func test_findMLXModelDirectory_missingEnvOverride_returnsNilRatherThanFirstCandidate() {
+        // An explicit env name-fragment that matches no candidate is a request
+        // for a specific model. The function must return nil (caller skips)
+        // rather than silently running against an unrelated model.
         let zeta = tempDirectory.appendingPathComponent("zeta-model", isDirectory: true)
         let alpha = tempDirectory.appendingPathComponent("alpha-model", isDirectory: true)
         createValidMLXDirectory(at: zeta)
@@ -105,6 +108,33 @@ final class HardwareRequirementsMLXTests: XCTestCase {
             in: [tempDirectory],
             environment: ["MLX_TEST_MODEL": "missing"]
         )
+
+        XCTAssertNil(result, "Env name-fragment matching nothing must not fall back to another model")
+    }
+
+    func test_findMLXModelDirectory_nameContainsMatchingNothing_returnsNil() {
+        let zeta = tempDirectory.appendingPathComponent("zeta-model", isDirectory: true)
+        let alpha = tempDirectory.appendingPathComponent("alpha-model", isDirectory: true)
+        createValidMLXDirectory(at: zeta)
+        createValidMLXDirectory(at: alpha)
+
+        let result = HardwareRequirements.findMLXModelDirectory(
+            in: [tempDirectory],
+            nameContains: "mistral"
+        )
+
+        XCTAssertNil(result, "nameContains matching nothing must not fall back to another model")
+    }
+
+    func test_findMLXModelDirectory_noSelector_returnsFirstSortedCandidate() {
+        // No env override and no nameContains: the "any model" path is
+        // unchanged — the first sorted candidate wins.
+        let zeta = tempDirectory.appendingPathComponent("zeta-model", isDirectory: true)
+        let alpha = tempDirectory.appendingPathComponent("alpha-model", isDirectory: true)
+        createValidMLXDirectory(at: zeta)
+        createValidMLXDirectory(at: alpha)
+
+        let result = HardwareRequirements.findMLXModelDirectory(in: [tempDirectory])
 
         XCTAssertEqual(result?.standardizedFileURL.path, alpha.standardizedFileURL.path)
     }


### PR DESCRIPTION
## The false positive

`HardwareRequirements.findGGUFModel(nameContains:)` (and the MLX twin
`findMLXModelDirectory(nameContains:)`) silently returned the **wrong model**
when a family-targeted selector matched nothing.

Concretely: a test asking for `nameContains: "mistral"` when no mistral GGUF
was on disk got back the **smallest other GGUF** instead of `nil`. The MLX
path had the identical bug (returning the first-sorted other directory). The
same hole applied to a bare-name `LLAMA_TEST_MODEL` / `MLX_TEST_MODEL` env
fragment that matched nothing.

Root cause: `selectGGUFModel` / `selectFilesystemModel` tried the env override,
then the substring, and on no match fell through to `return ordered.first`.
That fallback is correct only when *no* name selector was supplied at all.

A family-targeted test silently ran against an unrelated model — a false pass
that makes those grammar/family tests untrustworthy.

## The fix (narrow)

In both selectors: if an explicit name selector was provided (env name-fragment
**or** `nameContains` argument) and it matched no candidate, return `nil` so the
caller skips. Only fall back to the first/smallest candidate when **no** name
selector was provided — the legit `MANIFOLD_DISCOVER_LOCAL_MODELS=1`
"any model" discovery path, which is unchanged.

This matches the already-correct reference `findOllamaModel(nameContains:)`,
which returns `nil` when no installed model name contains the substring.
Direct-path override semantics (`directFilesystemModelOverride` /
`isDirectPathSelector`) are untouched.

## Tests

Two existing tests encoded the buggy fallback and were rewritten to the new
contract:
- `test_findGGUFModel_missingOverrideFallsBackToSmallestValidCandidate` →
  `test_findGGUFModel_missingEnvOverride_returnsNilRatherThanSmallestCandidate`
- `test_findMLXModelDirectory_overrideFallsBackToFirstSortedCandidate` →
  `test_findMLXModelDirectory_missingEnvOverride_returnsNilRatherThanFirstCandidate`

New regression tests (using the `in:` explicit-candidate overloads, no real disk):
- GGUF + MLX: `nameContains` matching nothing → nil
- GGUF: `nameContains` matching → that model
- GGUF + MLX: no selector, candidates present → first/smallest (unchanged contract)

`swift build --build-tests` clean; `swift test --filter HardwareRequirements`
green (41 XCTest cases).

This makes family-targeted local-inference tests trustworthy: they now skip
honestly rather than passing against the wrong model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)