### PR TITLE
feat: model-selection enablers — ModelInfo fit-score bridge + service-vended shared load coordinator

### DIFF
--- a/Sources/ManifoldHardware/AppleSiliconBandwidth.swift
+++ b/Sources/ManifoldHardware/AppleSiliconBandwidth.swift
@@ -548,9 +548,19 @@ public struct ModelFitScorer: Sendable {
     /// tier from `DownloadableModel.sizeBytes` rather than adding fields to
     /// `ModelCapabilityTier`, which is a pure file-size enum by design.
     private func qualityScore(for model: DownloadableModel) -> Double {
+        Self.qualityScore(sizeBytes: model.sizeBytes, quantization: model.quantization)
+    }
+
+    /// Capability proxy in 0...1 from raw size bytes and a quantization tag.
+    ///
+    /// Exposed at `package` visibility so the `ModelInfo` bridge in
+    /// `ManifoldInference` (which sees `ModelInfo` but not `DownloadableModel`)
+    /// can reuse the *exact* same tier × quant-width curve as the downloadable
+    /// path — keeping a resident model and its downloadable twin on one scale.
+    package static func qualityScore(sizeBytes: UInt64, quantization: String?) -> Double {
         // Reconstruct the tier from size using the same thresholds ModelCapabilityTier
         // applies to on-disk models, then map to a 0...1 capability base.
-        let gb = Double(model.sizeBytes) / 1_073_741_824
+        let gb = Double(sizeBytes) / 1_073_741_824
         let tierBase: Double
         switch gb {
         case ..<2:    tierBase = 0.20  // minimal
@@ -567,23 +577,58 @@ public struct ModelFitScorer: Sendable {
         // factor is gentle (0.90...1.0, diminishing returns past Q6), but below it the
         // penalty steepens so a Q2 (factor ~0.55) cannot ride its larger param count
         // past a Q4/Q5 of the adjacent smaller tier.
-        let bpw = QuantizationBits.bitsPerWeight(for: model.quantization)
+        let bpw = QuantizationBits.bitsPerWeight(for: quantization)
         let quantFactor: Double
         if bpw >= 4.0 {
             // 4 bpw → 0.90, 8.5 bpw → ~1.0.
-            quantFactor = clamp(0.90 + (bpw - 4.0) / 4.5 * 0.10, min: 0.90, max: 1.0)
+            quantFactor = clampStatic(0.90 + (bpw - 4.0) / 4.5 * 0.10, min: 0.90, max: 1.0)
         } else {
             // 4 bpw → 0.90 down to ~2 bpw → 0.50: steep penalty in the sub-Q4 cliff.
-            quantFactor = clamp(0.50 + (bpw - 2.0) / 2.0 * 0.40, min: 0.40, max: 0.90)
+            quantFactor = clampStatic(0.50 + (bpw - 2.0) / 2.0 * 0.40, min: 0.40, max: 0.90)
         }
 
-        return clamp01(tierBase * quantFactor)
+        return clampStatic(tierBase * quantFactor, min: 0.0, max: 1.0)
     }
 
     // MARK: - Math helpers
 
+    /// `package`-visible composite assembler used by both the downloadable path
+    /// and the `ModelInfo` bridge so the four dimensions combine identically.
+    ///
+    /// `willRun == false` collapses the composite into a strictly-lower band
+    /// (× 0.1), matching the in-line gate in `score(_:DownloadableModel...)` —
+    /// a model that won't load must rank below every runnable candidate.
+    package static func composite(
+        quality: Double,
+        speed: Double,
+        fit: Double,
+        context: Double,
+        weights: FitWeights,
+        willRun: Bool
+    ) -> Double {
+        let weightedSum = quality * weights.quality
+            + speed * weights.speed
+            + fit * weights.fit
+            + context * weights.context
+        return willRun ? weightedSum : weightedSum * 0.1
+    }
+
+    /// `package`-visible decode-throughput estimate (tokens/sec) and its
+    /// normalised `speed` dimension, shared with the `ModelInfo` bridge.
+    package func speedDimension(
+        activeBytes: UInt64,
+        device: DeviceProfile
+    ) -> (estimatedTokensPerSecond: Double, speed: Double) {
+        let activeGB = max(Double(activeBytes) / 1_073_741_824, 0.001)
+        let estimatedTPS = (device.memoryBandwidthGBs / activeGB) * efficiencyFactor
+        return (estimatedTPS, clamp01(estimatedTPS / speedSaturationTokensPerSecond))
+    }
+
     private func clamp01(_ x: Double) -> Double { clamp(x, min: 0.0, max: 1.0) }
     private func clamp(_ x: Double, min lo: Double, max hi: Double) -> Double {
+        Swift.max(lo, Swift.min(hi, x))
+    }
+    private static func clampStatic(_ x: Double, min lo: Double, max hi: Double) -> Double {
         Swift.max(lo, Swift.min(hi, x))
     }
 }

--- a/Sources/ManifoldInference/Extensions/ModelFitScorer+ModelInfo.swift
+++ b/Sources/ManifoldInference/Extensions/ModelFitScorer+ModelInfo.swift
@@ -1,0 +1,147 @@
+import Foundation
+// @_spi(BackendInternals): the scorer reuses ManifoldHardware primitives
+// (DeviceProfile, ModelLoadPlan.Environment, package-visible composite helpers).
+@_spi(BackendInternals) import ManifoldHardware
+
+// MARK: - ModelFitScorer bridge for ModelInfo
+
+/// Fit-scoring for the models a user actually has on disk.
+///
+/// `ModelFitScorer` ships scoring overloads for `DownloadableModel` (pre-download
+/// catalog entries) and `ModelSelectionProfile` (resident descriptors), but
+/// `ModelRegistry.availableModels` is `[ModelInfo]` — the on-disk shape. Without
+/// this bridge nothing could rank the models already present locally.
+///
+/// This overload derives the scorer's four inputs from `ModelInfo`'s existing
+/// fields and reuses the *same* dimension math as the downloadable path:
+/// - **fit**: from `ModelLoadPlan.compute(for: model, ...)` — the ModelInfo-aware
+///   plan factory in `ModelLoadPlan+ModelInfo.swift`, which reads the GGUF KV
+///   estimate when present rather than the legacy fallback. We never recompute
+///   resident/KV byte math here.
+/// - **quality**: `ModelFitScorer.qualityScore(sizeBytes:quantization:)` — the
+///   identical size-tier × quant-width curve `DownloadableModel` scoring uses.
+/// - **speed**: `bandwidth ÷ active-bytes-per-token`, with `activeParameterBytes`
+///   as the denominator (MoE) falling back to `fileSize` (dense/unknown).
+/// - **context**: `detectedContextLength` vs. the use case's `contextNeed`,
+///   neutral (0.5) when the header carried no context length.
+public extension ModelFitScorer {
+
+    /// Scores a single on-disk `ModelInfo` under a use case.
+    ///
+    /// - Parameters:
+    ///   - model: The on-disk candidate.
+    ///   - useCase: Biases the dimension weights and context need.
+    ///   - requestedContextSize: Context size the fit dimension is evaluated at.
+    ///   - device: Device profile supplying memory + bandwidth (injectable for tests).
+    ///   - environment: Memory environment for the `ModelLoadPlan` fit estimate.
+    ///     Defaults to one derived from `device` so a single injected `DeviceProfile`
+    ///     drives both the speed and fit dimensions consistently.
+    /// - Returns: A `ModelFitScore`, or `nil` if the model has no usable size and is
+    ///   not an OS-resident foundation model (size 0 is legitimate for foundation).
+    func score(
+        _ model: ModelInfo,
+        useCase: ModelUseCase,
+        requestedContextSize: Int = 4_096,
+        device: DeviceProfile = .current,
+        environment: ModelLoadPlan.Environment? = nil
+    ) -> ModelFitScore? {
+        // Foundation models are OS-resident with a 0-byte file footprint; every other
+        // type needs a real size to score. A genuine 0-byte local file is unscoreable.
+        guard model.modelType == .foundation || model.fileSize > 0 else { return nil }
+
+        let weights = useCase.weights
+        let env = environment ?? ModelLoadPlan.Environment(
+            availableMemoryBytes: { device.usableMemoryBytes },
+            physicalMemoryBytes: device.physicalMemoryBytes
+        )
+
+        // --- fit: reuse the ModelInfo-aware load plan; do NOT recompute byte math. ---
+        let plan = ModelLoadPlan.compute(
+            for: model,
+            requestedContextSize: requestedContextSize,
+            environment: env
+        )
+        let willRun = plan.verdict != .deny
+        let fit: Double
+        switch plan.verdict {
+        case .allow: fit = 1.0
+        case .warn:  fit = 0.5
+        case .deny:  fit = 0.0
+        }
+
+        // --- quality: identical size-tier × quant-width curve as downloadable scoring. ---
+        let quality = ModelFitScorer.qualityScore(
+            sizeBytes: model.fileSize,
+            quantization: model.quantization
+        )
+
+        // --- speed: bandwidth ÷ active-bytes-per-token. ---
+        // why: decode throughput is memory-bandwidth bound by the bytes streamed per
+        // token-pass. For MoE only the active experts are touched, so
+        // `activeParameterBytes` is the right denominator; dense/unknown falls back to
+        // the full file size. Foundation models have a 0-byte file, so they fall back
+        // to the OS-resident assumed active footprint to land in the usable speed band.
+        let activeBytes: UInt64
+        if let active = model.activeParameterBytes, active > 0 {
+            activeBytes = active
+        } else if model.modelType == .foundation {
+            activeBytes = ModelFitScorer.osResidentAssumedActiveBytes
+        } else {
+            activeBytes = model.fileSize
+        }
+        let (estimatedTPS, speed) = speedDimension(activeBytes: activeBytes, device: device)
+
+        // --- context: detected length vs. need; neutral when unknown. ---
+        let context: Double
+        if let known = model.detectedContextLength, known > 0 {
+            let raw = Double(known) / Double(max(useCase.contextNeed, 1))
+            context = Swift.max(0.0, Swift.min(1.0, raw))
+        } else {
+            context = 0.5
+        }
+
+        let composite = ModelFitScorer.composite(
+            quality: quality,
+            speed: speed,
+            fit: fit,
+            context: context,
+            weights: weights,
+            willRun: willRun
+        )
+
+        return ModelFitScore(
+            quality: quality,
+            speed: speed,
+            fit: fit,
+            context: context,
+            composite: composite,
+            estimatedTokensPerSecond: estimatedTPS,
+            memoryBytes: plan.outcome.totalEstimatedBytes,
+            willRun: willRun
+        )
+    }
+
+    /// Ranks on-disk models best-first (descending composite) under a use case.
+    ///
+    /// Mirrors the `rank(_:DownloadableModel...)` convenience: models that fail to
+    /// score (0-byte non-foundation files) are dropped.
+    func rank(
+        _ models: [ModelInfo],
+        useCase: ModelUseCase,
+        requestedContextSize: Int = 4_096,
+        device: DeviceProfile = .current,
+        environment: ModelLoadPlan.Environment? = nil
+    ) -> [(ModelInfo, ModelFitScore)] {
+        models.compactMap { model in
+            guard let s = score(
+                model,
+                useCase: useCase,
+                requestedContextSize: requestedContextSize,
+                device: device,
+                environment: environment
+            ) else { return nil }
+            return (model, s)
+        }
+        .sorted { $0.1.composite > $1.1.composite }
+    }
+}

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -73,6 +73,30 @@ public final class InferenceService {
     private let lifecycle: ModelLifecycleCoordinator
     private let generation: GenerationQueue
 
+    // MARK: - Shared Model-Load Coordinator
+
+    /// Backing store for the single ``modelLoadCoordinator`` vended per service.
+    private var _modelLoadCoordinator: ModelLoadCoordinator?
+
+    /// The one ``ModelLoadCoordinator`` shared by every consumer of this service.
+    ///
+    /// "One coordinator per service" is structural: both `ChatViewModel` and a
+    /// headless `ModelSelection` façade receive *this* instance rather than each
+    /// constructing their own. Two coordinators over a single service would
+    /// cross-talk on the shared ``modelLoadProgress`` scalar (the progress bridge
+    /// in one would mirror the other's load), so the service owns the single
+    /// instance and lazily creates it on first access.
+    ///
+    /// Multiple observers watch a load without clobbering each other via
+    /// ``ModelLoadCoordinator/statusUpdates()``; chat-only side effects stay on the
+    /// callback seams, which `ChatViewModel` (the load *driver*) installs.
+    public var modelLoadCoordinator: ModelLoadCoordinator {
+        if let existing = _modelLoadCoordinator { return existing }
+        let coordinator = ModelLoadCoordinator(inferenceService: self)
+        _modelLoadCoordinator = coordinator
+        return coordinator
+    }
+
     // MARK: - Memory Pressure Broadcasting
 
     /// Fan-out broadcaster for memory-pressure and model-lifecycle events.

--- a/Sources/ManifoldInference/Services/ModelLoadCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLoadCoordinator.swift
@@ -1,11 +1,9 @@
 import Foundation
-import ManifoldRuntime
-import ManifoldInference
 
 // MARK: - LoadIntent
 
 /// The two kinds of load request that can be dispatched to the coordinator.
-enum LoadIntent {
+public enum LoadIntent: Sendable {
     case localModel(ModelInfo)
     case cloudEndpoint(APIEndpointRecord)
 }
@@ -15,9 +13,17 @@ enum LoadIntent {
 /// Owns the "latest-wins with cancellation" model-load state machine extracted
 /// from `ChatViewModel` (phase 3 of #329).
 ///
+/// Relocated from `ManifoldUI` to `ManifoldInference` so `InferenceService` can
+/// **own and vend a single instance** ("one coordinator per service" is now
+/// structural). Two consumers over one `InferenceService` — the existing
+/// `ChatViewModel` and a future headless `ModelSelection` façade — must share the
+/// same coordinator: two coordinators over one service would cross-talk on the
+/// shared `InferenceService.modelLoadProgress` scalar.
+///
 /// The coordinator is `@MainActor` but NOT `@Observable` — it holds no
-/// SwiftUI-observed state of its own. All observable side-effects are routed
-/// back to `ChatViewModel` through the callback seams set at construction.
+/// SwiftUI-observed state of its own. Chat-specific observable side-effects are
+/// routed through the callback seams set at construction; the multi-observer
+/// progress / phase / error path is published via ``statusUpdates()``.
 ///
 /// ## Race safety
 ///
@@ -29,48 +35,92 @@ enum LoadIntent {
 /// - `InferenceService` suppresses any stale completion that does reach it via its
 ///   own monotonic `LoadRequestToken`.
 @MainActor
-final class ModelLoadCoordinator {
+public final class ModelLoadCoordinator {
 
     // MARK: - Seams (set by ChatViewModel at init)
 
     /// Forwards to `ChatViewModel.transitionPhase(to:)`. Returns `true` if the
     /// transition was accepted (matches `transitionPhase`'s own return value).
-    var onTransitionPhase: @MainActor (BackendActivityPhase) -> Bool = { _ in false }
+    public var onTransitionPhase: @MainActor (BackendActivityPhase) -> Bool = { _ in false }
 
     /// Forwards to setting `ChatViewModel.errorMessage` to a non-nil string.
-    var onSurfaceError: @MainActor (String) -> Void = { _ in }
+    public var onSurfaceError: @MainActor (String) -> Void = { _ in }
 
     /// Clears `ChatViewModel.errorMessage` (sets it to `nil`).
-    var onClearError: @MainActor () -> Void = {}
+    public var onClearError: @MainActor () -> Void = {}
 
     /// Forwards to setting `ChatViewModel.selectedPromptTemplate`.
-    var onSetSelectedPromptTemplate: @MainActor (PromptTemplate) -> Void = { _ in }
+    public var onSetSelectedPromptTemplate: @MainActor (PromptTemplate) -> Void = { _ in }
 
     /// Forwards to `ChatViewModel.invalidateTokenCaches()`.
-    var onInvalidateTokenCaches: @MainActor () -> Void = {}
+    public var onInvalidateTokenCaches: @MainActor () -> Void = {}
 
     /// Returns `ChatViewModel.isRestoringSession`.
-    var isRestoringSession: @MainActor () -> Bool = { false }
+    public var isRestoringSession: @MainActor () -> Bool = { false }
 
     /// Returns `ChatViewModel.activityPhase`.
-    var currentActivityPhase: @MainActor () -> BackendActivityPhase = { .idle }
+    public var currentActivityPhase: @MainActor () -> BackendActivityPhase = { .idle }
 
     /// Returns the `ModelLoadPlan.Environment` to use for local-model load plans.
-    var currentLoadPlanEnvironment: @MainActor () -> ModelLoadPlan.Environment = { .current }
+    public var currentLoadPlanEnvironment: @MainActor () -> ModelLoadPlan.Environment = { .current }
+
+    // MARK: - Multi-observer load-status surface
+
+    /// The most recent published load status. New subscribers receive this as their
+    /// first element so a late observer is not stuck on a stale `.idle`.
+    public private(set) var status: ModelLoadStatus = .idle
+
+    /// Live fan-out continuations, keyed by subscription token. Each observer owns
+    /// one entry; publishing fans out to all of them. Unbounded buffering with the
+    /// newest value winning keeps observers from blocking the load path.
+    private var statusContinuations: [UUID: AsyncStream<ModelLoadStatus>.Continuation] = [:]
+
+    /// Returns a fresh `AsyncStream` of load-status transitions for one observer.
+    ///
+    /// Multiple observers (e.g. `ChatViewModel` AND a headless façade) may each call
+    /// this and watch the *same* load without clobbering each other — this replaces
+    /// the single-owner callback pattern for the progress / phase / error path. The
+    /// stream yields the current ``status`` immediately, then every subsequent
+    /// transition. It finishes when the coordinator is deinitialised.
+    public func statusUpdates() -> AsyncStream<ModelLoadStatus> {
+        let token = UUID()
+        let current = status
+        return AsyncStream { continuation in
+            statusContinuations[token] = continuation
+            continuation.yield(current)
+            continuation.onTermination = { [weak self] _ in
+                // onTermination can fire off-actor; hop back to drop the entry.
+                Task { @MainActor [weak self] in
+                    self?.statusContinuations[token] = nil
+                }
+            }
+        }
+    }
+
+    /// Publishes a new status to every subscribed observer and records it as the
+    /// latest value. Idempotent: re-publishing the same status is a no-op so we
+    /// don't wake observers on redundant transitions.
+    private func publish(_ newStatus: ModelLoadStatus) {
+        guard newStatus != status else { return }
+        status = newStatus
+        for continuation in statusContinuations.values {
+            continuation.yield(newStatus)
+        }
+    }
 
     // MARK: - State
 
     /// Polling interval for the model-load progress bridge task that mirrors
     /// `inferenceService.modelLoadProgress` into the view model's `activityPhase`.
     /// Tests may override this to a small value for deterministic timing.
-    var progressBridgePollInterval: Duration = .milliseconds(50)
+    public var progressBridgePollInterval: Duration = .milliseconds(50)
 
     /// Minimum interval between published phase transitions for in-flight
     /// model-load progress. Keeps steadily-progressing backends from
     /// re-rendering every view observing `activityPhase` on every poll tick.
     /// The first emission in a load cycle and the terminal (≥ 1.0) emission
     /// always publish regardless of this window.
-    var progressBridgeMinTransitionInterval: Duration = .milliseconds(250)
+    public var progressBridgeMinTransitionInterval: Duration = .milliseconds(250)
 
     /// Timestamp of the most recent published phase transition from
     /// `applyModelLoadProgress`. `nil` means the next progress change will
@@ -86,13 +136,13 @@ final class ModelLoadCoordinator {
     /// continuations to detect they are no longer current.
     var latestLoadIntentGeneration: UInt64 = 0
 
-    // MARK: - Dependencies (injected by ChatViewModel)
+    // MARK: - Dependencies (injected by InferenceService)
 
     private let inferenceService: InferenceService
 
     // MARK: - Init
 
-    init(inferenceService: InferenceService) {
+    public init(inferenceService: InferenceService) {
         self.inferenceService = inferenceService
     }
 
@@ -100,7 +150,7 @@ final class ModelLoadCoordinator {
 
     /// Dispatches a load for the given intent. The newest dispatch always wins;
     /// any older in-flight coordinated load is cancelled and invalidated.
-    func dispatchLoad(_ intent: LoadIntent) {
+    public func dispatchLoad(_ intent: LoadIntent) {
         let generation = nextLoadIntentGeneration(cancelInFlightTask: true)
         coordinatedLoadTask = Task { [weak self] in
             await self?.performLoad(intent, generation: generation)
@@ -110,16 +160,19 @@ final class ModelLoadCoordinator {
     /// Cancels any in-flight coordinated load and (optionally) resets the
     /// activity phase back to `.idle`. Called from `unloadModel()` and
     /// `handleMemoryPressure()` on the VM.
-    func invalidatePendingLoadIntent(resetActivityPhase: Bool = false) {
+    public func invalidatePendingLoadIntent(resetActivityPhase: Bool = false) {
         _ = nextLoadIntentGeneration(cancelInFlightTask: true)
         if resetActivityPhase, case .modelLoading = currentActivityPhase() {
             _ = onTransitionPhase(.idle)
         }
+        // A cancelled / invalidated load is no longer in flight: collapse the
+        // headless status to idle so observers don't sit on a stale `.loading`.
+        publish(.idle)
     }
 
     // MARK: - Load Entry Points (called from ChatViewModel for non-dispatch paths)
 
-    func loadLocalModel(_ model: ModelInfo, generation: UInt64?) async {
+    public func loadLocalModel(_ model: ModelInfo, generation: UInt64?) async {
         guard isCurrentLoadIntentGeneration(generation) else { return }
 
         // Clamp the local-model context request. Some headers advertise a huge
@@ -184,6 +237,7 @@ final class ModelLoadCoordinator {
 
         do {
             try await inferenceService.loadModel(from: model, plan: plan)
+            publishLoadedIfCurrent(generation: generation)
         } catch is CancellationError {
             return
         } catch {
@@ -191,7 +245,7 @@ final class ModelLoadCoordinator {
         }
     }
 
-    func loadCloudEndpointInternal(_ endpoint: APIEndpointRecord, generation: UInt64?) async {
+    public func loadCloudEndpointInternal(_ endpoint: APIEndpointRecord, generation: UInt64?) async {
         guard beginLoadUIState(generation: generation) else { return }
         let bridge = Task { @MainActor [weak self] in
             await self?.observeModelLoadProgress(generation: generation)
@@ -203,6 +257,7 @@ final class ModelLoadCoordinator {
 
         do {
             try await inferenceService.loadEndpointBackend(from: endpoint)
+            publishLoadedIfCurrent(generation: generation)
         } catch is CancellationError {
             return
         } catch {
@@ -242,7 +297,9 @@ final class ModelLoadCoordinator {
         guard isCurrentLoadIntentGeneration(generation) else { return false }
         onClearError()
         lastProgressTransitionInstant = nil
-        _ = onTransitionPhase(.modelLoading(progress: inferenceService.modelLoadProgress))
+        let progress = inferenceService.modelLoadProgress
+        _ = onTransitionPhase(.modelLoading(progress: progress))
+        publish(.loading(progress: progress))
         return true
     }
 
@@ -288,6 +345,12 @@ final class ModelLoadCoordinator {
 
         if onTransitionPhase(.modelLoading(progress: snapshot)) {
             lastProgressTransitionInstant = now
+            // Mirror in-flight progress to headless observers. Only while we are
+            // still in a loading cycle — `publish` is idempotent so a repeated
+            // value is dropped.
+            if case .loading = status {
+                publish(.loading(progress: snapshot))
+            }
         }
     }
 
@@ -297,11 +360,25 @@ final class ModelLoadCoordinator {
         if case .modelLoading = currentActivityPhase() {
             _ = onTransitionPhase(.idle)
         }
+        // A load cycle that ended without committing or failing (e.g. a `.deny`
+        // returned before the load began, or a superseded generation) collapses
+        // the headless status back to idle. A successful `.loaded` or a `.failed`
+        // was already published on the relevant path and is preserved here because
+        // `endLoadUIState` only resets a still-`loading` status.
+        if case .loading = status {
+            publish(.idle)
+        }
     }
 
     private func setLoadErrorIfCurrent(_ message: String, generation: UInt64?) {
         guard isCurrentLoadIntentGeneration(generation) else { return }
         onSurfaceError(message)
+        publish(.failed(reason: message))
+    }
+
+    private func publishLoadedIfCurrent(generation: UInt64?) {
+        guard isCurrentLoadIntentGeneration(generation) else { return }
+        publish(.loaded)
     }
 
     /// Translates a denied plan's primary `Reason` into a user-visible message.

--- a/Sources/ManifoldInference/Services/ModelLoadStatus.swift
+++ b/Sources/ManifoldInference/Services/ModelLoadStatus.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// MARK: - ModelLoadStatus
+
+/// A headless, multi-observer view of a model load's lifecycle.
+///
+/// `ModelLoadCoordinator`'s original output was a set of single-owner
+/// `@MainActor` callback seams wired into one `ChatViewModel`. That shape cannot
+/// serve two consumers at once — a future headless `ModelSelection` façade and the
+/// existing chat view model both want to watch the same load. `ModelLoadStatus`
+/// is the shared, fan-out signal: every observer subscribes to its own
+/// `AsyncStream` (see ``ModelLoadCoordinator/statusUpdates()``) and sees the same
+/// transitions without clobbering anyone else's callbacks.
+///
+/// The richer chat-only side effects (prompt-template selection, token-cache
+/// invalidation) stay on the callback seams; only the progress / phase / error
+/// path is mirrored here, because that is the part multiple observers need.
+public enum ModelLoadStatus: Sendable, Equatable {
+    /// No load is in flight (initial state, and the terminal state after a load
+    /// completes, is unloaded, or is invalidated).
+    case idle
+    /// A load is in flight. `progress` is `nil` until the backend reports a
+    /// fractional value (some backends never do).
+    case loading(progress: Double?)
+    /// The most recent load committed successfully.
+    case loaded
+    /// The most recent load failed. `reason` is a user-presentable message.
+    case failed(reason: String)
+}

--- a/Sources/ManifoldInference/Services/ModelLoadStatus.swift
+++ b/Sources/ManifoldInference/Services/ModelLoadStatus.swift
@@ -16,8 +16,9 @@ import Foundation
 /// invalidation) stay on the callback seams; only the progress / phase / error
 /// path is mirrored here, because that is the part multiple observers need.
 public enum ModelLoadStatus: Sendable, Equatable {
-    /// No load is in flight (initial state, and the terminal state after a load
-    /// completes, is unloaded, or is invalidated).
+    /// No load is in flight: the initial state, and the terminal state after an
+    /// unload or invalidation. A *successful* load terminates on ``loaded`` —
+    /// status does not fall back to `idle` when a load finishes.
     case idle
     /// A load is in flight. `progress` is `nil` until the backend reports a
     /// fractional value (some backends never do).

--- a/Sources/ManifoldModelCatalog/ModelInfo.swift
+++ b/Sources/ManifoldModelCatalog/ModelInfo.swift
@@ -84,6 +84,24 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
     }
 
+    /// Quantization tag parsed from the GGUF filename (e.g. "Q4_K_M", "Q8_0"), or
+    /// `nil` for non-GGUF models and filenames that carry no recognisable tag.
+    ///
+    /// Mirrors ``DownloadableModel/quantization`` so an on-disk model and its
+    /// downloadable twin resolve to the same tag — the fit scorer reads this to
+    /// derive the quality dimension's quantization-width factor.
+    public var quantization: String? {
+        guard modelType == .gguf else { return nil }
+        // Match common GGUF quant patterns: Q4_K_M, Q8_0, IQ2_XS, F16, etc.
+        // The trailing `_SEGMENT` repetition is bounded to {0,5} to prevent
+        // catastrophic backtracking on crafted filenames; input is clipped to
+        // 128 chars (any legitimate HuggingFace filename fits well under that).
+        let pattern = #"[_\-\.]((?:Q|IQ|F|BF)\d+(?:_[A-Z0-9]+){0,5})\."#
+        let boundedName = String(fileName.prefix(128))
+        guard let range = boundedName.range(of: pattern, options: .regularExpression) else { return nil }
+        return String(boundedName[range].dropFirst().dropLast())
+    }
+
     /// Short label for the backend type.
     public var backendLabel: String {
         BackendDescriptorRegistry.shared.descriptor(for: modelType)?.backendLabel

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -861,7 +861,11 @@ public final class ChatViewModel {
         let firstRunKey = "\(ManifoldConfiguration.shared.bundleIdentifier).hasCompletedFirstLaunch"
         self.isFirstRun = !userDefaults.bool(forKey: firstRunKey)
 
-        let coordinator = ModelLoadCoordinator(inferenceService: inferenceService)
+        // Consume the single coordinator the service vends rather than constructing
+        // our own — "one coordinator per service" is structural now (see
+        // `InferenceService.modelLoadCoordinator`). A headless model-selection
+        // surface can share this same instance.
+        let coordinator = inferenceService.modelLoadCoordinator
         self.loadCoordinator = coordinator
         coordinator.onTransitionPhase = { [weak self] phase in
             self?.transitionPhase(to: phase) ?? false

--- a/Tests/ManifoldInferenceTests/ModelFitScorerModelInfoBridgeTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelFitScorerModelInfoBridgeTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit tests for the `ModelFitScorer.score(_ model: ModelInfo, ...)` bridge.
+///
+/// The bridge lets the scorer rank the models a user actually has on disk
+/// (`ModelRegistry.availableModels` is `[ModelInfo]`). Inputs are injected
+/// (device profile + memory environment) so results are deterministic.
+final class ModelFitScorerModelInfoBridgeTests: XCTestCase {
+
+    private let oneGB: UInt64 = 1_073_741_824
+
+    // MARK: - Fixtures
+
+    /// A GGUF on-disk fixture. `quant` is encoded into the filename so the
+    /// production `ModelInfo.quantization` regex extracts it, exactly as the
+    /// `DownloadableModel` fixtures do for the downloadable scoring path.
+    private func ggufModel(
+        sizeGB: Double,
+        quant: String,
+        name: String = "Model",
+        contextLength: Int? = nil
+    ) -> ModelInfo {
+        ModelInfo(
+            name: name,
+            fileName: "\(name).\(quant).gguf",
+            url: URL(fileURLWithPath: "/virtual/\(name).\(quant).gguf"),
+            fileSize: UInt64(sizeGB * Double(oneGB)),
+            modelType: .gguf,
+            detectedContextLength: contextLength
+        )
+    }
+
+    private func device(ramGB: UInt64, bandwidthGBs: Double) -> DeviceProfile {
+        let bytes = ramGB * oneGB
+        return DeviceProfile(
+            physicalMemoryBytes: bytes,
+            usableMemoryBytes: bytes,
+            memoryBandwidthGBs: bandwidthGBs
+        )
+    }
+
+    private func environment(for device: DeviceProfile) -> ModelLoadPlan.Environment {
+        ModelLoadPlan.Environment(
+            availableMemoryBytes: { device.usableMemoryBytes },
+            physicalMemoryBytes: device.physicalMemoryBytes
+        )
+    }
+
+    // MARK: - Quantization parsing
+
+    func test_modelInfo_quantization_parsedFromFileName() {
+        XCTAssertEqual(ggufModel(sizeGB: 4, quant: "Q4_K_M").quantization, "Q4_K_M")
+        XCTAssertEqual(ggufModel(sizeGB: 4, quant: "Q8_0").quantization, "Q8_0")
+        XCTAssertEqual(ggufModel(sizeGB: 4, quant: "IQ2_XS").quantization, "IQ2_XS")
+    }
+
+    func test_modelInfo_quantization_nilForNonGGUF() {
+        let mlx = ModelInfo(
+            name: "snap",
+            fileName: "mlx-community/snap",
+            url: URL(fileURLWithPath: "/virtual/snap"),
+            fileSize: oneGB,
+            modelType: .mlx
+        )
+        XCTAssertNil(mlx.quantization)
+    }
+
+    // MARK: - Scoring
+
+    func test_score_returnsNilForZeroByteNonFoundationModel() {
+        let scorer = ModelFitScorer()
+        let empty = ModelInfo(
+            name: "empty",
+            fileName: "empty.Q4_K_M.gguf",
+            url: URL(fileURLWithPath: "/virtual/empty.gguf"),
+            fileSize: 0,
+            modelType: .gguf
+        )
+        XCTAssertNil(scorer.score(empty, useCase: .general))
+    }
+
+    func test_score_foundationModel_isScoredDespiteZeroFileSize() {
+        let scorer = ModelFitScorer()
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let score = scorer.score(
+            ModelInfo.builtInFoundation,
+            useCase: .general,
+            device: dev,
+            environment: environment(for: dev)
+        )
+        XCTAssertNotNil(score)
+        // OS-resident: the load plan always allows, so it must rank as runnable.
+        XCTAssertTrue(score?.willRun ?? false)
+    }
+
+    func test_smallQ4_outranks_largeQ2_onTightMemory() {
+        // 8 GB device: the ~5.5 GB Q2 is a tight/over fit while the ~4 GB Q4 fits
+        // comfortably AND has the wider quant. Composite should favour the Q4.
+        let dev = device(ramGB: 8, bandwidthGBs: 100)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let smallQ4 = ggufModel(sizeGB: 4.0, quant: "Q4_K_M", name: "Seven")
+        let bigQ2 = ggufModel(sizeGB: 5.5, quant: "Q2_K", name: "Thirteen")
+
+        let s7 = scorer.score(smallQ4, useCase: .general, device: dev, environment: env)
+        let s13 = scorer.score(bigQ2, useCase: .general, device: dev, environment: env)
+
+        XCTAssertNotNil(s7)
+        XCTAssertNotNil(s13)
+        XCTAssertGreaterThan(s7!.composite, s13!.composite)
+    }
+
+    func test_oversizeModel_denied_collapsesBelowRunnable() {
+        // A 40 GB model on a 8 GB device cannot load: willRun == false and the
+        // composite must collapse below any runnable candidate.
+        let dev = device(ramGB: 8, bandwidthGBs: 100)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let huge = ggufModel(sizeGB: 40.0, quant: "Q4_K_M", name: "Seventy")
+        let small = ggufModel(sizeGB: 3.0, quant: "Q4_K_M", name: "Three")
+
+        let sHuge = scorer.score(huge, useCase: .reasoning, device: dev, environment: env)
+        let sSmall = scorer.score(small, useCase: .reasoning, device: dev, environment: env)
+
+        XCTAssertNotNil(sHuge)
+        XCTAssertNotNil(sSmall)
+        XCTAssertFalse(sHuge!.willRun)
+        XCTAssertGreaterThan(sSmall!.composite, sHuge!.composite)
+    }
+
+    func test_rank_ordersByCompositeBestFirst_andDropsUnscoreable() {
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let good = ggufModel(sizeGB: 7.0, quant: "Q5_K_M", name: "Good", contextLength: 8_192)
+        let weak = ggufModel(sizeGB: 1.5, quant: "Q2_K", name: "Weak")
+        let empty = ModelInfo(
+            name: "empty",
+            fileName: "empty.Q4_K_M.gguf",
+            url: URL(fileURLWithPath: "/virtual/empty.gguf"),
+            fileSize: 0,
+            modelType: .gguf
+        )
+
+        let ranked = scorer.rank([weak, good, empty], useCase: .general, device: dev, environment: env)
+
+        // Empty (size 0) is dropped; the rest are ordered best-first.
+        XCTAssertEqual(ranked.count, 2)
+        XCTAssertEqual(ranked.first?.0.name, "Good")
+        XCTAssertGreaterThanOrEqual(ranked[0].1.composite, ranked[1].1.composite)
+    }
+
+    func test_contextDimension_reactsToDetectedContextLength() {
+        // Coding needs 32k context; a model that declares 32k should score at least
+        // as high on context as an otherwise-identical model with no declared length.
+        let dev = device(ramGB: 16, bandwidthGBs: 200)
+        let env = environment(for: dev)
+        let scorer = ModelFitScorer()
+
+        let withCtx = ggufModel(sizeGB: 7.0, quant: "Q4_K_M", name: "Ctx", contextLength: 32_768)
+        let noCtx = ggufModel(sizeGB: 7.0, quant: "Q4_K_M", name: "NoCtx", contextLength: nil)
+
+        let sCtx = scorer.score(withCtx, useCase: .coding, device: dev, environment: env)
+        let sNo = scorer.score(noCtx, useCase: .coding, device: dev, environment: env)
+
+        XCTAssertNotNil(sCtx)
+        XCTAssertNotNil(sNo)
+        XCTAssertGreaterThan(sCtx!.context, sNo!.context)
+    }
+}

--- a/Tests/ManifoldInferenceTests/ModelLoadCoordinatorStatusTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelLoadCoordinatorStatusTests.swift
@@ -1,0 +1,255 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Tests for the multi-observer headless load-status surface on the
+/// service-vended `ModelLoadCoordinator`.
+///
+/// The decision under test: `InferenceService` vends a single coordinator, and
+/// multiple observers (simulating `ChatViewModel` AND a headless `ModelSelection`
+/// façade) watch the SAME load via independent `statusUpdates()` streams without
+/// cross-contaminating each other.
+@MainActor
+final class ModelLoadCoordinatorStatusTests: XCTestCase {
+
+    // MARK: - One coordinator per service
+
+    func test_modelLoadCoordinator_isSameInstanceAcrossAccesses() {
+        let service = InferenceService()
+        let a = service.modelLoadCoordinator
+        let b = service.modelLoadCoordinator
+        XCTAssertTrue(a === b, "InferenceService must vend a single shared coordinator")
+    }
+
+    // MARK: - Multi-observer fan-out
+
+    func test_twoObservers_seeSameLoadStatus_withoutCrossContamination() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let coordinator = service.modelLoadCoordinator
+        coordinator.currentActivityPhase = { .modelLoading(progress: nil) }
+        // Accept the phase transitions the coordinator drives so its internal
+        // `.modelLoading` gate stays satisfied for the progress bridge.
+        coordinator.onTransitionPhase = { _ in true }
+
+        // Two independent observers, as a chat VM and a headless façade would be.
+        let chatObserver = StatusCollector(coordinator.statusUpdates())
+        let headlessObserver = StatusCollector(coordinator.statusUpdates())
+
+        // Both must immediately receive the current status (.idle) so a late
+        // subscriber is never stuck on nothing.
+        try await chatObserver.waitForLatest(.idle)
+        try await headlessObserver.waitForLatest(.idle)
+
+        let loadTask = Task { await coordinator.loadLocalModel(makeModel(), generation: nil) }
+        await backend.waitUntilLoadStarted()
+
+        // Both observers see the SAME loading transition.
+        try await chatObserver.waitForLatest(.loading(progress: 0.0))
+        try await headlessObserver.waitForLatest(.loading(progress: 0.0))
+
+        await backend.releaseLoadSuccess()
+        await loadTask.value
+
+        // Both observers see the terminal loaded status — neither clobbered the other.
+        try await chatObserver.waitForLatest(.loaded)
+        try await headlessObserver.waitForLatest(.loaded)
+
+        chatObserver.finish()
+        headlessObserver.finish()
+    }
+
+    func test_oneObserverCancelling_doesNotStarveTheOther() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let coordinator = service.modelLoadCoordinator
+        coordinator.currentActivityPhase = { .modelLoading(progress: nil) }
+        coordinator.onTransitionPhase = { _ in true }
+
+        let survivor = StatusCollector(coordinator.statusUpdates())
+        try await survivor.waitForLatest(.idle)
+
+        // A second observer subscribes then immediately tears down its stream.
+        do {
+            let transient = StatusCollector(coordinator.statusUpdates())
+            transient.finish()
+        }
+        // Let the transient observer's onTermination cleanup hop back to the actor.
+        await Task.yield()
+
+        let loadTask = Task { await coordinator.loadLocalModel(makeModel(), generation: nil) }
+        await backend.waitUntilLoadStarted()
+        try await survivor.waitForLatest(.loading(progress: 0.0))
+
+        await backend.releaseLoadSuccess()
+        await loadTask.value
+        try await survivor.waitForLatest(.loaded)
+
+        survivor.finish()
+    }
+
+    func test_failedLoad_publishesFailureToAllObservers() async throws {
+        let service = InferenceService()
+        let backend = GatedLoadBackend()
+        service.registerBackendFactory { type in type == .gguf ? backend : nil }
+
+        let coordinator = service.modelLoadCoordinator
+        coordinator.currentActivityPhase = { .modelLoading(progress: nil) }
+        coordinator.onTransitionPhase = { _ in true }
+
+        let a = StatusCollector(coordinator.statusUpdates())
+        let b = StatusCollector(coordinator.statusUpdates())
+        try await a.waitForLatest(.idle)
+        try await b.waitForLatest(.idle)
+
+        let loadTask = Task { await coordinator.loadLocalModel(makeModel(), generation: nil) }
+        await backend.waitUntilLoadStarted()
+        await backend.releaseLoadFailure(StatusTestError.planned)
+        await loadTask.value
+
+        try await a.waitForFailure()
+        try await b.waitForFailure()
+
+        a.finish()
+        b.finish()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeModel(name: String = "Gated") -> ModelInfo {
+        ModelInfo(
+            name: name,
+            fileName: "\(name).Q4_K_M.gguf",
+            url: URL(fileURLWithPath: "/virtual/\(name).gguf"),
+            fileSize: 1_024,
+            modelType: .gguf
+        )
+    }
+}
+
+// MARK: - Status collector
+
+/// Drains a `statusUpdates()` stream into an array, with a tight-deadline poll
+/// helper so tests assert on the *latest* delivered status deterministically.
+@MainActor
+private final class StatusCollector {
+    private(set) var received: [ModelLoadStatus] = []
+    private var task: Task<Void, Never>?
+
+    init(_ stream: AsyncStream<ModelLoadStatus>) {
+        task = Task { @MainActor in
+            for await status in stream {
+                received.append(status)
+            }
+        }
+    }
+
+    func finish() {
+        task?.cancel()
+        task = nil
+    }
+
+    func waitForLatest(
+        _ expected: ModelLoadStatus,
+        timeout: Duration = .seconds(2),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if received.last == expected { return }
+            await Task.yield()
+        }
+        XCTFail("Did not observe \(expected); saw \(received)", file: file, line: line)
+    }
+
+    func waitForFailure(
+        timeout: Duration = .seconds(2),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if case .failed = received.last { return }
+            await Task.yield()
+        }
+        XCTFail("Did not observe a .failed status; saw \(received)", file: file, line: line)
+    }
+}
+
+// MARK: - Gated backend
+
+private enum StatusTestError: Error, Sendable { case planned }
+
+/// A backend that blocks inside `loadModel` until the test releases it, so the
+/// coordinator's load-status transitions can be observed mid-flight.
+private final class GatedLoadBackend: InferenceBackend, @unchecked Sendable {
+    private let gate = GateBox()
+
+    var isModelLoaded = false
+    var isGenerating = false
+
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    func waitUntilLoadStarted() async { await gate.waitUntilStarted() }
+    func releaseLoadSuccess() async { await gate.releaseSuccess() }
+    func releaseLoadFailure(_ error: any Error & Sendable) async { await gate.releaseFailure(error) }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        await gate.markStarted()
+        switch await gate.waitForRelease() {
+        case .success: isModelLoaded = true
+        case .failure(let error): throw error
+        }
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        GenerationStream(AsyncThrowingStream { $0.finish() })
+    }
+
+    func stopGeneration() { isGenerating = false }
+    func unloadModel() { isModelLoaded = false }
+}
+
+/// A small async gate: the loader signals "started", the test releases it.
+private actor GateBox {
+    enum Release { case success, failure(any Error & Sendable) }
+
+    private var started = false
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var release: Release?
+    private var releaseWaiters: [CheckedContinuation<Release, Never>] = []
+
+    func markStarted() {
+        started = true
+        for w in startedWaiters { w.resume() }
+        startedWaiters.removeAll()
+    }
+
+    func waitUntilStarted() async {
+        if started { return }
+        await withCheckedContinuation { startedWaiters.append($0) }
+    }
+
+    func waitForRelease() async -> Release {
+        if let release { return release }
+        return await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func releaseSuccess() { deliver(.success) }
+    func releaseFailure(_ error: any Error & Sendable) { deliver(.failure(error)) }
+
+    private func deliver(_ r: Release) {
+        release = r
+        for w in releaseWaiters { w.resume(returning: r) }
+        releaseWaiters.removeAll()
+    }
+}


### PR DESCRIPTION
**PR 0** of the reusable model-selection initiative (plan: `docs/plans/reusable-model-selection-surfaces.md`). Ships the two bridges a later headless `ModelSelection` façade can't exist without. No public view, no façade — those are PR 2/PR 3.

## Deliverable 1 — `ModelInfo → ModelFitScore` bridge
`ModelFitScorer` previously scored only `DownloadableModel` / resident profiles, but `ModelRegistry.availableModels` is `[ModelInfo]` — so nothing could fit-score the models a user actually has (this is why consumers re-derive tier/recommendation logic). Adds `ModelFitScorer.score(_:ModelInfo,…)` + `rank([ModelInfo],…)` deriving the scorer inputs from existing `ModelInfo` fields. Foundation (zero-byte) models score; zero-byte non-Foundation models return nil (dropped from rank).

## Deliverable 2 — service-vended shared coordinator + multi-observer load status
`ModelLoadCoordinator` relocated `ManifoldUI → ManifoldInference`. `InferenceService` now **vends a single shared coordinator** (one per service), so a `ChatViewModel` and a future headless `ModelSelection` can't each build one and cross-talk on the shared `modelLoadProgress` scalar. New `ModelLoadStatus` stream publishes progress/phase/error to **multiple observers** without the old single-owner callback clobbering. `ChatViewModel` adapted to consume the vended coordinator; behavior preserved.

## Tests (local, green)
- New: `ModelFitScorerModelInfoBridgeTests` (8), `ModelLoadCoordinatorStatusTests` (4 — incl. `test_twoObservers_seeSameLoadStatus_withoutCrossContamination`, the cross-talk race the review flagged).
- Characterization kept green: `LoadDispatchCoordinationTests`, `InterleavingTests`, `CoordinatorClosureIsolationTests`.
- 24/24 across these suites; full package `swift build --build-tests` clean.

## Notes
- Diff: 9 files, +802/−29 (~429 tests).
- Deliverable 2 was recovered + verified by the orchestrator after the implementing agent stopped mid-build; `Package.resolved` churn was reverted (not committed).
- Full `scripts/test.sh --profile local` gate + CI are being run before this is marked ready.