### PR TITLE
ci: batch README snippet compiles into one package + drop redundant push-to-main runs

### DIFF
--- a/.github/workflows/cold-start-human.yml
+++ b/.github/workflows/cold-start-human.yml
@@ -30,18 +30,6 @@
 name: cold-start-human
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "README.md"
-      - "Package.swift"
-      - "Package.resolved"
-      - "Sources/ManifoldKit/**"
-      - "Sources/ManifoldInference/**"
-      - "Sources/ManifoldUI/**"
-      - "scripts/cold-start-human.sh"
-      - ".github/workflows/cold-start-human.yml"
-      - ".github/actions/setup-swift-ci/**"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/nightly-slow-tests.yml
+++ b/.github/workflows/nightly-slow-tests.yml
@@ -405,3 +405,33 @@ jobs:
         if: success() || failure()
         timeout-minutes: 10
         run: scripts/cold-start-specialised-uimodelmanagement.sh
+
+  # Doc-snippet + human-path cold-start gates — the 24h post-merge backstop.
+  # readme-snippets.yml and cold-start-human.yml run these scripts on PRs (via
+  # their source `paths:` filters), but as of PR #1870 those workflows dropped
+  # their push-to-main triggers. This job restores a real backstop: it runs both
+  # gate scripts on the nightly schedule so a Sources-only change that landed via
+  # a PR whose paths filter didn't fire (or a direct doc edit) is still caught
+  # within 24h. cold-start-human.yml additionally wires a persistent build cache
+  # via MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR, but that is a per-run speed
+  # optimization only — the script runs correctly without it, so it is omitted
+  # here.
+  doc-gates:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Swift CI environment
+        uses: ./.github/actions/setup-swift-ci
+
+      - name: README + QUICKSTART + DocC snippet compile gate
+        timeout-minutes: 20
+        run: scripts/extract-snippets-test.sh
+
+      - name: Cold-start tier 4 — human path (README from line 1)
+        if: success() || failure()
+        timeout-minutes: 10
+        run: bash scripts/cold-start-human.sh

--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -47,25 +47,6 @@ on:
       - "scripts/extract-snippets.sh"
       - "scripts/extract-snippets-test.sh"
       - ".github/workflows/readme-snippets.yml"
-  push:
-    branches: [main]
-    paths:
-      - "README.md"
-      - "docs/QUICKSTART*.md"
-      - "docs/WHY-MANIFOLDKIT.md"
-      - "Sources/**/*.docc/**/*.md"
-      - "Sources/ManifoldKit/**"
-      - "Sources/ManifoldUI/**"
-      # ManifoldKitError lives in ManifoldModelCatalog; the dropped
-      # QuickStart*.swift glob never existed — the Sources/ManifoldKit/**
-      # glob above already covers the umbrella's Hello World surface.
-      - "Sources/ManifoldModelCatalog/ManifoldKitError.swift"
-      - "Package.swift"
-      - "Package.resolved"
-      - "scripts/check-readme.sh"
-      - "scripts/extract-snippets.sh"
-      - "scripts/extract-snippets-test.sh"
-      - ".github/workflows/readme-snippets.yml"
 
 concurrency:
   group: readme-snippets-${{ github.event_name }}-${{ github.ref }}

--- a/scripts/extract-snippets-test.sh
+++ b/scripts/extract-snippets-test.sh
@@ -89,11 +89,13 @@ failed=0
 fail_reports=()
 
 # Scaffold ONE package with one executable target per snippet. Each target
-# gets a sanitized, collision-proof name; we keep parallel maps from target
-# name → snippet base and target name → source location for the report.
+# gets a sanitized, collision-proof name; we keep three index-parallel arrays
+# (target name / snippet base / source location) so the report can map a
+# target back to its origin. Index-parallel arrays — NOT `declare -A` — because
+# the macOS CI runners ship Bash 3.2, which has no associative arrays.
 target_names=()
-declare -A src_for_target=()
-declare -A base_for_target=()
+target_bases=()
+target_srcs=()
 target_decls=""
 
 mkdir -p "$WORK/Sources"
@@ -113,19 +115,19 @@ for snippet in "${snippets[@]}"; do
 
     # Two distinct snippet bases can sanitize to the same identifier (e.g.
     # `hello-world` and `hello.world`). Without this guard the second would
-    # silently overwrite the first's source dir + map entries and drop it from
-    # the gate with no error. The `:-` default keeps this composable with
-    # `set -euo pipefail` when the key is unset.
-    if [[ -n "${base_for_target[$target]:-}" ]]; then
-        echo "::error::snippet target-name collision: '$target' from both '${base_for_target[$target]}' and '$base'." >&2
+    # silently overwrite the first's source dir and drop it from the gate with
+    # no error. The target's source dir is the collision artifact, so its prior
+    # existence is the cleanest Bash-3.2-safe detector.
+    target_dir="$WORK/Sources/$target"
+    if [[ -d "$target_dir" ]]; then
+        echo "::error::snippet target-name collision: '$target' (sanitized from '$base') already exists." >&2
         exit 1
     fi
 
     target_names+=("$target")
-    src_for_target["$target"]="$src_location"
-    base_for_target["$target"]="$base"
+    target_bases+=("$base")
+    target_srcs+=("$src_location")
 
-    target_dir="$WORK/Sources/$target"
     mkdir -p "$target_dir"
     # Copy the snippet verbatim (including its `// Source:` header). We
     # deliberately do NOT inject imports — the test is "does the published
@@ -192,9 +194,10 @@ else
     # authoritative per-snippet signal. Never shortcut this pass by trusting
     # the aggregate exit code.
     echo "   linking the aggregate build did not complete — verifying each snippet compiles…"
-    for target in "${target_names[@]}"; do
-        base="${base_for_target[$target]}"
-        src_location="${src_for_target[$target]}"
+    for i in "${!target_names[@]}"; do
+        target="${target_names[$i]}"
+        base="${target_bases[$i]}"
+        src_location="${target_srcs[$i]}"
         echo
         echo "── ${base}  (from ${src_location})"
 

--- a/scripts/extract-snippets-test.sh
+++ b/scripts/extract-snippets-test.sh
@@ -4,22 +4,40 @@
 #
 # Companion to scripts/extract-snippets.sh. The extract script writes one
 # .swift per kept snippet into a working directory; this script scaffolds a
-# throwaway SwiftPM consumer per snippet, drops the snippet in, and runs
-# `swift build`. Failures print the source location (file:line) the snippet
-# was lifted from so the docs author can fix the original block.
+# SINGLE SwiftPM consumer package with one executable target per snippet,
+# drops each snippet into its own target, and runs `swift build` ONCE.
+# Failures print the source location (file:line) the snippet was lifted from
+# so the docs author can fix the original block.
 #
-# Why one package per snippet:
-#   - Snippets are independent SwiftUI apps (Hello World variants have `@main`
-#     on `App` types) and cannot coexist in one executable target.
-#   - Per-snippet isolation also lets the next snippet still build when an
-#     earlier one fails, so the report is complete instead of stopping at
-#     the first error.
+# One package, one executable target per snippet:
+#   - The whole package builds with a SINGLE `swift build`. SwiftPM compiles
+#     the ManifoldKit umbrella (the long pole) ONCE and links it into every
+#     target, parallelizing the cheap per-snippet target compiles. This
+#     replaces the previous package-per-snippet loop that re-linked the heavy
+#     umbrella N times serially and cost ~17 min in CI.
+#   - Separate executable TARGETS (not one shared target) are still required:
+#     snippets are independent SwiftUI apps — Hello World variants carry
+#     `@main` on `App` types, and two snippets can declare the same type
+#     names. Each target is its own module, so `@main` and type-name
+#     collisions are impossible across snippets.
+#   - The aggregate `swift build` also *links* each executable, and snippets
+#     that are valid top-level/library code but carry no `@main` entry point
+#     fail at link ("Undefined symbols … _main") despite compiling cleanly.
+#     This gate validates COMPILATION, not linking, so a non-zero aggregate
+#     exit is not trusted as a snippet failure. Instead we re-build each target
+#     compile-only (`swift build --target <name>` stops at emit-module, no
+#     link step) to attribute PASS/FAIL per snippet. The umbrella and every
+#     snippet module are already in .build from the aggregate pass, so those
+#     per-target builds are near-instant cache hits — and the report stays
+#     complete (one PASS/FAIL line per snippet) instead of stopping at the
+#     first error.
 #
-# Each per-snippet package:
+# The shared package:
 #   - tools-version 6.2 (matches cold-start-conformance.sh)
-#   - platforms macOS .v15 (ManifoldKit's floor)
+#   - platforms macOS .v15 / iOS .v18 (ManifoldKit's floor)
 #   - depends on the local ManifoldKit checkout via .package(name: ..., path: ...)
-#   - links the ManifoldKit umbrella product (covers ManifoldUI / Inference re-exports)
+#   - each target links the ManifoldKit umbrella product (covers ManifoldUI /
+#     Inference re-exports)
 #   - no traits: parameter — since v0.48 PR C2 the core package has no
 #     default traits and the MLX/Llama families live in companion packages,
 #     so a bare dependency is already the lean full-core build.
@@ -65,67 +83,117 @@ passed=0
 failed=0
 fail_reports=()
 
+# Scaffold ONE package with one executable target per snippet. Each target
+# gets a sanitized, collision-proof name; we keep parallel maps from target
+# name → snippet base and target name → source location for the report.
+target_names=()
+declare -A src_for_target=()
+declare -A base_for_target=()
+target_decls=""
+
+mkdir -p "$WORK/Sources"
+
 for snippet in "${snippets[@]}"; do
     base="$(basename "$snippet" .swift)"
     # Read source-location header for failure reports.
     src_header=$(head -n 1 "$snippet")
     src_location="${src_header#// Source: }"
 
-    pkg_dir="$WORK/$base"
-    mkdir -p "$pkg_dir/Sources/SnippetApp"
+    # Sanitize the snippet base into a valid Swift target identifier: any char
+    # outside [A-Za-z0-9_] becomes `_`. The `Snippet_` prefix guarantees the
+    # identifier never starts with a digit. Separate targets = separate
+    # modules, so `@main` / type-name collisions across snippets are impossible.
+    sanitized="${base//[^A-Za-z0-9_]/_}"
+    target="Snippet_${sanitized}"
 
-    # SwiftPM derives package identity from the last path component of
-    # .package(path:); explicit name: keeps this worktree-portable.
-    cat > "$pkg_dir/Package.swift" <<EOF
-// swift-tools-version: 6.2
-import PackageDescription
+    target_names+=("$target")
+    src_for_target["$target"]="$src_location"
+    base_for_target["$target"]="$base"
 
-let package = Package(
-    name: "Snippet_${base//-/_}",
-    platforms: [.macOS(.v15), .iOS(.v18)],
-    products: [
-        .executable(name: "SnippetApp", targets: ["SnippetApp"]),
-    ],
-    dependencies: [
-        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
-    ],
-    targets: [
-        .executableTarget(
-            name: "SnippetApp",
+    target_dir="$WORK/Sources/$target"
+    mkdir -p "$target_dir"
+    # Copy the snippet verbatim (including its `// Source:` header). We
+    # deliberately do NOT inject imports — the test is "does the published
+    # snippet compile as-published?".
+    cp "$snippet" "$target_dir/Snippet.swift"
+
+    target_decls+="        .executableTarget(
+            name: \"$target\",
             dependencies: [
-                .product(name: "ManifoldKit", package: "ManifoldKit"),
+                .product(name: \"ManifoldKit\", package: \"ManifoldKit\"),
                 // ManifoldUI is re-exported by the umbrella, but the README
                 // Hello World imports it explicitly. Link it as a direct
                 // product too so the import resolves under both umbrella
                 // and direct-import patterns.
-                .product(name: "ManifoldUI", package: "ManifoldKit"),
+                .product(name: \"ManifoldUI\", package: \"ManifoldKit\"),
             ],
-            path: "Sources/SnippetApp"
+            path: \"Sources/$target\"
         ),
-    ]
+"
+done
+
+# Write the single shared manifest. `products:` is omitted — `swift build`
+# builds all targets in the root package regardless. SwiftPM derives package
+# identity from the last path component of .package(path:); explicit name:
+# keeps this worktree-portable.
+cat > "$WORK/Package.swift" <<EOF
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ManifoldKitSnippets",
+    platforms: [.macOS(.v15), .iOS(.v18)],
+    dependencies: [
+        .package(name: "ManifoldKit", path: "$REPO_ROOT"),
+    ],
+    targets: [
+$target_decls    ]
 )
 EOF
 
-    # Drop the snippet in. If it lacks `import Foundation` but uses Foundation
-    # types, the build will catch it — we deliberately do NOT inject imports
-    # because the test is "does the published snippet compile as-published?".
-    cp "$snippet" "$pkg_dir/Sources/SnippetApp/Snippet.swift"
+echo
+echo "── Building ${#target_names[@]} snippet target(s) in one package (single umbrella compile)…"
 
-    echo
-    echo "── ${base}  (from ${src_location})"
+# Pass 1: one aggregate `swift build`. SwiftPM compiles the ManifoldKit
+# umbrella (the long pole) ONCE and the per-snippet target compiles run in
+# parallel against it. We do NOT trust a non-zero exit here as a snippet
+# failure: `swift build` also *links* each executable target, and a doc
+# snippet that is valid library/top-level code but has no `@main` entry point
+# will fail at link ("Undefined symbols … _main") even though it compiled
+# cleanly. Compilation — not linking — is what this gate validates, so the
+# aggregate run exists to warm the umbrella + emit every snippet module; pass 2
+# reads off the authoritative per-snippet result.
+if (cd "$WORK" && swift build) > "$WORK/build.log" 2>&1; then
+    # Linked cleanly too → every snippet compiled; nothing more to check.
+    echo "   PASS — all ${#target_names[@]} snippet(s) compiled."
+    passed=${#target_names[@]}
+    failed=0
+else
+    # Pass 2: attribute PASS/FAIL per snippet with a compile-only per-target
+    # build (`swift build --target` stops at emit-module — no link step, so
+    # no-`@main` snippets are not penalized). The umbrella and every snippet
+    # module are already in .build from pass 1, so each of these is a near-
+    # instant cache hit; this is the per-snippet correctness signal.
+    echo "   linking the aggregate build did not complete — verifying each snippet compiles…"
+    for target in "${target_names[@]}"; do
+        base="${base_for_target[$target]}"
+        src_location="${src_for_target[$target]}"
+        echo
+        echo "── ${base}  (from ${src_location})"
 
-    log="$pkg_dir/build.log"
-    if (cd "$pkg_dir" && swift build) > "$log" 2>&1; then
-        echo "   PASS"
-        passed=$((passed + 1))
-    else
-        echo "   FAIL — log:"
-        sed -n '1,80p' "$log" | sed 's/^/     /'
-        echo "   (full log: $log)"
-        failed=$((failed + 1))
-        fail_reports+=("$base  from  $src_location")
-    fi
-done
+        log="$WORK/$target.build.log"
+        if (cd "$WORK" && swift build --target "$target") > "$log" 2>&1; then
+            echo "   PASS"
+            passed=$((passed + 1))
+        else
+            echo "   FAIL — log:"
+            sed -n '1,80p' "$log" | sed 's/^/     /'
+            echo "   (full log: $log)"
+            failed=$((failed + 1))
+            fail_reports+=("$base  from  $src_location")
+        fi
+    done
+fi
 
 # 3. Validate Package.swift manifest fragments.
 #

--- a/scripts/extract-snippets-test.sh
+++ b/scripts/extract-snippets-test.sh
@@ -23,14 +23,19 @@
 #   - The aggregate `swift build` also *links* each executable, and snippets
 #     that are valid top-level/library code but carry no `@main` entry point
 #     fail at link ("Undefined symbols … _main") despite compiling cleanly.
-#     This gate validates COMPILATION, not linking, so a non-zero aggregate
-#     exit is not trusted as a snippet failure. Instead we re-build each target
+#     A non-zero aggregate exit is also triggered by transient parallel-build
+#     module-ordering errors (e.g. `error: no such module 'ManifoldInference'`
+#     when a snippet target compiles before that re-exported module is emitted);
+#     pass 2's serial per-target build resolves these too. This gate validates
+#     COMPILATION, not linking, so a non-zero aggregate exit is not trusted as
+#     a snippet failure. Instead we re-build each target
 #     compile-only (`swift build --target <name>` stops at emit-module, no
-#     link step) to attribute PASS/FAIL per snippet. The umbrella and every
-#     snippet module are already in .build from the aggregate pass, so those
-#     per-target builds are near-instant cache hits — and the report stays
-#     complete (one PASS/FAIL line per snippet) instead of stopping at the
-#     first error.
+#     link step) to attribute PASS/FAIL per snippet. Already-compiled modules
+#     are cache hits; a module that FAILED in the aggregate pass has no cached
+#     object and is genuinely recompiled here — that recompile is the
+#     authoritative per-snippet signal, so never shortcut pass-2 by trusting
+#     the aggregate exit code. The report also stays complete (one PASS/FAIL
+#     line per snippet) instead of stopping at the first error.
 #
 # The shared package:
 #   - tools-version 6.2 (matches cold-start-conformance.sh)
@@ -106,6 +111,16 @@ for snippet in "${snippets[@]}"; do
     sanitized="${base//[^A-Za-z0-9_]/_}"
     target="Snippet_${sanitized}"
 
+    # Two distinct snippet bases can sanitize to the same identifier (e.g.
+    # `hello-world` and `hello.world`). Without this guard the second would
+    # silently overwrite the first's source dir + map entries and drop it from
+    # the gate with no error. The `:-` default keeps this composable with
+    # `set -euo pipefail` when the key is unset.
+    if [[ -n "${base_for_target[$target]:-}" ]]; then
+        echo "::error::snippet target-name collision: '$target' from both '${base_for_target[$target]}' and '$base'." >&2
+        exit 1
+    fi
+
     target_names+=("$target")
     src_for_target["$target"]="$src_location"
     base_for_target["$target"]="$base"
@@ -171,9 +186,11 @@ if (cd "$WORK" && swift build) > "$WORK/build.log" 2>&1; then
 else
     # Pass 2: attribute PASS/FAIL per snippet with a compile-only per-target
     # build (`swift build --target` stops at emit-module — no link step, so
-    # no-`@main` snippets are not penalized). The umbrella and every snippet
-    # module are already in .build from pass 1, so each of these is a near-
-    # instant cache hit; this is the per-snippet correctness signal.
+    # no-`@main` snippets are not penalized). Modules that already compiled in
+    # pass 1 are cache hits; a module that FAILED in the aggregate has no
+    # cached object and is genuinely recompiled here — that recompile is the
+    # authoritative per-snippet signal. Never shortcut this pass by trusting
+    # the aggregate exit code.
     echo "   linking the aggregate build did not complete — verifying each snippet compiles…"
     for target in "${target_names[@]}"; do
         base="${base_for_target[$target]}"


### PR DESCRIPTION
Two CI-cost reductions for the doc-snippet and cold-start lanes, plus a restored post-merge backstop and snippet-attribution hardening.

## 1. Batch README snippet compiles into ONE package (the big win)

`scripts/extract-snippets-test.sh` previously scaffolded a **separate throwaway SwiftPM package per kept snippet** and ran `swift build` once per snippet — re-compiling and **re-linking the heavy ManifoldKit umbrella N times serially**. That job took **~17 min** in CI.

New design: **one package, one `.executableTarget` per snippet, a single `swift build`.** SwiftPM compiles the umbrella (the long pole) **once** and links it into every target, parallelizing the cheap per-snippet target compiles.

- Separate executable targets (not one shared target) are still required: snippets are independent SwiftUI apps — Hello World variants carry `@main` on `App` types, and two snippets can declare the same type names. Separate modules make `@main` / type-name collisions impossible.
- Snippet base names are sanitized into valid Swift identifiers (`[^A-Za-z0-9_] → _`, `Snippet_` prefix) so any doc filename is safe. A **collision guard** now errors out if two distinct bases sanitize to the same target identifier (which would otherwise silently overwrite one snippet's source dir and drop it from the gate).
- The aggregate `swift build` also *links* each executable. Doc snippets that are valid top-level/library code but carry no `@main` entry point fail at **link** (`Undefined symbols … _main`) despite compiling cleanly. A non-zero aggregate exit is **also** triggered by transient parallel-build module-ordering errors (e.g. `error: no such module 'ManifoldInference'` when a snippet target compiles before that re-exported module is emitted). This gate validates **compilation, not linking**, so a non-zero aggregate exit is not trusted — it triggers a compile-only per-target pass (`swift build --target`, which stops at emit-module). Already-compiled modules are cache hits; a module that **failed** in the aggregate has no cached object and is genuinely **recompiled** here — that recompile is the authoritative per-snippet signal, so pass 2 is never shortcut by trusting the aggregate exit code. Reports stay complete (one line per snippet); exit codes (0 all-pass / 1 any-fail / 2 zero-snippets) are unchanged. Step 3 manifest-fragment validation and the summary block are untouched.

**Measured locally:** 13 snippets, **0 failures, exit 0, ~61s wall** (one umbrella compile) vs the **~17 min** CI baseline.

## 2. Drop redundant `push:`-to-main triggers + restore a real nightly backstop

`readme-snippets.yml` and `cold-start-human.yml` ran on both `pull_request` and `push` to `main`. The push run re-validated a state the PR already validated, on a 10×-billed macOS runner — near-pure redundancy. Both now trigger on `pull_request` only.

A reviewer confirmed `nightly-slow-tests.yml` did **not** previously run either gate's script (`scripts/extract-snippets-test.sh` / `scripts/cold-start-human.sh`), so dropping the push triggers would have left **no** post-merge backstop. This PR fixes that:

- The two gates now run **on PRs** via their source `paths:` filters, **and** in `nightly-slow-tests.yml` as the **24h post-merge backstop** — a new `doc-gates` job (macos-15, same checkout + `./.github/actions/setup-swift-ci` setup as the other nightly jobs) runs both scripts on the nightly schedule. This catches a Sources-only change that landed via a PR whose paths filter did not fire (or a direct doc edit).
- `cold-start-human.yml` additionally wires a persistent build cache via `MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR`; that is a per-run speed optimization only, so the nightly job omits it (the script runs correctly without it).
- `concurrency:` blocks left as-is (the `|| github.run_id` fallback is now dead but harmless).
- `ci.yml` / `docs.yml` untouched.

## Verification
- Snippet gate run end-to-end: **exited 0**, 13 passed / 0 failed, ~61s wall.
- `actionlint` (on PATH) passes on `nightly-slow-tests.yml`, `readme-snippets.yml`, and `cold-start-human.yml`.
- `Package.resolved` not modified.

## Scope checklist
- [x] `scripts/extract-snippets-test.sh` rewritten (single-package, per-target attribution) + collision guard + comment hardening
- [x] `readme-snippets.yml` push trigger removed
- [x] `cold-start-human.yml` push trigger removed
- [x] `nightly-slow-tests.yml` gains a `doc-gates` job running both gate scripts (the real 24h backstop)
- [x] No backend-family code touched (CI-tooling only)
- [x] No `Package.swift` / `Package.resolved` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)