### PR TITLE
ci: add on-demand companion compat check against an arbitrary core ref

### DIFF
--- a/.github/workflows/companion-compat.yml
+++ b/.github/workflows/companion-compat.yml
@@ -1,0 +1,67 @@
+name: Companion compat (pre-release)
+
+# On-demand pre-tag check: build the companion backend packages
+# (manifold-mlx / manifold-llama) against an arbitrary ManifoldKit ref
+# (default: main HEAD) BEFORE cutting a release, so a core seam break — e.g. a
+# new non-frozen Contract enum case like GenerationEvent.promptRendered — is
+# caught in lockstep instead of surfacing only after the tag ships.
+#
+# Why a button and not a required gate: the breaking code lands on main before
+# the release PR exists (that PR only touches CHANGELOG/manifest), so there's
+# nothing on the release PR's diff to gate; and the post-release `core-bump`
+# automation already blocks a broken companion *release* from shipping. This
+# fills the residual "core tag is out while companion main is briefly red" gap
+# for risky minors, on demand. Press it before merging a feat!/minor release PR.
+#
+# All three repos are public, so cross-repo checkout needs no token — the
+# default GITHUB_TOKEN suffices.
+
+on:
+  workflow_dispatch:
+    inputs:
+      core_ref:
+        description: "ManifoldKit ref to build the companions against"
+        required: true
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  compat:
+    strategy:
+      # Report both companions even if one breaks.
+      fail-fast: false
+      matrix:
+        companion: [manifold-mlx, manifold-llama]
+    runs-on: macos-15
+    steps:
+      - name: Check out ${{ matrix.companion }}
+        uses: actions/checkout@v4
+        with:
+          repository: roryford/${{ matrix.companion }}
+          path: companion
+      - name: Check out ManifoldKit @ ${{ inputs.core_ref }}
+        uses: actions/checkout@v4
+        with:
+          repository: roryford/ManifoldKit
+          ref: ${{ inputs.core_ref }}
+          path: core
+      - name: Select newest Xcode 26 toolchain
+        # Match the companions' own CI: the image default mis-resolves the
+        # dependency graph; Swift 6.3 (Xcode 26.3) prunes the trait-disabled
+        # edges correctly.
+        run: |
+          DEVELOPER_DIR="$(printf '%s\n' /Applications/Xcode_26*.app | sort -V | tail -1)/Contents/Developer"
+          sudo xcode-select -s "$DEVELOPER_DIR"
+          swift --version
+      - name: Build companion against core ref
+        working-directory: companion
+        # `swift package edit` swaps the ManifoldKit dependency to the local
+        # core checkout, bypassing the .upToNextMinor pin (which only resolves
+        # to published tags) and Package.resolved. Build-only — exercising the
+        # compile/source seam is the point; the companions' own CI owns tests.
+        run: |
+          swift package edit manifoldkit --path ../core
+          swift build

--- a/.github/workflows/companion-compat.yml
+++ b/.github/workflows/companion-compat.yml
@@ -38,12 +38,12 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Check out ${{ matrix.companion }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: roryford/${{ matrix.companion }}
           path: companion
       - name: Check out ManifoldKit @ ${{ inputs.core_ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: roryford/ManifoldKit
           ref: ${{ inputs.core_ref }}


### PR DESCRIPTION
Adds `.github/workflows/companion-compat.yml` — a `workflow_dispatch` button that builds **manifold-mlx** and **manifold-llama** against a chosen ManifoldKit ref (default `main` HEAD), so a core seam break is caught **before** tagging a release rather than after (cf. the v0.52.0 `.promptRendered` break that hit mlx post-tag).

**Design (from the shift-left retro):**
- `workflow_dispatch` only → **zero automatic CI cost**, not a required check. Press it before merging a risky `feat!`/minor release PR.
- A required cross-repo gate was **rejected**: the breaking code is on `main` before the release PR (which only changes CHANGELOG/manifest) exists, so there's nothing on the release-PR diff to gate; and the post-release `core-bump` automation already blocks a broken companion *release* from shipping. This fills only the residual "core tag is out while companion main is briefly red" gap.
- All three repos are public → cross-repo `actions/checkout` needs no token. `swift package edit manifoldkit --path ../core` swaps the dependency to the local checkout, bypassing the `.upToNextMinor` pin + `Package.resolved` without dirtying `Package.swift`. Build-only (companions' own CI owns tests).

Paired with a fix to the companions' `canary.yml`, which today silently tests the latest *published* tag instead of main (false confidence) — separate PRs in each companion repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)