### PR TITLE
feat: model capability flags on ModelInfo (code/multilingual/reasoning) with curation override

### DIFF
--- a/Sources/ManifoldInference/ManifoldInference.docc/Articles/Capabilities.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/Articles/Capabilities.md
@@ -1,0 +1,102 @@
+# Model Capability Flags
+
+Resolve a model's code, multilingual, and reasoning capabilities from
+``ModelInfo`` instead of re-deriving them in your app.
+
+## Overview
+
+Every host app that builds a model picker eventually re-implements the same
+question: *can this model write code? Is it multilingual? Does it reason?*
+ManifoldKit answers those questions on ``ModelInfo`` — honestly, and only where
+it can actually tell.
+
+Three resolved flags are exposed:
+
+- ``ModelInfo/supportsCode`` — the checkpoint advertises code-generation
+  specialisation.
+- ``ModelInfo/supportsMultilingual`` — the checkpoint advertises two or more
+  natural languages.
+- ``ModelInfo/supportsReasoning`` — the model exposes extended-thinking /
+  reasoning output.
+
+Each resolves `curated ?? detected ?? false`: an explicit curation override
+wins; otherwise an auto-detected value; otherwise an honest `false`.
+
+## Where each flag is sourced
+
+**Code / multilingual** are auto-detected by `ModelCapabilityProbe`, which reads
+a Hugging Face model directory's `config.json` plus `README.md` front-matter
+(`pipeline_tag`, `tags`, `language`). MLX directory models carry a sibling
+`config.json`, so discovery populates these automatically.
+
+**Reasoning** for *cloud* models is sourced from the vendored
+`CloudModelManifestTable` (which already tracks which OpenAI / Anthropic
+families expose extended thinking). Call
+``ModelInfo/detectCloudReasoning(modelName:producer:)`` with the configured
+model name.
+
+## Two honesty limits — read these before you branch on a flag
+
+**1. GGUF code/multilingual ship honest-`false` unless curated.** A GGUF model
+is a single file with no sibling `config.json`, so `ModelCapabilityProbe` cannot
+run — it throws `configNotFound`, which ManifoldKit treats as *no detection*
+(the detected layer stays `nil`), never a fatal error. The resolved flag is
+therefore `false` for an uncurated GGUF coder. To assert the capability, set a
+curation override.
+
+**2. `supportsReasoning` is honest-`false` for every local model unless
+curated.** There is no reliable local-model reasoning signal, so GGUF / MLX /
+Foundation models resolve `supportsReasoning == false` by default.
+
+> Important: This is a routing footgun. A snippet like
+> `if model.supportsReasoning { useReasoningPrompt() }` silently takes the
+> `false` branch for every uncurated local model — including ones that really
+> do reason. If your router depends on reasoning, curate the flag explicitly
+> rather than trusting the default.
+
+## Curating a capability
+
+Use ``ModelInfo/applyCuratedCapabilities(_:)`` to override detection. Only
+non-`nil` fields override; `nil` leaves the detected layer intact, so a re-probe
+can still refresh detection without clobbering your curation.
+
+```swift
+import ManifoldKit
+
+/// Marks a known GGUF coder model as code-capable even though its single-file
+/// format carries no `config.json` for auto-detection, and routes on the
+/// resolved flags.
+func curateAndRoute(_ model: ModelInfo) -> ModelInfo {
+    var curated = model
+    curated.applyCuratedCapabilities(
+        CuratedModelCapabilities(supportsCode: true)
+    )
+
+    // Resolved accessors fold curated-over-detected-over-false.
+    if curated.supportsCode {
+        // route to a code-oriented system prompt
+    }
+    if curated.supportsReasoning {
+        // honest-false for uncurated local models — see the footgun note above
+    }
+    return curated
+}
+```
+
+## Topics
+
+### Resolved flags
+
+- ``ModelInfo/supportsCode``
+- ``ModelInfo/supportsMultilingual``
+- ``ModelInfo/supportsReasoning``
+
+### Curation override
+
+- ``CuratedModelCapabilities``
+- ``ModelInfo/applyCuratedCapabilities(_:)``
+
+### Detection
+
+- ``ModelInfo/detectCapabilities(fromModelDirectory:)``
+- ``ModelInfo/detectCloudReasoning(modelName:producer:)``

--- a/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
+++ b/Sources/ManifoldInference/ManifoldInference.docc/ManifoldInference.md
@@ -298,3 +298,8 @@ documentation for the high-level vs. direct-backend chooser.
 - ``ImageModelInfo``
 - ``ImageModelFormat``
 - ``PrecisionVariant``
+
+### Model capabilities
+
+- <doc:Capabilities>
+- ``CuratedModelCapabilities``

--- a/Sources/ManifoldModelCatalog/ModelCatalog.swift
+++ b/Sources/ManifoldModelCatalog/ModelCatalog.swift
@@ -277,6 +277,17 @@ private struct ModelInfoSnapshot: Codable, Equatable {
     var modelType: StoredModelType
     var mmprojURL: URL?
     var huggingFaceRepoID: String?
+    // Resolved capability flags survive without a re-probe. Both the curated
+    // override and detected layers are persisted so the override-over-detected
+    // resolution round-trips exactly (a re-probe can still refresh `detected*`
+    // without clobbering a host's curation). All optional + decodeIfPresent so
+    // catalogs written before this field shipped decode cleanly (nil = absent).
+    var curatedSupportsCode: Bool?
+    var detectedSupportsCode: Bool?
+    var curatedSupportsMultilingual: Bool?
+    var detectedSupportsMultilingual: Bool?
+    var curatedSupportsReasoning: Bool?
+    var detectedSupportsReasoning: Bool?
 
     init(_ modelInfo: ModelInfo) {
         id = modelInfo.id
@@ -287,6 +298,12 @@ private struct ModelInfoSnapshot: Codable, Equatable {
         modelType = StoredModelType(modelInfo.modelType)
         mmprojURL = modelInfo.mmprojURL
         huggingFaceRepoID = modelInfo.huggingFaceRepoID
+        curatedSupportsCode = modelInfo.curatedSupportsCode
+        detectedSupportsCode = modelInfo.detectedSupportsCode
+        curatedSupportsMultilingual = modelInfo.curatedSupportsMultilingual
+        detectedSupportsMultilingual = modelInfo.detectedSupportsMultilingual
+        curatedSupportsReasoning = modelInfo.curatedSupportsReasoning
+        detectedSupportsReasoning = modelInfo.detectedSupportsReasoning
     }
 
     var modelInfo: ModelInfo {
@@ -298,7 +315,13 @@ private struct ModelInfoSnapshot: Codable, Equatable {
             fileSize: fileSize,
             modelType: modelType.modelType,
             mmprojURL: mmprojURL,
-            huggingFaceRepoID: huggingFaceRepoID
+            huggingFaceRepoID: huggingFaceRepoID,
+            curatedSupportsCode: curatedSupportsCode,
+            detectedSupportsCode: detectedSupportsCode,
+            curatedSupportsMultilingual: curatedSupportsMultilingual,
+            detectedSupportsMultilingual: detectedSupportsMultilingual,
+            curatedSupportsReasoning: curatedSupportsReasoning,
+            detectedSupportsReasoning: detectedSupportsReasoning
         )
     }
 }

--- a/Sources/ManifoldModelCatalog/ModelInfo.swift
+++ b/Sources/ManifoldModelCatalog/ModelInfo.swift
@@ -61,6 +61,103 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     /// When `nil`, ``effectiveCapabilityTier`` falls back to a static estimate.
     public var capabilityTier: ModelCapabilityTier?
 
+    // MARK: - Capability flags (override-over-detected)
+
+    // Each capability flag is modelled as two layers so consumers stop
+    // re-deriving what the catalog can compute *honestly*:
+    //
+    //   • `detected*` — what ManifoldKit inferred from durable signals
+    //     (HF `config.json` + README front-matter via ``ModelCapabilityProbe``,
+    //     or ``CloudModelManifestTable`` for cloud reasoning). `nil` means "no
+    //     detection ran / no signal" — NOT "false". GGUF single files carry no
+    //     `config.json`, so their detected code/multilingual stay `nil`.
+    //
+    //   • `curated*` — an explicit override a host app's ``CuratedModel`` list
+    //     (or any curation seam) can set to assert a capability the probe
+    //     cannot see. Non-nil always wins over detection.
+    //
+    // The public ``supportsCode`` / ``supportsMultilingual`` / ``supportsReasoning``
+    // accessors resolve `curated ?? detected ?? false`, so the default is an
+    // honest `false` with no silent over-reporting and an explicit override seam.
+
+    /// Curation override for code-generation capability. `nil` defers to detection.
+    public var curatedSupportsCode: Bool?
+    /// Auto-detected code-generation capability (HF `config.json` / README).
+    /// `nil` when no probe ran or no signal was found (e.g. GGUF single files).
+    public var detectedSupportsCode: Bool?
+
+    /// Curation override for multilingual capability. `nil` defers to detection.
+    public var curatedSupportsMultilingual: Bool?
+    /// Auto-detected multilingual capability (HF `config.json` / README).
+    /// `nil` when no probe ran or no signal was found (e.g. GGUF single files).
+    public var detectedSupportsMultilingual: Bool?
+
+    /// Curation override for reasoning/extended-thinking capability.
+    /// `nil` defers to detection.
+    public var curatedSupportsReasoning: Bool?
+    /// Auto-detected reasoning capability. Sourced from
+    /// ``CloudModelManifestTable`` for cloud models; `nil` for local models
+    /// (GGUF/MLX/Foundation), which ManifoldKit cannot honestly probe for
+    /// reasoning support — so ``supportsReasoning`` is `false` for local models
+    /// unless curated. See the `Capabilities` DocC article for the routing footgun.
+    public var detectedSupportsReasoning: Bool?
+
+    /// Resolved code-generation capability: `curated ?? detected ?? false`.
+    public var supportsCode: Bool {
+        curatedSupportsCode ?? detectedSupportsCode ?? false
+    }
+
+    /// Resolved multilingual capability: `curated ?? detected ?? false`.
+    public var supportsMultilingual: Bool {
+        curatedSupportsMultilingual ?? detectedSupportsMultilingual ?? false
+    }
+
+    /// Resolved reasoning capability: `curated ?? detected ?? false`.
+    ///
+    /// Honest-`false` for local models unless curated — there is no reliable
+    /// local-model reasoning signal. A routing snippet that branches on this
+    /// silently takes the `false` branch for every uncurated local model.
+    public var supportsReasoning: Bool {
+        curatedSupportsReasoning ?? detectedSupportsReasoning ?? false
+    }
+
+    /// Applies a curation override, copying the three capability flags from a
+    /// ``CuratedModelCapabilities`` value. Only non-nil fields override; `nil`
+    /// leaves the existing detected/curated layer untouched. This is the
+    /// explicit seam for a host's curated list to assert capabilities the probe
+    /// cannot derive — notably for GGUF single files (no `config.json`) and for
+    /// local-model reasoning.
+    public mutating func applyCuratedCapabilities(_ caps: CuratedModelCapabilities) {
+        if let code = caps.supportsCode { curatedSupportsCode = code }
+        if let multilingual = caps.supportsMultilingual { curatedSupportsMultilingual = multilingual }
+        if let reasoning = caps.supportsReasoning { curatedSupportsReasoning = reasoning }
+    }
+
+    /// Populates the detected code/multilingual layers from a HF/MLX model
+    /// directory using ``ModelCapabilityProbe``.
+    ///
+    /// **GGUF limit:** single-file GGUF models have no sibling `config.json`,
+    /// so the probe throws ``ModelCapabilityProbeError/configNotFound``. That is
+    /// treated here as "no detection" (leaves the detected layers `nil`), NOT a
+    /// fatal error — GGUF code/multilingual ship honest-`false` unless a host's
+    /// curated list overrides them via ``applyCuratedCapabilities(_:)``.
+    /// Reasoning is never sourced from a config probe; it stays `nil` for local
+    /// models. See the `Capabilities` DocC article.
+    public mutating func detectCapabilities(fromModelDirectory directory: URL) {
+        do {
+            let caps = try ModelCapabilityProbe.probe(modelDirectory: directory)
+            detectedSupportsCode = caps.supportsCodeGeneration
+            detectedSupportsMultilingual = caps.supportsMultilingual
+        } catch ModelCapabilityProbeError.configNotFound {
+            // Expected for GGUF single files and snapshots that strip config.json.
+            // No signal → leave detected layers nil so resolution falls to
+            // curated-or-false rather than a misleading hard `false`.
+            Log.inference.debug("ModelInfo: no config.json for capability probe at \(directory.lastPathComponent, privacy: .public); code/multilingual stay curated-or-false")
+        } catch {
+            Log.inference.warning("ModelInfo: capability probe failed at \(directory.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     /// The most recent benchmark result for this model, if one has been run.
     public var benchmarkResult: ModelBenchmarkResult?
 
@@ -407,7 +504,13 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         activeParameterBytes: UInt64? = nil,
         capabilityTier: ModelCapabilityTier? = nil,
         benchmarkResult: ModelBenchmarkResult? = nil,
-        huggingFaceRepoID: String? = nil
+        huggingFaceRepoID: String? = nil,
+        curatedSupportsCode: Bool? = nil,
+        detectedSupportsCode: Bool? = nil,
+        curatedSupportsMultilingual: Bool? = nil,
+        detectedSupportsMultilingual: Bool? = nil,
+        curatedSupportsReasoning: Bool? = nil,
+        detectedSupportsReasoning: Bool? = nil
     ) {
         self.id = id
         self.name = name
@@ -425,6 +528,12 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         self.capabilityTier = capabilityTier
         self.benchmarkResult = benchmarkResult
         self.huggingFaceRepoID = huggingFaceRepoID
+        self.curatedSupportsCode = curatedSupportsCode
+        self.detectedSupportsCode = detectedSupportsCode
+        self.curatedSupportsMultilingual = curatedSupportsMultilingual
+        self.detectedSupportsMultilingual = detectedSupportsMultilingual
+        self.curatedSupportsReasoning = curatedSupportsReasoning
+        self.detectedSupportsReasoning = detectedSupportsReasoning
     }
 
     // MARK: - Private
@@ -453,6 +562,61 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         name = name.replacingOccurrences(of: "-", with: " ")
         name = name.replacingOccurrences(of: "_", with: " ")
         return name
+    }
+}
+
+// MARK: - Curated capability override
+
+/// A curation override for the three resolvable capability flags on
+/// ``ModelInfo``.
+///
+/// Each field is `Bool?`: a non-nil value asserts (or denies) a capability the
+/// auto-detection path cannot derive, while `nil` defers to detection. This is
+/// the seam a host app's curated list uses to mark, for example, a GGUF coder
+/// model `supportsCode = true` even though its single-file format carries no
+/// `config.json` for ``ModelCapabilityProbe`` to read.
+public struct CuratedModelCapabilities: Sendable, Hashable {
+    public var supportsCode: Bool?
+    public var supportsMultilingual: Bool?
+    public var supportsReasoning: Bool?
+
+    public init(
+        supportsCode: Bool? = nil,
+        supportsMultilingual: Bool? = nil,
+        supportsReasoning: Bool? = nil
+    ) {
+        self.supportsCode = supportsCode
+        self.supportsMultilingual = supportsMultilingual
+        self.supportsReasoning = supportsReasoning
+    }
+}
+
+// MARK: - Cloud reasoning detection
+
+public extension ModelInfo {
+    /// Sets ``detectedSupportsReasoning`` from ``CloudModelManifestTable`` for a
+    /// cloud model identified by `modelName`.
+    ///
+    /// Cloud is the one place ManifoldKit can honestly detect reasoning: the
+    /// vendored manifest table already tracks which families expose extended
+    /// thinking. Pass the producer so the correct table is consulted. Local
+    /// models have no equivalent signal — ``supportsReasoning`` stays `false`
+    /// for them unless curated.
+    mutating func detectCloudReasoning(modelName: String, producer: CloudReasoningProducer) {
+        let manifest: ModelManifest
+        switch producer {
+        case .openAI:
+            manifest = CloudModelManifestTable.openAI(modelName: modelName)
+        case .anthropic:
+            manifest = CloudModelManifestTable.claude(modelName: modelName)
+        }
+        detectedSupportsReasoning = manifest.supportsThinking
+    }
+
+    /// Cloud producer whose manifest table sources reasoning detection.
+    enum CloudReasoningProducer: Sendable {
+        case openAI
+        case anthropic
     }
 }
 

--- a/Sources/ManifoldModelCatalog/ModelStorageService.swift
+++ b/Sources/ManifoldModelCatalog/ModelStorageService.swift
@@ -244,7 +244,12 @@ public final class ModelStorageService: @unchecked Sendable {
                 continue
             }
 
-            if let model = ModelInfo(mlxDirectory: url), seenIDs.insert(model.id).inserted {
+            if var model = ModelInfo(mlxDirectory: url), seenIDs.insert(model.id).inserted {
+                // MLX directories always carry a sibling config.json, so the
+                // capability probe populates detected code/multilingual flags.
+                // GGUF single files have no config.json — see ModelInfo.load,
+                // where the detected flags stay nil (curated-or-false).
+                model.detectCapabilities(fromModelDirectory: url)
                 models.append(model)
                 continue
             }
@@ -270,10 +275,11 @@ public final class ModelStorageService: @unchecked Sendable {
                 guard fileManager.fileExists(atPath: nestedURL.path, isDirectory: &nestedIsDir),
                       !isImagePackageDirectory(nestedURL),
                       nestedIsDir.boolValue,
-                      let model = ModelInfo(mlxDirectory: nestedURL, namespace: namespace),
+                      var model = ModelInfo(mlxDirectory: nestedURL, namespace: namespace),
                       seenIDs.insert(model.id).inserted else {
                     continue
                 }
+                model.detectCapabilities(fromModelDirectory: nestedURL)
                 models.append(model)
             }
         }

--- a/Sources/ManifoldModelCatalog/ModelStorageService.swift
+++ b/Sources/ManifoldModelCatalog/ModelStorageService.swift
@@ -247,8 +247,9 @@ public final class ModelStorageService: @unchecked Sendable {
             if var model = ModelInfo(mlxDirectory: url), seenIDs.insert(model.id).inserted {
                 // MLX directories always carry a sibling config.json, so the
                 // capability probe populates detected code/multilingual flags.
-                // GGUF single files have no config.json — see ModelInfo.load,
-                // where the detected flags stay nil (curated-or-false).
+                // GGUF single files have no config.json — see
+                // ModelInfo.detectCapabilities, where configNotFound leaves the
+                // detected flags nil (curated-or-false).
                 model.detectCapabilities(fromModelDirectory: url)
                 models.append(model)
                 continue

--- a/Tests/ManifoldModelCatalogTests/ModelInfoCapabilityFlagsTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ModelInfoCapabilityFlagsTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+import ManifoldInference
+@testable import ManifoldModelCatalog
+
+/// Verifies the override-over-detected resolution model for the three
+/// ``ModelInfo`` capability flags (code / multilingual / reasoning), the GGUF
+/// `configNotFound` fallback (no throw, curated-or-false), cloud reasoning
+/// detection from ``CloudModelManifestTable``, and catalog round-trip
+/// persistence of the flags.
+final class ModelInfoCapabilityFlagsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeModel() -> ModelInfo {
+        ModelInfo(
+            name: "Test",
+            fileName: "test.gguf",
+            url: URL(fileURLWithPath: "/tmp/test.gguf"),
+            fileSize: 1024,
+            modelType: .gguf
+        )
+    }
+
+    private func makeFixtureDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelInfoCapabilityFlagsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    // MARK: - Resolution: curated ?? detected ?? false
+
+    func testResolution_defaultsToFalse() {
+        let model = makeModel()
+        XCTAssertFalse(model.supportsCode)
+        XCTAssertFalse(model.supportsMultilingual)
+        XCTAssertFalse(model.supportsReasoning)
+    }
+
+    func testResolution_detectedWinsOverDefault() {
+        var model = makeModel()
+        model.detectedSupportsCode = true
+        XCTAssertTrue(model.supportsCode, "detected true should resolve true with no override")
+    }
+
+    func testResolution_curatedOverridesDetected() {
+        var model = makeModel()
+        model.detectedSupportsCode = false
+        model.curatedSupportsCode = true
+        XCTAssertTrue(model.supportsCode, "curated override must win over a detected value")
+
+        // And the reverse: curation can deny a detected-true capability.
+        model.detectedSupportsMultilingual = true
+        model.curatedSupportsMultilingual = false
+        XCTAssertFalse(model.supportsMultilingual, "curated false must win over detected true")
+    }
+
+    func testApplyCuratedCapabilities_onlyOverridesNonNilFields() {
+        var model = makeModel()
+        model.detectedSupportsMultilingual = true
+        // Override only code; multilingual nil must leave detected layer intact.
+        model.applyCuratedCapabilities(CuratedModelCapabilities(supportsCode: true))
+        XCTAssertTrue(model.supportsCode)
+        XCTAssertTrue(model.supportsMultilingual, "nil curation field must not clobber detected value")
+        XCTAssertFalse(model.supportsReasoning)
+    }
+
+    // MARK: - GGUF fallback: configNotFound → no throw, curated-or-false
+
+    func testDetectCapabilities_GGUFNoConfig_doesNotThrowAndStaysFalse() throws {
+        // A directory with NO config.json mirrors a GGUF single-file layout.
+        let dir = try makeFixtureDirectory()
+        var model = makeModel()
+        // Must not throw (detectCapabilities swallows configNotFound).
+        model.detectCapabilities(fromModelDirectory: dir)
+        XCTAssertNil(model.detectedSupportsCode, "no config.json → detected layer stays nil")
+        XCTAssertNil(model.detectedSupportsMultilingual)
+        XCTAssertFalse(model.supportsCode, "uncurated GGUF resolves honest-false")
+
+        // Curation is the documented escape hatch for GGUF.
+        model.applyCuratedCapabilities(CuratedModelCapabilities(supportsCode: true))
+        XCTAssertTrue(model.supportsCode)
+    }
+
+    func testDetectCapabilities_withConfig_populatesDetectedLayer() throws {
+        let dir = try makeFixtureDirectory()
+        // config.json carries a multi-language array (multilingual signal). The
+        // code signal comes from README front-matter `tags`, which is the
+        // probe's primary path (the architectures heuristic only fires on class
+        // names literally containing "coder", so it is not exercised here).
+        try #"""
+        {
+            "model_type": "llama",
+            "language": ["en", "fr", "de"]
+        }
+        """#.write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try #"""
+        ---
+        tags:
+          - code
+        ---
+        # Model card
+        """#.write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        var model = makeModel()
+        model.detectCapabilities(fromModelDirectory: dir)
+        XCTAssertEqual(model.detectedSupportsCode, true)
+        XCTAssertEqual(model.detectedSupportsMultilingual, true)
+        XCTAssertTrue(model.supportsCode)
+        XCTAssertTrue(model.supportsMultilingual)
+    }
+
+    // MARK: - Cloud reasoning detection
+
+    func testDetectCloudReasoning_anthropicThinkingFamily() {
+        var model = makeModel()
+        model.detectCloudReasoning(modelName: "claude-opus-4-5-20260101", producer: .anthropic)
+        XCTAssertEqual(model.detectedSupportsReasoning, true)
+        XCTAssertTrue(model.supportsReasoning)
+    }
+
+    func testDetectCloudReasoning_nonThinkingFamily() {
+        var model = makeModel()
+        model.detectCloudReasoning(modelName: "claude-3-5-haiku-20241022", producer: .anthropic)
+        XCTAssertEqual(model.detectedSupportsReasoning, false)
+        XCTAssertFalse(model.supportsReasoning)
+    }
+
+    func testDetectCloudReasoning_openAIReasoningFamily() {
+        var model = makeModel()
+        model.detectCloudReasoning(modelName: "o3-mini", producer: .openAI)
+        XCTAssertEqual(model.detectedSupportsReasoning, true)
+        XCTAssertTrue(model.supportsReasoning)
+    }
+
+    func testReasoning_localModelHonestFalse() {
+        // Local models never get a detected reasoning signal; honest-false
+        // unless curated.
+        var model = makeModel()
+        XCTAssertFalse(model.supportsReasoning)
+        model.applyCuratedCapabilities(CuratedModelCapabilities(supportsReasoning: true))
+        XCTAssertTrue(model.supportsReasoning, "curation is the only path to local reasoning=true")
+    }
+
+    // MARK: - Catalog round-trip persistence
+
+    func testCatalogRoundTrip_persistsResolvedFlags() async throws {
+        let modelsDir = try makeFixtureDirectory()
+        let storage = ModelStorageService(baseDirectory: modelsDir)
+        let manifestURL = modelsDir.appendingPathComponent(ModelCatalog.manifestFileName)
+        let catalog = ModelCatalog(storage: storage, manifestURL: manifestURL)
+
+        // The catalog reconciles against disk presence (missing artifacts are
+        // dropped), so the model must point at a real on-disk GGUF inside the
+        // models directory to survive reload. A 4-byte GGUF magic header is
+        // enough to pass ModelInfo.load's validity check.
+        let ggufURL = modelsDir.appendingPathComponent("coder.gguf")
+        try Data([0x47, 0x47, 0x55, 0x46] + Array(repeating: UInt8(0), count: 1020))
+            .write(to: ggufURL)
+        var model = try ModelInfo.load(ggufURL: ggufURL)
+        model.curatedSupportsCode = true
+        model.detectedSupportsMultilingual = true
+        model.detectedSupportsReasoning = false
+        let entry = CatalogEntry(modelInfo: model, source: .imported)
+        try await catalog.record(entry)
+
+        // Reload from a fresh catalog instance reading the same manifest file.
+        let reloaded = ModelCatalog(storage: storage, manifestURL: manifestURL)
+        let entries = try await reloaded.catalog()
+        let restored = try XCTUnwrap(entries.first { $0.id == model.id }).modelInfo
+
+        XCTAssertEqual(restored.curatedSupportsCode, true)
+        XCTAssertEqual(restored.detectedSupportsMultilingual, true)
+        XCTAssertEqual(restored.detectedSupportsReasoning, false)
+        XCTAssertTrue(restored.supportsCode, "resolved code flag survives round-trip")
+        XCTAssertTrue(restored.supportsMultilingual)
+        XCTAssertFalse(restored.supportsReasoning)
+    }
+}


### PR DESCRIPTION
## Summary

Stop consumers re-deriving capability flags ManifoldKit can compute — honestly, and only where it can. Adds three resolved capability flags to `ModelInfo`:

- `supportsCode`
- `supportsMultilingual`
- `supportsReasoning`

### Resolution model (override-over-detected)

Each flag is modelled as **two `Bool?` layers** plus a resolved computed accessor:

```
resolved = curated ?? detected ?? false
```

- `detectedSupports*` — what ManifoldKit inferred (probe / manifest table). `nil` = no detection ran / no signal — **not** `false`.
- `curatedSupports*` — explicit override a host's curated list can set. Non-nil always wins.

`CuratedModelCapabilities` + `ModelInfo.applyCuratedCapabilities(_:)` are the override seam: only non-nil fields override, so a re-probe can refresh `detected*` without clobbering curation, and curation can *deny* a detected-true capability.

### Sourcing & honesty limits

- **code / multilingual**: `ModelCapabilityProbe` over a HF/MLX directory's `config.json` + README front-matter. Wired into `ModelStorageService` MLX discovery (both top-level and namespaced paths).
- **GGUF single files** carry no `config.json`. `ModelInfo.detectCapabilities(fromModelDirectory:)` treats `configNotFound` as "no detection" (**does not throw**), leaving detected layers `nil` → flag is honest-`false` unless curated. Documented in code + the DocC article.
- **reasoning**: sourced from `CloudModelManifestTable` for cloud (`detectCloudReasoning(modelName:producer:)`). Local models have no reliable reasoning signal → `supportsReasoning` is honest-`false` for local unless curated.

### Persistence

Both layers of all three flags persist through the catalog via `ModelInfoSnapshot` (all `decodeIfPresent`, so older catalogs decode cleanly). Round-trip confirmed by test.

### Docs

`Sources/ManifoldInference/ManifoldInference.docc/Articles/Capabilities.md` — explains each flag, its source, the GGUF and local-reasoning honesty limits, and calls out the **routing footgun**: a branch on `supportsReasoning` silently takes the false branch for every uncurated local model. The `swift` snippet compiles against the umbrella (verified locally with the snippet gate's exact package shape).

## Files touched

- `Sources/ManifoldModelCatalog/ModelInfo.swift` — flags, resolved accessors, `CuratedModelCapabilities`, `applyCuratedCapabilities`, `detectCapabilities(fromModelDirectory:)`, `detectCloudReasoning(modelName:producer:)`
- `Sources/ManifoldModelCatalog/ModelCatalog.swift` — `ModelInfoSnapshot` persistence of the six optional fields
- `Sources/ManifoldModelCatalog/ModelStorageService.swift` — probe wiring into MLX discovery
- `Sources/ManifoldInference/ManifoldInference.docc/Articles/Capabilities.md` (new) + root DocC Topics link
- `Tests/ManifoldModelCatalogTests/ModelInfoCapabilityFlagsTests.swift` (new, 11 tests)

Diff: 6 files, ~+430 / -8.

## Tests run (local)

- `ModelInfoCapabilityFlagsTests` — 11/11 pass (resolution, curation override, GGUF `configNotFound` fallback no-throw, cloud reasoning openAI+anthropic, local honest-false, catalog round-trip).
- `ManifoldModelCatalogTests` — 174/174 pass.
- `ManifoldInferenceTests` (re-exports `ModelInfo`) — 1401/1401 pass.
- DocC snippet compiles + links against the `ManifoldKit` umbrella.

Full `scripts/test.sh --profile local` gate is the orchestrator's to run.

## API-break gate

**PASS.** `swift package diagnose-api-breaking-changes origin/main --targets ManifoldInference` reports **"No breaking changes detected in ManifoldInference"** — all changes are additive (new optional stored properties, new memberwise init params with defaults, new methods/types). **No allowlist entry needed.** Note: the CI gate checks ManifoldInference/Runtime/CloudCore/Persistence/UI, not ManifoldModelCatalog directly, but `ModelInfo` is re-exported through ManifoldInference, so the check covers the user-facing surface.

## For orchestrator review

- **Override-seam shape**: two `Bool?` layers (curated + detected) per flag, resolved `curated ?? detected ?? false`. Chosen over a single `Bool?` so curation can both assert AND deny detection, and so a re-probe never clobbers curation. `applyCuratedCapabilities` only overrides non-nil fields.
- **GGUF curation fallback**: `configNotFound` is swallowed (logged at debug), detected layers stay nil. This is the deliberate "no detection, use curated-or-false" behavior — no fatal throw on the GGUF path.
- This PR is independent of the in-flight model-selection PR; it does not touch the load path, `ModelSelection`, or any view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)