### PR TITLE
test(ollama): capability-based tool-call discovery and align E2E setup docs

### DIFF
--- a/Sources/ManifoldTestSupport/HardwareRequirements.swift
+++ b/Sources/ManifoldTestSupport/HardwareRequirements.swift
@@ -114,6 +114,86 @@ public enum HardwareRequirements {
         return models.compactMap { $0["name"] as? String }
     }
 
+    /// Returns the name of an installed, tool-calling-capable Ollama model, or
+    /// `nil` if the server is unreachable or no installed model advertises the
+    /// `"tools"` capability.
+    ///
+    /// Capability is probed via Ollama's `/api/show` endpoint, whose
+    /// `capabilities` array carries `"tools"` for models with native tool
+    /// support — so this discovers newer tool-callers (e.g. `qwen3.5`,
+    /// `gemma4`) without hardcoding model names.
+    ///
+    /// Selection order:
+    /// 1. If `OLLAMA_TEST_MODEL` is set, is installed, and is tool-capable, use it.
+    /// 2. Otherwise iterate installed models and return the first whose
+    ///    `/api/show` capabilities contain `"tools"`.
+    public static func findOllamaToolCapableModel(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        guard let names = listOllamaModels() else { return nil }
+        return selectOllamaToolCapableModel(
+            from: names,
+            environment: environment,
+            isToolCapable: { ollamaModelIsToolCapable($0) }
+        )
+    }
+
+    /// Picks a tool-capable model name from a pre-fetched list, given a
+    /// capability probe. Extracted from `findOllamaToolCapableModel` so it can
+    /// be unit-tested without a live server: inject a stub `isToolCapable`.
+    ///
+    /// When `OLLAMA_TEST_MODEL` names an installed *and* tool-capable model it
+    /// wins; otherwise the first installed model that probes tool-capable is
+    /// returned.
+    public static func selectOllamaToolCapableModel(
+        from names: [String],
+        environment: [String: String] = [:],
+        isToolCapable: (String) -> Bool
+    ) -> String? {
+        if let override = environment["OLLAMA_TEST_MODEL"], !override.isEmpty,
+           names.contains(override), isToolCapable(override) {
+            return override
+        }
+        return names.first(where: isToolCapable)
+    }
+
+    /// Probes Ollama's `/api/show` for `name` and reports whether its
+    /// `capabilities` array contains `"tools"`. Returns `false` on any
+    /// transport/decoding failure (treated as "not tool-capable").
+    public static func ollamaModelIsToolCapable(_ name: String) -> Bool {
+        ollamaModelCapabilities(name)?.contains("tools") ?? false
+    }
+
+    /// Fetches the `capabilities` array for a model from `/api/show`
+    /// synchronously. Returns `nil` if the server is unreachable or the
+    /// response is malformed.
+    private static func ollamaModelCapabilities(_ name: String) -> [String]? {
+        guard let url = URL(string: "http://localhost:11434/api/show") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 3
+        guard let body = try? JSONSerialization.data(
+            withJSONObject: ["model": name]
+        ) else { return nil }
+        request.httpBody = body
+
+        let semaphore = DispatchSemaphore(value: 0)
+        final class Box: @unchecked Sendable { var value: [String]? }
+        let box = Box()
+
+        URLSession.shared.dataTask(with: request) { data, response, _ in
+            defer { semaphore.signal() }
+            guard let data,
+                  let http = response as? HTTPURLResponse, http.statusCode == 200,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let capabilities = json["capabilities"] as? [String] else { return }
+            box.value = capabilities
+        }.resume()
+        let result = semaphore.wait(timeout: .now() + 5)
+        return result == .success ? box.value : nil
+    }
+
     /// Selects the best model from a pre-fetched Ollama model list.
     /// Extracted from `findOllamaModel` for testability.
     ///

--- a/Tests/ManifoldE2ETests/OllamaToolCallingE2ETests.swift
+++ b/Tests/ManifoldE2ETests/OllamaToolCallingE2ETests.swift
@@ -25,14 +25,6 @@ final class OllamaToolCallingE2ETests: XCTestCase {
     private var backend: OllamaBackend!
     private var modelName: String!
 
-    /// Preferred tool-calling-capable model (Llama 3.1 8B has native tool
-    /// support on Ollama). Fallback to a smaller Qwen 2.5 tag that also
-    /// supports tool calling via the `/api/chat` tools envelope.
-    private static let preferredModels: [String] = [
-        "llama3.1:8b",
-        "qwen2.5:7b-instruct",
-    ]
-
     override func setUp() async throws {
         try await super.setUp()
         try XCTSkipUnless(
@@ -40,10 +32,15 @@ final class OllamaToolCallingE2ETests: XCTestCase {
             "Ollama server not running at localhost:11434"
         )
 
-        let available = HardwareRequirements.listOllamaModels() ?? []
-        guard let match = Self.preferredModels.first(where: { available.contains($0) }) else {
+        // Discover a tool-capable model by probing each installed model's
+        // `/api/show` capabilities (the array carries `"tools"` for native
+        // tool-callers) rather than matching a hardcoded name list. This picks
+        // up newer tool-callers (qwen3.5, gemma4, …) the user has installed,
+        // and honours `OLLAMA_TEST_MODEL` when that model is tool-capable.
+        guard let match = HardwareRequirements.findOllamaToolCapableModel() else {
+            let installed = HardwareRequirements.listOllamaModels() ?? []
             throw XCTSkip(
-                "No tool-calling-capable Ollama model installed; need one of \(Self.preferredModels). Installed: \(available)"
+                "No tool-calling-capable Ollama model installed (none advertise the `tools` capability via /api/show). Installed: \(installed)"
             )
         }
         modelName = match

--- a/Tests/ManifoldE2ETests/README.md
+++ b/Tests/ManifoldE2ETests/README.md
@@ -37,8 +37,25 @@ Run Ollama locally:
 ```bash
 brew install ollama
 ollama serve &
-ollama pull qwen3.5:4b   # for thinking tests
-ollama pull llama3.2:3b  # for general tests
+ollama pull llama3.1:8b   # general + tool-calling tests
+```
+
+`OllamaE2ETests` / `OllamaThinkingE2ETests` select via
+`HardwareRequirements.findOllamaModel()`, whose default `preferredSizeRange`
+is `6.5...9.0` (B params) — so they pick an **8B-class** model. A 3–4B pull
+(`llama3.2:3b`, `qwen3.5:4b`) is ignored unless it's the only model installed,
+which is why the recommended pull above is 8B-class.
+
+`OllamaToolCallingE2ETests` **auto-discovers a tool-capable model** by probing
+each installed model's `/api/show` `capabilities` for `"tools"` — no fixed
+name list — so any installed native tool-caller (e.g. `llama3.1:8b`,
+`qwen3.5`, `gemma4`) works. It skips cleanly when none advertise `"tools"`.
+
+To pin a specific model across these suites, set `OLLAMA_TEST_MODEL` (it must
+be installed; for the tool-calling suite it must also be tool-capable):
+
+```bash
+OLLAMA_TEST_MODEL=qwen3.5:latest swift test --filter ManifoldE2ETests
 ```
 
 The tests skip automatically when `localhost:11434` is unreachable.


### PR DESCRIPTION
## What

Two fixes in the same live-test-setup area for Ollama E2E.

### Fix 1 — capability-based tool-calling model discovery
`OllamaToolCallingE2ETests` hardcoded a 2-name preferred list (`llama3.1:8b`, `qwen2.5:7b-instruct`) and skipped if neither was installed — skipping newer tool-callers the user has (qwen3.5, gemma4, …).

- New `HardwareRequirements` helpers in `Sources/ManifoldTestSupport/HardwareRequirements.swift`:
  - `findOllamaToolCapableModel(environment:)` — honors `OLLAMA_TEST_MODEL` when that model is installed and tool-capable; otherwise returns the first installed model whose `/api/show` `capabilities` contains `"tools"`.
  - `selectOllamaToolCapableModel(from:environment:isToolCapable:)` — pure, testable selection split (inject a stub capability probe).
  - `ollamaModelIsToolCapable(_:)` + private `ollamaModelCapabilities(_:)` — synchronous `/api/show` POST probe with a short timeout, matching the existing `fetchOllamaModels` style.
- `OllamaToolCallingE2ETests` now uses the new discovery with a clear `XCTSkip` listing installed models when none advertise `"tools"`. Test assertions unchanged; setUp shape kept consistent with `OllamaE2ETests`.

**Premise verified against the live server**: `/api/show` returns a `capabilities` array, and tool-capable models (llama3.1:8b, qwen3.5, gemma4) carry `"tools"`; embedding/vision-only models do not.

### Fix 2 — README/selection mismatch
`Tests/ManifoldE2ETests/README.md` told users to `ollama pull qwen3.5:4b` / `llama3.2:3b`, but `findOllamaModel`'s default `preferredSizeRange` is `6.5...9.0` (B params), so it actually picks an 8B-class model and ignores those 3–4B pulls.

- Recommend an 8B-class pull (`llama3.1:8b`), document the `OLLAMA_TEST_MODEL` override, and clarify that the tool-calling suite now auto-discovers by probed capability rather than fixed names.

## Files changed
- `Sources/ManifoldTestSupport/HardwareRequirements.swift`
- `Tests/ManifoldE2ETests/OllamaToolCallingE2ETests.swift`
- `Tests/ManifoldE2ETests/README.md`

## Verification
- `swift build --build-tests` — passes (exit 0).
- Did not run the full suite.

Draft — orchestrator verifies live + watches CI before merge.
