### PR TITLE
docs(contract): state GenerationConfig throw-vs-silent rule + Codable-lossy warning (#1834)

### DIFF
--- a/Sources/ManifoldContract/InferenceBackend.swift
+++ b/Sources/ManifoldContract/InferenceBackend.swift
@@ -102,6 +102,18 @@ public struct LlamaMirostatV2SamplerOptions: Sendable, Codable, Equatable {
 ///   silently ignore it. A missing hint is never an error.
 ///
 /// See each field's own documentation for the per-backend specifics.
+///
+/// ## Codable round-trip is intentionally lossy
+///
+/// `GenerationConfig` conforms to `Codable` so it can be persisted (e.g. as a
+/// sampler preset), but three fields are **per-request runtime hints that are
+/// never encoded** and always decode back to their defaults:
+/// ``GenerationConfig/jsonMode`` (decodes to `false`),
+/// ``GenerationConfig/thinkingMarkers`` (decodes to `nil`), and
+/// ``GenerationConfig/structuredOutput`` (decodes to `nil`). They are absent
+/// from the `CodingKeys`, so an encode-then-decode cycle silently drops them.
+/// Do not rely on Codable round-trip to preserve these fields — carry them
+/// alongside the persisted config at the call site if you need them to survive.
 public struct GenerationConfig: Sendable, Codable {
     public var temperature: Float
     public var topP: Float


### PR DESCRIPTION
Doc-only hardening for the remaining deferred items of #1834. **No code, signature, default, or behavior change.** `swift build --target ManifoldContract` succeeds.

## #1834 checklist status

- [x] **Item #1 — throw-vs-silently-ignore rule at the type level.** **Already present** on `GenerationConfig` (the `## Throw vs. silently ignore` doc block, shipped via #1887). Left unchanged. The #1902 comment re-listing it appears to be stale — verified against origin/main = 0.54.0.
- [x] **Item #3 — Codable round-trip is silently lossy.** **Added** a type-level `## Codable round-trip is intentionally lossy` doc block warning that three per-request runtime-only fields are never encoded and decode back to defaults.
- EmbeddingCapabilities + doc hardening — already shipped (#1887).
- `InferenceError.idleTimeout` neutral error — already shipped (#1887).
- `streamsToolCallArgumentDeltas` alias dedup — already shipped (#1902).
- Message text-only scope-boundary doc — already shipped (#1887).
- Vendor sampler knobs (#2) — deliberately left in place per maintainer comments; not freeze-blocking. Not touched.

This PR does **not** close #1834.

## Verified lossy field set (item #3)

Read `CodingKeys` / `encode(to:)` / `init(from:)` in `Sources/ManifoldContract/InferenceBackend.swift`. The three fields are absent from `CodingKeys` entirely — never encoded; on decode `jsonMode = false`, `thinkingMarkers = nil`, `structuredOutput = nil`. Matches the issue text exactly.

## Doc text added (type-level on `GenerationConfig`)

> ## Codable round-trip is intentionally lossy
> `GenerationConfig` conforms to `Codable` so it can be persisted (e.g. as a sampler preset), but three fields are **per-request runtime hints that are never encoded** and always decode back to their defaults: `jsonMode` (decodes to `false`), `thinkingMarkers` (decodes to `nil`), and `structuredOutput` (decodes to `nil`). They are absent from the `CodingKeys`, so an encode-then-decode cycle silently drops them...

## Snippet gate

No fenced code blocks added — prose with inline-backtick symbol references and DocC `` ``symbol`` `` links only, so nothing for the readme-snippet compiler to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)