### PR TITLE
feat(inference): derive tool-call GBNF grammar from config.tools for grammar-capable backends (#1859)

### DIFF
--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -504,6 +504,20 @@ final class GenerationQueue {
             throw InferenceError.inferenceFailure("Tools passed to a backend that does not support tool calling (\(backendType)); set capabilities.supportsToolCalling = true or remove tools from the request.")
         }
 
+        // Derive a tool-call GBNF grammar (#1859) when the backend supports
+        // grammar-constrained sampling, tools are present, and the caller did
+        // NOT supply an explicit grammar. An explicit caller grammar always
+        // wins — we never overwrite a host-authored string. The derived grammar
+        // pins the emitted tool-call envelope's `"name"` to the enum of the
+        // supplied tool names so the model can't drift off-format.
+        var config = config
+        if config.grammar == nil,
+           !config.tools.isEmpty,
+           backend.capabilities.supportsGrammarConstrainedSampling,
+           let derived = ToolGrammarBuilder().buildGrammar(for: config.tools) {
+            config.grammar = derived
+        }
+
         let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)
         nextGenerationToken = token
 

--- a/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
+++ b/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Derives a GBNF grammar that constrains a grammar-capable local backend to
+/// emit a well-formed tool-call envelope: a JSON object whose `"name"` field is
+/// pinned to the *enum of the provided tool names* and whose `"arguments"`
+/// field is a generic well-formed JSON object.
+///
+/// ## Why this exists (#1859)
+///
+/// Without grammar-constrained decoding, local models drift off the tool-call
+/// format and hosts fall back to brittle text-scraping (with silent drops and
+/// stray-markup leaks). `GenerationConfig.grammar` was previously a raw,
+/// host-supplied string applied independently of `config.tools`; nothing
+/// compiled the tool list into a grammar. This builder fills that gap so the
+/// queue can force well-formed tool-call emission whenever the backend
+/// advertises `supportsGrammarConstrainedSampling`.
+///
+/// ## Scope: implemented vs deferred
+///
+/// **Implemented:** the `"name"` field is constrained to the exact set of
+/// supplied tool names (alternation of string literals), and the overall shape
+/// is forced to `{ "name": <enum>, "arguments": <json-object> }`. Tool names
+/// are escaped for safe embedding as GBNF string literals.
+///
+/// **Deferred:** per-tool *parameter-schema* lowering — i.e. making
+/// `"arguments"` match each tool's exact JSON Schema (typed fields, required
+/// keys, enums on values). That is the hard, correctness-sensitive part and is
+/// intentionally out of scope for this PR. `"arguments"` is constrained to a
+/// generic well-formed JSON object instead. The name-enum constraint alone is
+/// the core value of #1859 (guaranteed-parseable envelope + correct tool name).
+///
+/// ## Pre-validator gate
+///
+/// Each tool's `parameters` schema is run through ``GBNFSchemaPreValidator``
+/// before the tool is included. A tool whose schema the pre-validator rejects
+/// is dropped from the name enum (it cannot be safely grammar-constrained under
+/// the current conservative policy).
+///
+/// NOTE: the pre-validator's rejection set is *conservative* and its premise is
+/// partly inaccurate — it claims `anyOf`/`oneOf`/`allOf` and nullable unions are
+/// inexpressible in GBNF, but GBNF supports alternation (`|`) and llama.cpp's
+/// own `json_schema_to_grammar` lowers these. Because this builder only emits a
+/// generic JSON object for `"arguments"` (it does not lower the param schema at
+/// all), the pre-validator is used here purely as a defensive safety gate: it
+/// keeps known-crashy schema shapes out of any future per-tool lowering and
+/// documents intent. Fixing the pre-validator's premise is a separate concern
+/// (tracks the "dead validator" note in #1859's review) and is NOT done here.
+public struct ToolGrammarBuilder: Sendable {
+
+    private let preValidator: GBNFSchemaPreValidator
+
+    public init(preValidator: GBNFSchemaPreValidator = GBNFSchemaPreValidator()) {
+        self.preValidator = preValidator
+    }
+
+    /// Builds a GBNF grammar string constraining output to a tool-call envelope
+    /// over the supplied tools, or `nil` when no grammar can be derived.
+    ///
+    /// Returns `nil` when `tools` is empty or when every tool's parameter schema
+    /// is rejected by the pre-validator — in both cases there is no usable name
+    /// enum, so the caller should fall back to unconstrained sampling.
+    ///
+    /// - Parameter tools: the tool definitions for this request.
+    public func buildGrammar(for tools: [ToolDefinition]) -> String? {
+        guard !tools.isEmpty else { return nil }
+
+        // Drop tools whose parameter schema the (conservative) pre-validator
+        // rejects. De-duplicate names so the enum has no redundant alternatives
+        // and preserve first-seen order for deterministic output.
+        var seen = Set<String>()
+        var acceptedNames: [String] = []
+        for tool in tools {
+            if preValidator.validate(tool.parameters) != nil { continue }
+            if seen.insert(tool.name).inserted {
+                acceptedNames.append(tool.name)
+            }
+        }
+
+        guard !acceptedNames.isEmpty else { return nil }
+
+        let nameAlternation = acceptedNames
+            .map { "\"\\\"\(Self.escapeForGBNFLiteral($0))\\\"\"" }
+            .joined(separator: " | ")
+
+        // The grammar forces:
+        //   root      ::= { "name": <one of the tool names>, "arguments": <object> }
+        //   value/object/array/string/number/etc. — a self-contained JSON subset.
+        //
+        // Whitespace ("ws") is permitted between tokens so the model isn't forced
+        // into a single canonical spacing. The JSON value rules are a standard,
+        // self-contained GBNF JSON grammar (no external rule references).
+        return """
+        root      ::= "{" ws "\\"name\\"" ws ":" ws toolname ws "," ws "\\"arguments\\"" ws ":" ws object ws "}"
+        toolname  ::= \(nameAlternation)
+        object    ::= "{" ws ( member ( ws "," ws member )* )? ws "}"
+        member    ::= string ws ":" ws value
+        array     ::= "[" ws ( value ( ws "," ws value )* )? ws "]"
+        value     ::= object | array | string | number | "true" | "false" | "null"
+        string    ::= "\\"" char* "\\""
+        char      ::= [^"\\\\] | "\\\\" escape
+        escape    ::= ["\\\\/bfnrt] | "u" hex hex hex hex
+        hex       ::= [0-9a-fA-F]
+        number    ::= "-"? int frac? exp?
+        int       ::= "0" | [1-9] [0-9]*
+        frac      ::= "." [0-9]+
+        exp       ::= [eE] [+-]? [0-9]+
+        ws        ::= [ \\t\\n]*
+        """
+    }
+
+    // MARK: - Escaping
+
+    /// Escapes a tool name for embedding inside a GBNF double-quoted string
+    /// literal that itself represents a JSON string literal.
+    ///
+    /// The emitted token in the grammar is `"\"<name>\""` — a GBNF literal whose
+    /// *content* is `"<name>"` (the JSON-quoted name). Two layers therefore need
+    /// escaping:
+    ///
+    /// 1. Characters that are special inside the JSON string the model emits
+    ///    (`"` and `\`) must be backslash-escaped so the model is constrained to
+    ///    emit them in escaped form (a literal `"` inside the name would close
+    ///    the JSON string).
+    /// 2. The resulting bytes must survive being written into a GBNF
+    ///    double-quoted literal. GBNF literals use backslash escapes too, so a
+    ///    backslash and a double-quote each need one more backslash.
+    ///
+    /// Concretely each `"` in the name becomes `\\\"` (escaped JSON quote, then
+    /// GBNF-escaped) and each `\` becomes `\\\\`. Control characters (newline,
+    /// tab, etc.) are emitted as JSON `\uXXXX` escapes, themselves GBNF-escaped.
+    /// Tool names are normally `[a-zA-Z0-9_-]`, so this defends the edge cases.
+    static func escapeForGBNFLiteral(_ name: String) -> String {
+        var out = ""
+        out.reserveCapacity(name.count)
+        for scalar in name.unicodeScalars {
+            switch scalar {
+            case "\"":
+                // JSON-escape (\") then GBNF-escape both chars: \\\"
+                out += "\\\\\\\""
+            case "\\":
+                // JSON-escape (\\) then GBNF-escape both: \\\\\\\\
+                out += "\\\\\\\\"
+            case "\n":
+                out += "\\\\n"
+            case "\r":
+                out += "\\\\r"
+            case "\t":
+                out += "\\\\t"
+            default:
+                if scalar.value < 0x20 {
+                    // Other control chars → JSON \u escape, GBNF-escaped backslash.
+                    out += String(format: "\\\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out
+    }
+}

--- a/Tests/ManifoldInferenceTests/EnqueueToolGrammarWiringTests.swift
+++ b/Tests/ManifoldInferenceTests/EnqueueToolGrammarWiringTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Verifies that ``GenerationQueue`` derives a tool-call GBNF grammar from
+/// `config.tools` (#1859) for grammar-capable backends, and that the rules
+/// around explicit caller grammars and the capability flag are honored.
+@MainActor
+final class EnqueueToolGrammarWiringTests: XCTestCase {
+
+    private func tool(_ name: String) -> ToolDefinition {
+        ToolDefinition(name: name, description: "d", parameters: .object([:]))
+    }
+
+    private func makeBackend(grammar: Bool) -> MockInferenceBackend {
+        let backend = MockInferenceBackend(capabilities: BackendCapabilities(
+            supportsToolCalling: true,
+            supportsGrammarConstrainedSampling: grammar
+        ))
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["x"]
+        return backend
+    }
+
+    func test_grammarCapableBackend_withTools_derivesToolGrammar() async throws {
+        let backend = makeBackend(grammar: true)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let (_, stream) = try service.enqueue(
+            messages: [("user", "hi")],
+            tools: [tool("get_weather"), tool("get_time")]
+        )
+        for try await _ in stream.events {}
+
+        let grammar = try XCTUnwrap(backend.lastConfig?.grammar)
+        let expected = try XCTUnwrap(
+            ToolGrammarBuilder().buildGrammar(for: [tool("get_weather"), tool("get_time")])
+        )
+        XCTAssertEqual(grammar, expected, "queue must assign the ToolGrammarBuilder output")
+        XCTAssertTrue(grammar.contains("\\\"get_weather\\\""))
+        XCTAssertTrue(grammar.contains("\\\"get_time\\\""))
+    }
+
+    func test_nonGrammarBackend_withTools_leavesGrammarNil() async throws {
+        let backend = makeBackend(grammar: false)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let (_, stream) = try service.enqueue(
+            messages: [("user", "hi")],
+            tools: [tool("get_weather")]
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertNil(backend.lastConfig?.grammar, "no grammar capability → no derived grammar")
+    }
+
+    func test_explicitCallerGrammar_isPreserved() async throws {
+        let backend = makeBackend(grammar: true)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let caller = "root ::= \"x\""
+        let (_, stream) = try service.enqueue(
+            messages: [("user", "hi")],
+            grammar: caller,
+            tools: [tool("get_weather")]
+        )
+        for try await _ in stream.events {}
+
+        XCTAssertEqual(
+            backend.lastConfig?.grammar,
+            caller,
+            "an explicit caller grammar must always win over the derived tool grammar"
+        )
+    }
+
+    func test_grammarCapableBackend_noTools_leavesGrammarNil() async throws {
+        let backend = makeBackend(grammar: true)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let (_, stream) = try service.enqueue(messages: [("user", "hi")])
+        for try await _ in stream.events {}
+
+        XCTAssertNil(backend.lastConfig?.grammar, "no tools → nothing to constrain")
+    }
+}

--- a/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import ManifoldInference
+
+final class ToolGrammarBuilderTests: XCTestCase {
+
+    private let builder = ToolGrammarBuilder()
+
+    private func tool(_ name: String, parameters: JSONSchemaValue = .object([:])) -> ToolDefinition {
+        ToolDefinition(name: name, description: "d", parameters: parameters)
+    }
+
+    // MARK: - Empty / nil cases
+
+    func test_emptyTools_returnsNil() {
+        XCTAssertNil(builder.buildGrammar(for: []))
+    }
+
+    // MARK: - Structural sanity
+
+    func test_singleTool_hasRootRuleAndQuotedName() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("get_weather")]))
+        XCTAssertTrue(grammar.contains("root"), "grammar must define a root rule")
+        XCTAssertTrue(grammar.contains("toolname"), "grammar must define a toolname rule")
+        // The name appears as a JSON-quoted literal inside a GBNF literal.
+        XCTAssertTrue(
+            grammar.contains("\\\"get_weather\\\""),
+            "tool name must appear as a quoted literal; got:\n\(grammar)"
+        )
+        // The envelope constrains the "name" and "arguments" keys.
+        XCTAssertTrue(grammar.contains("\\\"name\\\""))
+        XCTAssertTrue(grammar.contains("\\\"arguments\\\""))
+    }
+
+    func test_multipleTools_produceAlternationOfNames() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a"), tool("b"), tool("c")]))
+        XCTAssertTrue(grammar.contains("\\\"a\\\""))
+        XCTAssertTrue(grammar.contains("\\\"b\\\""))
+        XCTAssertTrue(grammar.contains("\\\"c\\\""))
+        // Alternation: the toolname rule must join names with `|`.
+        let toolnameLine = grammar
+            .split(separator: "\n")
+            .first { $0.hasPrefix("toolname") }
+            .map(String.init) ?? ""
+        XCTAssertTrue(toolnameLine.contains("|"), "multiple tools must alternate with `|`; got: \(toolnameLine)")
+        XCTAssertEqual(toolnameLine.components(separatedBy: "|").count, 3, "three tools → two `|` separators")
+    }
+
+    func test_duplicateNames_deduplicated() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("dup"), tool("dup")]))
+        let toolnameLine = grammar
+            .split(separator: "\n")
+            .first { $0.hasPrefix("toolname") }
+            .map(String.init) ?? ""
+        XCTAssertFalse(toolnameLine.contains("|"), "duplicate names collapse to a single alternative")
+    }
+
+    // MARK: - Escaping
+
+    func test_escaping_quoteInName() {
+        // A name containing a double quote must not produce an unbalanced literal.
+        let escaped = ToolGrammarBuilder.escapeForGBNFLiteral("a\"b")
+        // JSON-escaped quote (\") then GBNF-escaped → backslash-backslash-backslash-quote.
+        XCTAssertEqual(escaped, "a\\\\\\\"b")
+    }
+
+    func test_escaping_backslashInName() {
+        let escaped = ToolGrammarBuilder.escapeForGBNFLiteral("a\\b")
+        XCTAssertEqual(escaped, "a\\\\\\\\b")
+    }
+
+    func test_escaping_controlCharsAndTab() {
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\tb"), "a\\\\tb")
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\nb"), "a\\\\nb")
+        // A bell (U+0007) is an "other" control char → \u escape.
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\u{07}b"), "a\\\\u0007b")
+    }
+
+    func test_escaping_plainNameUnchanged() {
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("get_weather-2"), "get_weather-2")
+    }
+
+    func test_nameWithQuote_appearsEscapedInGrammar_noBareQuote() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\"b")]))
+        XCTAssertTrue(grammar.contains("a\\\\\\\"b"), "quoted name must be doubly escaped in the grammar")
+    }
+
+    // MARK: - Pre-validator fallback
+
+    func test_preValidatorRejectedSchema_droppedFromEnum() {
+        // `anyOf` is rejected by the (conservative) pre-validator.
+        let rejected = tool("bad", parameters: .object([
+            "anyOf": .array([.object(["type": .string("string")])])
+        ]))
+        let ok = tool("good")
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [rejected, ok]))
+        XCTAssertTrue(grammar.contains("\\\"good\\\""))
+        XCTAssertFalse(grammar.contains("\\\"bad\\\""), "tool with rejected schema must be dropped")
+    }
+
+    func test_allToolsRejected_returnsNil() {
+        let rejected = tool("bad", parameters: .object([
+            "oneOf": .array([.object(["type": .string("string")])])
+        ]))
+        XCTAssertNil(builder.buildGrammar(for: [rejected]))
+    }
+
+    // MARK: - Golden snapshot (fixed 2-tool input)
+
+    func test_goldenSnapshot_twoTools() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("alpha"), tool("beta")]))
+        let expected = """
+        root      ::= "{" ws "\\"name\\"" ws ":" ws toolname ws "," ws "\\"arguments\\"" ws ":" ws object ws "}"
+        toolname  ::= "\\"alpha\\"" | "\\"beta\\""
+        object    ::= "{" ws ( member ( ws "," ws member )* )? ws "}"
+        member    ::= string ws ":" ws value
+        array     ::= "[" ws ( value ( ws "," ws value )* )? ws "]"
+        value     ::= object | array | string | number | "true" | "false" | "null"
+        string    ::= "\\"" char* "\\""
+        char      ::= [^"\\\\] | "\\\\" escape
+        escape    ::= ["\\\\/bfnrt] | "u" hex hex hex hex
+        hex       ::= [0-9a-fA-F]
+        number    ::= "-"? int frac? exp?
+        int       ::= "0" | [1-9] [0-9]*
+        frac      ::= "." [0-9]+
+        exp       ::= [eE] [+-]? [0-9]+
+        ws        ::= [ \\t\\n]*
+        """
+        XCTAssertEqual(grammar, expected)
+    }
+}

--- a/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
@@ -84,6 +84,32 @@ final class ToolGrammarBuilderTests: XCTestCase {
         XCTAssertTrue(grammar.contains("a\\\\\\\"b"), "quoted name must be doubly escaped in the grammar")
     }
 
+    // A name containing a double quote must yield a *balanced* GBNF literal:
+    // the only place an unescaped `"` may appear on the toolname line is the
+    // literal's own opening/closing delimiters. There is no live llama.cpp
+    // grammar compiler in this package's CI (see ToolGrammarBuilder docs), so
+    // this asserts the exact emitted token byte-for-byte to catch a malformed
+    // literal that would otherwise ship undetected.
+    func test_nameWithQuote_emitsExactBalancedGBNFLiteral() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\"b")]))
+        let toolnameLine = grammar
+            .split(separator: "\n")
+            .first { $0.hasPrefix("toolname") }
+            .map(String.init) ?? ""
+        // Exact RHS: GBNF literal "\"a\\\"b\"" — content decodes to JSON `"a\"b"`.
+        XCTAssertEqual(toolnameLine, #"toolname  ::= "\"a\\\"b\"""#)
+    }
+
+    func test_nameWithBackslash_emitsExactBalancedGBNFLiteral() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\\b")]))
+        let toolnameLine = grammar
+            .split(separator: "\n")
+            .first { $0.hasPrefix("toolname") }
+            .map(String.init) ?? ""
+        // Exact RHS: GBNF literal "\"a\\\\b\"" — content decodes to JSON `"a\\b"`.
+        XCTAssertEqual(toolnameLine, #"toolname  ::= "\"a\\\\b\"""#)
+    }
+
     // MARK: - Pre-validator fallback
 
     func test_preValidatorRejectedSchema_droppedFromEnum() {


### PR DESCRIPTION
## Summary

Adds `ToolGrammarBuilder`, the first schema→GBNF emitter in the codebase. It compiles `config.tools` into a GBNF grammar that constrains a grammar-capable local backend to emit a well-formed tool-call envelope, so hosts get guaranteed-parseable tool calls instead of brittle text-scraping.

The grammar forces:

```
{ "name": <one of the supplied tool names>, "arguments": <well-formed JSON object> }
```

## What it does

- **Name-enum constraint (the core of #1859):** `"name"` is pinned to the exact set of supplied tool names as an alternation of GBNF string literals. The model cannot drift onto an unknown tool name or off the envelope format.
- **Wiring:** `GenerationQueue.enqueue(structuredMessages:config:...)` assigns the derived grammar to `config.grammar` when the backend advertises `supportsGrammarConstrainedSampling`, tools are present, AND `config.grammar == nil`. **An explicit caller grammar always wins** — we never overwrite a host-authored string.
- **Pre-validator gate (first production call site):** each tool's `parameters` runs through `GBNFSchemaPreValidator` before inclusion; a tool with a rejected schema is dropped from the name enum. If every tool is rejected (or `tools` is empty) the builder returns `nil` and the request falls back to unconstrained sampling.
- **Escaping:** tool names are escaped for safe embedding as GBNF string literals (quotes, backslashes, control chars). Tested directly.

## Implemented vs deferred

- **Implemented:** name-enum constraint + envelope shape + escaping + pre-validator gate + queue wiring.
- **DEFERRED:** per-tool *parameter-schema → GBNF lowering* (making `"arguments"` match each tool's exact JSON Schema). That is the hard, correctness-sensitive part; `"arguments"` is constrained to a generic well-formed JSON object for now. The name-enum constraint alone already delivers a guaranteed-parseable envelope + correct tool name. Documented inline in the builder.

## Pre-validator caveat

`GBNFSchemaPreValidator`'s rejection set is **conservative and its premise is partly inaccurate** — it claims `anyOf`/`oneOf`/`allOf` and nullable unions are inexpressible in GBNF, but GBNF supports alternation (`|`) and llama.cpp's own `json_schema_to_grammar` lowers these. Because this PR only emits a generic JSON object for `"arguments"` (no param-schema lowering), the pre-validator is used purely as a defensive safety gate here. Fixing its premise is a separate concern and is **not** done in this PR — flagged inline so the next person knows.

## Tests

- `ToolGrammarBuilderTests` (12): name-enum present, multi-tool alternation, dedup, empty→nil, escaping (quote/backslash/control/tab/plain), pre-validator-rejected→dropped, all-rejected→nil, structural sanity, and a golden 2-tool snapshot.
- `EnqueueToolGrammarWiringTests` (4): grammar-capable backend with tools sets `config.grammar`; non-grammar backend leaves it nil; explicit caller grammar preserved; no tools → nil.

`swift build --build-tests` clean. `swift test --filter ToolGrammar` (16) and `--filter EnqueueGrammar` (2) pass; broader `GenerationQueue|Enqueue|...` run (173) green — no regressions.

Refs #1859 (scoped slice — per-param schema lowering deferred, so not auto-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)