### PR TITLE
feat: harden EmbeddingBackend documented contract for 1.0 freeze

### DIFF
--- a/Sources/ManifoldContract/EmbeddingBackend.swift
+++ b/Sources/ManifoldContract/EmbeddingBackend.swift
@@ -32,15 +32,37 @@ public struct EmbeddingCapabilities: Sendable, Codable, Equatable, Hashable {
     public static let `default` = EmbeddingCapabilities()
 }
 
+/// Common interface for text-embedding backends.
+///
+/// Each backend wraps a different sentence-embedding engine (Apple
+/// `NaturalLanguage`, an on-device MLX/llama embedder, a remote Ollama
+/// embedder, …) and exposes the same async API. RAG retrieval delegates all
+/// embedding work here through the injected conformer; when none is supplied,
+/// `ManifoldBootstrap` resolves the bundled `NLEmbeddingBackend`.
+///
+/// ## Thread Safety
+///
+/// Conformers are `Sendable` and their methods may be called from **any**
+/// thread. There is no service-level serialization analogous to
+/// `InferenceBackend`'s generation queue: a host may invoke ``embed(_:)``
+/// concurrently with itself (RAG indexing batches in parallel) and with
+/// ``loadModel(from:)`` / ``unloadModel()`` arriving from a different actor.
+/// Conformers with mutable state **must** provide their own synchronization
+/// (an `actor`, an `NSLock`, or genuinely immutable state).
+///
+/// Existing conformers either hold immutable/thread-safe state and declare
+/// `@unchecked Sendable` (`NLEmbeddingBackend`, `OllamaEmbeddingBackend`) or
+/// rely on actor isolation. Custom conformers should follow the same pattern.
 public protocol EmbeddingBackend: AnyObject, Sendable {
     var isModelLoaded: Bool { get }
 
     /// The dimensionality of vectors produced by ``embed(_:)``.
     ///
-    /// Only meaningful after a successful ``loadModel(from:)`` — i.e. when
-    /// ``isModelLoaded`` is `true`. Behavior before a model is loaded is
-    /// backend-defined (a backend may return `0`, a placeholder, or its
-    /// model-independent default).
+    /// **Precondition: only defined after a successful ``loadModel(from:)``** —
+    /// i.e. when ``isModelLoaded`` is `true`. Reading `dimensions` before a
+    /// model is loaded is backend-defined and carries no contract: a backend
+    /// may return `0`, a placeholder, or its model-independent default, and
+    /// consumers must not depend on the value until ``isModelLoaded`` is `true`.
     var dimensions: Int { get }
 
     /// Static capabilities of this backend (batch/input bounds, normalization).
@@ -53,10 +75,18 @@ public protocol EmbeddingBackend: AnyObject, Sendable {
 
     /// Produces one embedding vector per input text.
     ///
-    /// - Postcondition: the returned array has exactly one vector per input
-    ///   (`result.count == texts.count`), each of length ``dimensions``. A
-    ///   backend that cannot satisfy this signals the violation by throwing
-    ///   ``EmbeddingError/dimensionMismatch(expected:actual:)``.
+    /// - Postcondition (guaranteed): on normal return the result has exactly
+    ///   one vector per input (`result.count == texts.count`), in input order,
+    ///   each of length ``dimensions``. Callers may zip the result against the
+    ///   input array without a length check.
+    /// - The guarantee holds **only** on non-throwing return. A backend that
+    ///   cannot satisfy the per-input count or vector length does **not**
+    ///   silently return a short/ragged array — it throws
+    ///   ``EmbeddingError/dimensionMismatch(expected:actual:)`` (partial
+    ///   mitigation: the error surfaces the violation rather than letting a
+    ///   mismatched array propagate into RAG index math). Other failures throw
+    ///   ``EmbeddingError/modelNotLoaded`` or
+    ///   ``EmbeddingError/encodingFailed(underlying:)``.
     func embed(_ texts: [String]) async throws -> [[Float]]
 
     func unloadModel()
@@ -66,9 +96,17 @@ public extension EmbeddingBackend {
     var capabilities: EmbeddingCapabilities { .default }
 }
 
+/// Errors thrown by ``EmbeddingBackend`` operations.
 public enum EmbeddingError: LocalizedError {
+    /// ``EmbeddingBackend/embed(_:)`` was called before a successful
+    /// ``EmbeddingBackend/loadModel(from:)``.
     case modelNotLoaded
+    /// A produced vector did not have the expected length, or the result had a
+    /// different count than the input. Signals a violated ``EmbeddingBackend``
+    /// postcondition instead of returning a mismatched array.
     case dimensionMismatch(expected: Int, actual: Int)
+    /// The underlying engine failed to encode one of the input texts; the
+    /// original error is preserved for diagnostics.
     case encodingFailed(underlying: Error)
 
     public var errorDescription: String? {


### PR DESCRIPTION
Worker B on #1834 (pre-1.0 Contract API hardening), item #15: `EmbeddingBackend` was thinly specified vs `InferenceBackend`. This brings its documented contract up to the same level so it is safe to **freeze for 1.0**.

## What changed (doc-only, `Sources/ManifoldContract/EmbeddingBackend.swift`)

- **Top-level protocol doc + `## Thread Safety` section**, modeled on `InferenceBackend`. States that conformers are `Sendable`, methods may be called from **any** thread, and — unlike `InferenceBackend` — there is **no** service-level serialization (RAG indexes batches in parallel, and `loadModel`/`unloadModel` may arrive from a different actor concurrently with `embed`). Mutable-state conformers must self-synchronize; existing conformers (`NLEmbeddingBackend`, `OllamaEmbeddingBackend`) hold immutable/thread-safe state under `@unchecked Sendable`.
- **`dimensions` precondition** stated explicitly: undefined until `isModelLoaded == true`; value before load is backend-defined and carries no contract.
- **`embed(_:)` count/length guarantee** made explicit: on non-throwing return, `result.count == texts.count` in input order, each vector of length `dimensions` (callers may zip without a length check). A backend that cannot satisfy this does not return a short/ragged array — it throws `EmbeddingError.dimensionMismatch` (the noted partial mitigation).
- **`EmbeddingError` cases documented.**

No behavior change. Existing `EmbeddingBackendProtocolTests` (7 tests) already cover the postcondition, capabilities default, and error descriptions — no new test needed for a doc-only change.

## Freeze relevance / capabilities decision: **DONE (already on main)**

The freeze-critical question was whether to add a `capabilities` member now (un-addable non-breakingly to a third-party-implementable protocol after 1.0). **This was already closed on `origin/main`**: `EmbeddingCapabilities` (batch/input bounds + normalization) plus a protocol-extension `default` so existing conformers — including the companion `manifold-mlx` / `manifold-llama` embedders — don't break. So this PR needed **no** API break; it's the remaining doc-hardening that the capabilities work didn't cover.

## Gate

- `swift build` — Build complete (167s)
- `swift test --filter EmbeddingBackendProtocolTests` — 7 tests, 0 failures

Scoped check only; full CI is the orchestrator's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)