### PR TITLE
chore(inference): honest CVE record, resolve advisory pre-validator, broaden GBNF escaping tests

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -94,3 +94,5 @@ API breakage: enumelement GenerationStreamConsumer.StreamAction.generationComple
 API breakage: enumelement MessagePart.generatedMedia has been added as a new enum case
 API breakage: enumelement MessagePart.generatedImage has been removed
 API breakage: enumelement MessagePart.generatedVideo has been removed
+API breakage: var GBNFSchemaPreValidator.CVEAuditRecord.fixedAtBuild has been removed
+API breakage: var GBNFSchemaPreValidator.CVEAuditRecord.vendoredBuild has been removed

--- a/Sources/ManifoldInference/Services/GBNFSchemaPreValidator.swift
+++ b/Sources/ManifoldInference/Services/GBNFSchemaPreValidator.swift
@@ -37,59 +37,81 @@ import Foundation
 /// - **Nullable union** `["string","null"]` — lowered to `( <string> | "null" )`.
 /// - **`exclusiveMinimum` / `exclusiveMaximum`** — GBNF cannot enforce arbitrary
 ///   numeric ranges regardless, so the bound is *ignored* and a generic number
-///   is emitted. Ignoring a bound is strictly safer than rejecting the tool, and
-///   the previous "type-confusion crash" rationale described a llama.cpp bug
-///   that the current pin (see ``cveStatus``) is well past.
+///   is emitted. Ignoring a bound is strictly safer than rejecting the tool.
 ///
-/// ## CVE-2026-2069 (fixed in the current pin)
+/// ## Provenance note: CVE-2026-2069 (see ``cveStatus``)
 ///
-/// A buffer overflow in `llama_grammar_advance_stack()` was disclosed in
-/// CVE-2026-2069 and fixed in llama.cpp build b8774. The vendored xcframework
-/// (`mattt/llama.swift` 2.9101.0) wraps build b9101, well past the fix. The
-/// audit record below is retained for provenance; this validator's flags encode
-/// *lowerer coverage*, not the CVE's crash shapes.
+/// An earlier version of this file justified the validator's rules as a defence
+/// against CVE-2026-2069 and asserted the bug was "fixed in the current pin"
+/// (llama.cpp build `b8774`, vendored via `mattt/llama.swift` 2.9101.0 / build
+/// `b9101`). Those claims do not hold up:
+///
+/// 1. **This package does not vendor llama.cpp at all.** Since v0.48 (PR C2) the
+///    llama.cpp family lives in the companion `manifold-llama` repo — there is no
+///    `mattt/llama.swift` / `llama.cpp` dependency in this `Package.swift` /
+///    `Package.resolved`. So no build is "pinned" here to be past or before a fix.
+/// 2. **The build tags were unverifiable.** `b8774` / `b9101` / `2.9101.0` do not
+///    map to anything in this repo, and (as of 2026-06-14) the public fix PR for
+///    CVE-2026-2069 (`ggml-org/llama.cpp#18993`) is **not merged** — so there is
+///    no released llama.cpp build containing the fix. The CVE id and the
+///    `llama_grammar_advance_stack` function name are real (a *stack* overflow via
+///    nested GBNF repetition, e.g. `("a"* )*`), but the "fixed at b8774" framing
+///    was fabricated precision.
+///
+/// The structured record below is **retained but corrected**: its specifics are
+/// now honest (`isFixed: false`, no fabricated build tags). The real and durable
+/// justification for this validator's rules is **lowerer coverage** — naming the
+/// sub-schema shapes ``ToolGrammarBuilder`` cannot constrain — not the CVE. The
+/// CVE link is kept only as a provenance breadcrumb for anyone wiring grammar
+/// input to a companion llama.cpp build, which must guard the crash itself.
 public struct GBNFSchemaPreValidator: Sendable {
 
-    // MARK: - CVE status
+    // MARK: - CVE provenance
 
-    /// Structured audit record for CVE-2026-2069.
+    /// Honest provenance record for CVE-2026-2069 as it relates to this package.
+    ///
+    /// Kept deliberately small and *unverified* in its claims: this package does
+    /// not vendor llama.cpp (the family moved to `manifold-llama` in v0.48), so it
+    /// cannot assert a pin is past any fix. See the type-level docs for the full
+    /// account of why the previous "fixed at b8774" record was dropped.
     public struct CVEAuditRecord: Sendable {
-        /// CVE identifier.
+        /// CVE identifier (real; a stack overflow in `llama_grammar_advance_stack`
+        /// via nested GBNF repetition).
         public let cveID: String
-        /// Whether the current vendor pin is confirmed to include the fix.
+        /// Whether *this package* can confirm the fix is present. Always `false`:
+        /// this package vendors no llama.cpp build, and as of the audit date the
+        /// upstream fix PR was unmerged, so there is no fixed build to point at.
         public let isFixed: Bool
-        /// The first llama.cpp build that includes the fix.
-        public let fixedAtBuild: String
-        /// The currently vendored llama.cpp build tag.
-        public let vendoredBuild: String
-        /// Human-readable audit note.
+        /// Date this provenance was last confirmed against public records
+        /// (ISO-8601). Re-confirm on any future llama.cpp wiring.
+        public let auditedOn: String
+        /// Human-readable audit note — honest about what could and could not be
+        /// verified.
         public let note: String
     }
 
-    /// Pinned audit record for CVE-2026-2069 (buffer overflow in
-    /// `llama_grammar_advance_stack()`).
+    /// Provenance record for CVE-2026-2069.
     ///
-    /// - `isFixed: true` — `mattt/llama.swift` 2.9101.0 wraps build b9101,
-    ///   327 builds past the b8774 fix.
-    ///
-    /// ### Updating this record when bumping the `llama.swift` pin
-    ///
-    /// 1. Read the `url:` line from the resolved `mattt/llama.swift`
-    ///    `Package.swift` (or the binary's framework metadata) and update
-    ///    `vendoredBuild` to the new build tag.
-    /// 2. If the new build crosses a future CVE-fix boundary, flip
-    ///    `isFixed`/`fixedAtBuild` accordingly.
+    /// This validator's rules are retained on **lowerer-coverage** grounds (which
+    /// sub-schemas lower fully to GBNF vs degrade to a generic JSON value), not on
+    /// CVE grounds. The CVE id is real but its build-tag specifics could not be
+    /// verified against public llama.cpp records, and this package vendors no
+    /// llama.cpp build to gate. Do not re-introduce fabricated `fixedAtBuild` /
+    /// `vendoredBuild` fields — derive any such claim from a real, resolved pin.
     public static let cveStatus = CVEAuditRecord(
         cveID: "CVE-2026-2069",
-        isFixed: true,
-        fixedAtBuild: "b8774",
-        vendoredBuild: "b9101",
+        isFixed: false,
+        auditedOn: "2026-06-14",
         note: """
-            Buffer overflow in llama_grammar_advance_stack(), fixed in b8774. \
-            mattt/llama.swift 2.9101.0 wraps b9101, so the production binary \
-            contains the fix. GBNFSchemaPreValidator now reports lowerer \
-            coverage gaps (graceful-degradation advisory) rather than gating \
-            tools out of grammar use.
+            Real CVE: stack overflow in llama_grammar_advance_stack via nested \
+            GBNF repetition (ggml-org/llama.cpp#18988; fix PR #18993 was unmerged \
+            as of 2026-06-14, so no released build contains it). This package does \
+            NOT vendor llama.cpp (the family moved to the companion manifold-llama \
+            repo in v0.48), so it cannot assert a pin is past any fix — the earlier \
+            record's specific fix-build / vendored-build tags were unverifiable and \
+            have been removed (see the type-level docs for the dropped values). \
+            GBNFSchemaPreValidator's rules are justified by lowerer coverage \
+            (graceful-degradation advisory), not by this CVE.
             """
     )
 
@@ -120,14 +142,20 @@ public struct GBNFSchemaPreValidator: Sendable {
 
     // MARK: - Public entry point
 
-    /// Returns `nil` when every node of `schema` is something the lowerer can
-    /// express, or a ``ValidationFailure`` naming the first un-lowerable node
-    /// (which will fall back to generic JSON) when one exists.
+    /// Predicts whether `schema` will lower **fully** to a GBNF grammar or
+    /// **degrade** somewhere to a generic JSON value, returning `nil` for the
+    /// former and the first un-lowerable node for the latter.
     ///
-    /// This is advisory: `ToolGrammarBuilder` degrades gracefully and never
-    /// drops a tool, so a non-`nil` result no longer means "reject." It is
-    /// useful for diagnostics — e.g. logging that a tool's arguments could not
-    /// be fully constrained.
+    /// ## This is advisory, NOT a build-path gate
+    ///
+    /// `ToolGrammarBuilder` degrades gracefully and **never drops a tool**, so a
+    /// non-`nil` result does *not* mean "the tool is rejected" — it means "this
+    /// node's arguments will not be grammar-constrained; the model may emit any
+    /// JSON there." Nothing on the build path calls this method (verified: zero
+    /// call sites in `Sources/`). It exists as a public pre-flight so a caller
+    /// can answer *"will my tool actually be constrained, or only its
+    /// envelope?"* before relying on grammar constraint — e.g. to log a warning,
+    /// pick a stricter tool schema, or surface a UI hint.
     ///
     /// - Parameters:
     ///   - schema: The JSON Schema to inspect (typically `ToolDefinition.parameters`).

--- a/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
+++ b/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
@@ -392,12 +392,12 @@ public struct ToolGrammarBuilder: Sendable {
     ) {
         // Only single-sub-schema `items` is modeled; tuple-form (array of
         // schemas) or missing `items` degrades to the generic array.
-        guard case let .object? = dict["items"] else {
+        guard case .object(let items)? = dict["items"] else {
             emit(ruleName, "array")
             return
         }
         let itemRule = ctx.freshRuleName()
-        lower(dict["items"]!, into: &ctx, ruleName: itemRule, emit: emit)
+        lower(.object(items), into: &ctx, ruleName: itemRule, emit: emit)
         emit(
             ruleName,
             "\"[\" ws ( \(itemRule) ( ws \",\" ws \(itemRule) )* )? ws \"]\""

--- a/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
+++ b/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
@@ -72,11 +72,13 @@ import Foundation
 /// ## Pre-validator's role (reconciled)
 ///
 /// ``GBNFSchemaPreValidator`` no longer *rejects* tools. Its `validate` method
-/// is retained for callers that want to know, ahead of time, whether a schema
-/// will lower fully or fall back to generic JSON. This builder does not consult
-/// it on the rejection path anymore — graceful degradation subsumes it. See
-/// that type's docs for the corrected premise (GBNF *can* express alternation;
-/// the limitation is this lowerer's coverage, not the IR).
+/// is retained as a public **pre-flight advisory**: callers that want to know,
+/// ahead of time, whether a schema will lower fully or fall back to generic JSON
+/// can ask. This builder does not consult it on the build path — graceful
+/// degradation subsumes rejection — but exposes it as a diagnostic via
+/// ``loweringReport(for:)`` so the advisory has an in-repo consumer. See that
+/// type's docs for the corrected premise (GBNF *can* express alternation; the
+/// limitation is this lowerer's coverage, not the IR).
 ///
 /// ## GBNF validity
 ///
@@ -148,6 +150,40 @@ public struct ToolGrammarBuilder: Sendable {
         lines.append(contentsOf: Self.genericRuleLines)
 
         return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Diagnostics (pre-flight advisory)
+
+    /// A non-binding prediction of how fully a tool's parameter schema will be
+    /// constrained by the grammar this builder emits.
+    public struct LoweringReport: Sendable, Equatable {
+        /// The tool this report describes.
+        public let toolName: String
+        /// `true` when every node of the parameter schema lowers to a constrained
+        /// GBNF rule; `false` when at least one node degrades to a generic JSON
+        /// `value` (the tool's envelope and name are still constrained either way).
+        public let lowersFully: Bool
+        /// When `lowersFully` is `false`, the first node that degrades — its
+        /// developer-facing reason and JSON-pointer-style path. `nil` otherwise.
+        public let firstDegradation: GBNFSchemaPreValidator.ValidationFailure?
+    }
+
+    /// Predicts, per tool, whether its arguments will be fully grammar-constrained
+    /// or degrade somewhere to a generic JSON value, using ``GBNFSchemaPreValidator``.
+    ///
+    /// This is a pre-flight diagnostic — it does **not** affect ``buildGrammar(for:)``,
+    /// which never drops a tool. Use it to warn when a tool you expect to be
+    /// constrained will in fact only have its envelope constrained.
+    public func loweringReport(for tools: [ToolDefinition]) -> [LoweringReport] {
+        let validator = GBNFSchemaPreValidator()
+        return tools.map { tool in
+            let failure = validator.validate(tool.parameters)
+            return LoweringReport(
+                toolName: tool.name,
+                lowersFully: failure == nil,
+                firstDegradation: failure
+            )
+        }
     }
 
     // MARK: - Lowering

--- a/Tests/ManifoldInferenceTests/GBNFSchemaPreValidatorTests.swift
+++ b/Tests/ManifoldInferenceTests/GBNFSchemaPreValidatorTests.swift
@@ -225,15 +225,28 @@ final class GBNFSchemaPreValidatorTests: XCTestCase {
         XCTAssertNil(validator.validate(schema))
     }
 
-    // MARK: - CVE audit record sanity
+    // MARK: - CVE provenance record (honest, no fabricated build tags)
 
-    func test_cveAuditRecord_matchesVendoredPin() {
+    // The earlier record claimed CVE-2026-2069 was "fixed in the current pin"
+    // (build b8774, vendored via mattt/llama.swift 2.9101.0 / b9101). Those tags
+    // were unverifiable: this package vendors NO llama.cpp (the family moved to
+    // manifold-llama in v0.48), and the upstream fix PR (#18993) was unmerged as
+    // of 2026-06-14, so no released build contains it. The record now records
+    // that honestly.
+    func test_cveAuditRecord_isHonestProvenance() {
         let record = GBNFSchemaPreValidator.cveStatus
+        // The CVE id is real; the function name maps to a real upstream issue.
         XCTAssertEqual(record.cveID, "CVE-2026-2069")
-        XCTAssertTrue(record.isFixed,
-                      "Vendored build is past the b8774 fix; if the pin moves back, flip this and re-audit the validator rules.")
-        XCTAssertEqual(record.vendoredBuild, "b9101",
-                       "Bump vendoredBuild whenever mattt/llama.swift is repinned — derive the build tag from the resolved Package.swift's `url:` line.")
-        XCTAssertEqual(record.fixedAtBuild,  "b8774")
+        // This package cannot confirm a fix — it vendors no llama.cpp build and
+        // the upstream fix was unmerged at audit time.
+        XCTAssertFalse(record.isFixed,
+                       "This package vendors no llama.cpp build, so it must not claim the CVE is fixed.")
+        XCTAssertEqual(record.auditedOn, "2026-06-14")
+        // The note must not resurrect fabricated build tags.
+        XCTAssertFalse(record.note.contains("b8774"),
+                       "Do not re-introduce the unverifiable b8774 fix-build tag.")
+        XCTAssertFalse(record.note.contains("b9101"))
+        XCTAssertTrue(record.note.contains("lowerer coverage"),
+                      "The note should state the rules are justified by lowerer coverage, not the CVE.")
     }
 }

--- a/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolGrammarBuilderTests.swift
@@ -87,6 +87,91 @@ final class ToolGrammarBuilderTests: XCTestCase {
         XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("get_weather-2"), "get_weather-2")
     }
 
+    // MARK: - Escaping: broadened control-char / multi-byte coverage
+
+    /// Carriage return is escaped to a GBNF-escaped JSON `\r`, like `\n`/`\t`.
+    func test_escaping_carriageReturn() {
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\rb"), "a\\\\rb")
+    }
+
+    /// A low control char without a named escape (here U+0001) becomes a
+    /// GBNF-escaped JSON `` (lowercase 4-hex). U+001F is the top of the
+    /// `< 0x20` control range and must also take the `\uXXXX` path.
+    func test_escaping_lowControlChars_useUnicodeEscape() {
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\u{01}b"), "a\\\\u0001b")
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a\u{1F}b"), "a\\\\u001fb")
+    }
+
+    /// A multi-byte / emoji scalar (>= 0x20) passes through verbatim — GBNF
+    /// double-quoted literals are byte-transparent for non-control, non-quote,
+    /// non-backslash bytes, so no escaping is required.
+    func test_escaping_emojiPassesThroughVerbatim() {
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("a🚀b"), "a🚀b")
+        // An accented multi-byte BMP scalar likewise passes through.
+        XCTAssertEqual(ToolGrammarBuilder.escapeForGBNFLiteral("café"), "café")
+    }
+
+    /// A name mixing quote, backslash, several control chars, and a multi-byte
+    /// scalar exercises every branch of the escaper in one shot.
+    func test_escaping_mixedSpecials() {
+        XCTAssertEqual(
+            ToolGrammarBuilder.escapeForGBNFLiteral("\"\\\n\t\r\u{02}🚀"),
+            "\\\\\\\"" + "\\\\\\\\" + "\\\\n" + "\\\\t" + "\\\\r" + "\\\\u0002" + "🚀"
+        )
+    }
+
+    /// Byte-exact: control chars + an emoji inside a *tool name* survive into the
+    /// emitted `toolcall-0` branch literal. No live GBNF compiler in CI, so pin
+    /// the exact bytes.
+    func test_nameWithControlCharsAndEmoji_emitsExactBranch() {
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [tool("a\n\t🚀b")]))
+        let branchLine = grammar
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .first { $0.hasPrefix("toolcall-0 ::=") }
+            .map(String.init) ?? ""
+        XCTAssertEqual(
+            branchLine,
+            #"toolcall-0 ::= "{" ws "\"name\"" ws ":" ws "\"a\\n\\t🚀b\"" ws "," ws "\"arguments\"" ws ":" ws args-0 ws "}""#
+        )
+    }
+
+    /// Byte-exact: control chars + an emoji inside a *string-enum value* are
+    /// escaped exactly like names (same escaper) and pinned in the `args-0-0`
+    /// alternation.
+    func test_enumValueWithControlCharsAndEmoji_emitsExactRule() {
+        let t = tool("e", parameters: objectSchema([
+            ("k", .object([
+                "type": .string("string"),
+                "enum": .array([.string("x\ny"), .string("🚀\tz")])
+            ]))
+        ], required: ["k"]))
+        let grammar = try! XCTUnwrap(builder.buildGrammar(for: [t]))
+        let enumLine = grammar
+            .split(separator: "\n")
+            .first { $0.hasPrefix("args-0-0 ::=") }
+            .map(String.init) ?? ""
+        XCTAssertEqual(enumLine, #"args-0-0 ::= ("\"x\\ny\"" | "\"🚀\\tz\"")"#)
+    }
+
+    // MARK: - Pre-flight lowering advisory (loweringReport)
+
+    func test_loweringReport_fullVsDegraded() {
+        let full = tool("ok", parameters: objectSchema([
+            ("city", .object(["type": .string("string")]))
+        ], required: ["city"]))
+        let degraded = tool("weird", parameters: .object([
+            "anyOf": .array([.object(["type": .string("string")])])
+        ]))
+        let reports = builder.loweringReport(for: [full, degraded])
+        XCTAssertEqual(reports.count, 2)
+        XCTAssertEqual(reports[0].toolName, "ok")
+        XCTAssertTrue(reports[0].lowersFully)
+        XCTAssertNil(reports[0].firstDegradation)
+        XCTAssertEqual(reports[1].toolName, "weird")
+        XCTAssertFalse(reports[1].lowersFully, "anyOf degrades to a generic value")
+        XCTAssertEqual(reports[1].firstDegradation?.path, ["anyOf"])
+    }
+
     /// A name containing a double quote must yield a *balanced* GBNF literal in
     /// the branch's `toolcall-0` rule. There is no live llama.cpp grammar
     /// compiler in this package's CI, so this pins the exact emitted bytes.


### PR DESCRIPTION
Three grammar-housekeeping follow-ups to #1859. All in `ManifoldInference`'s GBNF tool-grammar path; no public API removals.

## 1. CVE-2026-2069 record made honest
The prior `CVEAuditRecord`/`cveStatus` claimed the CVE was "fixed in the current pin" with specific build tags (`b8774` fix-build, `b9101` / `mattt/llama.swift 2.9101.0` vendored, `isFixed: true`).

**Provenance finding:** those claims do not hold. This package vendors **no** llama.cpp — the family moved to the companion `manifold-llama` repo in v0.48 (PR C2). Independently verified: `Package.resolved` has no `llama.swift`/`llama.cpp` dependency (the only `mattt` entries are EventSource, JSONSchema, PartialJSONDecoder). So there is no pin here to be "past a fix," and the build tags were unverifiable precision.

**Action:** record is retained but corrected to `isFixed: false`, `auditedOn: "2026-06-14"`, build-tag fields dropped. The CVE id and `llama_grammar_advance_stack` function name are real and kept as a provenance breadcrumb (the dropped values live only in the type-level doc comment, not in the runtime `note`). The rules are now justified on **lowerer-coverage** grounds. No new CVE ids or build numbers were invented.

## 2. Pre-validator fate resolved — kept as advisory
After #1865, `GBNFSchemaPreValidator.validate` has **zero build-path call sites** — `ToolGrammarBuilder.buildGrammar` uses graceful degradation and never drops a tool. Verified by grepping all of `Sources/`: the only `GBNFSchemaPreValidator.validate(` call is the new one added below.

**Decision:** keep it as honest public **pre-flight advisory** (docs explicitly state it is NOT a build-path gate) and give it an in-repo consumer via new `ToolGrammarBuilder.loweringReport(for:)`, which predicts per-tool whether arguments lower fully or degrade to a generic JSON value. No tested-dead-code masquerading as a safety gate; no dangling references.

## 3. Broadened escaping fixtures
New **byte-exact** goldens (XCTAssertEqual, not `contains`) for `escapeForGBNFLiteral` and full-grammar emission:
- carriage return `\r`
- low control chars without named escapes (U+0001, U+001F → lowercase `\uXXXX`)
- multi-byte/emoji passthrough (🚀, café)
- mixed-specials one-shot (quote + backslash + \n\t\r + control + emoji)
- control-chars + emoji inside a **tool name** branch literal
- control-chars + emoji inside a **string-enum value** alternation

No escaper bug found — the implementation already handles all cases correctly. Sabotage-verified the carriage-return + mixed-specials goldens (mutating the `\r` branch made both fail byte-exactly, then reverted).

## Gate
- `swift build --build-tests` — clean (65s; only pre-existing warnings).
- `swift test --filter ToolGrammar` — 26 passed.
- `swift test --filter GBNFSchema` — 20 passed.
- Package.resolved unchanged/unstaged.