### PR TITLE
feat(mcp-host): HTTP/SSE server-side transport for MCPHostServer

### DIFF
--- a/Sources/ManifoldMCPHost/MCPHostHTTPTransport.swift
+++ b/Sources/ManifoldMCPHost/MCPHostHTTPTransport.swift
@@ -46,7 +46,6 @@ public actor MCPHostHTTPTransport: MCPHostTransport {
     // MARK: Private
 
     private let port: NWEndpoint.Port
-    private let bindHost: NWEndpoint.Host
     private let maxMessageBytes: Int
     private let continuation: AsyncThrowingStream<Data, Error>.Continuation
 
@@ -61,23 +60,23 @@ public actor MCPHostHTTPTransport: MCPHostTransport {
 
     /// Creates a loopback HTTP/SSE transport.
     ///
+    /// The listener always binds `127.0.0.1` (loopback only) via
+    /// `NWParameters.requiredInterfaceType = .loopback`. Network.framework
+    /// enforces this at the OS level — the transport is not reachable from
+    /// other hosts regardless of the machine's network configuration.
+    ///
     /// - Parameters:
     ///   - port: TCP port to bind. `0` binds an OS-assigned ephemeral port
     ///     (read back via ``boundPort``).
-    ///   - host: Bind address. Defaults to loopback (`127.0.0.1`). Binding a
-    ///     non-loopback address exposes the host to other machines — only do so
-    ///     behind TLS + authentication.
     ///   - maxMessageBytes: Hard cap on a single inbound request body.
     public init(
         port: UInt16,
-        host: String = "127.0.0.1",
         maxMessageBytes: Int = 4 * 1024 * 1024
     ) throws {
         guard let nwPort = NWEndpoint.Port(rawValue: port) else {
             throw MCPHostTransportError.invalidPort(port)
         }
         self.port = nwPort
-        self.bindHost = NWEndpoint.Host(host)
         self.maxMessageBytes = maxMessageBytes
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: Data.self, throwing: Error.self)
         self.incomingMessages = stream

--- a/Sources/ManifoldMCPHost/MCPHostHTTPTransport.swift
+++ b/Sources/ManifoldMCPHost/MCPHostHTTPTransport.swift
@@ -1,0 +1,448 @@
+#if os(macOS) && !targetEnvironment(macCatalyst)
+import Foundation
+import ManifoldInference
+import Network
+import os
+
+/// Server-side **streamable-HTTP / SSE** transport for ``ManifoldMCPHost``
+/// (issue #1842).
+///
+/// This is the transport shape Claude Desktop's *streamable-HTTP*
+/// configuration and remote MCP clients use, and the server-side mirror of the
+/// client transport in `ManifoldMCP` (`MCPStreamableHTTPTransport`). Where the
+/// client opens an SSE stream and POSTs JSON-RPC requests, this transport plays
+/// the other half:
+///
+/// - A client **GET** with `Accept: text/event-stream` opens a long-lived SSE
+///   response channel. Server-originated JSON-RPC responses are written to it
+///   as `data:`-framed Server-Sent Events.
+/// - A client **POST** carries a JSON-RPC request body. The body is decoded by
+///   ``ManifoldMCPHost`` exactly as it would be over stdio; the matching
+///   response is delivered over the open SSE channel.
+///
+/// Instantiate, `start()`, then hand to ``ManifoldMCPHost/run(transport:)``:
+///
+/// ```swift
+/// let transport = try MCPHostHTTPTransport(port: 8765)
+/// try await transport.start()
+/// try await host.run(transport: transport)
+/// ```
+///
+/// ## Scope & limitations
+///
+/// - macOS only (not available on iOS or Catalyst), like the stdio transport.
+/// - Binds `127.0.0.1` by default — loopback only. This is a local-first
+///   surface; do not expose it to untrusted networks without front-loading
+///   TLS + authentication (e.g. via a reverse proxy).
+/// - The stdio transport remains the default for local single-client use; this
+///   transport exists for streamable-HTTP clients that cannot launch the host
+///   as a subprocess.
+public actor MCPHostHTTPTransport: MCPHostTransport {
+
+    // MARK: MCPHostTransport
+
+    public nonisolated let incomingMessages: AsyncThrowingStream<Data, Error>
+
+    // MARK: Private
+
+    private let port: NWEndpoint.Port
+    private let bindHost: NWEndpoint.Host
+    private let maxMessageBytes: Int
+    private let continuation: AsyncThrowingStream<Data, Error>.Continuation
+
+    private var listener: NWListener?
+    /// Open SSE response channels keyed by a per-connection id. A server
+    /// response is fanned out to every open channel; a streamable-HTTP client
+    /// keeps exactly one open, so in practice this is single-entry.
+    private var sseChannels: [ObjectIdentifier: NWConnection] = [:]
+    private var didStart = false
+
+    // MARK: Init
+
+    /// Creates a loopback HTTP/SSE transport.
+    ///
+    /// - Parameters:
+    ///   - port: TCP port to bind. `0` binds an OS-assigned ephemeral port
+    ///     (read back via ``boundPort``).
+    ///   - host: Bind address. Defaults to loopback (`127.0.0.1`). Binding a
+    ///     non-loopback address exposes the host to other machines — only do so
+    ///     behind TLS + authentication.
+    ///   - maxMessageBytes: Hard cap on a single inbound request body.
+    public init(
+        port: UInt16,
+        host: String = "127.0.0.1",
+        maxMessageBytes: Int = 4 * 1024 * 1024
+    ) throws {
+        guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+            throw MCPHostTransportError.invalidPort(port)
+        }
+        self.port = nwPort
+        self.bindHost = NWEndpoint.Host(host)
+        self.maxMessageBytes = maxMessageBytes
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: Data.self, throwing: Error.self)
+        self.incomingMessages = stream
+        self.continuation = continuation
+    }
+
+    // MARK: Lifecycle
+
+    /// Begins listening for connections. Idempotent — a second call is a no-op.
+    public func start() async throws {
+        guard didStart == false else { return }
+
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        // Loopback-only by default. The bind host narrows the interface; this
+        // flag additionally refuses connections routed in from other hosts.
+        parameters.requiredInterfaceType = .loopback
+
+        let listener: NWListener
+        do {
+            listener = try NWListener(using: parameters, on: port)
+        } catch {
+            throw MCPHostTransportError.listenFailed(error.localizedDescription)
+        }
+
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            Task { await self.accept(connection) }
+        }
+
+        // Surface a bind failure synchronously rather than letting the caller
+        // believe the server is up.
+        let ready = ReadyBox()
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                ready.resolve(.success(()))
+            case .failed(let error):
+                ready.resolve(.failure(MCPHostTransportError.listenFailed(error.localizedDescription)))
+            case .cancelled:
+                ready.resolve(.failure(MCPHostTransportError.listenFailed("listener cancelled")))
+            default:
+                break
+            }
+        }
+
+        listener.start(queue: .global(qos: .userInitiated))
+        self.listener = listener
+        self.didStart = true
+
+        do {
+            try await ready.wait()
+        } catch {
+            self.shutdown()
+            throw error
+        }
+    }
+
+    /// The port the listener is actually bound to. Useful for tests that bind
+    /// an ephemeral port (`port: 0`).
+    public var boundPort: UInt16? {
+        listener?.port?.rawValue
+    }
+
+    /// Tears down the listener, all open SSE channels, and finishes the stream.
+    public func shutdown() {
+        for (_, connection) in sseChannels {
+            connection.cancel()
+        }
+        sseChannels.removeAll()
+        listener?.cancel()
+        listener = nil
+        continuation.finish()
+    }
+
+    // MARK: MCPHostTransport.send
+
+    /// Writes a JSON-RPC response payload to every open SSE channel as a
+    /// `data:`-framed Server-Sent Event.
+    ///
+    /// Actor isolation serialises concurrent sends so writes to a channel never
+    /// interleave across concurrent MCP responses.
+    public func send(_ payload: Data) async throws {
+        guard sseChannels.isEmpty == false else {
+            // No open SSE stream — the streamable-HTTP client has not yet
+            // (or has stopped) listening. Drop rather than buffer unbounded.
+            Log.inference.debug("MCPHostHTTPTransport: dropping response — no open SSE channel")
+            return
+        }
+        let frame = Self.sseFrame(payload)
+        for (id, connection) in sseChannels {
+            connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+                if let error {
+                    Task { await self?.removeChannel(id) }
+                    Log.inference.debug("MCPHostHTTPTransport: SSE write failed: \(error.localizedDescription, privacy: .public)")
+                }
+            })
+        }
+    }
+
+    // MARK: Connection handling
+
+    private func accept(_ connection: NWConnection) {
+        connection.start(queue: .global(qos: .userInitiated))
+        receiveRequest(on: connection, accumulated: Data())
+    }
+
+    /// Reads bytes until a complete HTTP request (headers + any declared body)
+    /// is buffered, then dispatches it.
+    private func receiveRequest(on connection: NWConnection, accumulated: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            Task {
+                await self.handleReceived(
+                    data: data,
+                    isComplete: isComplete,
+                    error: error,
+                    connection: connection,
+                    accumulated: accumulated
+                )
+            }
+        }
+    }
+
+    private func handleReceived(
+        data: Data?,
+        isComplete: Bool,
+        error: NWError?,
+        connection: NWConnection,
+        accumulated: Data
+    ) {
+        if error != nil {
+            connection.cancel()
+            return
+        }
+
+        var buffer = accumulated
+        if let data {
+            buffer.append(data)
+        }
+
+        if buffer.count > maxMessageBytes {
+            respondAndClose(connection, status: "413 Payload Too Large", body: "request too large")
+            return
+        }
+
+        switch HTTPRequest.parse(buffer) {
+        case .incomplete:
+            if isComplete {
+                // Client closed before sending a full request.
+                connection.cancel()
+                return
+            }
+            receiveRequest(on: connection, accumulated: buffer)
+        case .invalid:
+            respondAndClose(connection, status: "400 Bad Request", body: "malformed HTTP request")
+        case .complete(let request):
+            dispatch(request, on: connection)
+        }
+    }
+
+    private func dispatch(_ request: HTTPRequest, on connection: NWConnection) {
+        switch request.method {
+        case "GET":
+            openSSEChannel(on: connection)
+        case "POST":
+            handlePOST(request, on: connection)
+        case "OPTIONS":
+            // CORS / capability preflight — answer permissively for local use.
+            respondAndClose(connection, status: "204 No Content", body: "")
+        default:
+            respondAndClose(connection, status: "405 Method Not Allowed", body: "unsupported method")
+        }
+    }
+
+    private func openSSEChannel(on connection: NWConnection) {
+        let header = "HTTP/1.1 200 OK\r\n"
+            + "Content-Type: text/event-stream\r\n"
+            + "Cache-Control: no-cache\r\n"
+            + "Connection: keep-alive\r\n"
+            + "Access-Control-Allow-Origin: *\r\n"
+            + "\r\n"
+        connection.send(content: Data(header.utf8), completion: .contentProcessed { _ in })
+        let id = ObjectIdentifier(connection)
+        sseChannels[id] = connection
+
+        // Drop the channel when the peer closes.
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .cancelled, .failed:
+                Task { await self?.removeChannel(id) }
+            default:
+                break
+            }
+        }
+        // Keep reading so the OS surfaces a peer FIN as a state change rather
+        // than silently stalling; any body of a GET is ignored.
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { _, _, _, _ in }
+    }
+
+    private func handlePOST(_ request: HTTPRequest, on connection: NWConnection) {
+        let body = request.body
+        if body.count > maxMessageBytes {
+            respondAndClose(connection, status: "413 Payload Too Large", body: "request too large")
+            return
+        }
+        // Hand the JSON-RPC payload to the host's run loop. The matching
+        // response is written back over the open SSE channel by `send(_:)`.
+        continuation.yield(body)
+
+        // Per the streamable-HTTP spec a POST may be answered with 202 Accepted
+        // when the response is delivered out-of-band over the SSE stream.
+        respondAndClose(connection, status: "202 Accepted", body: "")
+    }
+
+    private func removeChannel(_ id: ObjectIdentifier) {
+        if let connection = sseChannels.removeValue(forKey: id) {
+            connection.cancel()
+        }
+    }
+
+    // MARK: HTTP helpers
+
+    private func respondAndClose(_ connection: NWConnection, status: String, body: String) {
+        let bodyData = Data(body.utf8)
+        let header = "HTTP/1.1 \(status)\r\n"
+            + "Content-Type: text/plain; charset=utf-8\r\n"
+            + "Content-Length: \(bodyData.count)\r\n"
+            + "Access-Control-Allow-Origin: *\r\n"
+            + "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+            + "Access-Control-Allow-Headers: Content-Type\r\n"
+            + "Connection: close\r\n"
+            + "\r\n"
+        var response = Data(header.utf8)
+        response.append(bodyData)
+        connection.send(content: response, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    /// Frames a JSON-RPC payload as a single SSE event.
+    ///
+    /// SSE requires `data:` per line and a blank line to terminate the event.
+    /// JSON-RPC payloads are single-line JSON, so one `data:` line suffices;
+    /// embedded newlines (none expected from the codec) are split defensively.
+    private static func sseFrame(_ payload: Data) -> Data {
+        let text = String(decoding: payload, as: UTF8.self)
+        var event = ""
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            event += "data: \(line)\n"
+        }
+        event += "\n"
+        return Data(event.utf8)
+    }
+}
+
+// MARK: - ReadyBox
+
+/// Bridges the listener's callback-driven `.ready`/`.failed` state into a
+/// single `async` await. `@unchecked Sendable` is safe: the lock serialises the
+/// one-shot resolve against the one waiter.
+private final class ReadyBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<Void, Error>?
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func resolve(_ value: Result<Void, Error>) {
+        lock.lock()
+        if result == nil {
+            result = value
+            let pending = continuation
+            continuation = nil
+            lock.unlock()
+            if let pending {
+                pending.resume(with: value)
+            }
+        } else {
+            lock.unlock()
+        }
+    }
+
+    func wait() async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            lock.lock()
+            if let result {
+                lock.unlock()
+                cont.resume(with: result)
+            } else {
+                continuation = cont
+                lock.unlock()
+            }
+        }
+    }
+}
+
+// MARK: - HTTPRequest
+
+/// Minimal HTTP/1.1 request parser: method, headers, and a `Content-Length`-
+/// declared body. Sufficient for the JSON-RPC POST / SSE GET shapes this
+/// transport serves; it is not a general-purpose HTTP server.
+private struct HTTPRequest {
+    let method: String
+    let path: String
+    let headers: [String: String]
+    let body: Data
+
+    enum ParseResult {
+        case complete(HTTPRequest)
+        case incomplete
+        case invalid
+    }
+
+    private static let headerDelimiter = Data("\r\n\r\n".utf8)
+
+    static func parse(_ buffer: Data) -> ParseResult {
+        guard let delimiterRange = buffer.range(of: headerDelimiter) else {
+            return .incomplete
+        }
+        let headerData = buffer[..<delimiterRange.lowerBound]
+        guard let headerString = String(data: headerData, encoding: .utf8) else {
+            return .invalid
+        }
+
+        let lines = headerString.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else { return .invalid }
+        let requestParts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
+        guard requestParts.count >= 2 else { return .invalid }
+
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            headers[name] = value
+        }
+
+        let bodyStart = delimiterRange.upperBound
+        let available = buffer.distance(from: bodyStart, to: buffer.endIndex)
+
+        let contentLength: Int
+        if let raw = headers["content-length"], let value = Int(raw), value >= 0 {
+            contentLength = value
+        } else {
+            contentLength = 0
+        }
+
+        guard available >= contentLength else {
+            return .incomplete
+        }
+
+        let bodyEnd = buffer.index(bodyStart, offsetBy: contentLength)
+        let body = Data(buffer[bodyStart..<bodyEnd])
+
+        return .complete(HTTPRequest(
+            method: requestParts[0].uppercased(),
+            path: requestParts[1],
+            headers: headers,
+            body: body
+        ))
+    }
+}
+#endif

--- a/Sources/ManifoldMCPHost/MCPHostServer.swift
+++ b/Sources/ManifoldMCPHost/MCPHostServer.swift
@@ -44,8 +44,17 @@ import os
 ///
 /// ## HTTP/SSE transport
 ///
-/// HTTP/SSE server-side transport (for Claude Desktop's streamable-HTTP
-/// configuration) is not yet implemented. Track progress in issue #1842.
+/// For Claude Desktop's streamable-HTTP configuration and remote MCP clients
+/// that cannot launch the host as a subprocess, use ``MCPHostHTTPTransport``
+/// instead of ``MCPHostStdioTransport`` (#1842):
+///
+/// ```swift
+/// let transport = try MCPHostHTTPTransport(port: 8765)
+/// try await transport.start()
+/// try await host.run(transport: transport)
+/// ```
+///
+/// stdio remains the default for local single-client use.
 ///
 /// ## Concurrency
 ///
@@ -659,9 +668,9 @@ public enum MCPHostError: Error, LocalizedError, Sendable {
 /// Transport abstraction for the server side of an MCP connection.
 ///
 /// The server reads incoming JSON-RPC frames from `incomingMessages` and
-/// writes response frames via `send(_:)`. The built-in implementation is
-/// ``MCPHostStdioTransport`` (macOS only). HTTP/SSE support is tracked in
-/// issue #1842.
+/// writes response frames via `send(_:)`. Two built-in implementations exist
+/// (both macOS only): ``MCPHostStdioTransport`` for local subprocess clients
+/// and ``MCPHostHTTPTransport`` for streamable-HTTP / SSE clients (#1842).
 public protocol MCPHostTransport: Sendable {
     /// Inbound frames from the remote MCP client.
     var incomingMessages: AsyncThrowingStream<Data, Error> { get }

--- a/Sources/ManifoldMCPHost/MCPHostStdioTransport.swift
+++ b/Sources/ManifoldMCPHost/MCPHostStdioTransport.swift
@@ -19,7 +19,8 @@ import os
 ///
 /// - macOS only (not available on iOS or Catalyst).
 /// - Single-connection by design — a new process is expected per client.
-/// - HTTP/SSE server-side transport is not yet implemented (see issue #1842).
+/// - For streamable-HTTP clients that cannot launch the host as a subprocess,
+///   use ``MCPHostHTTPTransport`` (the server-side HTTP/SSE transport, #1842).
 public actor MCPHostStdioTransport: MCPHostTransport {
 
     // MARK: MCPHostTransport
@@ -165,6 +166,8 @@ public enum MCPHostTransportError: Error, LocalizedError, Sendable {
     case invalidHeader
     case missingContentLength
     case invalidContentLength(String)
+    case invalidPort(UInt16)
+    case listenFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -180,6 +183,10 @@ public enum MCPHostTransportError: Error, LocalizedError, Sendable {
             return "Incoming frame is missing the Content-Length header"
         case .invalidContentLength(let raw):
             return "Incoming frame has an invalid Content-Length value: '\(raw)'"
+        case .invalidPort(let port):
+            return "Invalid TCP port for HTTP transport: \(port)"
+        case .listenFailed(let detail):
+            return "HTTP transport failed to start listening: \(detail)"
         }
     }
 }

--- a/Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md
+++ b/Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md
@@ -31,7 +31,9 @@ let host = ManifoldMCPHost(
 
 ### 2. Pick a transport
 
-For local clients (Claude Desktop, scripts on the same machine), use the stdio transport:
+Two server-side transports ship, both macOS-only.
+
+**stdio** — for local clients that launch your app as a subprocess (Claude Desktop's default, scripts on the same machine):
 
 ```swift,no-build
 #if os(macOS)
@@ -39,7 +41,16 @@ let transport = MCPHostStdioTransport()
 #endif
 ```
 
-HTTP/SSE server-side transport is not yet implemented. It is tracked in issue #1842.
+**streamable-HTTP / SSE** (``MCPHostHTTPTransport``) — for Claude Desktop's streamable-HTTP configuration and remote MCP clients that connect over a socket rather than a subprocess. A client opens a long-lived SSE `GET` stream and `POST`s JSON-RPC requests to the same endpoint; server responses are delivered back over the SSE stream as `data:`-framed events:
+
+```swift,no-build
+#if os(macOS)
+let transport = try MCPHostHTTPTransport(port: 8765)
+try await transport.start()
+#endif
+```
+
+By default the listener binds `127.0.0.1` (loopback only). It is a local-first surface — front it with TLS and authentication (e.g. a reverse proxy) before exposing it beyond the machine. stdio remains the default for local single-client use.
 
 ### 3. Start serving
 
@@ -97,6 +108,20 @@ Add an entry to your `claude_desktop_config.json`:
 ```
 
 Your app should detect `--mcp-stdio` in its launch arguments and start the stdio transport instead of presenting its normal UI.
+
+For the streamable-HTTP transport, point the client at the bound URL instead:
+
+```json
+{
+  "mcpServers": {
+    "myapp": {
+      "url": "http://127.0.0.1:8765/"
+    }
+  }
+}
+```
+
+Start ``MCPHostHTTPTransport`` when your app launches (keeping its normal UI) so the endpoint is reachable while the app runs.
 
 ## Notes
 

--- a/Tests/ManifoldMCPTests/MCPHostHTTPTransportTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHostHTTPTransportTests.swift
@@ -1,0 +1,279 @@
+#if os(macOS) && !targetEnvironment(macCatalyst)
+import Foundation
+import Network
+import XCTest
+@testable import ManifoldMCP
+@testable import ManifoldMCPHost
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldTestSupport
+
+// MARK: - MCPHostHTTPTransportTests
+//
+// Integration tests for the server-side streamable-HTTP / SSE transport
+// (issue #1842). They bind a real loopback listener on an ephemeral port and
+// drive it with `URLSession` — the same shape a streamable-HTTP MCP client
+// uses: open an SSE GET stream, POST a JSON-RPC request, read the response
+// back as a `data:`-framed Server-Sent Event.
+
+@MainActor
+final class MCPHostHTTPTransportTests: XCTestCase {
+
+    // MARK: Fixture
+
+    private func makeHost(
+        sessions: [ChatSession] = []
+    ) -> ManifoldMCPHost {
+        let sessionStore = InMemorySessionStore(sessions: sessions)
+        let messageStore = InMemoryMessageStore()
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        let inferenceService = InferenceService(backend: backend)
+        let runtime = ConversationRuntime(
+            messageStore: messageStore,
+            sessionStore: sessionStore,
+            inferenceService: inferenceService
+        )
+        return ManifoldMCPHost(
+            sessionStore: sessionStore,
+            messageStore: messageStore,
+            conversationRuntime: runtime
+        )
+    }
+
+    // MARK: ephemeral bind
+
+    func test_start_bindsEphemeralPort() async throws {
+        // Port 0 asks the OS for an ephemeral port; the transport must bind and
+        // report a concrete non-zero bound port.
+        let transport = try MCPHostHTTPTransport(port: 0)
+        try await transport.start()
+        defer { Task { await transport.shutdown() } }
+        let bound = await transport.boundPort
+        XCTAssertNotNil(bound)
+        XCTAssertNotEqual(bound, 0)
+    }
+
+    // MARK: end-to-end initialize over HTTP/SSE
+
+    func test_initialize_roundTripsOverHTTPSSE() async throws {
+        let host = await makeHost()
+        let transport = try MCPHostHTTPTransport(port: 0)
+        try await transport.start()
+        guard let port = await transport.boundPort else {
+            XCTFail("transport did not bind a port")
+            return
+        }
+
+        let runTask = Task { try await host.run(transport: transport) }
+        defer {
+            runTask.cancel()
+            Task { await transport.shutdown() }
+        }
+
+        // 1. Open the SSE response channel (raw socket GET). We drive raw HTTP
+        //    over an `NWConnection` rather than `URLSession` because URLSession's
+        //    streaming-response buffering is non-deterministic for a never-
+        //    closing SSE GET; the raw client mirrors what a streamable-HTTP MCP
+        //    client (or `curl -N`) does on the wire.
+        let sse = RawSocketClient(port: port)
+        try await sse.connect()
+        try await sse.write(Data("GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nAccept: text/event-stream\r\n\r\n".utf8))
+
+        // Wait for the SSE 200 header so the channel is registered server-side
+        // before we POST.
+        let sseHeader = try await sse.readUntilConsuming(substring: "\r\n\r\n", timeout: .seconds(3))
+        XCTAssertTrue(sseHeader.contains("200 OK"), "SSE GET should return 200; got: \(sseHeader)")
+        XCTAssertTrue(sseHeader.lowercased().contains("text/event-stream"))
+
+        // 2. POST a JSON-RPC initialize request on a second socket.
+        let codec = MCPJSONRPCCodec(maxMessageBytes: 512 * 1024, maxJSONNestingDepth: 32)
+        let request = MCPJSONRPCMessage.request(
+            id: .int(1),
+            method: "initialize",
+            params: .object(["protocolVersion": .string("2025-03-26")])
+        )
+        let payload = try codec.encode(request)
+
+        let post = RawSocketClient(port: port)
+        try await post.connect()
+        var postBytes = Data("POST / HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: \(payload.count)\r\n\r\n".utf8)
+        postBytes.append(payload)
+        try await post.write(postBytes)
+        let postResponse = try await post.readUntilConsuming(substring: "\r\n\r\n", timeout: .seconds(3))
+        XCTAssertTrue(postResponse.contains("202"), "POST should be accepted with 202; got: \(postResponse)")
+
+        // 3. The JSON-RPC response should arrive over the SSE channel as a
+        //    `data:`-framed event terminated by a blank line. The header has
+        //    already been consumed, so the buffer now holds only the event.
+        let event = try await sse.readUntilConsuming(substring: "\n\n", timeout: .seconds(5))
+        guard let dataLine = event.split(separator: "\n").first(where: { $0.hasPrefix("data:") }) else {
+            XCTFail("no data: line in SSE event: \(event)")
+            return
+        }
+        let json = dataLine.dropFirst("data:".count).drop(while: { $0 == " " })
+        let decoded = try codec.decode(Data(String(json).utf8))
+        guard case .result(let id, let result) = decoded else {
+            XCTFail("expected a result frame over SSE, got \(decoded)")
+            return
+        }
+        XCTAssertEqual(id, .int(1))
+        guard case .object(let r) = result,
+              case .string(let version) = r["protocolVersion"] else {
+            XCTFail("expected initialize result with protocolVersion")
+            return
+        }
+        XCTAssertEqual(version, "2025-03-26")
+
+        await sse.close()
+        await post.close()
+    }
+
+    // MARK: unsupported method
+
+    func test_unsupportedHTTPMethod_returns405() async throws {
+        let transport = try MCPHostHTTPTransport(port: 0)
+        try await transport.start()
+        guard let port = await transport.boundPort else {
+            XCTFail("transport did not bind a port")
+            return
+        }
+        defer { Task { await transport.shutdown() } }
+
+        let client = RawSocketClient(port: port)
+        try await client.connect()
+        try await client.write(Data("DELETE / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".utf8))
+        let response = try await client.readUntilConsuming(substring: "\r\n\r\n", timeout: .seconds(3))
+        XCTAssertTrue(response.contains("405"), "expected 405; got: \(response)")
+        await client.close()
+    }
+}
+
+// MARK: - RawSocketClient
+
+/// A minimal loopback TCP client over `NWConnection` for driving the HTTP/SSE
+/// transport deterministically in tests. Reads accumulate into a buffer that
+/// `readUntil` scans for a delimiter, with a wall-clock ceiling so a missing
+/// response fails fast instead of hanging CI.
+private actor RawSocketClient {
+    private let connection: NWConnection
+    private var buffer = Data()
+    private var receiving = false
+
+    enum SocketError: Error { case timeout, closed, connectFailed(String) }
+
+    init(port: UInt16) {
+        let endpoint = NWEndpoint.hostPort(
+            host: .ipv4(.loopback),
+            port: NWEndpoint.Port(rawValue: port)!
+        )
+        self.connection = NWConnection(to: endpoint, using: .tcp)
+    }
+
+    func connect() async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    cont.resume()
+                    self.connection.stateUpdateHandler = nil
+                case .failed(let error):
+                    cont.resume(throwing: SocketError.connectFailed(error.localizedDescription))
+                    self.connection.stateUpdateHandler = nil
+                default:
+                    break
+                }
+            }
+            connection.start(queue: .global(qos: .userInitiated))
+        }
+        startReceiving()
+    }
+
+    private func startReceiving() {
+        guard receiving == false else { return }
+        receiving = true
+        pump()
+    }
+
+    private func pump() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, _ in
+            guard let self else { return }
+            Task { await self.absorb(data: data, isComplete: isComplete) }
+        }
+    }
+
+    private func absorb(data: Data?, isComplete: Bool) {
+        if let data { buffer.append(data) }
+        if isComplete == false { pump() }
+    }
+
+    func write(_ data: Data) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            connection.send(content: data, completion: .contentProcessed { error in
+                if let error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume()
+                }
+            })
+        }
+    }
+
+    /// Polls the receive buffer until `substring` appears, then returns the
+    /// portion up to and including the delimiter and removes it from the buffer
+    /// (so a subsequent read sees only later bytes). Throws `.timeout` if the
+    /// delimiter never arrives.
+    func readUntilConsuming(substring: String, timeout: Duration) async throws -> String {
+        let needle = Data(substring.utf8)
+        let deadline = ContinuousClock().now + timeout
+        while ContinuousClock().now < deadline {
+            if let range = buffer.range(of: needle) {
+                let consumed = buffer[..<range.upperBound]
+                let text = String(decoding: consumed, as: UTF8.self)
+                buffer.removeSubrange(..<range.upperBound)
+                return text
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw SocketError.timeout
+    }
+
+    func close() {
+        connection.cancel()
+    }
+}
+
+// MARK: - In-memory stores
+
+@MainActor
+private final class InMemorySessionStore: SessionStore, @unchecked Sendable {
+    private var sessions: [ChatSession]
+    init(sessions: [ChatSession] = []) { self.sessions = sessions }
+    func insertSession(_ session: ChatSession) async throws { sessions.append(session) }
+    func updateSession(_ session: ChatSession) async throws {
+        guard let idx = sessions.firstIndex(where: { $0.id == session.id }) else {
+            throw ChatPersistenceError.sessionNotFound(session.id)
+        }
+        sessions[idx] = session
+    }
+    func deleteSession(_ sessionID: UUID) async throws { sessions.removeAll { $0.id == sessionID } }
+    func fetchSessions() async throws -> [ChatSession] { sessions }
+}
+
+@MainActor
+private final class InMemoryMessageStore: MessageStore, @unchecked Sendable {
+    private var messages: [ChatMessage] = []
+    func insertMessage(_ message: ChatMessage) async throws { messages.append(message) }
+    func updateMessage(_ message: ChatMessage) async throws {
+        guard let idx = messages.firstIndex(where: { $0.id == message.id }) else {
+            throw ChatPersistenceError.messageNotFound(message.id)
+        }
+        messages[idx] = message
+    }
+    func deleteMessage(_ messageID: UUID) async throws { messages.removeAll { $0.id == messageID } }
+    func fetchMessages(for sessionID: UUID) async throws -> [ChatMessage] {
+        messages.filter { $0.sessionID == sessionID }
+    }
+    func deleteMessages(for sessionID: UUID) async throws { messages.removeAll { $0.sessionID == sessionID } }
+}
+#endif

--- a/Tests/ManifoldMCPTests/MCPHostHTTPTransportTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHostHTTPTransportTests.swift
@@ -171,20 +171,24 @@ private actor RawSocketClient {
     }
 
     func connect() async throws {
+        // Capture the NWConnection reference so the stateUpdateHandler closure
+        // can nil it out without hopping back onto the actor (NW delivers state
+        // callbacks on its own queue, not the actor's executor).
+        let conn = connection
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            connection.stateUpdateHandler = { state in
+            conn.stateUpdateHandler = { state in
                 switch state {
                 case .ready:
                     cont.resume()
-                    self.connection.stateUpdateHandler = nil
+                    conn.stateUpdateHandler = nil
                 case .failed(let error):
                     cont.resume(throwing: SocketError.connectFailed(error.localizedDescription))
-                    self.connection.stateUpdateHandler = nil
+                    conn.stateUpdateHandler = nil
                 default:
                     break
                 }
             }
-            connection.start(queue: .global(qos: .userInitiated))
+            conn.start(queue: .global(qos: .userInitiated))
         }
         startReceiving()
     }


### PR DESCRIPTION
Closes #1842.

Implements the server-side **streamable-HTTP / SSE** transport for `MCPHostServer` — the mirror of the client-side `MCPStreamableHTTPTransport` in `ManifoldMCP`. Until now the host exposed app data/tools only over stdio (subprocess clients); the new `MCPHostHTTPTransport` serves Claude Desktop's streamable-HTTP configuration and remote MCP clients.

## How it works

- A client **GET** with `Accept: text/event-stream` opens a long-lived SSE response channel. Server-originated JSON-RPC responses are written back as `data:`-framed Server-Sent Events.
- A client **POST** carries a JSON-RPC request body, decoded by `ManifoldMCPHost` exactly as over stdio; the matching response is delivered over the open SSE channel (the POST is answered `202 Accepted`).

Built on the `Network` framework (`NWListener`) — **no new package dependency**, no Hummingbird/trait gate, macOS-only like the stdio transport. Binds `127.0.0.1` by default (loopback-only, `requiredInterfaceType = .loopback`); an ephemeral `port: 0` bind is supported and read back via `boundPort`. stdio remains the default for local single-client use.

## Repointed stale comments

- `Sources/ManifoldMCPHost/MCPHostServer.swift` (`## HTTP/SSE transport` doc + `MCPHostTransport` protocol doc)
- `Sources/ManifoldMCPHost/MCPHostStdioTransport.swift` limitations note
- `Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md` — now documents the streamable-HTTP setup and Claude Desktop `url:` config

## Checklist

- [x] Server-side HTTP/SSE transport (`MCPHostHTTPTransport`)
- [x] stdio transport kept as default (unchanged behavior)
- [x] Stale `#1842` comments repointed at the shipped transport
- [x] DocC article updated
- [x] Tests: ephemeral bind, full `initialize` round-trip over real loopback sockets (POST -> JSON-RPC result over SSE), 405 for unsupported methods
- [x] `swift build` + `swift build --build-tests --traits Server,Macros` clean
- [x] `ManifoldMCPTests` (223 tests) green; new suite green
- [x] `Package.resolved` not staged

## Test notes

The round-trip is exercised over real loopback TCP via a raw `NWConnection` test client. URLSession's streaming-response buffering proved non-deterministic for a never-closing SSE GET, so the test drives the wire the way `curl -N` / a streamable-HTTP MCP client does. **Not verified:** interop against a live external MCP client (Claude Desktop) — only the in-process wire round-trip is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)