### PR TITLE
feat(inference): lower per-tool parameter schemas to GBNF and reconcile the schema pre-validator (#1859)

### DIFF
--- a/Sources/ManifoldInference/Services/GBNFSchemaPreValidator.swift
+++ b/Sources/ManifoldInference/Services/GBNFSchemaPreValidator.swift
@@ -1,45 +1,58 @@
 import Foundation
 
-/// Pre-validates a ``JSONSchemaValue`` tool-parameter schema before
-/// handing it to the GBNF compiler in llama.cpp.
+/// Inspects a ``JSONSchemaValue`` tool-parameter schema and reports which
+/// sub-schema shapes ``ToolGrammarBuilder``'s lowerer cannot express, so the
+/// builder (or a caller) knows those nodes will fall back to a generic JSON
+/// value rather than being constrained.
 ///
 /// ## Why this exists
 ///
-/// llama.cpp's GBNF compiler (`llama_sampler_init_grammar`) can SIGSEGV on
-/// certain JSON Schema constructs:
+/// `ToolGrammarBuilder` lowers a tool's parameter schema to GBNF so a
+/// grammar-capable backend emits well-typed `"arguments"`. The lowerer covers
+/// the common shapes (typed objects, string enums, arrays, scalars, nullable
+/// unions) and **degrades gracefully** to a generic JSON value for anything it
+/// does not model. This type names those un-modeled shapes — it is an advisory,
+/// not a gate.
 ///
-/// - `anyOf` / `oneOf` / `allOf` / `not` — combiners the GBNF IR cannot
-///   express as a regular grammar.
-/// - Nullable union types — `"type": ["string", "null"]` — produce an
-///   unbounded alternation that causes stack overflow in the GBNF compiler.
-/// - `exclusiveMinimum` / `exclusiveMaximum` — numeric bounds expressed as
-///   integers in Draft 2020-12 trigger a type-confusion path in the GBNF
-///   numeric rule builder.
+/// ## Premise correction (#1859 review)
+///
+/// An earlier version of this file claimed `anyOf`/`oneOf`/`allOf`/`not` and
+/// nullable unions are "inexpressible in the GBNF IR." **That is wrong.** GBNF
+/// supports alternation (`|`), and llama.cpp's own `json_schema_to_grammar`
+/// lowers combiners and nullable unions to alternations. The real limitation is
+/// narrower: *this builder's lowerer does not implement those combiners.* The
+/// distinction matters because it sets the correct remedy — extend the lowerer,
+/// not "give up because GBNF can't." Nullable unions, in fact, *are* now lowered
+/// (`( <T> | "null" )`), so they are no longer flagged.
+///
+/// ## What is flagged vs handled now
+///
+/// **Flagged as un-lowerable (the lowerer emits generic `value` for the node):**
+/// - `anyOf` / `oneOf` / `allOf` / `not` — combiners the lowerer does not yet
+///   implement. (Lowering them is future work; generic JSON is the safe interim
+///   behavior — the envelope and tool name stay constrained.)
+/// - `$ref`, `patternProperties` — not modeled.
+///
+/// **No longer flagged (handled or harmlessly ignored):**
+/// - **Nullable union** `["string","null"]` — lowered to `( <string> | "null" )`.
+/// - **`exclusiveMinimum` / `exclusiveMaximum`** — GBNF cannot enforce arbitrary
+///   numeric ranges regardless, so the bound is *ignored* and a generic number
+///   is emitted. Ignoring a bound is strictly safer than rejecting the tool, and
+///   the previous "type-confusion crash" rationale described a llama.cpp bug
+///   that the current pin (see ``cveStatus``) is well past.
 ///
 /// ## CVE-2026-2069 (fixed in the current pin)
 ///
 /// A buffer overflow in `llama_grammar_advance_stack()` was disclosed in
-/// CVE-2026-2069 and fixed in llama.cpp build b8774. The vendored
-/// xcframework (`mattt/llama.swift` 2.9101.0) wraps build b9101, well past
-/// the fix.
-///
-/// The validation rules below are retained because they reject schema
-/// constructs that exceed GBNF's expressiveness independent of the CVE:
-/// `anyOf`/`oneOf`/`allOf`/`not` have no representation in the GBNF IR,
-/// and nullable union types produce unbounded alternation. Removing them
-/// would surface a different class of llama.cpp crashes (parse failure
-/// or runtime grammar-stack errors) rather than make grammar use safer.
-/// See ``GBNFSchemaPreValidator/cveStatus`` for the pinned audit record.
+/// CVE-2026-2069 and fixed in llama.cpp build b8774. The vendored xcframework
+/// (`mattt/llama.swift` 2.9101.0) wraps build b9101, well past the fix. The
+/// audit record below is retained for provenance; this validator's flags encode
+/// *lowerer coverage*, not the CVE's crash shapes.
 public struct GBNFSchemaPreValidator: Sendable {
 
     // MARK: - CVE status
 
     /// Structured audit record for CVE-2026-2069.
-    ///
-    /// When `isFixed` is `true`, the vendored llama.cpp build has been
-    /// confirmed post-patch and callers may reduce the strictness of schema
-    /// rules if desired. Until then, treat `isFixed == false` as "always run
-    /// the full rule set."
     public struct CVEAuditRecord: Sendable {
         /// CVE identifier.
         public let cveID: String
@@ -66,9 +79,6 @@ public struct GBNFSchemaPreValidator: Sendable {
     ///    `vendoredBuild` to the new build tag.
     /// 2. If the new build crosses a future CVE-fix boundary, flip
     ///    `isFixed`/`fixedAtBuild` accordingly.
-    /// 3. The validation rules in `validate(_:path:)` are kept regardless of
-    ///    CVE status — they encode GBNF expressiveness limits, not just the
-    ///    overflow's PoC shapes.
     public static let cveStatus = CVEAuditRecord(
         cveID: "CVE-2026-2069",
         isFixed: true,
@@ -77,17 +87,23 @@ public struct GBNFSchemaPreValidator: Sendable {
         note: """
             Buffer overflow in llama_grammar_advance_stack(), fixed in b8774. \
             mattt/llama.swift 2.9101.0 wraps b9101, so the production binary \
-            contains the fix. GBNFSchemaPreValidator remains mandatory for \
-            tool-schema grammars to keep llama.cpp inside its GBNF \
-            expressiveness envelope.
+            contains the fix. GBNFSchemaPreValidator now reports lowerer \
+            coverage gaps (graceful-degradation advisory) rather than gating \
+            tools out of grammar use.
             """
     )
 
-    // MARK: - Validation failure
+    // MARK: - Coverage report
 
-    /// Describes why a schema is unsafe to compile to GBNF.
+    /// Describes a sub-schema shape the lowerer cannot express, which will
+    /// therefore fall back to a generic JSON value.
+    ///
+    /// Renamed semantics (#1859): this is no longer a hard "validation failure"
+    /// that drops a tool — it flags a node that degrades to generic JSON. The
+    /// type name and shape are retained for source compatibility with existing
+    /// callers and tests; `reason`/`path` keep their meaning.
     public struct ValidationFailure: Sendable, Equatable, Error {
-        /// Short developer-facing description of the rejection reason.
+        /// Short developer-facing description of why the node is un-lowerable.
         public let reason: String
         /// JSON-pointer-style path components to the offending key (e.g.
         /// `["properties", "address", "anyOf"]`). Empty when the issue is at
@@ -104,62 +120,59 @@ public struct GBNFSchemaPreValidator: Sendable {
 
     // MARK: - Public entry point
 
-    /// Returns `nil` when `schema` is safe to compile to GBNF, or a
-    /// ``ValidationFailure`` naming the first unsafe construct when it is not.
+    /// Returns `nil` when every node of `schema` is something the lowerer can
+    /// express, or a ``ValidationFailure`` naming the first un-lowerable node
+    /// (which will fall back to generic JSON) when one exists.
     ///
-    /// Always run this before calling `llama_sampler_init_grammar` with a
-    /// grammar derived from `schema`. See the type-level documentation and
-    /// ``cveStatus`` for the full rationale.
+    /// This is advisory: `ToolGrammarBuilder` degrades gracefully and never
+    /// drops a tool, so a non-`nil` result no longer means "reject." It is
+    /// useful for diagnostics — e.g. logging that a tool's arguments could not
+    /// be fully constrained.
     ///
     /// - Parameters:
-    ///   - schema: The JSON Schema to check (typically `ToolDefinition.parameters`).
+    ///   - schema: The JSON Schema to inspect (typically `ToolDefinition.parameters`).
     ///   - path:   Accumulated path prefix for nested calls — callers should
     ///             use the default empty array.
     public func validate(_ schema: JSONSchemaValue, path: [String] = []) -> ValidationFailure? {
         guard case let .object(dict) = schema else {
-            // Non-object schemas (scalars, arrays-as-values) are safe; skip.
+            // Non-object schema nodes (bare scalars) carry no un-lowerable shape.
             return nil
         }
 
-        // Reject schema combiners — the GBNF IR has no alternation / negation nodes.
+        // Combiners the lowerer does not implement → these nodes degrade to
+        // generic JSON. (GBNF *can* express alternation; the lowerer just
+        // doesn't lower these yet — see the type docs.)
         for combiner in ["anyOf", "oneOf", "allOf", "not"] {
             if dict[combiner] != nil {
                 return ValidationFailure(
-                    reason: "'\(combiner)' is not supported by the GBNF compiler and may cause a crash.",
+                    reason: "'\(combiner)' is not implemented by this builder's lowerer; the node falls back to generic JSON.",
                     path: path + [combiner]
                 )
             }
         }
 
-        // Reject Draft 2020-12 integer-form exclusive bounds — triggers a
-        // type-confusion path in the GBNF numeric rule builder.
-        for bound in ["exclusiveMinimum", "exclusiveMaximum"] {
-            if dict[bound] != nil {
+        // `$ref` / `patternProperties` are likewise un-modeled and fall back.
+        for unmodeled in ["$ref", "patternProperties"] {
+            if dict[unmodeled] != nil {
                 return ValidationFailure(
-                    reason: "'\(bound)' triggers a type-confusion path in the GBNF numeric rule builder.",
-                    path: path + [bound]
+                    reason: "'\(unmodeled)' is not implemented by this builder's lowerer; the node falls back to generic JSON.",
+                    path: path + [unmodeled]
                 )
             }
         }
 
-        // Reject nullable union: `"type": ["string", "null"]` — any array
-        // `type` value containing `"null"` produces unbounded alternation.
-        if let typeValue = dict["type"], case let .array(typeArr) = typeValue {
-            let hasNull = typeArr.contains {
-                if case .string(let s) = $0 { return s == "null" }
-                return false
-            }
-            if hasNull {
-                return ValidationFailure(
-                    reason: "Nullable union type (array containing 'null') produces unbounded alternation in GBNF.",
-                    path: path + ["type"]
-                )
-            }
-        }
+        // NOTE (#1859): `exclusiveMinimum`/`exclusiveMaximum` are NO LONGER
+        // flagged. GBNF cannot enforce arbitrary numeric ranges anyway, so the
+        // lowerer emits a generic number and ignores the bound — safer than
+        // dropping the tool, and the old "type-confusion crash" rationale
+        // described a llama.cpp bug the current pin is past.
+        //
+        // NOTE (#1859): nullable union `["T","null"]` is NO LONGER flagged —
+        // the lowerer expresses it as `( <T> | "null" )`.
 
-        // Recurse into `properties` sub-schemas.
+        // Recurse into `properties` sub-schemas (sorted for deterministic
+        // reporting).
         if let propsValue = dict["properties"], case let .object(properties) = propsValue {
-            // Sort for deterministic failure reporting.
             for (key, subSchema) in properties.sorted(by: { $0.key < $1.key }) {
                 if let failure = validate(subSchema, path: path + ["properties", key]) {
                     return failure
@@ -167,11 +180,7 @@ public struct GBNFSchemaPreValidator: Sendable {
             }
         }
 
-        // Recurse into `items`. JSON Schema permits two shapes:
-        //   - a single sub-schema object (list validation), or
-        //   - an array of sub-schemas (tuple validation, draft-04 / 2019-09).
-        // Without the array branch, unsafe constructs nested inside a tuple-form
-        // `items` would bypass the pre-validator and reach the GBNF compiler.
+        // Recurse into `items` (single sub-schema or tuple-form array).
         if let itemsValue = dict["items"] {
             switch itemsValue {
             case .object:

--- a/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
+++ b/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// Derives a GBNF grammar that constrains a grammar-capable local backend to
-/// emit a well-formed tool-call envelope: a JSON object whose `"name"` field is
-/// pinned to the *enum of the provided tool names* and whose `"arguments"`
-/// field is a generic well-formed JSON object.
+/// emit a well-formed tool-call envelope as a *discriminated union over the
+/// supplied tools*: each branch pins `"name"` to one tool's literal name and
+/// pins `"arguments"` to a grammar lowered from *that tool's* JSON-Schema
+/// parameters.
 ///
 /// ## Why this exists (#1859)
 ///
@@ -15,130 +16,431 @@ import Foundation
 /// queue can force well-formed tool-call emission whenever the backend
 /// advertises `supportsGrammarConstrainedSampling`.
 ///
-/// ## Scope: implemented vs deferred
+/// ## Envelope shape (discriminated union)
 ///
-/// **Implemented:** the `"name"` field is constrained to the exact set of
-/// supplied tool names (alternation of string literals), and the overall shape
-/// is forced to `{ "name": <enum>, "arguments": <json-object> }`. Tool names
-/// are escaped for safe embedding as GBNF string literals.
+/// ```
+/// root        ::= toolcall-0 | toolcall-1 | ...
+/// toolcall-N  ::= "{" ws "\"name\"" ws ":" ws "\"<name_N>\"" ws ","
+///                     ws "\"arguments\"" ws ":" ws args-N ws "}"
+/// args-N      ::= <lowered from tool N's `parameters` schema>
+/// ```
 ///
-/// **Deferred:** per-tool *parameter-schema* lowering — i.e. making
-/// `"arguments"` match each tool's exact JSON Schema (typed fields, required
-/// keys, enums on values). That is the hard, correctness-sensitive part and is
-/// intentionally out of scope for this PR. `"arguments"` is constrained to a
-/// generic well-formed JSON object instead. The name-enum constraint alone is
-/// the core value of #1859 (guaranteed-parseable envelope + correct tool name).
+/// Rule names use hyphens, never underscores: llama.cpp's GBNF parser
+/// (`is_word_char`) accepts only `[a-zA-Z0-9-]` in a rule name and stops at
+/// `_`, so `args_0` would be misparsed as `args` followed by a syntax error.
 ///
-/// ## Pre-validator gate
+/// Pinning `"name"` *per branch* (rather than to a shared `name`-enum followed
+/// by one shared `arguments`) is what lets each tool's `arguments` be
+/// constrained to its own parameter schema. A single tool collapses to one
+/// branch; `root` is still emitted as `root ::= toolcall-0` for uniformity.
 ///
-/// Each tool's `parameters` schema is run through ``GBNFSchemaPreValidator``
-/// before the tool is included. A tool whose schema the pre-validator rejects
-/// is dropped from the name enum (it cannot be safely grammar-constrained under
-/// the current conservative policy).
+/// ## Lowering: supported shapes vs graceful fallback
 ///
-/// NOTE: the pre-validator's rejection set is *conservative* and its premise is
-/// partly inaccurate — it claims `anyOf`/`oneOf`/`allOf` and nullable unions are
-/// inexpressible in GBNF, but GBNF supports alternation (`|`) and llama.cpp's
-/// own `json_schema_to_grammar` lowers these. Because this builder only emits a
-/// generic JSON object for `"arguments"` (it does not lower the param schema at
-/// all), the pre-validator is used here purely as a defensive safety gate: it
-/// keeps known-crashy schema shapes out of any future per-tool lowering and
-/// documents intent. Fixing the pre-validator's premise is a separate concern
-/// (tracks the "dead validator" note in #1859's review) and is NOT done here.
+/// The lowerer (``lower(_:into:ruleName:)``) handles the common JSON-Schema
+/// shapes used by real tool definitions:
+///
+/// - **object** with `properties` + `required`: required keys are emitted in
+///   declared order (sorted for determinism); optional keys are emitted as
+///   `( "," ws "\"key\"" ws ":" ws <val> )?` *after* the required block.
+///   `additionalProperties` is **not** modeled — the object is closed to the
+///   declared keys. (A tool that needs free-form extra keys should declare them
+///   or accept the closed shape.)
+/// - **string**: generic JSON string; **string enum** lowers to an alternation
+///   of quoted literals (`"\"north\"" | "\"south\""`).
+/// - **integer**: signed integer rule. **number**: signed decimal with optional
+///   fraction/exponent.
+/// - **boolean**: `"true" | "false"`.
+/// - **array** with `items` (single sub-schema): homogeneous list of the lowered
+///   item rule.
+/// - **nullable union** `["string","null"]` (and any `["T","null"]`): lowers to
+///   `( <T> | "null" )`. (The pre-validator no longer rejects this — see
+///   ``GBNFSchemaPreValidator``.)
+/// - nested objects / arrays recurse.
+///
+/// **Graceful degradation.** Any sub-schema shape the lowerer does not model
+/// (combiners `anyOf`/`oneOf`/`allOf`/`not`, `$ref`, `pattern`, `format`,
+/// `patternProperties`, tuple-form `items`, an unrecognised `type`, …) lowers
+/// to the shared generic JSON `value` rule for *that sub-schema only*. The rest
+/// of the tool is still constrained. A whole-tool schema that is itself
+/// unloweliable degrades its `args-N` to `value`, never dropping the tool from
+/// the union. This is strictly better than rejecting the tool: the envelope and
+/// tool name stay constrained even when the arguments can't be.
+///
+/// The shared generic rules (`value`/`object`/`array`/`string`/`number` …) are
+/// always emitted so the fallback has something to reference.
+///
+/// ## Pre-validator's role (reconciled)
+///
+/// ``GBNFSchemaPreValidator`` no longer *rejects* tools. Its `validate` method
+/// is retained for callers that want to know, ahead of time, whether a schema
+/// will lower fully or fall back to generic JSON. This builder does not consult
+/// it on the rejection path anymore — graceful degradation subsumes it. See
+/// that type's docs for the corrected premise (GBNF *can* express alternation;
+/// the limitation is this lowerer's coverage, not the IR).
+///
+/// ## GBNF validity
+///
+/// CI cannot compile GBNF, so the emitted grammar is hand-verified against
+/// llama.cpp's `grammars/README.md`: a single `root`; every nonterminal
+/// defined; no undefined references; no left-recursion; no nullable members
+/// that could form a zero-width loop; correctly escaped quoted literals; `ws`
+/// between structural tokens. Byte-exact golden tests pin the output.
 public struct ToolGrammarBuilder: Sendable {
 
-    private let preValidator: GBNFSchemaPreValidator
-
     public init(preValidator: GBNFSchemaPreValidator = GBNFSchemaPreValidator()) {
-        self.preValidator = preValidator
+        // The pre-validator is no longer consulted on the build path (graceful
+        // degradation replaced rejection). The parameter is retained for source
+        // compatibility with existing call sites.
+        _ = preValidator
     }
 
-    /// Builds a GBNF grammar string constraining output to a tool-call envelope
-    /// over the supplied tools, or `nil` when no grammar can be derived.
-    ///
-    /// Returns `nil` when `tools` is empty or when every tool's parameter schema
-    /// is rejected by the pre-validator — in both cases there is no usable name
-    /// enum, so the caller should fall back to unconstrained sampling.
+    /// Builds a GBNF grammar string constraining output to a tool-call
+    /// discriminated union over the supplied tools, or `nil` when `tools` is
+    /// empty (no envelope to constrain — caller should fall back to
+    /// unconstrained sampling).
     ///
     /// - Parameter tools: the tool definitions for this request.
     public func buildGrammar(for tools: [ToolDefinition]) -> String? {
         guard !tools.isEmpty else { return nil }
 
-        // Drop tools whose parameter schema the (conservative) pre-validator
-        // rejects. De-duplicate names so the enum has no redundant alternatives
-        // and preserve first-seen order for deterministic output.
+        // De-duplicate names, preserving first-seen order, so the union has no
+        // redundant branches and output is deterministic.
         var seen = Set<String>()
-        var acceptedNames: [String] = []
-        for tool in tools {
-            if preValidator.validate(tool.parameters) != nil { continue }
-            if seen.insert(tool.name).inserted {
-                acceptedNames.append(tool.name)
+        var uniqueTools: [ToolDefinition] = []
+        for tool in tools where seen.insert(tool.name).inserted {
+            uniqueTools.append(tool)
+        }
+
+        // Accumulates the per-tool lowered rules in deterministic emission order.
+        var emittedOrder: [String] = []
+        var rules: [String: String] = [:]
+        func emit(_ name: String, _ rhs: String) {
+            if rules[name] == nil { emittedOrder.append(name) }
+            rules[name] = rhs
+        }
+
+        var branchNames: [String] = []
+        for (index, tool) in uniqueTools.enumerated() {
+            let argsRule = "args-\(index)"
+            var ctx = LoweringContext(toolIndex: index, suffix: 0)
+            lower(tool.parameters, into: &ctx, ruleName: argsRule, emit: emit)
+
+            let literalName = "\"\\\"\(Self.escapeForGBNFLiteral(tool.name))\\\"\""
+            let branch = "toolcall-\(index)"
+            branchNames.append(branch)
+            emit(
+                branch,
+                "\"{\" ws \"\\\"name\\\"\" ws \":\" ws \(literalName) ws \",\" ws "
+                    + "\"\\\"arguments\\\"\" ws \":\" ws \(argsRule) ws \"}\""
+            )
+        }
+
+        // root is the alternation of all tool branches (one branch for a single
+        // tool). Emitting `root` first keeps it as the grammar's entry point.
+        let rootRHS = branchNames.joined(separator: " | ")
+
+        var lines: [String] = ["root ::= \(rootRHS)"]
+        for name in emittedOrder {
+            lines.append("\(name) ::= \(rules[name]!)")
+        }
+        // Shared generic JSON value rule set — the fallback target plus the
+        // primitives every lowered rule references (string, number, …).
+        lines.append(contentsOf: Self.genericRuleLines)
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Lowering
+
+    /// Mutable state threaded through the recursive lowerer so generated helper
+    /// rules get unique, deterministic names (`args-<tool>-<n>`).
+    private struct LoweringContext {
+        let toolIndex: Int
+        var suffix: Int
+
+        /// Returns a fresh unique rule name and advances the counter.
+        mutating func freshRuleName() -> String {
+            defer { suffix += 1 }
+            // llama.cpp's GBNF parser (`is_word_char`) accepts only
+            // `[a-zA-Z0-9-]` in rule names — NOT underscore. Use hyphens.
+            return "args-\(toolIndex)-\(suffix)"
+        }
+    }
+
+    /// Lowers `schema` into a GBNF rule named `ruleName`, emitting that rule and
+    /// any helper rules it needs via `emit`. Unsupported shapes degrade to the
+    /// shared generic `value` rule.
+    private func lower(
+        _ schema: JSONSchemaValue,
+        into ctx: inout LoweringContext,
+        ruleName: String,
+        emit: (String, String) -> Void
+    ) {
+        guard case let .object(dict) = schema else {
+            // A non-object schema node (bare scalar) carries no structural
+            // information we can constrain — accept any JSON value.
+            emit(ruleName, "value")
+            return
+        }
+
+        // Combiners and other unmodeled keywords → generic value for this node.
+        // (Detect them explicitly so a schema that *also* has a `type` doesn't
+        // get partially — and wrongly — constrained.)
+        for unmodeled in ["anyOf", "oneOf", "allOf", "not", "$ref", "patternProperties"] {
+            if dict[unmodeled] != nil {
+                emit(ruleName, "value")
+                return
             }
         }
 
-        guard !acceptedNames.isEmpty else { return nil }
+        let typeValue = dict["type"]
 
-        let nameAlternation = acceptedNames
-            .map { "\"\\\"\(Self.escapeForGBNFLiteral($0))\\\"\"" }
-            .joined(separator: " | ")
+        // Nullable / multi-type union: `type` as an array.
+        if case let .array(typeArr)? = typeValue {
+            lowerUnion(typeArr, dict: dict, into: &ctx, ruleName: ruleName, emit: emit)
+            return
+        }
 
-        // The grammar forces:
-        //   root      ::= { "name": <one of the tool names>, "arguments": <object> }
-        //   value/object/array/string/number/etc. — a self-contained JSON subset.
-        //
-        // Whitespace ("ws") is permitted between tokens so the model isn't forced
-        // into a single canonical spacing. The JSON value rules are a standard,
-        // self-contained GBNF JSON grammar (no external rule references).
-        return """
-        root      ::= "{" ws "\\"name\\"" ws ":" ws toolname ws "," ws "\\"arguments\\"" ws ":" ws object ws "}"
-        toolname  ::= \(nameAlternation)
-        object    ::= "{" ws ( member ( ws "," ws member )* )? ws "}"
-        member    ::= string ws ":" ws value
-        array     ::= "[" ws ( value ( ws "," ws value )* )? ws "]"
-        value     ::= object | array | string | number | "true" | "false" | "null"
-        string    ::= "\\"" char* "\\""
-        char      ::= [^"\\\\] | "\\\\" escape
-        escape    ::= ["\\\\/bfnrt] | "u" hex hex hex hex
-        hex       ::= [0-9a-fA-F]
-        number    ::= "-"? int frac? exp?
-        int       ::= "0" | [1-9] [0-9]*
-        frac      ::= "." [0-9]+
-        exp       ::= [eE] [+-]? [0-9]+
-        ws        ::= [ \\t\\n]*
-        """
+        guard case let .string(typeName)? = typeValue else {
+            // No usable scalar `type` — accept any JSON value.
+            emit(ruleName, "value")
+            return
+        }
+
+        switch typeName {
+        case "object":
+            lowerObject(dict, into: &ctx, ruleName: ruleName, emit: emit)
+        case "array":
+            lowerArray(dict, into: &ctx, ruleName: ruleName, emit: emit)
+        case "string":
+            lowerString(dict, ruleName: ruleName, emit: emit)
+        case "integer":
+            emit(ruleName, "integer")
+        case "number":
+            emit(ruleName, "number")
+        case "boolean":
+            emit(ruleName, "(\"true\" | \"false\")")
+        case "null":
+            emit(ruleName, "\"null\"")
+        default:
+            emit(ruleName, "value")
+        }
     }
+
+    /// Lowers a `"type": [...]` union. The common case is `["T", "null"]`, which
+    /// becomes `( <T> | "null" )`. Any unmodeled member degrades the whole union
+    /// to generic `value`.
+    private func lowerUnion(
+        _ typeArr: [JSONSchemaValue],
+        dict: [String: JSONSchemaValue],
+        into ctx: inout LoweringContext,
+        ruleName: String,
+        emit: (String, String) -> Void
+    ) {
+        var alternatives: [String] = []
+        for member in typeArr {
+            guard case let .string(name) = member else {
+                emit(ruleName, "value")
+                return
+            }
+            if name == "null" {
+                alternatives.append("\"null\"")
+                continue
+            }
+            // Lower the non-null member by reusing the scalar lowerer with the
+            // surrounding dict (so an enum/items alongside the union still
+            // applies). Give it a helper rule name and reference it.
+            let helper = ctx.freshRuleName()
+            var memberDict = dict
+            memberDict["type"] = .string(name)
+            lower(.object(memberDict), into: &ctx, ruleName: helper, emit: emit)
+            alternatives.append(helper)
+        }
+        guard !alternatives.isEmpty else {
+            emit(ruleName, "value")
+            return
+        }
+        emit(ruleName, "(\(alternatives.joined(separator: " | ")))")
+    }
+
+    /// Lowers an `object` schema with `properties` + `required`.
+    ///
+    /// Required keys (sorted for determinism) are emitted in order; optional
+    /// keys follow, each wrapped in an optional group. An object with no
+    /// declared `properties` accepts the generic JSON object.
+    private func lowerObject(
+        _ dict: [String: JSONSchemaValue],
+        into ctx: inout LoweringContext,
+        ruleName: String,
+        emit: (String, String) -> Void
+    ) {
+        guard case let .object(properties)? = dict["properties"], !properties.isEmpty else {
+            // No property constraints — any JSON object.
+            emit(ruleName, "object")
+            return
+        }
+
+        var requiredKeys = Set<String>()
+        if case let .array(req)? = dict["required"] {
+            for item in req {
+                if case let .string(key) = item { requiredKeys.insert(key) }
+            }
+        }
+
+        // Deterministic order: sort all keys, required ones first.
+        let sortedKeys = properties.keys.sorted()
+        let required = sortedKeys.filter { requiredKeys.contains($0) }
+        let optional = sortedKeys.filter { !requiredKeys.contains($0) }
+
+        // Lower each property's value to its own helper rule.
+        func valueRule(forKey key: String) -> String {
+            let helper = ctx.freshRuleName()
+            lower(properties[key]!, into: &ctx, ruleName: helper, emit: emit)
+            return helper
+        }
+
+        // Emit value helpers first (deterministic order) so member fragments can
+        // reference them.
+        var keyToRule: [String: String] = [:]
+        for key in required + optional {
+            keyToRule[key] = valueRule(forKey: key)
+        }
+
+        func member(_ key: String) -> String {
+            let lit = "\"\\\"\(Self.escapeForGBNFLiteral(key))\\\"\""
+            return "\(lit) ws \":\" ws \(keyToRule[key]!)"
+        }
+
+        var parts: [String] = ["\"{\" ws"]
+
+        // Required members joined by commas.
+        let requiredMembers = required.map(member)
+        for (i, m) in requiredMembers.enumerated() {
+            if i == 0 {
+                parts.append(m)
+            } else {
+                parts.append("ws \",\" ws \(m)")
+            }
+        }
+
+        // Optional members. If there are no required keys, the *first* optional
+        // key carries no leading comma but must itself be optional, and
+        // subsequent optionals each need the leading comma inside their own
+        // optional group. To keep this regular (and avoid a nullable-with-
+        // trailing-comma hazard), when there are no required keys we model the
+        // object as: an optional leading member, then comma-prefixed optionals.
+        if required.isEmpty {
+            if let first = optional.first {
+                parts.append("( \(member(first))")
+                for key in optional.dropFirst() {
+                    parts.append("( ws \",\" ws \(member(key)) )?")
+                }
+                parts.append(")?")
+            }
+        } else {
+            for key in optional {
+                parts.append("( ws \",\" ws \(member(key)) )?")
+            }
+        }
+
+        parts.append("ws \"}\"")
+        emit(ruleName, parts.joined(separator: " "))
+    }
+
+    /// Lowers an `array` schema with a single-sub-schema `items`.
+    private func lowerArray(
+        _ dict: [String: JSONSchemaValue],
+        into ctx: inout LoweringContext,
+        ruleName: String,
+        emit: (String, String) -> Void
+    ) {
+        // Only single-sub-schema `items` is modeled; tuple-form (array of
+        // schemas) or missing `items` degrades to the generic array.
+        guard case let .object? = dict["items"] else {
+            emit(ruleName, "array")
+            return
+        }
+        let itemRule = ctx.freshRuleName()
+        lower(dict["items"]!, into: &ctx, ruleName: itemRule, emit: emit)
+        emit(
+            ruleName,
+            "\"[\" ws ( \(itemRule) ( ws \",\" ws \(itemRule) )* )? ws \"]\""
+        )
+    }
+
+    /// Lowers a `string` schema. A `string` with an `enum` of string literals
+    /// lowers to an alternation of quoted literals; otherwise the generic JSON
+    /// `string` rule.
+    private func lowerString(
+        _ dict: [String: JSONSchemaValue],
+        ruleName: String,
+        emit: (String, String) -> Void
+    ) {
+        if case let .array(cases)? = dict["enum"] {
+            var literals: [String] = []
+            for c in cases {
+                guard case let .string(s) = c else {
+                    // Non-string enum member — not a clean string enum; fall back.
+                    literals = []
+                    break
+                }
+                literals.append("\"\\\"\(Self.escapeForGBNFLiteral(s))\\\"\"")
+            }
+            if !literals.isEmpty {
+                emit(ruleName, "(\(literals.joined(separator: " | ")))")
+                return
+            }
+        }
+        emit(ruleName, "string")
+    }
+
+    // MARK: - Shared generic rules
+
+    /// The shared, self-contained JSON value rule set. Always appended so the
+    /// fallback `value` reference and the primitive rules (`string`, `number`,
+    /// `integer`, `object`, `array`) every lowered rule may reference are
+    /// defined exactly once.
+    static let genericRuleLines: [String] = [
+        #"object ::= "{" ws ( member ( ws "," ws member )* )? ws "}""#,
+        #"member ::= string ws ":" ws value"#,
+        #"array ::= "[" ws ( value ( ws "," ws value )* )? ws "]""#,
+        #"value ::= object | array | string | number | "true" | "false" | "null""#,
+        #"string ::= "\"" char* "\"""#,
+        #"char ::= [^"\\] | "\\" escape"#,
+        #"escape ::= ["\\/bfnrt] | "u" hex hex hex hex"#,
+        "hex ::= [0-9a-fA-F]",
+        #"number ::= "-"? int frac? exp?"#,
+        "integer ::= \"-\"? int",
+        "int ::= \"0\" | [1-9] [0-9]*",
+        #"frac ::= "." [0-9]+"#,
+        "exp ::= [eE] [+-]? [0-9]+",
+        #"ws ::= [ \t\n]*"#,
+    ]
 
     // MARK: - Escaping
 
-    /// Escapes a tool name for embedding inside a GBNF double-quoted string
-    /// literal that itself represents a JSON string literal.
+    /// Escapes a name for embedding inside a GBNF double-quoted string literal
+    /// that itself represents a JSON string literal.
     ///
-    /// The emitted token in the grammar is `"\"<name>\""` — a GBNF literal whose
-    /// *content* is `"<name>"` (the JSON-quoted name). Two layers therefore need
-    /// escaping:
+    /// The emitted token is `"\"<name>\""` — a GBNF literal whose *content* is
+    /// `"<name>"` (the JSON-quoted name). Two layers need escaping:
     ///
-    /// 1. Characters that are special inside the JSON string the model emits
-    ///    (`"` and `\`) must be backslash-escaped so the model is constrained to
-    ///    emit them in escaped form (a literal `"` inside the name would close
-    ///    the JSON string).
+    /// 1. Characters special inside the JSON string the model emits (`"` and
+    ///    `\`) are backslash-escaped so the model emits them in escaped form.
     /// 2. The resulting bytes must survive being written into a GBNF
-    ///    double-quoted literal. GBNF literals use backslash escapes too, so a
-    ///    backslash and a double-quote each need one more backslash.
+    ///    double-quoted literal (which also uses backslash escapes).
     ///
-    /// Concretely each `"` in the name becomes `\\\"` (escaped JSON quote, then
-    /// GBNF-escaped) and each `\` becomes `\\\\`. Control characters (newline,
-    /// tab, etc.) are emitted as JSON `\uXXXX` escapes, themselves GBNF-escaped.
-    /// Tool names are normally `[a-zA-Z0-9_-]`, so this defends the edge cases.
+    /// Each `"` becomes `\\\"` and each `\` becomes `\\\\`. Control characters
+    /// are emitted as JSON `\uXXXX`, GBNF-escaped. Used for both tool names and
+    /// enum/property-key literals.
     static func escapeForGBNFLiteral(_ name: String) -> String {
         var out = ""
         out.reserveCapacity(name.count)
         for scalar in name.unicodeScalars {
             switch scalar {
             case "\"":
-                // JSON-escape (\") then GBNF-escape both chars: \\\"
                 out += "\\\\\\\""
             case "\\":
-                // JSON-escape (\\) then GBNF-escape both: \\\\\\\\
                 out += "\\\\\\\\"
             case "\n":
                 out += "\\\\n"
@@ -148,7 +450,6 @@ public struct ToolGrammarBuilder: Sendable {
                 out += "\\\\t"
             default:
                 if scalar.value < 0x20 {
-                    // Other control chars → JSON \u escape, GBNF-escaped backslash.
                     out += String(format: "\\\\u%04x", scalar.value)
                 } else {
                     out.unicodeScalars.append(scalar)

--- a/Tests/ManifoldInferenceTests/GBNFSchemaPreValidatorTests.swift
+++ b/Tests/ManifoldInferenceTests/GBNFSchemaPreValidatorTests.swift
@@ -4,6 +4,19 @@ import XCTest
 /// Unit tests for ``GBNFSchemaPreValidator``.
 ///
 /// These tests run without hardware — no llama.cpp symbols are touched.
+///
+/// ## #1859 behavior change (advisory, not a gate)
+///
+/// The validator's role shifted from "reject the tool" to "flag sub-schema
+/// shapes the lowerer can't express (they degrade to generic JSON)." Two
+/// previously-rejected shapes are now *accepted* because the lowerer handles or
+/// safely ignores them:
+///   - **nullable union** `["T","null"]` → lowered to `( <T> | "null" )`.
+///   - **`exclusiveMinimum`/`exclusiveMaximum`** → bound ignored, generic number.
+/// Combiners (`anyOf`/`oneOf`/`allOf`/`not`) are still flagged (the lowerer
+/// doesn't implement them yet — they fall back to generic JSON, the tool is
+/// NOT dropped). `$ref`/`patternProperties` are newly flagged for the same
+/// reason. The tests below were updated accordingly.
 final class GBNFSchemaPreValidatorTests: XCTestCase {
 
     private let validator = GBNFSchemaPreValidator()
@@ -55,7 +68,7 @@ final class GBNFSchemaPreValidatorTests: XCTestCase {
         XCTAssertNil(validator.validate(.null))
     }
 
-    // MARK: - Combiners rejected
+    // MARK: - Combiners flagged (un-lowerable → generic-JSON fallback)
 
     func test_anyOf_isRejected() {
         let schema = JSONSchemaValue.object([
@@ -91,46 +104,44 @@ final class GBNFSchemaPreValidatorTests: XCTestCase {
         XCTAssertNotNil(validator.validate(schema))
     }
 
-    // MARK: - Nullable union rejected
+    // MARK: - Nullable union now ACCEPTED (#1859)
 
-    func test_nullableUnionType_isRejected() {
+    // Behavior change: the lowerer expresses `["T","null"]` as `( <T> | "null" )`,
+    // so a nullable union is no longer flagged.
+    func test_nullableUnionType_nowPasses() {
         let schema = JSONSchemaValue.object([
             "type": .array([.string("string"), .string("null")])
         ])
-        let failure = validator.validate(schema)
-        XCTAssertNotNil(failure)
-        XCTAssertEqual(failure?.path, ["type"])
-        XCTAssertTrue(failure?.reason.lowercased().contains("null") == true)
+        XCTAssertNil(validator.validate(schema))
     }
 
     func test_nonNullableArrayType_passes() {
-        // An array `type` that does NOT contain "null" is safe.
+        // An array `type` that does NOT contain "null" is also fine.
         let schema = JSONSchemaValue.object([
             "type": .array([.string("string"), .string("integer")])
         ])
         XCTAssertNil(validator.validate(schema))
     }
 
-    // MARK: - exclusiveMinimum / exclusiveMaximum rejected
+    // MARK: - exclusiveMinimum / exclusiveMaximum now ACCEPTED (#1859)
 
-    func test_exclusiveMinimum_isRejected() {
+    // Behavior change: GBNF can't enforce arbitrary numeric ranges anyway, so the
+    // lowerer ignores the bound and emits a generic number. Ignoring a bound
+    // beats dropping the tool, so these are no longer flagged.
+    func test_exclusiveMinimum_nowPasses() {
         let schema = JSONSchemaValue.object([
             "type": .string("integer"),
             "exclusiveMinimum": .number(0)
         ])
-        let failure = validator.validate(schema)
-        XCTAssertNotNil(failure)
-        XCTAssertEqual(failure?.path, ["exclusiveMinimum"])
+        XCTAssertNil(validator.validate(schema))
     }
 
-    func test_exclusiveMaximum_isRejected() {
+    func test_exclusiveMaximum_nowPasses() {
         let schema = JSONSchemaValue.object([
             "type": .string("integer"),
             "exclusiveMaximum": .number(100)
         ])
-        let failure = validator.validate(schema)
-        XCTAssertNotNil(failure)
-        XCTAssertEqual(failure?.path, ["exclusiveMaximum"])
+        XCTAssertNil(validator.validate(schema))
     }
 
     // MARK: - Nested rejection (recursive)
@@ -152,16 +163,34 @@ final class GBNFSchemaPreValidatorTests: XCTestCase {
         XCTAssertEqual(failure?.path, ["properties", "address", "anyOf"])
     }
 
-    func test_nullableUnion_inItemsSchema_isRejected() {
+    // Behavior change (#1859): a nullable union nested in `items` is no longer
+    // flagged — the lowerer expresses it.
+    func test_nullableUnion_inItemsSchema_nowPasses() {
         let schema = JSONSchemaValue.object([
             "type": .string("array"),
             "items": .object([
                 "type": .array([.string("string"), .string("null")])
             ])
         ])
+        XCTAssertNil(validator.validate(schema))
+    }
+
+    // `$ref` and `patternProperties` are newly flagged (un-lowerable → generic).
+    func test_ref_isFlagged() {
+        let schema = JSONSchemaValue.object(["$ref": .string("#/defs/X")])
         let failure = validator.validate(schema)
         XCTAssertNotNil(failure)
-        XCTAssertEqual(failure?.path, ["items", "type"])
+        XCTAssertEqual(failure?.path, ["$ref"])
+    }
+
+    func test_patternProperties_isFlagged() {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "patternProperties": .object(["^x": .object(["type": .string("string")])])
+        ])
+        let failure = validator.validate(schema)
+        XCTAssertNotNil(failure)
+        XCTAssertEqual(failure?.path, ["patternProperties"])
     }
 
     func test_anyOf_inTupleItemsArray_isRejected() {

--- a/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
@@ -9,6 +9,25 @@ final class ToolGrammarBuilderTests: XCTestCase {
         ToolDefinition(name: name, description: "d", parameters: parameters)
     }
 
+    /// The shared generic-JSON rule block appended to every grammar. Pulled out
+    /// so the structural goldens below stay focused on the per-tool prologue.
+    private let genericTail = #"""
+    object ::= "{" ws ( member ( ws "," ws member )* )? ws "}"
+    member ::= string ws ":" ws value
+    array ::= "[" ws ( value ( ws "," ws value )* )? ws "]"
+    value ::= object | array | string | number | "true" | "false" | "null"
+    string ::= "\"" char* "\""
+    char ::= [^"\\] | "\\" escape
+    escape ::= ["\\/bfnrt] | "u" hex hex hex hex
+    hex ::= [0-9a-fA-F]
+    number ::= "-"? int frac? exp?
+    integer ::= "-"? int
+    int ::= "0" | [1-9] [0-9]*
+    frac ::= "." [0-9]+
+    exp ::= [eE] [+-]? [0-9]+
+    ws ::= [ \t\n]*
+    """#
+
     // MARK: - Empty / nil cases
 
     func test_emptyTools_returnsNil() {
@@ -19,47 +38,37 @@ final class ToolGrammarBuilderTests: XCTestCase {
 
     func test_singleTool_hasRootRuleAndQuotedName() {
         let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("get_weather")]))
-        XCTAssertTrue(grammar.contains("root"), "grammar must define a root rule")
-        XCTAssertTrue(grammar.contains("toolname"), "grammar must define a toolname rule")
+        XCTAssertTrue(grammar.hasPrefix("root ::="), "grammar must define a root rule first")
+        XCTAssertTrue(grammar.contains("toolcall-0"), "single tool → one toolcall branch")
         // The name appears as a JSON-quoted literal inside a GBNF literal.
         XCTAssertTrue(
-            grammar.contains("\\\"get_weather\\\""),
+            grammar.contains(#""\"get_weather\"""#),
             "tool name must appear as a quoted literal; got:\n\(grammar)"
         )
-        // The envelope constrains the "name" and "arguments" keys.
-        XCTAssertTrue(grammar.contains("\\\"name\\\""))
-        XCTAssertTrue(grammar.contains("\\\"arguments\\\""))
+        XCTAssertTrue(grammar.contains(#""\"name\"""#))
+        XCTAssertTrue(grammar.contains(#""\"arguments\"""#))
     }
 
-    func test_multipleTools_produceAlternationOfNames() {
+    func test_multipleTools_produceUnionOfBranches() {
         let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a"), tool("b"), tool("c")]))
-        XCTAssertTrue(grammar.contains("\\\"a\\\""))
-        XCTAssertTrue(grammar.contains("\\\"b\\\""))
-        XCTAssertTrue(grammar.contains("\\\"c\\\""))
-        // Alternation: the toolname rule must join names with `|`.
-        let toolnameLine = grammar
-            .split(separator: "\n")
-            .first { $0.hasPrefix("toolname") }
-            .map(String.init) ?? ""
-        XCTAssertTrue(toolnameLine.contains("|"), "multiple tools must alternate with `|`; got: \(toolnameLine)")
-        XCTAssertEqual(toolnameLine.components(separatedBy: "|").count, 3, "three tools → two `|` separators")
+        let rootLine = grammar.split(separator: "\n").first.map(String.init) ?? ""
+        // root alternates the per-tool branches.
+        XCTAssertEqual(rootLine, "root ::= toolcall-0 | toolcall-1 | toolcall-2")
+        XCTAssertTrue(grammar.contains(#""\"a\"""#))
+        XCTAssertTrue(grammar.contains(#""\"b\"""#))
+        XCTAssertTrue(grammar.contains(#""\"c\"""#))
     }
 
     func test_duplicateNames_deduplicated() {
         let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("dup"), tool("dup")]))
-        let toolnameLine = grammar
-            .split(separator: "\n")
-            .first { $0.hasPrefix("toolname") }
-            .map(String.init) ?? ""
-        XCTAssertFalse(toolnameLine.contains("|"), "duplicate names collapse to a single alternative")
+        let rootLine = grammar.split(separator: "\n").first.map(String.init) ?? ""
+        XCTAssertEqual(rootLine, "root ::= toolcall-0", "duplicate names collapse to a single branch")
     }
 
     // MARK: - Escaping
 
     func test_escaping_quoteInName() {
-        // A name containing a double quote must not produce an unbalanced literal.
         let escaped = ToolGrammarBuilder.escapeForGBNFLiteral("a\"b")
-        // JSON-escaped quote (\") then GBNF-escaped → backslash-backslash-backslash-quote.
         XCTAssertEqual(escaped, "a\\\\\\\"b")
     }
 
@@ -71,7 +80,6 @@ final class ToolGrammarBuilderTests: XCTestCase {
     func test_escaping_controlCharsAndTab() {
         XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\tb"), "a\\\\tb")
         XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\nb"), "a\\\\nb")
-        // A bell (U+0007) is an "other" control char → \u escape.
         XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\u{07}b"), "a\\\\u0007b")
     }
 
@@ -79,78 +87,206 @@ final class ToolGrammarBuilderTests: XCTestCase {
         XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("get_weather-2"), "get_weather-2")
     }
 
-    func test_nameWithQuote_appearsEscapedInGrammar_noBareQuote() {
-        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\"b")]))
-        XCTAssertTrue(grammar.contains("a\\\\\\\"b"), "quoted name must be doubly escaped in the grammar")
-    }
-
-    // A name containing a double quote must yield a *balanced* GBNF literal:
-    // the only place an unescaped `"` may appear on the toolname line is the
-    // literal's own opening/closing delimiters. There is no live llama.cpp
-    // grammar compiler in this package's CI (see ToolGrammarBuilder docs), so
-    // this asserts the exact emitted token byte-for-byte to catch a malformed
-    // literal that would otherwise ship undetected.
+    /// A name containing a double quote must yield a *balanced* GBNF literal in
+    /// the branch's `toolcall-0` rule. There is no live llama.cpp grammar
+    /// compiler in this package's CI, so this pins the exact emitted bytes.
     func test_nameWithQuote_emitsExactBalancedGBNFLiteral() {
         let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\"b")]))
-        let toolnameLine = grammar
+        let branchLine = grammar
             .split(separator: "\n")
-            .first { $0.hasPrefix("toolname") }
+            .first { $0.hasPrefix("toolcall-0 ::=") }
             .map(String.init) ?? ""
-        // Exact RHS: GBNF literal "\"a\\\"b\"" — content decodes to JSON `"a\"b"`.
-        XCTAssertEqual(toolnameLine, #"toolname  ::= "\"a\\\"b\"""#)
+        // The name literal decodes to JSON `"a\"b"`.
+        XCTAssertEqual(
+            branchLine,
+            #"toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"a\\\"b\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}""#
+        )
     }
 
     func test_nameWithBackslash_emitsExactBalancedGBNFLiteral() {
         let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\\b")]))
-        let toolnameLine = grammar
+        let branchLine = grammar
             .split(separator: "\n")
-            .first { $0.hasPrefix("toolname") }
+            .first { $0.hasPrefix("toolcall-0 ::=") }
             .map(String.init) ?? ""
-        // Exact RHS: GBNF literal "\"a\\\\b\"" — content decodes to JSON `"a\\b"`.
-        XCTAssertEqual(toolnameLine, #"toolname  ::= "\"a\\\\b\"""#)
+        XCTAssertEqual(
+            branchLine,
+            #"toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"a\\\\b\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}""#
+        )
     }
 
-    // MARK: - Pre-validator fallback
+    // MARK: - Per-param lowering (byte-exact goldens)
 
-    func test_preValidatorRejectedSchema_droppedFromEnum() {
-        // `anyOf` is rejected by the (conservative) pre-validator.
-        let rejected = tool("bad", parameters: .object([
+    private func objectSchema(_ props: [(String, JSONSchemaValue)], required: [String]) -> JSONSchemaValue {
+        var properties: [String: JSONSchemaValue] = [:]
+        for (k, v) in props { properties[k] = v }
+        return .object([
+            "type": .string("object"),
+            "properties": .object(properties),
+            "required": .array(required.map { .string($0) })
+        ])
+    }
+
+    func test_golden_stringEnumParam() {
+        let t = tool("set_direction", parameters: objectSchema([
+            ("direction", .object([
+                "type": .string("string"),
+                "enum": .array([.string("north"), .string("south")])
+            ]))
+        ], required: ["direction"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let expected = #"""
+        root ::= toolcall-0
+        args-0-0 ::= ("\"north\"" | "\"south\"")
+        args-0 ::= "{" ws "\"direction\"" ws ":" ws args-0-0 ws "}"
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"set_direction\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
+    }
+
+    func test_golden_typedObjectTwoFields() {
+        let t = tool("get_weather", parameters: objectSchema([
+            ("city", .object(["type": .string("string")])),
+            ("days", .object(["type": .string("integer")]))
+        ], required: ["city", "days"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let expected = #"""
+        root ::= toolcall-0
+        args-0-0 ::= string
+        args-0-1 ::= integer
+        args-0 ::= "{" ws "\"city\"" ws ":" ws args-0-0 ws "," ws "\"days\"" ws ":" ws args-0-1 ws "}"
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"get_weather\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
+    }
+
+    func test_golden_arrayParam() {
+        let t = tool("tag", parameters: objectSchema([
+            ("tags", .object([
+                "type": .string("array"),
+                "items": .object(["type": .string("string")])
+            ]))
+        ], required: ["tags"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let expected = #"""
+        root ::= toolcall-0
+        args-0-1 ::= string
+        args-0-0 ::= "[" ws ( args-0-1 ( ws "," ws args-0-1 )* )? ws "]"
+        args-0 ::= "{" ws "\"tags\"" ws ":" ws args-0-0 ws "}"
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"tag\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
+    }
+
+    func test_golden_genericFallbackForUnsupportedShape() {
+        // A schema using `anyOf` is not lowerable → args degrades to `value`,
+        // but the tool is NOT dropped from the union (graceful degradation).
+        let t = tool("weird", parameters: .object([
             "anyOf": .array([.object(["type": .string("string")])])
         ]))
-        let ok = tool("good")
-        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [rejected, ok]))
-        XCTAssertTrue(grammar.contains("\\\"good\\\""))
-        XCTAssertFalse(grammar.contains("\\\"bad\\\""), "tool with rejected schema must be dropped")
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let expected = #"""
+        root ::= toolcall-0
+        args-0 ::= value
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"weird\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
     }
 
-    func test_allToolsRejected_returnsNil() {
-        let rejected = tool("bad", parameters: .object([
-            "oneOf": .array([.object(["type": .string("string")])])
+    func test_golden_optionalKeys() {
+        // No `required` → both keys optional. Models the closed object as an
+        // optional leading member followed by comma-prefixed optionals.
+        let t = tool("opt", parameters: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "a": .object(["type": .string("string")]),
+                "b": .object(["type": .string("boolean")])
+            ])
         ]))
-        XCTAssertNil(builder.buildGrammar(for: [rejected]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let expected = #"""
+        root ::= toolcall-0
+        args-0-0 ::= string
+        args-0-1 ::= ("true" | "false")
+        args-0 ::= "{" ws ( "\"a\"" ws ":" ws args-0-0 ( ws "," ws "\"b\"" ws ":" ws args-0-1 )? )? ws "}"
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"opt\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
     }
 
-    // MARK: - Golden snapshot (fixed 2-tool input)
+    func test_golden_nullableUnionParam() {
+        // `["string","null"]` lowers to `( <string> | "null" )` — the
+        // pre-validator no longer rejects this shape.
+        let t = tool("nul", parameters: objectSchema([
+            ("x", .object(["type": .array([.string("string"), .string("null")])]))
+        ], required: ["x"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let expected = #"""
+        root ::= toolcall-0
+        args-0-1 ::= string
+        args-0-0 ::= (args-0-1 | "null")
+        args-0 ::= "{" ws "\"x\"" ws ":" ws args-0-0 ws "}"
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"nul\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
+    }
+
+    func test_golden_enumValueWithQuoteAndBackslash_escaped() {
+        // An enum value containing `"` and `\` must be doubly escaped in the
+        // emitted literal, exactly like tool names.
+        let t = tool("e", parameters: objectSchema([
+            ("k", .object([
+                "type": .string("string"),
+                "enum": .array([.string("a\"b"), .string("c\\d")])
+            ]))
+        ], required: ["k"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let enumLine = grammar
+            .split(separator: "\n")
+            .first { $0.hasPrefix("args-0-0 ::=") }
+            .map(String.init) ?? ""
+        XCTAssertEqual(enumLine, #"args-0-0 ::= ("\"a\\\"b\"" | "\"c\\\\d\"")"#)
+    }
+
+    // MARK: - Multi-tool discriminated union (byte-exact golden)
+
+    func test_golden_multiToolUnion() {
+        let enumTool = tool("set_direction", parameters: objectSchema([
+            ("direction", .object([
+                "type": .string("string"),
+                "enum": .array([.string("north"), .string("south")])
+            ]))
+        ], required: ["direction"]))
+        let objTool = tool("get_weather", parameters: objectSchema([
+            ("city", .object(["type": .string("string")])),
+            ("days", .object(["type": .string("integer")]))
+        ], required: ["city", "days"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [enumTool, objTool]))
+        let expected = #"""
+        root ::= toolcall-0 | toolcall-1
+        args-0-0 ::= ("\"north\"" | "\"south\"")
+        args-0 ::= "{" ws "\"direction\"" ws ":" ws args-0-0 ws "}"
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"set_direction\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        args-1-0 ::= string
+        args-1-1 ::= integer
+        args-1 ::= "{" ws "\"city\"" ws ":" ws args-1-0 ws "," ws "\"days\"" ws ":" ws args-1-1 ws "}"
+        toolcall-1 ::= "{" ws "\"name\"" ws ":" ws "\"get_weather\"" ws "," ws "\"arguments\"" ws ":" ws args-1 ws "}"
+        """# + "\n" + genericTail
+        XCTAssertEqual(grammar, expected)
+    }
+
+    // MARK: - Golden snapshot (fixed 2-tool, empty-params input)
 
     func test_goldenSnapshot_twoTools() {
+        // Empty-object params carry no `type` → args degrades to generic `value`.
         let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("alpha"), tool("beta")]))
-        let expected = """
-        root      ::= "{" ws "\\"name\\"" ws ":" ws toolname ws "," ws "\\"arguments\\"" ws ":" ws object ws "}"
-        toolname  ::= "\\"alpha\\"" | "\\"beta\\""
-        object    ::= "{" ws ( member ( ws "," ws member )* )? ws "}"
-        member    ::= string ws ":" ws value
-        array     ::= "[" ws ( value ( ws "," ws value )* )? ws "]"
-        value     ::= object | array | string | number | "true" | "false" | "null"
-        string    ::= "\\"" char* "\\""
-        char      ::= [^"\\\\] | "\\\\" escape
-        escape    ::= ["\\\\/bfnrt] | "u" hex hex hex hex
-        hex       ::= [0-9a-fA-F]
-        number    ::= "-"? int frac? exp?
-        int       ::= "0" | [1-9] [0-9]*
-        frac      ::= "." [0-9]+
-        exp       ::= [eE] [+-]? [0-9]+
-        ws        ::= [ \\t\\n]*
-        """
+        let expected = #"""
+        root ::= toolcall-0 | toolcall-1
+        args-0 ::= value
+        toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"alpha\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}"
+        args-1 ::= value
+        toolcall-1 ::= "{" ws "\"name\"" ws ":" ws "\"beta\"" ws "," ws "\"arguments\"" ws ":" ws args-1 ws "}"
+        """# + "\n" + genericTail
         XCTAssertEqual(grammar, expected)
     }
 }


### PR DESCRIPTION
Builds on #1863 (which wired `ToolGrammarBuilder.buildGrammar(for:)` into `GenerationQueue` for grammar-capable backends). This PR makes the builder lower each tool's parameter schema, instead of emitting a name-only envelope.

## What changed

`ToolGrammarBuilder` now lowers each tool's JSON-Schema `parameters` to GBNF and pins it **per branch** of a discriminated-union tool-call envelope, so a grammar-capable local backend is constrained to emit well-typed `"arguments"` — not merely a well-formed envelope.

### Discriminated-union envelope

```
root        ::= toolcall-0 | toolcall-1 | ...
toolcall-N  ::= "{" ws "\"name\"" ws ":" ws "\"<name_N>\"" ws "," ws "\"arguments\"" ws ":" ws args-N ws "}"
args-N      ::= <lowered from tool N's parameters schema>
```

Pinning `"name"` per branch is what lets each tool's `arguments` be constrained to *its own* schema. A single tool collapses to `root ::= toolcall-0`.

### Supported-shape matrix (lowerer)

| Schema shape | Lowering |
|---|---|
| `object` (properties + required) | required keys (sorted) then optional keys as `( "," ws "\"k\"" ws ":" ws <v> )?` |
| `string` | generic JSON `string` rule |
| `string` + `enum` | alternation of quoted literals `("\"north\"" \| "\"south\"")` |
| `integer` / `number` | signed int / signed decimal |
| `boolean` | `("true" \| "false")` |
| `array` + single-schema `items` | `"[" ws ( item ( ws "," ws item )* )? ws "]"` |
| nullable union `["T","null"]` | `( <T> \| "null" )` |
| nested object / array | recurse |

### Graceful degradation (policy)

Any unmodeled sub-schema — combiners (`anyOf`/`oneOf`/`allOf`/`not`), `$ref`, `pattern`, `format`, `patternProperties`, tuple-form `items`, unknown `type` — lowers to the shared generic JSON `value` rule **for that node only**. A whole-tool schema that can't be lowered degrades its `args-N` to `value` but is **never dropped from the union**. The envelope and tool name stay constrained even when the arguments can't be. This is strictly better than rejecting the tool.

### Pre-validator premise correction

The old `GBNFSchemaPreValidator` claimed combiners and nullable unions are "inexpressible in the GBNF IR." **That's wrong** — GBNF supports alternation (`|`), and llama.cpp's own `json_schema_to_grammar` lowers them. The real limit is *this lowerer's coverage*, not the IR.

- **Relaxed:** no longer gates the build path (graceful degradation subsumes rejection); retained as an advisory coverage report. Nullable unions and `exclusiveMinimum`/`exclusiveMaximum` are no longer flagged (the former is lowered; the latter is unenforceable in GBNF anyway, so the bound is ignored).
- **Kept:** combiners, `$ref`, `patternProperties` are still flagged as falling back to generic JSON.
- The CVE-2026-2069 audit record is retained for provenance; its docs now say the flags encode *lowerer coverage*, not crash shapes.

## GBNF validity (hand-verified — CI can't compile GBNF)

Emitted rule names use **hyphens, not underscores**. llama.cpp's `is_word_char` accepts only `[a-zA-Z0-9-]` and stops at `_`, so `args_0`/`toolcall_0` would be misparsed (`args` then a syntax error) and **every emitted grammar would have failed to compile**. Fixed to `args-0`, `toolcall-0`, `args-0-0`. Verified against llama.cpp's grammar parser source for: string-enum, mixed required/optional object, array, anyOf-fallback, and the two-tool union — single `root`, all nonterminals defined, no undefined refs, no left-recursion, no nullable zero-width loops, correctly escaped literals, `ws` between structural tokens.

## Tests

Byte-exact golden assertions for every per-param shape (enum, typed object, array, optional-keys, nullable union, generic fallback, multi-tool union, escaped enum literals). `EnqueueToolGrammarWiringTests` recompute expected output from the builder so they track the grammar string. `GBNFSchemaPreValidatorTests` updated for the advisory behavior change (nullable union + exclusiveMin/Max now pass; combiners/`$ref`/`patternProperties` flagged).

Closes #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)