### PR TITLE
feat: pre-1.0 Contract API polish — dedupe capability alias, neutral idle-timeout error, Message scope doc

### DIFF
--- a/Sources/ManifoldCloudCore/SSECloudBackend.swift
+++ b/Sources/ManifoldCloudCore/SSECloudBackend.swift
@@ -171,7 +171,7 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
     public var retrySleeper: (@Sendable (Duration) async throws -> Void)?
 
     /// Idle timeout for the generation stream. If no SSE event arrives within
-    /// this duration, the stream throws ``CloudBackendError/timeout(_:)``.
+    /// this duration, the stream throws ``InferenceError/idleTimeout(_:)``.
     /// `nil` disables idle detection (default).
     public var streamIdleTimeout: Duration?
 
@@ -876,10 +876,13 @@ open class SSECloudBackend: InferenceBackend, ConversationHistoryReceiver, @unch
             case .networkError:         return "networkError"
             case .invalidURL:           return "invalidURL"
             case .backendDeallocated:   return "backendDeallocated"
-            case .timeout:              return "timeout"
             default:                    return "cloudError"
             }
         }
+        // The idle-timeout wrapper now throws the backend-neutral
+        // `InferenceError.idleTimeout`, so classify it explicitly to preserve
+        // the "timeout" metric tag.
+        if case InferenceError.idleTimeout = error { return "timeout" }
         return String(describing: type(of: error))
     }
 }

--- a/Sources/ManifoldContract/EmbeddingBackend.swift
+++ b/Sources/ManifoldContract/EmbeddingBackend.swift
@@ -32,15 +32,37 @@ public struct EmbeddingCapabilities: Sendable, Codable, Equatable, Hashable {
     public static let `default` = EmbeddingCapabilities()
 }
 
+/// Common interface for text-embedding backends.
+///
+/// Each backend wraps a different sentence-embedding engine (Apple
+/// `NaturalLanguage`, an on-device MLX/llama embedder, a remote Ollama
+/// embedder, …) and exposes the same async API. RAG retrieval delegates all
+/// embedding work here through the injected conformer; when none is supplied,
+/// `ManifoldBootstrap` resolves the bundled `NLEmbeddingBackend`.
+///
+/// ## Thread Safety
+///
+/// Conformers are `Sendable` and their methods may be called from **any**
+/// thread. There is no service-level serialization analogous to
+/// `InferenceBackend`'s generation queue: a host may invoke ``embed(_:)``
+/// concurrently with itself (RAG indexing batches in parallel) and with
+/// ``loadModel(from:)`` / ``unloadModel()`` arriving from a different actor.
+/// Conformers with mutable state **must** provide their own synchronization
+/// (an `actor`, an `NSLock`, or genuinely immutable state).
+///
+/// Existing conformers either hold immutable/thread-safe state and declare
+/// `@unchecked Sendable` (`NLEmbeddingBackend`, `OllamaEmbeddingBackend`) or
+/// rely on actor isolation. Custom conformers should follow the same pattern.
 public protocol EmbeddingBackend: AnyObject, Sendable {
     var isModelLoaded: Bool { get }
 
     /// The dimensionality of vectors produced by ``embed(_:)``.
     ///
-    /// Only meaningful after a successful ``loadModel(from:)`` — i.e. when
-    /// ``isModelLoaded`` is `true`. Behavior before a model is loaded is
-    /// backend-defined (a backend may return `0`, a placeholder, or its
-    /// model-independent default).
+    /// **Precondition: only defined after a successful ``loadModel(from:)``** —
+    /// i.e. when ``isModelLoaded`` is `true`. Reading `dimensions` before a
+    /// model is loaded is backend-defined and carries no contract: a backend
+    /// may return `0`, a placeholder, or its model-independent default, and
+    /// consumers must not depend on the value until ``isModelLoaded`` is `true`.
     var dimensions: Int { get }
 
     /// Static capabilities of this backend (batch/input bounds, normalization).
@@ -53,10 +75,18 @@ public protocol EmbeddingBackend: AnyObject, Sendable {
 
     /// Produces one embedding vector per input text.
     ///
-    /// - Postcondition: the returned array has exactly one vector per input
-    ///   (`result.count == texts.count`), each of length ``dimensions``. A
-    ///   backend that cannot satisfy this signals the violation by throwing
-    ///   ``EmbeddingError/dimensionMismatch(expected:actual:)``.
+    /// - Postcondition (guaranteed): on normal return the result has exactly
+    ///   one vector per input (`result.count == texts.count`), in input order,
+    ///   each of length ``dimensions``. Callers may zip the result against the
+    ///   input array without a length check.
+    /// - The guarantee holds **only** on non-throwing return. A backend that
+    ///   cannot satisfy the per-input count or vector length does **not**
+    ///   silently return a short/ragged array — it throws
+    ///   ``EmbeddingError/dimensionMismatch(expected:actual:)`` (partial
+    ///   mitigation: the error surfaces the violation rather than letting a
+    ///   mismatched array propagate into RAG index math). Other failures throw
+    ///   ``EmbeddingError/modelNotLoaded`` or
+    ///   ``EmbeddingError/encodingFailed(underlying:)``.
     func embed(_ texts: [String]) async throws -> [[Float]]
 
     func unloadModel()
@@ -66,9 +96,17 @@ public extension EmbeddingBackend {
     var capabilities: EmbeddingCapabilities { .default }
 }
 
+/// Errors thrown by ``EmbeddingBackend`` operations.
 public enum EmbeddingError: LocalizedError {
+    /// ``EmbeddingBackend/embed(_:)`` was called before a successful
+    /// ``EmbeddingBackend/loadModel(from:)``.
     case modelNotLoaded
+    /// A produced vector did not have the expected length, or the result had a
+    /// different count than the input. Signals a violated ``EmbeddingBackend``
+    /// postcondition instead of returning a mismatched array.
     case dimensionMismatch(expected: Int, actual: Int)
+    /// The underlying engine failed to encode one of the input texts; the
+    /// original error is preserved for diagnostics.
     case encodingFailed(underlying: Error)
 
     public var errorDescription: String? {

--- a/Sources/ManifoldContract/GenerationStream.swift
+++ b/Sources/ManifoldContract/GenerationStream.swift
@@ -10,7 +10,7 @@ import Observation
 /// cases to ``GenerationEvent``.
 ///
 /// When ``idleTimeout`` is set, iterating ``events`` will throw
-/// ``CloudBackendError/timeout(_:)`` if no event arrives within the timeout.
+/// ``InferenceError/idleTimeout(_:)`` if no event arrives within the timeout.
 /// The phase transitions to `.stalled` before the timeout fires.
 ///
 /// ``setPhase(_:)`` must be called on the `@MainActor`.
@@ -21,7 +21,7 @@ public final class GenerationStream: Sendable {
     /// The content event stream. Iterate this to receive tokens.
     ///
     /// When ``idleTimeout`` is configured, this stream monitors inter-event
-    /// gaps and throws ``CloudBackendError/timeout(_:)`` if the gap exceeds
+    /// gaps and throws ``InferenceError/idleTimeout(_:)`` if the gap exceeds
     /// the timeout. The ``phase`` transitions to `.stalled` at the midpoint
     /// of the timeout to give the UI a chance to show a warning before the
     /// hard timeout fires.
@@ -34,7 +34,7 @@ public final class GenerationStream: Sendable {
     public private(set) var phase: Phase = .connecting
 
     /// Optional idle timeout. When set, ``events`` will throw
-    /// ``CloudBackendError/timeout(_:)`` if no event arrives within this duration.
+    /// ``InferenceError/idleTimeout(_:)`` if no event arrives within this duration.
     public nonisolated let idleTimeout: Duration?
 
     // MARK: - Phase
@@ -141,7 +141,10 @@ public final class GenerationStream: Sendable {
                             onStalled()
                         }
                         if elapsed >= timeout {
-                            continuation.finish(throwing: CloudBackendError.timeout(timeout))
+                            // Backend-neutral error: this wrapper serves local
+                            // backends too, so it must not surface a cloud-only
+                            // error type. See InferenceError.idleTimeout.
+                            continuation.finish(throwing: InferenceError.idleTimeout(timeout))
                             return
                         }
                     }

--- a/Sources/ManifoldContract/Message.swift
+++ b/Sources/ManifoldContract/Message.swift
@@ -23,6 +23,19 @@ import Foundation
 /// Replaces the typo-prone `[(role: String, content: String)]` tuple
 /// variant. The tuple variant remains as a deprecation shim for one minor
 /// (`enqueue(messages: [(role:content:)])` / `generate(messages:...)`).
+///
+/// ## Scope boundary — text-only by design
+///
+/// Every case carries a single `String` and nothing else. This type
+/// **intentionally cannot represent** tool calls, tool results, image or
+/// audio attachments, or any multi-part turn. That is not a gap to close:
+/// `Message` is the minimal one-shot wire shape for "send these plain turns
+/// and stream a reply." Anything richer — multimodal content, tool-call
+/// loops, persisted identity — flows through the value/`@Model` `ChatMessage`
+/// types described above, which the runtime turn loop (`ConversationRuntime`)
+/// drives. Keeping this enum thin is what lets callers script a quick
+/// generation without constructing those records; widening it would blur the
+/// boundary the two-tier design exists to draw.
 public enum Message: Sendable, Equatable {
     /// A system message, typically setting role/persona/policy.
     case system(String)

--- a/Sources/ManifoldHardware/BackendCapabilities.swift
+++ b/Sources/ManifoldHardware/BackendCapabilities.swift
@@ -110,13 +110,13 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// set `false`.
     public let streamsToolCallArguments: Bool
 
-    /// Whether the backend streams tool-call argument deltas incrementally.
-    /// Alias for ``streamsToolCallArguments`` with a clearer name.
+    /// Deprecated alias for ``streamsToolCallArguments``.
     ///
-    /// The original name `streamsToolCallArguments` is ambiguous — it could be
-    /// read as "streams the arguments as a whole". This alias makes the
-    /// incremental-delta semantics explicit. Both names refer to the same
-    /// capability and may be used interchangeably.
+    /// One capability should have one public name. ``streamsToolCallArguments``
+    /// is the canonical spelling — it is the stored property, the codable key,
+    /// and the name every backend and consumer already uses. This redundant
+    /// alias is retired before 1.0 to keep the frozen surface minimal.
+    @available(*, deprecated, renamed: "streamsToolCallArguments")
     public var streamsToolCallArgumentDeltas: Bool { streamsToolCallArguments }
 
     /// True when the backend can emit multiple ``GenerationEvent/toolCall(_:)``

--- a/Sources/ManifoldHardware/InferenceError.swift
+++ b/Sources/ManifoldHardware/InferenceError.swift
@@ -29,6 +29,11 @@ public enum InferenceError: LocalizedError, CategorizedError {
     /// value lists the unsatisfied requirements (across all children — i.e. the
     /// requirements no child could meet) so the host can surface a fix-it message.
     case noBackendSatisfiesRequirements([GenerationCapabilityRequirement])
+    /// Thrown by ``GenerationStream`` when no event arrives within the
+    /// configured idle-timeout window. Backend-neutral: the idle-timeout
+    /// wrapper is usable by local backends too, so this lives here rather than
+    /// in the cloud-specific `CloudBackendError`. Retryable transient.
+    case idleTimeout(Duration)
 
     public var errorDescription: String? {
         switch self {
@@ -58,6 +63,12 @@ public enum InferenceError: LocalizedError, CategorizedError {
             }
             let names = unmet.map { String(describing: $0) }.joined(separator: ", ")
             return "No wired backend satisfies the request's required capabilities: \(names)."
+        case .idleTimeout(let duration):
+            let totalMs = duration.components.seconds * 1000 + duration.components.attoseconds / 1_000_000_000_000_000
+            if totalMs < 1000 {
+                return "No response received for \(totalMs)ms."
+            }
+            return "No response received for \(duration.components.seconds)s."
         }
     }
 
@@ -71,7 +82,7 @@ public enum InferenceError: LocalizedError, CategorizedError {
             return .unsupportedRequest
         case .noBackendSatisfiesRequirements:
             return .unsupportedRequest
-        case .alreadyGenerating:
+        case .alreadyGenerating, .idleTimeout:
             return .retryableTransient
         case .modelNotFound, .modelLoadFailed, .inferenceFailure,
              .memoryInsufficient, .generationError:
@@ -81,12 +92,12 @@ public enum InferenceError: LocalizedError, CategorizedError {
 
     /// Whether this error represents a transient condition that may succeed on retry.
     ///
-    /// Currently only ``alreadyGenerating`` is retryable -- the caller can wait for the
-    /// in-flight generation to finish and try again. All other cases indicate permanent
-    /// failures (missing model, OOM, etc.).
+    /// ``alreadyGenerating`` (wait for the in-flight generation to finish) and
+    /// ``idleTimeout`` (the stall may be transient) are retryable. All other
+    /// cases indicate permanent failures (missing model, OOM, etc.).
     public var isRetryable: Bool {
         switch self {
-        case .alreadyGenerating:
+        case .alreadyGenerating, .idleTimeout:
             return true
         case .modelNotFound, .modelLoadFailed, .inferenceFailure,
              .memoryInsufficient, .generationError, .contextExhausted,

--- a/Sources/ManifoldModelCatalog/CloudBackendError.swift
+++ b/Sources/ManifoldModelCatalog/CloudBackendError.swift
@@ -16,6 +16,13 @@ public enum CloudBackendError: LocalizedError, CategorizedError {
     /// Not retryable — the backend no longer exists.
     case backendDeallocated
     /// No events received within the idle timeout duration.
+    ///
+    /// Deprecated: the idle-timeout wrapper (``GenerationStream``) serves local
+    /// backends too, so it now throws the backend-neutral
+    /// `InferenceError.idleTimeout`. This cloud-specific case is no longer
+    /// thrown by the framework and is retained only for source compatibility
+    /// until 1.0.
+    @available(*, deprecated, message: "Idle-timeout failures now surface as InferenceError.idleTimeout")
     case timeout(Duration)
     /// The endpoint's hostname resolved to a private, link-local, or reserved
     /// IP address at connect time, indicating a potential DNS rebinding attack.

--- a/Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift
+++ b/Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift
@@ -45,6 +45,14 @@ import ManifoldTestSupport
 @MainActor
 enum PublicSurfaceConsumer {
 
+    /// Touches deprecated-but-still-frozen aliases. Annotated `@available`
+    /// deprecated so referencing them here doesn't emit warnings — the freeze
+    /// test still fails to compile if the alias is removed outright.
+    @available(*, deprecated)
+    static func consumeDeprecatedAliases(_ caps: BackendCapabilities) {
+        _ = caps.streamsToolCallArgumentDeltas
+    }
+
     /// Statically referenced from `PublicSurfaceTests` so dead-code-elimination
     /// can't strip the consumer body. Returns `Void`; the body's purpose is
     /// purely to compile against the public surfaces named in it.
@@ -100,7 +108,11 @@ enum PublicSurfaceConsumer {
         _ = caps.contextWindowSize
         _ = caps.preferredStructuredOutputSupport
         _ = caps.visibleParameters
-        _ = caps.streamsToolCallArgumentDeltas
+        // Deprecated alias kept on the frozen surface until 1.0 removal; the
+        // freeze fixture must keep referencing it so its disappearance is
+        // caught as an API break, not a silent drop. Wrapped in a deprecated
+        // helper so the reference itself doesn't emit a warning.
+        Self.consumeDeprecatedAliases(caps)
 
         // Codable round-trip — exposed publicly so callers can persist
         // capability snapshots.

--- a/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
@@ -25,6 +25,21 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                       "OllamaBackend makes network calls — isRemote must be true")
     }
 
+    // MARK: - Deprecated alias parity
+
+    @available(*, deprecated)
+    func test_streamsToolCallArgumentDeltas_aliasesCanonicalFlag() {
+        // The deprecated alias must keep mirroring the canonical
+        // `streamsToolCallArguments` until it's removed at 1.0.
+        let streaming = ClaudeBackend().capabilities
+        XCTAssertEqual(streaming.streamsToolCallArgumentDeltas, streaming.streamsToolCallArguments)
+        XCTAssertTrue(streaming.streamsToolCallArgumentDeltas)
+
+        let nonStreaming = OllamaBackend().capabilities
+        XCTAssertEqual(nonStreaming.streamsToolCallArgumentDeltas, nonStreaming.streamsToolCallArguments)
+        XCTAssertFalse(nonStreaming.streamsToolCallArgumentDeltas)
+    }
+
     // MARK: - Tool Calling
 
     func test_cloudBackends_toolCallingCapabilities() {

--- a/Tests/ManifoldInferenceTests/ErrorDescriptionTests.swift
+++ b/Tests/ManifoldInferenceTests/ErrorDescriptionTests.swift
@@ -62,6 +62,7 @@ final class ErrorDescriptionTests: XCTestCase {
             .alreadyGenerating,
             .generationError("token limit"),
             .noBackendSatisfiesRequirements([.toolCalling]),
+            .idleTimeout(.seconds(30)),
         ]
 
         for error in cases {
@@ -105,6 +106,20 @@ final class ErrorDescriptionTests: XCTestCase {
 
         XCTAssertTrue(desc.contains("generation") || desc.contains("progress"),
                        "Should mention generation in progress")
+    }
+
+    func test_idleTimeout_isRetryableTransient() {
+        // The backend-neutral idle-timeout error (formerly CloudBackendError.timeout)
+        // is a transient stall — retry may succeed.
+        let error = InferenceError.idleTimeout(.seconds(30))
+        XCTAssertEqual(error.category, .retryableTransient)
+        XCTAssertTrue(error.isRetryable)
+    }
+
+    func test_idleTimeout_subSecondDescription_usesMilliseconds() {
+        let error = InferenceError.idleTimeout(.milliseconds(250))
+        let desc = error.errorDescription!
+        XCTAssertTrue(desc.contains("250ms"), "Sub-second timeout should render ms: \(desc)")
     }
 
     // MARK: - BackendError conformance

--- a/Tests/ManifoldInferenceTests/GenerationStreamTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationStreamTests.swift
@@ -133,12 +133,14 @@ final class GenerationStreamTests: XCTestCase {
         do {
             for try await _ in stream.events {}
             XCTFail("Should have thrown timeout error")
-        } catch let error as CloudBackendError {
-            // Sabotage check: removing the idle timeout race in events causes the stream to hang instead of throwing
-            guard case .timeout = error else {
-                XCTFail("Expected .timeout, got \(error)")
+        } catch let error as InferenceError {
+            // Idle timeout now surfaces as the backend-neutral
+            // InferenceError.idleTimeout (was CloudBackendError.timeout).
+            guard case .idleTimeout(let duration) = error else {
+                XCTFail("Expected .idleTimeout, got \(error)")
                 return
             }
+            XCTAssertEqual(duration, .milliseconds(100))
         }
     }
 


### PR DESCRIPTION
Pre-1.0 Contract API hardening — batched non-breaking polish from tracking issue #1834. All items are deprecate-in-place or doc-only; **no public removals**, so the API-break gate passes.

### Items
- [x] **#11 — dedupe capability alias.** `streamsToolCallArgumentDeltas` deprecated with `@available(*, deprecated, renamed: "streamsToolCallArguments")` (the canonical stored property). No internal call sites used the alias.
- [x] **#9 — neutral idle-timeout error.** New backend-neutral `InferenceError.idleTimeout(Duration)` (retryable); `GenerationStream` throws it instead of the leaky cloud-only `CloudBackendError.timeout`, which is deprecated (not removed). `SSECloudBackend.classifyError` keeps the "timeout" metric tag.
- [x] **#12 — `Message` scope-boundary doc.** Doc-only: explains the thin wire enum is text-only by design; richer turns go through the value/`@Model` `ChatMessage` types via `ConversationRuntime`.
- [x] **#15 — `EmbeddingBackend` doc hardening** (folded in from #1901). Thread-safety section (no service-level serialization — conformers self-synchronize), explicit `dimensions` precondition (undefined until `isModelLoaded`), strengthened `embed(_:)` count/length postcondition, documented `EmbeddingError` cases. The freeze-critical `EmbeddingCapabilities` member already shipped on main; this is the remaining doc gap.

### Tests
`GenerationStreamTests` (new error), `ErrorDescriptionTests` (all-cases + retryability + ms render), `BackendCapabilitiesContractTests` (deprecated-alias parity), API-freeze fixture keeps referencing the alias via a deprecated wrapper. Existing `EmbeddingBackendProtocolTests` cover the doc'd postconditions.

### Gate
`swift build --build-tests` exit 0; scoped suites green. `Package.resolved` untouched.

Closes the #11/#9/#12/#15 line-items of #1834. Supersedes #1901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)