### PR TITLE
ci: collapse push-to-main CI runs within a merge burst

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,19 @@ on:
       # must re-trigger CI so the action change is validated under the gate.
       - ".github/actions/setup-swift-ci/**"
 
+# Collapse concurrent runs, keyed differently per event:
+#   - pull_request → group per PR number, so a force-push cancels the PR's
+#     own in-flight run but never another PR's (force-push collapse, unchanged).
+#   - push to main → `pull_request.number` is empty, so we fall back to
+#     `github.ref` (= refs/heads/main) rather than the per-run `github.run_id`.
+#     That makes a BURST of rapid merges to main collapse to a single CI run on
+#     the newest commit: each new push cancels the previous push's in-flight run.
+#     Tradeoff — intermediate merges in a burst lose their own post-merge CI
+#     signal (coarser `git bisect` granularity on main); nightly-slow-tests.yml
+#     is the 24h backstop, and each PR was already green pre-merge. The
+#     readme-snippets gate already keys its push group on the ref the same way.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## What

Change `ci.yml`'s concurrency group to fall back to `github.ref` instead of `github.run_id` on `push` events:

```diff
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

## Why

On `push` to main, `pull_request.number` is empty, so the group previously fell back to `github.run_id` — unique per push — meaning **no two main-CI runs ever collapsed**. On a busy day (today: 24 merges) that's up to 24 full macOS CI runs on `main`, each paying the ~8-min cold-compile floor at 10× billing, even when merges land within minutes of each other.

Keying the push fallback on `github.ref` (`refs/heads/main`) lets `cancel-in-progress: true` collapse a **burst of rapid merges into a single CI run on the newest commit**.

This mirrors what `readme-snippets.yml` already does (it keys its push group on the ref).

## Scope notes

- **PR runs are unaffected** — still keyed per `pull_request.number`, so a force-push cancels only that PR's own in-flight run and never another PR's. No cross-PR cancellation.
- **Docs intentionally left out.** `docs.yml`'s `pages` concurrency group already collapses pending merge bursts to the latest (GitHub cancels previously-pending runs in a `cancel-in-progress: false` group), so it's already near-optimal — no change needed.

## Tradeoff

Intermediate merges in a burst lose their own post-merge CI signal (coarser `git bisect` granularity on `main`). `nightly-slow-tests.yml` is the 24h backstop, and each PR was already green pre-merge. Documented inline above the concurrency block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)