### PR TITLE
test(inference): make KeepAlivePolicyTests robust against CI scheduling starvation

### DIFF
--- a/Tests/ManifoldInferenceTests/KeepAlivePolicyTests.swift
+++ b/Tests/ManifoldInferenceTests/KeepAlivePolicyTests.swift
@@ -5,8 +5,30 @@ import ManifoldTestSupport
 /// Tests for ``KeepAlivePolicy`` and its idle auto-unload integration with
 /// ``InferenceService``.
 ///
-/// Timer-based tests use short idle timeouts (0.3 – 0.5 s) with 2-second
-/// XCTWaiter deadlines so they run fast on CI without being flaky.
+/// ## Timing under CI scheduling starvation
+///
+/// The idle watch task polls a **wall-clock** `idleDuration` against the
+/// configured `idleTimeout`. Under `swift test --parallel` on a CPU-
+/// oversubscribed CI runner, any `Task.sleep` the test issues can overrun its
+/// nominal duration by hundreds of milliseconds. Earlier revisions of this
+/// suite armed a short timeout (0.3–0.5 s) and then `sleep`-ed before doing the
+/// work whose effect they wanted to observe; when that pre-work sleep stretched
+/// past the timeout, the watch task auto-unloaded the model *before the work
+/// ran*, producing spurious `"No model loaded"` failures (and false negatives
+/// for the "activity keeps the model loaded" assertion).
+///
+/// To stay robust against arbitrary scheduling jitter these tests follow two
+/// rules:
+///   1. **Never sleep on the critical path before the action under test.** A
+///      freshly loaded service that has never generated reports
+///      `idleDuration == .infinity`, so any armed timeout would fire on its
+///      first poll. We establish activity (or arm the policy) only at the point
+///      we actually want the clock to start.
+///   2. **Use a large timeout relative to the observation window, and poll**
+///      rather than sleeping a fixed amount then asserting. The "stays loaded"
+///      window is a small fraction of the timeout, and the "eventually unloads"
+///      check polls against a generous deadline. Jitter that is small relative
+///      to the timeout can no longer flip the outcome.
 @MainActor
 final class KeepAlivePolicyTests: XCTestCase {
 
@@ -16,6 +38,22 @@ final class KeepAlivePolicyTests: XCTestCase {
         let backend = MockInferenceBackend()
         backend.isModelLoaded = true
         return InferenceService(backend: backend)
+    }
+
+    /// Polls `condition` until it is true or the deadline elapses.
+    /// - Returns: `true` if the condition became true before the deadline.
+    @discardableResult
+    private func poll(
+        timeout: TimeInterval,
+        interval: Duration = .milliseconds(20),
+        until condition: @MainActor () -> Bool
+    ) async throws -> Bool {
+        let deadline = Date.now.addingTimeInterval(timeout)
+        while Date.now < deadline {
+            if condition() { return true }
+            try await Task.sleep(for: interval)
+        }
+        return condition()
     }
 
     // MARK: - KeepAlivePolicy value semantics
@@ -94,34 +132,45 @@ final class KeepAlivePolicyTests: XCTestCase {
         backend.tokensToYield = ["hello"]
         let service = InferenceService(backend: backend)
 
-        // Set a 0.4-second idle timeout.
-        service.keepAlivePolicy = KeepAlivePolicy(idleTimeout: 0.4)
-
-        // Enqueue and fully consume a generation ~0.1 s after setting the policy,
-        // which should reset the idle clock to now.
-        try await Task.sleep(for: .milliseconds(100))
+        // Establish real generation activity FIRST, while the policy is still
+        // `.never`. This is the critical ordering: a service that has never
+        // generated reports `idleDuration == .infinity`, so arming a timeout
+        // before any activity would unload on the very first poll — and any
+        // pre-generate sleep racing that poll is exactly the CI-starvation flake
+        // this test previously suffered. By generating before arming, the idle
+        // clock starts from a concrete `lastActivityTimestamp`, not `.infinity`.
         let (_, genStream) = try service.enqueue(
             messages: [.user("hi")],
             config: GenerationConfig()
         )
         for try await _ in genStream.events {}
+        XCTAssertTrue(service.isModelLoaded, "Model loaded after a fresh generation")
 
-        // Shortly after the generation completes the model should still be loaded
-        // (idle clock was just reset).
-        try await Task.sleep(for: .milliseconds(100))
-        XCTAssertTrue(
-            service.isModelLoaded,
-            "Model should still be loaded — activity reset the idle clock"
-        )
+        // Now arm a generous timeout. The watch task polls wall-clock idle time;
+        // 5 s is far larger than any plausible scheduling jitter in the short
+        // "stays loaded" window below, so jitter cannot prematurely unload.
+        service.keepAlivePolicy = KeepAlivePolicy(idleTimeout: 5.0)
 
-        // But eventually (well after 0.4 s of silence post-generation) it should
-        // auto-unload.
-        let deadline = Date.now.addingTimeInterval(2.0)
-        while service.isModelLoaded && Date.now < deadline {
-            try await Task.sleep(for: .milliseconds(50))
-        }
+        // For a window much shorter than the timeout the model must stay loaded:
+        // the just-completed generation reset the idle clock. We poll and assert
+        // it never drops — if `isModelLoaded` flips to false the poll returns
+        // early and the assertion below catches it.
+        let stayedLoaded = try await poll(timeout: 0.4) { !service.isModelLoaded }
         XCTAssertFalse(
-            service.isModelLoaded,
+            stayedLoaded,
+            "Model should stay loaded well within the idle timeout — activity reset the clock"
+        )
+        XCTAssertTrue(service.isModelLoaded)
+
+        // Eventually, after silence exceeding the timeout, it must auto-unload.
+        // Shrink the timeout to a small value now (the watch task re-reads the
+        // current policy each poll) so we don't wait the full 5 s; the idle clock
+        // already carries the elapsed-since-generation time, so this fires
+        // promptly without ever having raced an empty (`.infinity`) idle window.
+        service.keepAlivePolicy = KeepAlivePolicy(idleTimeout: 0.3)
+        let didUnload = try await poll(timeout: 3.0) { !service.isModelLoaded }
+        XCTAssertTrue(
+            didUnload,
             "Model should eventually auto-unload after activity silence"
         )
     }


### PR DESCRIPTION
## Root cause

`KeepAlivePolicyTests.test_activity_resetsIdleClock` fails intermittently in CI (confirmed 3× consecutively under parallel load) with:

```
GenerationQueue.swift:595: error: ... caught error: "inferenceFailure(\"No model loaded\")"
```

The keep-alive idle watch task (`ModelLifecycleCoordinator.armIdleWatchTaskIfNeeded`) polls a **wall-clock** `idleDuration` against the configured `idleTimeout`. Two facts combine into a race:

1. A freshly loaded service that has **never generated** reports `GenerationQueue.idleDuration == .infinity` (no `lastActivityTimestamp` yet). So *any* armed timeout fires on its very first poll.
2. The test armed a `0.4 s` timeout (poll interval `max(0.4/4, 0.1) = 0.1 s`) and then did `try await Task.sleep(for: .milliseconds(100))` **before** enqueuing/consuming the generation.

Under CI CPU oversubscription that "100 ms" sleep stretches past the ~0.1 s first poll, so the watch task auto-unloads the model (`idle == .infinity >= 0.4`) **before the generation runs** → `generate` throws `"No model loaded"`. It passes locally / on light runners purely by luck. It is a wall-clock race baked into the test's timing assumptions — not caused by any other change.

## Fix chosen — starvation-tolerant timing (fallback approach)

I evaluated the **deterministic-clock seam** (preferred) but it is too invasive for this focused PR: `idleDuration` is wall-clock throughout — sourced from `GenerationQueue` via `idleDurationProvider` and `ResidentModelStatus` — so a clean clock injection would touch three production types. Out of scope for a flake fix.

The starvation-tolerant fix needs **no production change**:

- **Generate first, arm second.** `test_activity_resetsIdleClock` now establishes real generation activity while the policy is still `.never`, so the idle clock starts from a concrete `lastActivityTimestamp` instead of `.infinity`. This removes the pre-generate sleep that raced the unload entirely.
- **Generous timeout vs. observation window + polling.** It then arms a 5 s timeout and polls a short (0.4 s) "stays loaded" window — jitter small relative to 5 s can no longer flip the outcome — then shrinks the timeout to drive the eventual-unload assertion via a polled deadline. The watch task re-reads the current policy each poll, and the idle clock already carries the elapsed-since-generation time, so this fires promptly without ever racing an empty (`.infinity`) idle window.
- Added a `poll(timeout:until:)` helper and a class-level doc comment codifying the two timing rules (never sleep on the critical path before the action under test; large timeout relative to the observation window + poll instead of fixed-sleep-then-assert).

**Whole-suite audit:** the other timer tests were checked. `test_idleTimeout_unloadsAfterIdle` arms then polls up to 2 s for the *unload* it expects — starvation only delays it, well within the deadline (safe). `test_policyDisabledBeforeTimeout_keepsModelLoaded`, `test_never_policy_doesNotUnload`, and `test_explicitUnload_doesNotTriggerSecondUnload` all assert **non-events** (model stays loaded / no second unload), where a longer-than-nominal sleep only strengthens the assertion. `test_activity_resetsIdleClock` was the sole genuinely fragile case.

## Evidence

- `swift build --build-tests` — Build complete (94 s; only pre-existing unrelated warnings).
- `for i in 1..5; do swift test --filter KeepAlivePolicyTests; done` — **5/5 passed.**
- Re-ran once under full CPU oversubscription (`yes` on every core) — **passed** (the conditions that previously triggered the flake).

## Heads-up

A concurrent session owns the keep-alive feature branch (`feat/obs-keep-alive-policy`) which may touch this same file — a possible conflict to resolve later. The test is already merged to `origin/main`, so fixing it here is in-bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)