### PR TITLE
feat(contract): add BackendCapabilities.rendersFullPrompt for cloud prompt fidelity (#1905)

### DIFF
--- a/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
@@ -120,7 +120,11 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
         supportsThinking: true,
         supportsVision: true,
         streamsToolCallArguments: true,
-        supportsParallelToolCalls: true
+        supportsParallelToolCalls: true,
+        // Cloud Messages API sends a structured message array on the wire, so
+        // `.promptRendered` carries only the latest user message, not the full
+        // post-template prompt — a partial view (#1905).
+        rendersFullPrompt: false
     )
 
     // MARK: - Prompt Cache Policy
@@ -229,7 +233,9 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             supportsThinking: resolvedManifest.supportsThinking,
             supportsVision: BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
-            supportsParallelToolCalls: true
+            supportsParallelToolCalls: true,
+            // Structured message array on the wire → partial `.promptRendered` (#1905).
+            rendersFullPrompt: false
         )
     }
 

--- a/Sources/ManifoldCloudSaaS/OpenAIBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIBackend.swift
@@ -161,7 +161,10 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             // from upstream.
             supportsVision: BackendVisionCapability.openAIChatCompletionsSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
-            supportsParallelToolCalls: true
+            supportsParallelToolCalls: true,
+            // Chat Completions sends a structured message array on the wire, so
+            // `.promptRendered` carries only the latest user message — partial (#1905).
+            rendersFullPrompt: false
         )
     }
 

--- a/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
@@ -141,7 +141,10 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
         supportsThinking: true,
         supportsVision: false,
         streamsToolCallArguments: true,
-        supportsParallelToolCalls: true
+        supportsParallelToolCalls: true,
+        // Responses API sends structured input items on the wire, so
+        // `.promptRendered` carries only the latest user message — partial (#1905).
+        rendersFullPrompt: false
     )
 
     /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
@@ -187,7 +190,9 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             // MessagePart.image as input_image content items.
             supportsVision: BackendVisionCapability.openAIResponsesSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
-            supportsParallelToolCalls: true
+            supportsParallelToolCalls: true,
+            // Structured input items on the wire → partial `.promptRendered` (#1905).
+            rendersFullPrompt: false
         )
     }
 

--- a/Sources/ManifoldFoundation/FoundationBackend.swift
+++ b/Sources/ManifoldFoundation/FoundationBackend.swift
@@ -162,6 +162,12 @@ public final class FoundationBackend: InferenceBackend, @unchecked Sendable {
         // deltas as separate events (parity with MLXBackend's inline parser).
         streamsToolCallArguments: false,
         supportsGuidedStructuredOutput: true,
+        // `requiresPromptTemplate` is `false`: the FoundationModels SDK applies
+        // its own chat template internally and we hand it the conversation as a
+        // structured `Transcript`/`Prompt`, never a single templated string.
+        // GenerationQueue therefore captures only the latest user message into
+        // `.promptRendered`, so the rendered prompt is a partial view (#1905).
+        rendersFullPrompt: false,
         // Apple's on-device model degrades sharply once the tool catalogue
         // exceeds ~16 entries — the schema definitions consume an increasing
         // fraction of its fixed context budget. Advertising more than 16 tools

--- a/Sources/ManifoldHardware/BackendCapabilities.swift
+++ b/Sources/ManifoldHardware/BackendCapabilities.swift
@@ -144,6 +144,26 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// sharing the MLX runtime) sets this to `true`.
     public let sharesMLXProcessResources: Bool
 
+    /// Describes the fidelity of the ``GenerationEvent/promptRendered(text:)``
+    /// event this backend's generations produce (emitted when
+    /// `GenerationConfig.captureRenderedPrompt == true`).
+    ///
+    /// `true` means `.promptRendered` carries the **complete** submitted prompt —
+    /// system prompt + full history + the latest user message, post-template — as
+    /// a single string. This is the case for local/on-device backends that apply
+    /// a chat template to the whole conversation before generation.
+    ///
+    /// `false` means `.promptRendered` carries only a **partial** view (typically
+    /// just the most recent user message), because the full prompt is assembled
+    /// on the wire as a structured message array and is not recoverable as one
+    /// rendered string. This is the case for cloud chat-completion / messages
+    /// backends (Anthropic, OpenAI, Ollama, any SSE cloud backend).
+    ///
+    /// Consumers read this to honestly label a captured rendered prompt as full
+    /// vs partial. Defaults to `false` — a backend that does not opt in is
+    /// conservatively assumed to render only a partial prompt.
+    public let rendersFullPrompt: Bool
+
     /// Hard cap on the number of tools that may be advertised to this backend
     /// in a single generation turn.
     ///
@@ -200,6 +220,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsParallelToolCalls: Bool = false,
         supportsGuidedStructuredOutput: Bool = false,
         sharesMLXProcessResources: Bool = false,
+        rendersFullPrompt: Bool = false,
         maxAdvertisedToolCount: Int? = nil
     ) {
         self.supportedParameters = supportedParameters
@@ -223,6 +244,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.supportsParallelToolCalls = supportsParallelToolCalls
         self.supportsGuidedStructuredOutput = supportsGuidedStructuredOutput
         self.sharesMLXProcessResources = sharesMLXProcessResources
+        self.rendersFullPrompt = rendersFullPrompt
         self.maxAdvertisedToolCount = maxAdvertisedToolCount
     }
 
@@ -248,6 +270,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case supportsParallelToolCalls
         case supportsGuidedStructuredOutput
         case sharesMLXProcessResources
+        case rendersFullPrompt
         case maxAdvertisedToolCount
     }
 
@@ -277,6 +300,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
         supportsGuidedStructuredOutput = (try c.decodeIfPresent(Bool.self, forKey: .supportsGuidedStructuredOutput)) ?? false
         sharesMLXProcessResources = (try c.decodeIfPresent(Bool.self, forKey: .sharesMLXProcessResources)) ?? false
+        rendersFullPrompt = (try c.decodeIfPresent(Bool.self, forKey: .rendersFullPrompt)) ?? false
         maxAdvertisedToolCount = try c.decodeIfPresent(Int.self, forKey: .maxAdvertisedToolCount)
     }
 
@@ -303,6 +327,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
         try c.encode(supportsGuidedStructuredOutput, forKey: .supportsGuidedStructuredOutput)
         try c.encode(sharesMLXProcessResources, forKey: .sharesMLXProcessResources)
+        try c.encode(rendersFullPrompt, forKey: .rendersFullPrompt)
         try c.encodeIfPresent(maxAdvertisedToolCount, forKey: .maxAdvertisedToolCount)
     }
 }

--- a/Sources/ManifoldOllama/OllamaBackend.swift
+++ b/Sources/ManifoldOllama/OllamaBackend.swift
@@ -321,7 +321,10 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
         // that advertise the `vision` capability.
         supportsVision: false,
         streamsToolCallArguments: false,
-        supportsParallelToolCalls: true
+        supportsParallelToolCalls: true,
+        // Ollama's /api/chat takes a structured message array, so the captured
+        // `.promptRendered` is only the latest user message — partial (#1905).
+        rendersFullPrompt: false
     )
 
     /// Reads the snapshot the `parseResponseStream` override stashed
@@ -415,7 +418,9 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
             // in a single assistant message — the loop in `parseResponseStream`
             // emits them in array order so the orchestrator's serial dispatch
             // honours the model's intent.
-            supportsParallelToolCalls: true
+            supportsParallelToolCalls: true,
+            // Structured message array on the wire → partial `.promptRendered` (#1905).
+            rendersFullPrompt: false
         )
     }
 

--- a/Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift
+++ b/Tests/APIFreezeTests/Fixtures/PublicSurfaceConsumer.swift
@@ -101,7 +101,8 @@ enum PublicSurfaceConsumer {
             streamsToolCallArguments: false,
             supportsParallelToolCalls: false,
             supportsGuidedStructuredOutput: false,
-            sharesMLXProcessResources: false
+            sharesMLXProcessResources: false,
+            rendersFullPrompt: false
         )
 
         // Computed property accessors — host code reads these.

--- a/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
+++ b/Tests/ManifoldBackendsTests/BackendCapabilitiesContractTests.swift
@@ -93,6 +93,34 @@ final class BackendCapabilitiesContractTests: XCTestCase {
                        "OllamaBackend reports thinking only after /api/show probe runs at loadModel time")
     }
 
+    // MARK: - rendersFullPrompt (#1905)
+
+    /// Cloud chat-completion / messages backends assemble the full prompt as a
+    /// structured message array on the wire, so their `.promptRendered` event
+    /// carries only a partial view (the latest user message). They must report
+    /// `rendersFullPrompt == false` so consumers can label the capture honestly.
+    func test_cloudBackends_doNotRenderFullPrompt() {
+        XCTAssertFalse(ClaudeBackend().capabilities.rendersFullPrompt,
+                       "ClaudeBackend sends a structured Messages array — .promptRendered is partial")
+        XCTAssertFalse(OpenAIBackend().capabilities.rendersFullPrompt,
+                       "OpenAIBackend sends a structured Chat Completions array — .promptRendered is partial")
+        XCTAssertFalse(OpenAIResponsesBackend().capabilities.rendersFullPrompt,
+                       "OpenAIResponsesBackend sends structured input items — .promptRendered is partial")
+        XCTAssertFalse(OllamaBackend().capabilities.rendersFullPrompt,
+                       "OllamaBackend sends a structured /api/chat array — .promptRendered is partial")
+    }
+
+#if canImport(FoundationModels)
+    /// FoundationBackend does not template the whole conversation into a single
+    /// string (it hands the SDK a structured Transcript/Prompt), so its
+    /// `.promptRendered` is a partial view → `rendersFullPrompt == false`.
+    @available(iOS 26, macOS 26, *)
+    func test_foundationBackend_doesNotRenderFullPrompt() {
+        XCTAssertFalse(FoundationBackend().capabilities.rendersFullPrompt,
+                       "FoundationBackend applies its own chat template internally — .promptRendered is partial")
+    }
+#endif
+
     // MARK: - Local backends
 
 

--- a/Tests/ManifoldInferenceTests/BackendCapabilitiesTests.swift
+++ b/Tests/ManifoldInferenceTests/BackendCapabilitiesTests.swift
@@ -374,6 +374,64 @@ final class BackendCapabilitiesTests: XCTestCase {
         XCTAssertFalse(decoded.supportsNativeJSONMode)
     }
 
+    // MARK: - rendersFullPrompt (#1905)
+
+    func test_rendersFullPrompt_defaultsFalse() {
+        // Conservative default: a backend that doesn't opt in is assumed to
+        // render only a partial `.promptRendered` view.
+        XCTAssertFalse(BackendCapabilities().rendersFullPrompt)
+    }
+
+    func test_rendersFullPrompt_explicitTrue_isHonored() {
+        let caps = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: true,
+            supportsSystemPrompt: true,
+            rendersFullPrompt: true
+        )
+        XCTAssertTrue(caps.rendersFullPrompt)
+    }
+
+    func test_rendersFullPrompt_codableRoundTrip_true() throws {
+        let original = BackendCapabilities(
+            supportedParameters: [.temperature],
+            maxContextTokens: 4096,
+            requiresPromptTemplate: true,
+            supportsSystemPrompt: true,
+            rendersFullPrompt: true
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BackendCapabilities.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertTrue(decoded.rendersFullPrompt)
+    }
+
+    /// An older capabilities blob that predates the flag must decode without
+    /// throwing and fall back to the conservative `false` default.
+    func test_rendersFullPrompt_missingKey_defaultsFalse() throws {
+        let json = """
+        {
+            "supportedParameters": ["temperature"],
+            "maxContextTokens": 4096,
+            "maxOutputTokens": 2048,
+            "requiresPromptTemplate": false,
+            "supportsSystemPrompt": true,
+            "supportsStreaming": true,
+            "supportsToolCalling": false,
+            "supportsStructuredOutput": false,
+            "cancellationStyle": "cooperative",
+            "supportsTokenCounting": false,
+            "memoryStrategy": "resident",
+            "isRemote": false
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(BackendCapabilities.self, from: json)
+
+        XCTAssertFalse(decoded.rendersFullPrompt)
+    }
+
     // MARK: - PromptAssembler reads contextWindowSize from capabilities
 
     func test_promptAssembler_capabilities_overload_usesContextWindowSize() {


### PR DESCRIPTION
## Summary

Covers **Gap 1 of #1905 only** — the cloud full-prompt-fidelity flag. Gap 2 (local-backend token usage) is companion-repo work (manifold-mlx / manifold-llama) and **out of scope** for this PR.

Adds an additive capability flag `BackendCapabilities.rendersFullPrompt: Bool` so a consumer can honestly label a captured `.promptRendered` event (emitted when `GenerationConfig.captureRenderedPrompt == true`) as full vs partial:

- `true` — `.promptRendered` carries the **complete** submitted prompt (system + history + user, post-template) as one string. The case for local/on-device backends that template the whole conversation (`requiresPromptTemplate == true`).
- `false` (conservative default) — it carries only a **partial** view (the latest user message), because the full prompt is assembled on the wire as a structured message array and isn't recoverable as a single rendered string.

## Implementation

Wired `rendersFullPrompt` consistently across `BackendCapabilities`: stored `public let`, memberwise init param (defaulted `false`, placed at the end before `maxAdvertisedToolCount`), tolerant `init(from:)` (`decodeIfPresent ?? false`), `encode(to:)`, and `CodingKeys`. Additive only — no removals or type changes.

## In-core backends + flag values

All in-core backends send structured message arrays on the wire → `false`:

| Backend | `rendersFullPrompt` | Reason |
|---|---|---|
| `ClaudeBackend` (Anthropic Messages) | `false` | structured Messages array on the wire |
| `OpenAIBackend` (Chat Completions) | `false` | structured Chat Completions array |
| `OpenAIResponsesBackend` | `false` | structured input items |
| `OllamaBackend` (`/api/chat`) | `false` | structured message array |
| `FoundationBackend` | `false` | `requiresPromptTemplate == false`; hands the SDK a structured `Transcript`/`Prompt`, never a single templated string, so `GenerationQueue` captures only the latest user message |

**Foundation reasoning:** confirmed against `GenerationQueue` — the `.promptRendered` capture uses the templated `result.prompt` only on the `requiresPromptTemplate == true` path; otherwise it captures the last user message. Foundation is `requiresPromptTemplate: false`, so it is partial → `false`.

No in-core backend sets `requiresPromptTemplate: true` (the local MLX/Llama families that template the whole prompt live in companion repos). They opt into `rendersFullPrompt: true` from their own repos; the conservative default keeps them correct until they do.

## Test coverage

- `BackendCapabilitiesTests` (ManifoldInferenceTests): default `false`, explicit `true` honored, Codable round-trip of `true`, and decode of an older blob missing the key → `false`.
- `BackendCapabilitiesContractTests` (ManifoldBackendsTests): representative cloud backends (Claude/OpenAI/OpenAIResponses/Ollama) + Foundation report `false`.
- `PublicSurfaceConsumer` API-freeze fixture updated to exercise the new full-init param.

## Gate

- `swift build` ✅ and `swift build --build-tests` ✅
- Filtered suites pass: `BackendCapabilitiesTests` (30), `BackendCapabilitiesContractTests` (14), `APIFreezeTests` (2).
- **api-breakage gate:** not a concern — this is purely additive (new property + new defaulted init param). `api-breakage-allowlist.txt` untouched.
- `Package.resolved` not staged.

Closes the cloud half of #1905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)