### PR TITLE
feat(inference): auto-inject ToolSystemPromptBuilder for templates that don't render tools natively

### DIFF
--- a/Sources/ManifoldHardware/PromptTemplate.swift
+++ b/Sources/ManifoldHardware/PromptTemplate.swift
@@ -59,6 +59,24 @@ public enum PromptTemplate: String, CaseIterable, Sendable, Identifiable {
         return result
     }
 
+    /// Whether `format(messages:systemPrompt:tools:)` renders the `tools`
+    /// argument into the prompt itself (a native tool-declaration block).
+    ///
+    /// Only `.gemma4` does — it serialises each tool as a `<|tool>` block in the
+    /// system turn. Every other template silently discards `tools` and produces
+    /// the same output as `format(messages:systemPrompt:)`. Callers driving a
+    /// non-native template are responsible for folding tool descriptions into
+    /// `systemPrompt` (e.g. via `ToolSystemPromptBuilder.preferTools(for:)`);
+    /// `GenerationQueue` does this automatically (#1856). This predicate is the
+    /// signal the queue uses to decide whether that fold is needed — keep it in
+    /// lock-step with the `tools`-consuming branches of `format(…)`.
+    public var rendersToolsNatively: Bool {
+        switch self {
+        case .gemma4: return true
+        case .chatML, .llama3, .mistral, .alpaca, .gemma, .phi: return false
+        }
+    }
+
     /// Thinking markers for this template, or nil if the template does not emit reasoning blocks.
     public var thinkingMarkers: ThinkingMarkers? {
         switch self {

--- a/Sources/ManifoldInference/Services/GenerationPreflightTrimmer.swift
+++ b/Sources/ManifoldInference/Services/GenerationPreflightTrimmer.swift
@@ -49,10 +49,18 @@ struct GenerationPreflightTrimmer {
         var workingMessages = messages
         var attempt = 0
 
+        // Tools that the template renders natively (only `.gemma4` today) must be
+        // forwarded so the native tool block is emitted on this path too —
+        // otherwise the local TokenCounting path silently drops them. Templates
+        // that don't render tools natively ignore the argument; their tool
+        // guidance arrives folded into `systemPrompt` by the caller (#1856).
+        let nativeTools = promptTemplate.rendersToolsNatively ? config.tools : []
+
         while true {
             let prompt = promptTemplate.format(
                 messages: GenerationHistoryInstaller.flatten(workingMessages),
-                systemPrompt: systemPrompt
+                systemPrompt: systemPrompt,
+                tools: nativeTools
             )
             let promptTokens = try counter.countTokens(prompt)
 

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -417,7 +417,12 @@ final class GenerationQueue {
                 counter: counter,
                 backend: backend,
                 messages: messages,
-                systemPrompt: systemPrompt,
+                systemPrompt: Self.toolAugmentedSystemPrompt(
+                    template: selectedPromptTemplate,
+                    systemPrompt: systemPrompt,
+                    backend: backend,
+                    config: config
+                ),
                 config: config
             )
             GenerationHistoryInstaller.installHistory(on: backend, structuredMessages: result.trimmedMessages)
@@ -439,7 +444,17 @@ final class GenerationQueue {
         if backend.capabilities.requiresPromptTemplate {
             let template = selectedPromptTemplate
             if backend.capabilities.supportsToolCalling && !config.tools.isEmpty {
-                assembledPrompt = template.format(messages: flattened, systemPrompt: systemPrompt, tools: config.tools)
+                // Templates that render `tools` natively (only `.gemma4` today)
+                // consume the array directly. Templates that discard it get the
+                // tool guidance folded into the system prompt instead (#1856) —
+                // see `toolAugmentedSystemPrompt`. Doing both would double-inject.
+                let augmentedSystemPrompt = Self.toolAugmentedSystemPrompt(
+                    template: template,
+                    systemPrompt: systemPrompt,
+                    backend: backend,
+                    config: config
+                )
+                assembledPrompt = template.format(messages: flattened, systemPrompt: augmentedSystemPrompt, tools: config.tools)
             } else {
                 assembledPrompt = template.format(messages: flattened, systemPrompt: systemPrompt)
             }
@@ -456,6 +471,44 @@ final class GenerationQueue {
             systemPrompt: effectiveSystemPrompt,
             config: config
         )
+    }
+
+    /// Folds the canonical tool-preference preamble into `systemPrompt` when the
+    /// selected prompt template does **not** render tools natively (#1856).
+    ///
+    /// `GenerationQueue` passes `config.tools` to `PromptTemplate.format(…:tools:)`
+    /// for every prompt-template backend, but only `.gemma4` consumes them — it
+    /// emits a native `<|tool>` block. Every other template (`.llama3`, `.chatML`,
+    /// `.mistral`, `.phi`, `.gemma`, `.alpaca`) silently discards the array, so a
+    /// local non-Gemma model never sees the tool definitions unless the host
+    /// hand-injects them. That hand-injection was the documented manual recipe
+    /// (docs/LOCAL-TOOL-CALLING.md, Step 1); this folds it in automatically using
+    /// the same `ToolSystemPromptBuilder.preferTools(for:)` preamble.
+    ///
+    /// Returns `systemPrompt` unchanged when: tools are empty, the backend does
+    /// not support tool calling, or the template renders tools natively (no
+    /// double-injection). Otherwise prepends the preamble — matching the
+    /// documented `preamble + "\n\n" + appSystemPrompt` shape.
+    static func toolAugmentedSystemPrompt(
+        template: PromptTemplate,
+        systemPrompt: String?,
+        backend: InferenceBackend,
+        config: GenerationConfig
+    ) -> String? {
+        guard backend.capabilities.supportsToolCalling,
+              !config.tools.isEmpty,
+              !template.rendersToolsNatively else {
+            return systemPrompt
+        }
+
+        let preamble = ToolSystemPromptBuilder.preferTools(for: config.tools)
+        // `preferTools` returns "" only when tools is empty, which is guarded
+        // above — but stay defensive so an empty preamble never strands a stray
+        // separator in front of the host's prompt.
+        guard !preamble.isEmpty else { return systemPrompt }
+
+        guard let systemPrompt, !systemPrompt.isEmpty else { return preamble }
+        return preamble + "\n\n" + systemPrompt
     }
 
     // MARK: - Generation Queue

--- a/Tests/ManifoldInferenceTests/GenerationQueueToolSystemPromptTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueueToolSystemPromptTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Verifies that ``GenerationQueue`` auto-folds
+/// ``ToolSystemPromptBuilder/preferTools(for:)`` into the system prompt for
+/// prompt-template backends whose template does **not** render tools natively
+/// (#1856), and that it does *not* double-inject for `.gemma4` (which renders a
+/// native `<|tool>` block) or inject at all when there are no tools / no
+/// tool-calling support.
+///
+/// These exercise the exact-preflight (`TokenCountingBackend`) dispatch path —
+/// the one local GGUF models actually take — so the assembled prompt that
+/// reaches the backend is captured in `lastPrompt`.
+@MainActor
+final class GenerationQueueToolSystemPromptTests: XCTestCase {
+
+    private func tool(_ name: String) -> ToolDefinition {
+        ToolDefinition(name: name, description: "Gets \(name)", parameters: .object([:]))
+    }
+
+    /// The canonical preamble headline `ToolSystemPromptBuilder.preferTools`
+    /// emits for `.standard` — used to detect injection without coupling the
+    /// test to the full multi-line phrasing.
+    private let preambleMarker = "You have the following tools available:"
+
+    private func makeBackend(
+        template: PromptTemplate,
+        supportsToolCalling: Bool
+    ) -> (backend: ToolPromptCountingBackend, provider: ToolPromptFakeProvider, queue: GenerationQueue) {
+        let backend = ToolPromptCountingBackend(supportsToolCalling: supportsToolCalling)
+        // Always-fits: one count under budget so generate runs without trimming.
+        backend.countTokensResponses = [10]
+        let provider = ToolPromptFakeProvider(backend: backend)
+        provider.promptTemplate = template
+        let queue = GenerationQueue()
+        provider.bind(to: queue)
+        return (backend, provider, queue)
+    }
+
+    // (a) Non-Gemma template + tools → preamble folded into the prompt.
+    func test_nonGemmaTemplate_withTools_injectsPreamble() async throws {
+        let (backend, provider, queue) = makeBackend(template: .llama3, supportsToolCalling: true)
+
+        let (_, stream) = try queue.enqueue(
+            messages: [("user", "what time is it?")],
+            systemPrompt: "You are a helpful assistant.",
+            tools: [tool("get_time")]
+        )
+        for try await _ in stream.events {}
+
+        let prompt = try XCTUnwrap(backend.lastPrompt)
+        XCTAssertTrue(prompt.contains(preambleMarker),
+                      "non-native template must get the tool preamble folded in")
+        XCTAssertTrue(prompt.contains("get_time"),
+                      "the tool name must appear in the rendered preamble")
+        XCTAssertTrue(prompt.contains("You are a helpful assistant."),
+                      "the host system prompt must survive alongside the preamble")
+        withExtendedLifetime(provider) {}
+    }
+
+    // (b) Gemma 4 renders tools natively → preamble must NOT be injected.
+    func test_gemma4Template_withTools_doesNotInjectPreamble() async throws {
+        let (backend, provider, queue) = makeBackend(template: .gemma4, supportsToolCalling: true)
+
+        let (_, stream) = try queue.enqueue(
+            messages: [("user", "what time is it?")],
+            systemPrompt: "You are a helpful assistant.",
+            tools: [tool("get_time")]
+        )
+        for try await _ in stream.events {}
+
+        let prompt = try XCTUnwrap(backend.lastPrompt)
+        XCTAssertFalse(prompt.contains(preambleMarker),
+                       "gemma4 renders tools natively — the system-prompt preamble must not double-inject")
+        // Sanity: the native block still carries the tool (so we know tools
+        // weren't simply dropped — they reached the model the native way).
+        XCTAssertTrue(prompt.contains("<|tool>"),
+                      "gemma4 must still emit its native tool block")
+        withExtendedLifetime(provider) {}
+    }
+
+    // (c1) No tools → no injection regardless of template.
+    func test_nonGemmaTemplate_noTools_noInjection() async throws {
+        let (backend, provider, queue) = makeBackend(template: .llama3, supportsToolCalling: true)
+
+        let (_, stream) = try queue.enqueue(
+            messages: [("user", "hi")],
+            systemPrompt: "You are a helpful assistant."
+        )
+        for try await _ in stream.events {}
+
+        let prompt = try XCTUnwrap(backend.lastPrompt)
+        XCTAssertFalse(prompt.contains(preambleMarker),
+                       "empty tools → nothing to inject")
+        withExtendedLifetime(provider) {}
+    }
+
+    // (c2) Backend doesn't support tool calling → tools are rejected before
+    // dispatch, so no injection can occur. (The queue throws on enqueue, which
+    // is the established contract for tools-on-incapable-backends.)
+    func test_toolUnsupportedBackend_withTools_rejectsAndDoesNotInject() async throws {
+        let (backend, provider, queue) = makeBackend(template: .llama3, supportsToolCalling: false)
+
+        do {
+            _ = try queue.enqueue(
+                messages: [("user", "hi")],
+                systemPrompt: "You are a helpful assistant.",
+                tools: [tool("get_time")]
+            )
+            XCTFail("enqueue must reject tools on a backend that can't call them")
+        } catch {
+            // Expected: the queue refuses tools on an incapable backend.
+        }
+
+        XCTAssertNil(backend.lastPrompt,
+                     "rejected request must never reach the backend, so nothing is injected")
+        withExtendedLifetime(provider) {}
+    }
+}
+
+// MARK: - Local mocks
+
+/// A `TokenCountingBackend` with `requiresPromptTemplate = true` and a
+/// configurable `supportsToolCalling`, so it exercises the exact-preflight
+/// dispatch path and captures the assembled prompt.
+private final class ToolPromptCountingBackend: InferenceBackend, TokenCountingBackend, @unchecked Sendable {
+    var isModelLoaded: Bool = true
+    var isGenerating: Bool = false
+    var capabilities: BackendCapabilities
+
+    var tokensToYield: [String] = ["ok"]
+    private(set) var lastPrompt: String?
+
+    var countTokensResponses: [Int] = []
+    private(set) var countTokensCalled = 0
+
+    init(supportsToolCalling: Bool, contextSize: Int32 = 4096) {
+        self.capabilities = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: contextSize,
+            requiresPromptTemplate: true,
+            supportsSystemPrompt: true,
+            supportsToolCalling: supportsToolCalling,
+            supportsStructuredOutput: false,
+            cancellationStyle: .cooperative,
+            supportsTokenCounting: true
+        )
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {}
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        lastPrompt = prompt
+        let tokens = tokensToYield
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            Task {
+                for token in tokens { continuation.yield(.token(token)) }
+                continuation.finish()
+            }
+        }
+        return GenerationStream(stream)
+    }
+
+    func stopGeneration() { isGenerating = false }
+    func unloadModel() { isModelLoaded = false }
+
+    func countTokens(_ text: String) throws -> Int {
+        countTokensCalled += 1
+        guard !countTokensResponses.isEmpty else { return 10 }
+        let idx = min(countTokensCalled - 1, countTokensResponses.count - 1)
+        return countTokensResponses[idx]
+    }
+}
+
+@MainActor
+private final class ToolPromptFakeProvider {
+    let backend: ToolPromptCountingBackend
+    var promptTemplate: PromptTemplate = .chatML
+
+    init(backend: ToolPromptCountingBackend) {
+        self.backend = backend
+        self.backend.isModelLoaded = true
+    }
+
+    func bind(to queue: GenerationQueue) {
+        queue.bindContext(
+            currentBackend: { [weak self] in self?.backend },
+            isBackendLoaded: { [weak self] in self?.backend.isModelLoaded ?? false },
+            selectedPromptTemplate: { [weak self] in self?.promptTemplate ?? .chatML }
+        )
+    }
+}

--- a/docs/LOCAL-TOOL-CALLING.md
+++ b/docs/LOCAL-TOOL-CALLING.md
@@ -30,9 +30,10 @@ llama.cpp envelope parser lives in the companion package
 
 For a local non-Gemma model, a working turn is:
 
-1. **You** render the tool list into the system prompt yourself, using
-   `ToolSystemPromptBuilder.preferTools(for:)`. The queue will *not* do this for
-   you (see "Step 1" — this is the #1 footgun).
+1. The queue renders the tool list into the system prompt for you (#1856), via
+   `ToolSystemPromptBuilder.preferTools(for:)`, whenever the backend supports
+   tool calling and the selected template doesn't render tools natively. You may
+   still fold your own preamble in if you want a non-default style (see "Step 1").
 2. You instruct the model to emit calls in the envelope
    `<tool_call>{"name":"…","arguments":{…}}</tool_call>`.
 3. You pass the same `tools` to `enqueue(…)` so dispatch can match and run them.
@@ -47,14 +48,12 @@ import ManifoldKit
 
 let tools: [ToolDefinition] = [weatherTool]   // your ToolDefinitions
 
-// 1. YOU render the tool list into the system prompt. The queue does not.
-let preamble = ToolSystemPromptBuilder.preferTools(for: tools)   // .standard style
-let systemPrompt = preamble + "\n\n" + "You are a helpful assistant."
-
+// 1. The queue folds the tool preamble into the system prompt for you (#1856).
+//    Just pass your plain app system prompt.
 // 2 + 3. Pass tools to enqueue. Grammar auto-applies on grammar-capable backends.
 let (_, stream) = try inferenceService.enqueue(
     messages: [.user("What's the weather in Paris?")],
-    systemPrompt: systemPrompt,
+    systemPrompt: "You are a helpful assistant.",
     tools: tools,
     toolChoice: .auto,
     maxToolIterations: 10
@@ -72,25 +71,34 @@ for try await event in stream {
 
 ---
 
-## Step 1 — Render tools into the system prompt (you do this; the queue does not)
+## Step 1 — Tools are rendered into the system prompt for you (#1856)
 
-This is the single most important fact in this guide, and the easiest to get
-wrong because it *looks* like the queue handles it.
+This used to be the #1 footgun: the queue passed `tools:` to the template but only
+`.gemma4` consumed them, so on a Llama/Qwen/Mistral model the tool descriptions
+never reached the model. **The queue now folds them in automatically.**
 
-`GenerationQueue` does call `PromptTemplate.format(messages:systemPrompt:tools:)`
-for every prompt-template backend. But **only the `.gemma4` template consumes the
-`tools` argument** — it renders a native `<|tool>` block. Every other template
-(`.llama3`, `.chatML`, `.mistral`, `.phi`, `.gemma`, `.alpaca`) **silently
-discards `tools`** and produces exactly the same prompt it would have produced
-with no tools at all.
+`GenerationQueue` calls `PromptTemplate.format(messages:systemPrompt:tools:)` for
+every prompt-template backend. Only the `.gemma4` template consumes the `tools`
+argument — it renders a native `<|tool>` block. Every other template (`.llama3`,
+`.chatML`, `.mistral`, `.phi`, `.gemma`, `.alpaca`) discards `tools`. For those
+templates the queue now prepends the `ToolSystemPromptBuilder.preferTools(for:)`
+preamble to your system prompt before formatting — so the tool descriptions reach
+the model without any host code. (`.gemma4` keeps its native block and is **not**
+double-injected.)
 
-So on a Llama/Qwen/Mistral model, if you only pass `tools:` to `enqueue(…)`, the
-model **never sees the tool definitions** — it has nothing to call, and the turn
-comes back as plain prose. `tools:` still matters (dispatch uses it to match and
-run calls, and it drives grammar derivation — Step 3), but it does **not** put
-the tool descriptions in front of the model on these templates.
+This happens when **all** of the following hold:
 
-`ManifoldInference` ships the canonical preamble for this:
+- `backend.capabilities.supportsToolCalling == true`,
+- `config.tools` is non-empty, and
+- the selected template does **not** render tools natively
+  (`PromptTemplate.rendersToolsNatively == false`).
+
+`tools:` still matters beyond the preamble: dispatch uses it to match and run
+calls, and it drives grammar derivation (Step 3).
+
+If you want a non-default preamble style (`.strict` / `.minimal`) or your own
+phrasing, you can still fold it in by hand — `ManifoldInference` ships the
+canonical builder:
 
 ```swift,no-build
 public static func preferTools(
@@ -99,10 +107,11 @@ public static func preferTools(
 ) -> String
 ```
 
-Fold it into your system prompt before enqueuing:
+Fold it into your system prompt before enqueuing (only needed for a non-default
+style — the `.standard` preamble is auto-injected):
 
 ```swift,no-build
-let preamble = ToolSystemPromptBuilder.preferTools(for: tools)
+let preamble = ToolSystemPromptBuilder.preferTools(for: tools, style: .strict)
 let systemPrompt = preamble + "\n\n" + appSpecificSystemPrompt
 ```
 
@@ -114,14 +123,16 @@ tools by emitting the appropriate tool_call in your response." In ManifoldKit's
 own product testing this lifted `llama3.1:8b` tool-recall from ~50% (no preamble)
 to 70–85%.
 
-> **Is this auto-injected?** **No — not on `main` today.**
-> `ToolSystemPromptBuilder.preferTools(for:)` has **zero pipeline call sites**;
-> the queue never calls it. Auto-injection is tracked by
-> [#1856](https://github.com/roryford/ManifoldKit/issues/1856) and is **open /
-> unwired**. Until it ships, the host must fold the preamble in by hand as shown
-> above. (Foundation Models, OpenAI, and Anthropic backends render tools
-> natively on the wire and need none of this — the manual step is specific to
-> local prompt-template backends.)
+> **Is this auto-injected?** **Yes, as of [#1856](https://github.com/roryford/ManifoldKit/issues/1856).**
+> The queue calls `ToolSystemPromptBuilder.preferTools(for:)` (`.standard` style)
+> automatically for tool-capable backends whose template doesn't render tools
+> natively, prepending it to your system prompt. You no longer need to fold the
+> preamble in by hand for the default behaviour — supply only your app system
+> prompt. Hand-folding is still supported and is the way to opt into `.strict` /
+> `.minimal` styles or your own phrasing (it stacks on top of, not instead of,
+> your app prompt). (Foundation Models, OpenAI, and Anthropic backends render
+> tools natively on the wire and need none of this — auto-injection is specific
+> to local prompt-template backends.)
 
 The `.strict` style additionally tells the model to say "I don't have a tool for
 that" rather than guessing — use it for agent workflows that branch on tool
@@ -240,10 +251,14 @@ full chat orchestration, `ConversationRuntime.send`) is the entry point. Pass th
 These are the real, observable failure modes on `main`. Several produce **no
 event at all**, which is why "my tool never fires" is hard to debug.
 
-1. **Tools never rendered → model emits prose.** The most common one. You passed
-   `tools:` to `enqueue` but did *not* fold `ToolSystemPromptBuilder.preferTools`
-   into the system prompt. On a non-Gemma template the model never saw the tools,
-   so it answers in plain text. Fix: Step 1.
+1. **Tools never rendered → model emits prose.** *Largely closed by
+   [#1856](https://github.com/roryford/ManifoldKit/issues/1856).* This was the
+   most common failure when the host had to fold the preamble in by hand and
+   forgot. The queue now auto-injects `ToolSystemPromptBuilder.preferTools` for
+   tool-capable backends whose template doesn't render tools natively, so passing
+   `tools:` to `enqueue` is enough. It can still surface if the backend reports
+   `supportsToolCalling == false` (see #5) or you pin a release predating #1856 —
+   in that case fold the preamble in manually (Step 1).
 
 2. **Malformed body → silent drop (no event).** If the body between
    `<tool_call>`…`</tool_call>` isn't valid JSON, or has a missing/empty


### PR DESCRIPTION
## What

Local non-Gemma instruct models received **no** tool definitions unless the host hand-injected them. `GenerationQueue` passed `config.tools` to `PromptTemplate.format(…:tools:)` for every prompt-template backend, but every non-`.gemma4` template silently discarded them — and `ToolSystemPromptBuilder.preferTools(for:)` (with measured 50% → 70–85% tool-recall gains) had **zero pipeline call sites**.

This wires auto-injection: when `supportsToolCalling && !config.tools.isEmpty` **and** the selected template does not render tools natively, the queue folds `ToolSystemPromptBuilder.preferTools(for:)` (`.standard`) into the system prompt before formatting. `.gemma4` (which renders a native `<|tool>` block) is a no-op for the system-prompt fold, so tools are never double-injected.

## Changes

- **`PromptTemplate.rendersToolsNatively`** — new predicate, `true` only for `.gemma4`. Used as the robust "renders tools natively" signal rather than hardcoding `== .gemma4`, kept in lock-step with the `tools`-consuming branch of `format(…)`.
- **`GenerationQueue.toolAugmentedSystemPrompt(...)`** — folds the preamble into the system prompt (`preamble + "\n\n" + appPrompt`, matching the documented manual recipe). Returns the system prompt unchanged when tools are empty, the backend can't call tools, or the template renders tools natively. Applied on **both** dispatch paths.
- **`GenerationPreflightTrimmer`** now forwards native tools to `format`. This fixes a latent gap: the local `TokenCountingBackend` path (llama.cpp) never passed `tools` at all, so even `.gemma4`'s native block was dropped on that path.
- **docs/LOCAL-TOOL-CALLING.md** — the manual Step-1 fold is now default-on auto-injection; hand-folding documented as the opt-in for `.strict`/`.minimal` styles.

## Tests

`GenerationQueueToolSystemPromptTests` (exercises the local `TokenCountingBackend` dispatch path, asserts on the assembled `lastPrompt`):
- non-Gemma template + tools → preamble + tool name folded into the prompt, host system prompt preserved
- `.gemma4` + tools → preamble **not** double-injected; native `<|tool>` block still present
- empty tools → no injection
- backend without tool-calling support → request rejected, nothing reaches the backend

Sabotage-verified (disabling the fold fails the injection test while gemma4/no-tools stay green), then reverted.

## Premise vs source

The issue cited `PromptTemplate.swift ~98-119` and the non-TokenCounting path. Accurate, but **incomplete**: the path local GGUF models actually take is `GenerationPreflightTrimmer` (TokenCounting), which never forwarded `tools` to `format` at all — so it dropped tools for *every* template including `.gemma4`. Both paths are fixed here.

Resolves #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)