### PR TITLE
feat: in-core TTS reference backend + AudioGenerationRuntime (#1904)

### DIFF
--- a/Sources/ManifoldContract/AudioGenerationBackend.swift
+++ b/Sources/ManifoldContract/AudioGenerationBackend.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Common interface for on-device, one-shot text-to-speech (TTS) backends.
+///
+/// Sibling to ``ImageGenerationBackend`` for the audio modality. Each conformer
+/// wraps a different speech engine (Apple `AVSpeechSynthesizer` in core, Kokoro
+/// / CSM via the mlx-audio companion, or a cloud TTS provider) and exposes the
+/// same async streaming API: render a text prompt into a single audio artifact
+/// on disk, streaming ``AudioGenerationEvent`` progress ticks until the terminal
+/// ``AudioGenerationEvent/completed(_:)``.
+///
+/// ## Why no `loadModel`
+///
+/// Unlike ``ImageGenerationBackend``, the reference TTS backend
+/// (`AVSpeechSynthesizer`) needs no model download or weight unpack — the
+/// system voices are always resident. The protocol therefore omits a
+/// `loadModel(from:)` / `isLoaded` lifecycle: a conformer is ready to
+/// `generate` from construction. A companion backend that *does* need to load
+/// weights manages that internally (e.g. lazily on first `generate`) rather
+/// than widening this contract; keeping the seam minimal is the point.
+///
+/// ## Why `AnyObject + Sendable`, not `Actor`
+///
+/// TTS rendering looks like image inference under the hood: a synchronous
+/// render call (here, `AVSpeechSynthesizer.write(_:toBufferCallback:)`) driven
+/// from a background context. Modeling the protocol as an `Actor` would hold
+/// isolation across that render and block ``isGenerating`` / ``stopGeneration()``
+/// from the UI. ``ImageGenerationBackend`` solved this with reference semantics
+/// + a fine-grained lock; this protocol follows the same pattern so both
+/// backend protocols share one isolation strategy. Conformers protect mutable
+/// state with `NSLock` (or `OSAllocatedUnfairLock`); ``stopGeneration()`` may
+/// arrive concurrently from the main actor while generation runs on a detached
+/// task and must remain synchronous.
+public protocol AudioGenerationBackend: AnyObject, Sendable {
+
+    /// Whether a `generate()` call is currently in flight. Mirrors
+    /// ``ImageGenerationBackend/isGenerating`` so callers can synchronously
+    /// check that ``stopGeneration()`` took effect.
+    var isGenerating: Bool { get }
+
+    /// Renders `config.text` into a single audio artifact, streaming progress
+    /// events as the render proceeds.
+    ///
+    /// Errors during generation are thrown into the stream; callers iterate the
+    /// returned `AsyncThrowingStream` and observe ``AudioGenerationEvent``
+    /// values until either ``AudioGenerationEvent/completed(_:)`` or a thrown
+    /// error terminates it.
+    ///
+    /// ## Output destination contract
+    ///
+    /// Backends MUST honour ``SpeechGenerationConfig/outputDirectory`` when it
+    /// is non-`nil`: the URL surfaced in ``AudioGenerationEvent/completed(_:)``
+    /// must resolve under that directory. When `outputDirectory` is `nil` the
+    /// backend picks its own location (typically
+    /// `FileManager.default.temporaryDirectory`). Either way, the file at the
+    /// emitted URL must be fully written and closed before the event is
+    /// yielded.
+    ///
+    /// Backends honour the ``SpeechGenerationConfig`` knobs they support
+    /// (`voice`, `rate`, `pitch`) and silently ignore the rest, matching the
+    /// ``ImageGenerationBackend`` convention.
+    func generate(
+        config: SpeechGenerationConfig
+    ) throws -> AsyncThrowingStream<AudioGenerationEvent, Error>
+
+    /// Requests that the current generation stop as soon as possible.
+    ///
+    /// After return, the backend MUST satisfy: in-flight generation is
+    /// cancelled, the backend accepts a new ``generate(config:)`` call, and
+    /// ``isGenerating`` reads `false`. No-op when no generation is in progress.
+    /// Mirrors ``ImageGenerationBackend/stopGeneration()``.
+    func stopGeneration()
+}

--- a/Sources/ManifoldInference/Services/AppleTTSBackend.swift
+++ b/Sources/ManifoldInference/Services/AppleTTSBackend.swift
@@ -1,0 +1,282 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+/// Zero-dependency, in-core reference ``AudioGenerationBackend`` backed by
+/// Apple's `AVSpeechSynthesizer`.
+///
+/// Renders a text prompt to an audio file (CAF) using
+/// `AVSpeechSynthesizer.write(_:toBufferCallback:)` — the *render-to-file*
+/// path, **not** the speaker-playback path used by `ManifoldVoice`'s
+/// `AppleSpeechSynthesizer` (Lane 1 vs Lane 2 in the audio-generation design
+/// doc: this is the artifact-generation lane). The two share the same engine
+/// but serve different contracts.
+///
+/// Available on macOS + iOS with no external dependency or model download — the
+/// system voices are always resident, so the backend needs no `loadModel`
+/// step (see ``AudioGenerationBackend`` for the rationale).
+///
+/// ## Concurrency
+///
+/// Reference type with a fine-grained `NSLock`, mirroring the
+/// ``ImageGenerationBackend`` isolation strategy. `generate(config:)` returns
+/// synchronously after the synchronous-throw entrypoint; the actual render
+/// runs inside the returned `AsyncThrowingStream`'s producer task, off any
+/// caller actor. ``stopGeneration()`` flips a lock-protected cancellation flag
+/// the render loop polls, so a main-actor cancel does not block on the render.
+public final class AppleTTSBackend: AudioGenerationBackend, @unchecked Sendable {
+
+    /// Errors surfaced by the Apple TTS render path.
+    public enum BackendError: Error, Equatable, Sendable {
+        /// The supplied `voice` identifier did not resolve to an installed
+        /// system voice and no usable fallback was available.
+        case voiceUnavailable(String)
+        /// `AVSpeechSynthesizer.write` produced no audio buffers — typically an
+        /// empty prompt or a synthesiser that declined to render.
+        case noAudioProduced
+        /// The output file could not be created or written.
+        case fileWriteFailed
+    }
+
+    private struct State {
+        var isGenerating = false
+        var cancelled = false
+    }
+
+    private let lock = NSLock()
+    private var state = State()
+
+    public init() {}
+
+    public var isGenerating: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return state.isGenerating
+    }
+
+    public func stopGeneration() {
+        lock.lock(); defer { lock.unlock() }
+        // No-op when idle. When a render is running, flip the cancel flag the
+        // producer task polls between buffers; the task clears `isGenerating`
+        // once it observes the flag and tears down.
+        guard state.isGenerating else { return }
+        state.cancelled = true
+    }
+
+    public func generate(
+        config: SpeechGenerationConfig
+    ) throws -> AsyncThrowingStream<AudioGenerationEvent, Error> {
+        let trimmed = config.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw BackendError.noAudioProduced
+        }
+
+        // Resolve the destination up front so a bad output directory surfaces
+        // synchronously rather than mid-stream.
+        let outputURL = Self.makeOutputURL(directory: config.outputDirectory)
+
+        lock.lock()
+        // Latest-wins: a fresh generate clears any stale cancel flag.
+        state = State(isGenerating: true, cancelled: false)
+        lock.unlock()
+
+        return AsyncThrowingStream { continuation in
+            // Render off any caller actor. AVSpeechSynthesizer.write fires its
+            // buffer callback synchronously on an internal queue during the
+            // call; we drive it from a detached task and accumulate buffers
+            // into an AVAudioFile.
+            let task = Task.detached(priority: .userInitiated) { [self] in
+                do {
+                    try await self.render(
+                        text: trimmed,
+                        config: config,
+                        outputURL: outputURL,
+                        continuation: continuation
+                    )
+                } catch is CancellationError {
+                    self.finishGenerating()
+                    continuation.finish()
+                } catch {
+                    self.finishGenerating()
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { [self] termination in
+                if case .cancelled = termination {
+                    self.stopGeneration()
+                }
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - Render
+
+    private func finishGenerating() {
+        lock.lock(); defer { lock.unlock() }
+        state.isGenerating = false
+        state.cancelled = false
+    }
+
+    private func isCancelled() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return state.cancelled
+    }
+
+    /// Drives `AVSpeechSynthesizer.write` to completion, writing each rendered
+    /// buffer into `outputURL` and yielding progress ticks. Emits the terminal
+    /// `.completed(outputURL)` once the synthesiser signals end-of-stream.
+    private func render(
+        text: String,
+        config: SpeechGenerationConfig,
+        outputURL: URL,
+        continuation: AsyncThrowingStream<AudioGenerationEvent, Error>.Continuation
+    ) async throws {
+        let utterance = Self.makeUtterance(text: text, config: config)
+
+        // The write callback fires synchronously on an internal queue; we
+        // bridge it to the async producer via a continuation that resumes when
+        // the synthesiser signals the terminal (zero-frame) buffer. A class box
+        // collects render state shared between the callback thread and the
+        // resume site — guarded by its own lock because the callback can fire
+        // on a different thread than the awaiting task.
+        final class RenderBox: @unchecked Sendable {
+            let lock = NSLock()
+            var audioFile: AVAudioFile?
+            var bufferCount = 0
+            var error: Error?
+            var finished = false
+
+            // `withLock` is async-safe (the synchronous closure cannot suspend),
+            // unlike calling `lock.lock()/unlock()` directly across an `await`.
+            func withLock<R>(_ body: () -> R) -> R {
+                lock.lock(); defer { lock.unlock() }
+                return body()
+            }
+        }
+        let box = RenderBox()
+        let synthesizer = AVSpeechSynthesizer()
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            // `resumeOnce` guards against the (unlikely) double-resume if the
+            // synthesiser ever delivers two terminal buffers.
+            let resumeState = NSLock()
+            var resumed = false
+            func resumeOnce(_ result: Result<Void, Error>) {
+                resumeState.lock()
+                let alreadyResumed = resumed
+                resumed = true
+                resumeState.unlock()
+                guard !alreadyResumed else { return }
+                cont.resume(with: result)
+            }
+
+            synthesizer.write(utterance) { [self] buffer in
+                guard let pcm = buffer as? AVAudioPCMBuffer else {
+                    // Non-PCM buffer — nothing to write; ignore.
+                    return
+                }
+
+                // A zero-frame buffer is the synthesiser's end-of-stream
+                // signal.
+                if pcm.frameLength == 0 {
+                    let (produced, writeError): (Int, Error?) = box.withLock {
+                        box.finished = true
+                        return (box.bufferCount, box.error)
+                    }
+
+                    if let writeError {
+                        resumeOnce(.failure(writeError))
+                    } else if produced == 0 {
+                        resumeOnce(.failure(BackendError.noAudioProduced))
+                    } else {
+                        resumeOnce(.success(()))
+                    }
+                    return
+                }
+
+                // Cooperative cancellation: stop appending once cancelled. We
+                // still let the synthesiser run to its terminal buffer (it owns
+                // its own queue) but produce no further output.
+                if self.isCancelled() {
+                    resumeOnce(.failure(CancellationError()))
+                    return
+                }
+
+                let yieldedStep: Int? = box.withLock {
+                    if box.error != nil { return nil }
+                    do {
+                        if box.audioFile == nil {
+                            box.audioFile = try AVAudioFile(
+                                forWriting: outputURL,
+                                settings: pcm.format.settings
+                            )
+                        }
+                        try box.audioFile?.write(from: pcm)
+                        box.bufferCount += 1
+                        return box.bufferCount
+                    } catch {
+                        box.error = error
+                        return nil
+                    }
+                }
+                if let step = yieldedStep {
+                    // Unknown total ahead of time — report step==total so
+                    // consumers clamp to a monotonically-growing fraction.
+                    continuation.yield(.progress(step: step, total: step))
+                }
+            }
+        }
+
+        // Drop the file handle (closes/flushes) before emitting completion so
+        // the file at `outputURL` is fully written when the consumer reads it.
+        box.withLock { box.audioFile = nil }
+
+        if isCancelled() {
+            finishGenerating()
+            continuation.finish()
+            return
+        }
+
+        finishGenerating()
+        continuation.yield(.completed(outputURL))
+        continuation.finish()
+    }
+
+    // MARK: - Helpers
+
+    /// Builds the destination URL. Honours ``SpeechGenerationConfig/outputDirectory``
+    /// when set (per the ``AudioGenerationBackend`` output contract), otherwise
+    /// falls back to the temporary directory. CAF container — the native format
+    /// `AVAudioFile` writes from `AVSpeechSynthesizer`'s buffer format without a
+    /// re-encode.
+    static func makeOutputURL(directory: URL?) -> URL {
+        let base = directory ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("tts-\(UUID().uuidString).caf")
+    }
+
+    /// Maps a ``SpeechGenerationConfig`` onto an `AVSpeechUtterance`. Honours
+    /// `voice`, `rate`, and `pitch`; ignores knobs the engine does not expose.
+    static func makeUtterance(
+        text: String,
+        config: SpeechGenerationConfig
+    ) -> AVSpeechUtterance {
+        let utterance = AVSpeechUtterance(string: text)
+        if let rate = config.rate {
+            utterance.rate = rate
+        }
+        if let pitch = config.pitch {
+            utterance.pitchMultiplier = pitch
+        }
+        if let voiceID = config.voice {
+            // Try an explicit voice identifier first, then a BCP-47 language
+            // tag (callers commonly pass e.g. "en-US"). Leaving `voice` nil
+            // lets the system pick the default voice.
+            if let voice = AVSpeechSynthesisVoice(identifier: voiceID) {
+                utterance.voice = voice
+            } else if let voice = AVSpeechSynthesisVoice(language: voiceID) {
+                utterance.voice = voice
+            }
+        }
+        return utterance
+    }
+}

--- a/Sources/ManifoldInference/Services/AudioGenerationService.swift
+++ b/Sources/ManifoldInference/Services/AudioGenerationService.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Observation
+
+/// Errors thrown by ``AudioGenerationService`` for caller-observable conditions.
+public enum AudioGenerationServiceError: Error, Equatable, Sendable {
+    /// `generate` was called while another generation is already in progress.
+    case alreadyGenerating
+}
+
+/// Orchestrates an audio-generation (TTS) backend's lifecycle.
+///
+/// Sibling to ``ImageGenerationService`` / ``VideoGenerationService`` for the
+/// audio path. Like the video service — and unlike the image service — there is
+/// no `loadModel` concept: the reference backend (`AVSpeechSynthesizer`) has its
+/// voices always resident, so the service holds a backend directly from
+/// construction and is always "ready". State machine: `idle → generating → idle`.
+///
+/// Like the image service — and unlike the video service — the backend's
+/// `generate(config:)` is *synchronous-throw* (a local synth, no network
+/// submit handshake), so the service's `generate` is synchronous and returns
+/// the wrapped stream directly.
+///
+/// ## Concurrency
+///
+/// `@MainActor`-isolated; all state transitions happen on the main actor. The
+/// per-event iteration of the backend stream is the only off-actor work and
+/// runs on a detached task so the UI thread is never held across the render.
+@MainActor
+@Observable
+public final class AudioGenerationService {
+
+    // MARK: - State
+
+    /// High-level lifecycle state. Transitions:
+    ///
+    /// `idle → generating → idle`
+    public enum State: Sendable, Equatable {
+        case idle
+        case generating
+    }
+
+    public private(set) var state: State = .idle
+
+    // MARK: - Private
+
+    private let backend: any AudioGenerationBackend
+
+    // MARK: - Init
+
+    /// Creates a service that drives the supplied backend directly.
+    ///
+    /// - Parameter backend: The audio-generation backend to use. The backend
+    ///   is retained for the lifetime of the service. Defaults to
+    ///   ``AppleTTSBackend`` — the zero-dependency in-core reference backend.
+    public init(backend: any AudioGenerationBackend = AppleTTSBackend()) {
+        self.backend = backend
+    }
+
+    // MARK: - Generate
+
+    /// Streams events from the backend's `generate(config:)`.
+    ///
+    /// The state transitions to `.generating` before this method returns so a
+    /// follow-up call from the same actor observes `.generating`
+    /// deterministically. The returned stream is the backend's own stream
+    /// wrapped to drive service state transitions: `.generating → .idle` when
+    /// the stream finishes (normally or via thrown error). Cancellation is
+    /// treated as a normal finish.
+    ///
+    /// - Returns: a stream that finishes with
+    ///   ``AudioGenerationServiceError/alreadyGenerating`` when a generation is
+    ///   already in progress. All other errors come from the underlying backend.
+    public func generate(
+        config: SpeechGenerationConfig
+    ) -> AsyncThrowingStream<AudioGenerationEvent, Error> {
+        guard state == .idle else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: AudioGenerationServiceError.alreadyGenerating)
+            }
+        }
+
+        return AsyncThrowingStream { continuation in
+            let upstream: AsyncThrowingStream<AudioGenerationEvent, Error>
+            do {
+                upstream = try backend.generate(config: config)
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+
+            // Commit `.generating` synchronously on the main actor after the
+            // backend's synchronous-throw entrypoint returns, so a follow-up
+            // call from the same actor observes the transition deterministically.
+            state = .generating
+
+            let task = Task.detached(priority: .userInitiated) { [weak self] in
+                do {
+                    for try await event in upstream {
+                        if Task.isCancelled {
+                            await self?.restoreIdleState()
+                            continuation.finish()
+                            return
+                        }
+                        continuation.yield(event)
+                    }
+                    await self?.restoreIdleState()
+                    continuation.finish()
+                } catch is CancellationError {
+                    await self?.restoreIdleState()
+                    continuation.finish()
+                } catch {
+                    if Task.isCancelled {
+                        await self?.restoreIdleState()
+                        continuation.finish()
+                    } else {
+                        await self?.restoreIdleState()
+                        continuation.finish(throwing: error)
+                    }
+                }
+            }
+
+            continuation.onTermination = { [weak self] termination in
+                task.cancel()
+                if case .cancelled = termination {
+                    Task { @MainActor [weak self] in
+                        self?.backend.stopGeneration()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    /// Returns the service to `.idle` after a generation finishes, but only if
+    /// the currently-observed state is still `.generating`.
+    private func restoreIdleState() {
+        if state == .generating {
+            state = .idle
+        }
+    }
+}

--- a/Sources/ManifoldModelCatalog/AudioGenerationEvent.swift
+++ b/Sources/ManifoldModelCatalog/AudioGenerationEvent.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Streaming event emitted by an ``AudioGenerationBackend`` during a one-shot
+/// text-to-speech (TTS) generation run.
+///
+/// Sibling to ``ImageGenerationEvent`` / ``VideoGenerationEvent`` for the audio
+/// modality of the generic ``MediaGeneration`` seam (``AudioGeneration``). Two
+/// cases: progress ticks while the synthesiser renders, and a single terminal
+/// ``completed`` carrying a file URL pointing at the produced audio artifact.
+///
+/// ## Why `URL`, not raw samples?
+///
+/// Persisted audio messages reference the artifact by file URL (see
+/// ``GeneratedMediaPayload`` with ``MediaKind/audio``); the binary lives on
+/// disk in the app container rather than in SwiftData. Surfacing the file URL
+/// directly from the backend keeps the inference layer free of audio-buffer
+/// bridging concerns and avoids a `PCM → encode → disk` re-encode in the
+/// persistence layer. Backends are responsible for writing to a
+/// caller-controlled location and emitting the URL once the file is fully on
+/// disk.
+///
+/// ## One-shot only — no preview
+///
+/// Unlike ``ImageGenerationEvent``, audio generation has no `preview` case: a
+/// TTS render produces its artifact in one pass, so there is no
+/// progressively-refining intermediate to surface. Realtime/duplex speech is a
+/// different surface (#1415) and out of scope.
+public enum AudioGenerationEvent: Sendable {
+
+    /// Progress tick while the synthesiser renders.
+    ///
+    /// `step` is 1-indexed and monotonically increasing within a single
+    /// generation; `total` is the backend's estimate of the total number of
+    /// ticks (e.g. one per rendered buffer) after any backend-side clamping.
+    /// Backends that cannot estimate a total may report `total == step` on the
+    /// final tick — consumers must clamp before display.
+    case progress(step: Int, total: Int)
+
+    /// Terminal event: generation finished and the audio was written to
+    /// `url`. The file at `url` is fully closed and safe to read.
+    ///
+    /// The directory portion of `url` is determined by
+    /// ``SpeechGenerationConfig/outputDirectory``: when set, the backend MUST
+    /// write under it; when `nil`, the backend picks its own location
+    /// (typically `FileManager.default.temporaryDirectory`).
+    case completed(URL)
+}

--- a/Sources/ManifoldRuntime/Services/AudioGenerationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/AudioGenerationRuntime.swift
@@ -106,9 +106,9 @@ public final class AudioGenerationRuntime {
         self.service = service
         self.messageStore = messageStore
         self.modelIdentifierProvider = modelIdentifier ?? { "apple-tts" }
-        var cap: AsyncStream<AudioRuntimeEvent>.Continuation!
-        self.events = AsyncStream(bufferingPolicy: .unbounded) { cap = $0 }
-        self.continuation = cap
+        let (stream, continuation) = AsyncStream<AudioRuntimeEvent>.makeStream(bufferingPolicy: .unbounded)
+        self.events = stream
+        self.continuation = continuation
     }
 
     deinit {

--- a/Sources/ManifoldRuntime/Services/AudioGenerationRuntime.swift
+++ b/Sources/ManifoldRuntime/Services/AudioGenerationRuntime.swift
@@ -1,0 +1,305 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - AudioGenerationRuntime
+//
+// Sibling to `ImageGenerationRuntime` / `VideoGenerationRuntime` for the
+// audio-generation (TTS) path. Owns an `AudioGenerationService`, drives
+// `generate(config:)`, and persists the resulting `.generatedMedia` part (with
+// `MediaKind.audio`) via the `MessageStore` port.
+//
+// Per umbrella #1002:
+//   - Audio-side runtime is a sibling type, not a new method on the image/video
+//     runtimes or `ConversationRuntime`. Audio lifecycle has its own shape
+//     (one-shot synth, no model load, no preview) and squeezing it into another
+//     runtime would distort both surfaces.
+//   - Events ride `AudioRuntimeEvent` — distinct from `ImageRuntimeEvent`,
+//     `VideoRuntimeEvent`, and `ConversationEvent` so exhaustive switches in
+//     those consumers stay closed.
+//   - Persistence uses the existing `MessageStore` port. The runtime inserts an
+//     empty placeholder on `generate` and updates it in place with the
+//     `.generatedMedia` part when the backend completes.
+//
+// Concurrency: `@MainActor` because both `MessageStore` and
+// `AudioGenerationService` are `@MainActor`-isolated. The backend's stream is
+// consumed on a `Task` per generation so `cancel(messageID:)` can locate and
+// tear it down by ID without blocking the actor.
+
+/// Drives audio-generation (TTS) lifecycle through ``AudioGenerationService``
+/// and persists results via ``MessageStore``.
+///
+/// Sibling to ``ImageGenerationRuntime`` / ``VideoGenerationRuntime``. Hosts
+/// call ``generate(config:in:)`` to start a generation, observe progress on
+/// ``events`` (an ``AsyncStream`` of ``AudioRuntimeEvent``), and call
+/// ``cancel(messageID:)`` to tear down an in-flight job.
+///
+/// ## Persistence
+///
+/// On ``generate(config:in:)`` the runtime inserts a placeholder
+/// ``ChatMessage`` (role `.assistant`, empty `contentParts`) into the message
+/// store. Backend progress events are forwarded as
+/// ``AudioRuntimeEvent/progress(messageID:step:totalSteps:)`` *without* touching
+/// the store — UI subscribes to events for the in-flight indicator; persistence
+/// stays minimal until the terminal step.
+///
+/// On backend completion the runtime builds a ``GeneratedMediaPayload`` of
+/// ``MediaKind/audio`` and updates the placeholder via
+/// ``MessageStore/updateMessage(_:)`` so its `contentParts` becomes a single
+/// ``MessagePart/generatedMedia(_:)`` carrying the payload, then emits
+/// ``AudioRuntimeEvent/completed(messageID:payload:)``.
+///
+/// On error or cancellation the placeholder remains in the store with its
+/// original empty `contentParts`; the runtime emits the terminal event and the
+/// host decides UX.
+///
+/// ## Concurrency
+///
+/// `@MainActor`-isolated for parity with both ports. Each in-flight generation
+/// runs on a tracked `Task` keyed to its placeholder message ID;
+/// ``cancel(messageID:)`` cancels the task and stops the backend via
+/// ``AudioGenerationService``'s `AsyncThrowingStream` cancellation hook (which
+/// calls `backend.stopGeneration()` per the service contract).
+@MainActor
+public final class AudioGenerationRuntime {
+
+    // MARK: Ports
+
+    private let service: AudioGenerationService
+    private let messageStore: any MessageStore
+    private let modelIdentifierProvider: @MainActor () -> String
+
+    // MARK: Event stream
+
+    /// Lifecycle event stream. Single-consumer by design — adapters either
+    /// iterate it directly or install an observable wrapper.
+    public let events: AsyncStream<AudioRuntimeEvent>
+    private let continuation: AsyncStream<AudioRuntimeEvent>.Continuation
+
+    /// Fan-out registry for secondary observers installed via
+    /// ``addEventTap(bufferingPolicy:)``. Separate from the primary ``events``
+    /// stream so a developer inspector can observe the same event flow the host
+    /// adapter already drains, without competing for the single-consumer
+    /// ``events`` stream.
+    private let eventTaps = EventTapRegistry<AudioRuntimeEvent>()
+
+    // MARK: In-flight state
+
+    private var inFlight: [ChatMessage.ID: Task<Void, Never>] = [:]
+
+    // MARK: Init
+
+    /// Creates a runtime that composes the supplied service and message store.
+    ///
+    /// - Parameters:
+    ///   - service: The ``AudioGenerationService`` the runtime drives.
+    ///   - messageStore: Required. Persists the placeholder and final
+    ///     `.generatedMedia` (audio) part across the generation.
+    ///   - modelIdentifier: Closure returning the identifier embedded in
+    ///     ``GeneratedMediaPayload/modelIdentifier``. Defaults to
+    ///     `"apple-tts"` — the in-core reference backend. Tests inject this
+    ///     when they want a deterministic identifier.
+    public init(
+        service: AudioGenerationService,
+        messageStore: any MessageStore,
+        modelIdentifier: (@MainActor () -> String)? = nil
+    ) {
+        self.service = service
+        self.messageStore = messageStore
+        self.modelIdentifierProvider = modelIdentifier ?? { "apple-tts" }
+        var cap: AsyncStream<AudioRuntimeEvent>.Continuation!
+        self.events = AsyncStream(bufferingPolicy: .unbounded) { cap = $0 }
+        self.continuation = cap
+    }
+
+    deinit {
+        continuation.finish()
+        eventTaps.finishAll()
+    }
+
+    // MARK: Secondary event taps
+
+    /// Installs a secondary multicast tap on this runtime's event flow.
+    ///
+    /// The returned stream receives every ``AudioRuntimeEvent`` the primary
+    /// ``events`` stream sees. The tap is independent of the primary consumer.
+    ///
+    /// - Parameter bufferingPolicy: Controls what happens when the tap consumer
+    ///   falls behind. Defaults to `.unbounded` so no events are dropped.
+    /// - Returns: An `AsyncStream` that delivers events until the runtime
+    ///   terminates, at which point the stream finishes normally.
+    public func addEventTap(
+        bufferingPolicy: AsyncStream<AudioRuntimeEvent>.Continuation.BufferingPolicy = .unbounded
+    ) -> AsyncStream<AudioRuntimeEvent> {
+        AsyncStream(bufferingPolicy: bufferingPolicy) { [eventTaps] continuation in
+            let id = eventTaps.register(continuation)
+            continuation.onTermination = { _ in
+                eventTaps.deregister(id)
+            }
+        }
+    }
+
+    // MARK: Commands
+
+    /// Begins an audio generation in the supplied session.
+    ///
+    /// Persists a placeholder ``ChatMessage`` (role `.assistant`, empty
+    /// `contentParts`) before returning, then starts a detached task that
+    /// forwards backend events through ``events``. The returned message ID is
+    /// stable for the lifetime of the generation — pass it to
+    /// ``cancel(messageID:)`` to tear down the job, and observe the terminal
+    /// event (`completed` / `failed` / `cancelled`) on ``events`` to know when
+    /// the placeholder has been finalised.
+    ///
+    /// - Parameters:
+    ///   - config: TTS generation parameters (text, voice, rate, pitch,
+    ///     output directory).
+    ///   - sessionID: The session the placeholder message belongs to.
+    /// - Returns: The placeholder ``ChatMessage/ID`` so the host can pair UI
+    ///   state with the in-flight generation.
+    /// - Throws: Persistence errors from the placeholder insert.
+    @discardableResult
+    public func generate(
+        config: SpeechGenerationConfig,
+        in sessionID: UUID
+    ) async throws -> ChatMessage.ID {
+        let placeholder = ChatMessage(
+            role: .assistant,
+            contentParts: [],
+            sessionID: sessionID
+        )
+        try await messageStore.insertMessage(placeholder)
+
+        let messageID = placeholder.id
+        let prompt = config.text
+        emit(.started(messageID: messageID, prompt: prompt))
+
+        let stream = service.generate(config: config)
+
+        // Strong capture: the consumer task owns this generation's logical unit
+        // of work and must complete (emit terminal event, clean up `inFlight`)
+        // even if the host releases its last reference to the runtime mid-flight.
+        let task = Task { @MainActor [self] in
+            await self.consume(
+                stream: stream,
+                messageID: messageID,
+                prompt: prompt,
+                placeholder: placeholder
+            )
+        }
+        inFlight[messageID] = task
+        return messageID
+    }
+
+    /// Cancels an in-flight generation by its placeholder message ID.
+    ///
+    /// Idempotent — cancelling an unknown or already-finished message is a
+    /// no-op. The terminal ``AudioRuntimeEvent/cancelled(messageID:)`` event
+    /// fires once the underlying stream observes the cancellation.
+    public func cancel(messageID: ChatMessage.ID) async {
+        guard let task = inFlight[messageID] else { return }
+        task.cancel()
+        // Don't await `task.value` — the consumer task itself emits the
+        // terminal event and removes itself from `inFlight`.
+    }
+
+    // MARK: - Stream consumer
+
+    private func consume(
+        stream: AsyncThrowingStream<AudioGenerationEvent, Error>,
+        messageID: ChatMessage.ID,
+        prompt: String,
+        placeholder: ChatMessage
+    ) async {
+        defer {
+            inFlight.removeValue(forKey: messageID)
+        }
+
+        do {
+            for try await event in stream {
+                if Task.isCancelled {
+                    emit(.cancelled(messageID: messageID))
+                    return
+                }
+                switch event {
+                case .progress(let step, let total):
+                    let resolvedTotal = total > 0 ? total : step
+                    emit(.progress(messageID: messageID, step: step, totalSteps: resolvedTotal))
+
+                case .completed(let url):
+                    let payload = GeneratedMediaPayload(
+                        kind: .audio,
+                        prompt: prompt,
+                        url: url,
+                        modelIdentifier: modelIdentifierProvider(),
+                        format: Self.audioFormat(for: url)
+                    )
+                    var finalised = placeholder
+                    finalised.contentParts = [.generatedMedia(payload)]
+                    do {
+                        try await messageStore.updateMessage(finalised)
+                    } catch {
+                        emit(.failed(messageID: messageID, error: error))
+                        return
+                    }
+                    emit(.completed(messageID: messageID, payload: payload))
+                    return
+                }
+            }
+            // Stream ended without `.completed` — treat as cancellation when the
+            // task is cancelled, otherwise report a failure so adapters surface
+            // something rather than silently abandoning the placeholder.
+            if Task.isCancelled {
+                emit(.cancelled(messageID: messageID))
+            } else {
+                emit(.failed(
+                    messageID: messageID,
+                    error: AudioGenerationServiceError.alreadyGenerating
+                ))
+            }
+        } catch is CancellationError {
+            emit(.cancelled(messageID: messageID))
+        } catch {
+            if Task.isCancelled {
+                emit(.cancelled(messageID: messageID))
+            } else {
+                emit(.failed(messageID: messageID, error: error))
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private func emit(_ event: AudioRuntimeEvent) {
+        continuation.yield(event)
+        eventTaps.broadcast(event)
+    }
+
+    /// Best-effort MIME type from the artifact's file extension. Mirrors the
+    /// "consumer derives format from URL when nil" convention on
+    /// ``GeneratedMediaPayload`` but populates it eagerly for the common
+    /// extensions the reference backend writes.
+    private static func audioFormat(for url: URL) -> String? {
+        switch url.pathExtension.lowercased() {
+        case "caf": return "audio/x-caf"
+        case "wav": return "audio/wav"
+        case "m4a", "aac": return "audio/mp4"
+        case "mp3": return "audio/mpeg"
+        default: return nil
+        }
+    }
+}
+
+// MARK: - AsyncSequence Conformance
+
+extension AudioGenerationRuntime: AsyncSequence {
+    public typealias Element = AudioRuntimeEvent
+    public typealias AsyncIterator = AsyncStream<AudioRuntimeEvent>.AsyncIterator
+
+    /// Returns an iterator over the audio runtime events in this stream.
+    ///
+    /// Allows idiomatic iteration with `for await event in runtime { … }`
+    /// instead of `for await event in runtime.events { … }`.
+    public nonisolated func makeAsyncIterator() -> AsyncStream<AudioRuntimeEvent>.AsyncIterator {
+        events.makeAsyncIterator()
+    }
+}

--- a/Sources/ManifoldRuntime/Services/AudioRuntimeEvent.swift
+++ b/Sources/ManifoldRuntime/Services/AudioRuntimeEvent.swift
@@ -1,0 +1,83 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - AudioRuntimeEvent
+//
+// Sibling to `ImageRuntimeEvent` / `VideoRuntimeEvent` for the audio-generation
+// (TTS) runtime. Per the umbrella-#1002 architectural call, audio-side runtime
+// events ride a parallel enum rather than landing as new cases on the
+// image/video/text event surfaces, so exhaustive switches in those consumers
+// stay closed.
+//
+// `AudioRuntimeEvent` is distinct from the backend-level `AudioGenerationEvent`
+// (`.progress(step:total:)` / `.completed(URL)`): the runtime translates between
+// layers, keying every event to a `ChatMessage.ID` so adapters can pair UI
+// state to the right placeholder slot.
+
+/// Events emitted by ``AudioGenerationRuntime``.
+///
+/// Sibling to ``ImageRuntimeEvent`` / ``VideoRuntimeEvent``. The runtime
+/// translates the backend-level ``AudioGenerationEvent`` (raw step + URL) into
+/// these runtime-level events keyed to a placeholder ``ChatMessage/ID``.
+///
+/// Unlike the image and video runtime events — whose terminal `.completed`
+/// carries a legacy typed payload (`ImageMessagePayload` / `VideoMessagePayload`)
+/// — audio has no legacy typed payload, so `.completed` carries the unified
+/// ``GeneratedMediaPayload`` directly (with ``MediaKind/audio``). This is the
+/// shape the persisted ``MessagePart/generatedMedia(_:)`` part already uses.
+public enum AudioRuntimeEvent: Sendable, Equatable {
+
+    /// Generation started for the placeholder message at `messageID`. The
+    /// placeholder has been persisted via ``MessageStore`` with empty
+    /// `contentParts` — adapters render a "generating" affordance until the
+    /// terminal ``completed(messageID:payload:)`` event updates the message in
+    /// place.
+    case started(messageID: ChatMessage.ID, prompt: String)
+
+    /// Render progress. `step` is 1-indexed; `totalSteps` is the backend's
+    /// estimate (after clamping). Intermediate state is **not** persisted —
+    /// adapters subscribe to events for progressive UI; persistence stays
+    /// minimal until completion.
+    case progress(messageID: ChatMessage.ID, step: Int, totalSteps: Int)
+
+    /// Generation completed; the persisted message at `messageID` now carries a
+    /// single ``MessagePart/generatedMedia(_:)`` part with `payload` (a
+    /// ``GeneratedMediaPayload`` of ``MediaKind/audio``). Adapters refresh their
+    /// view-state for `messageID` from the store (the runtime has already
+    /// written through ``MessageStore``).
+    case completed(messageID: ChatMessage.ID, payload: GeneratedMediaPayload)
+
+    /// Generation failed. Carries the underlying error so adapters can surface
+    /// user-facing error UI; the placeholder message at `messageID` remains in
+    /// the store with its original (empty) `contentParts` — the runtime emits
+    /// the event, the host decides UX.
+    case failed(messageID: ChatMessage.ID, error: any Error)
+
+    /// User cancelled before completion. The placeholder message at `messageID`
+    /// remains in the store with empty `contentParts`; same host-decides-UX
+    /// policy as ``failed(messageID:error:)``.
+    case cancelled(messageID: ChatMessage.ID)
+
+    // MARK: - Equatable
+
+    // Custom because `any Error` is not `Equatable`. Two `.failed` events are
+    // considered equal when their message IDs match — sufficient for tests
+    // asserting event sequences without forcing every error type through
+    // `Equatable`.
+    public static func == (lhs: AudioRuntimeEvent, rhs: AudioRuntimeEvent) -> Bool {
+        switch (lhs, rhs) {
+        case let (.started(lid, lp), .started(rid, rp)):
+            return lid == rid && lp == rp
+        case let (.progress(lid, ls, lt), .progress(rid, rs, rt)):
+            return lid == rid && ls == rs && lt == rt
+        case let (.completed(lid, lp), .completed(rid, rp)):
+            return lid == rid && lp == rp
+        case let (.failed(lid, _), .failed(rid, _)):
+            return lid == rid
+        case let (.cancelled(lid), .cancelled(rid)):
+            return lid == rid
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/ManifoldInferenceTests/AppleTTSBackendTests.swift
+++ b/Tests/ManifoldInferenceTests/AppleTTSBackendTests.swift
@@ -1,0 +1,154 @@
+@preconcurrency import AVFoundation
+@preconcurrency import XCTest
+import Foundation
+@testable import ManifoldInference
+
+/// Coverage for ``AppleTTSBackend`` — the zero-dependency in-core reference
+/// audio-generation backend backed by `AVSpeechSynthesizer`.
+///
+/// ## Headless rendering
+///
+/// `AVSpeechSynthesizer.write(_:toBufferCallback:)` renders to a buffer
+/// callback rather than the speaker, so it does not require an audio output
+/// device and *should* work in a headless `swift test` run. The integration
+/// test that actually renders a file is written to tolerate environments where
+/// the synthesiser declines to produce audio (no installed voices, CI sandbox):
+/// it asserts a real, non-empty audio file *when* a `.completed` event fires,
+/// and skips (via `XCTSkip`) rather than failing if the render produces no
+/// audio — the deterministic mapping logic is covered by the unit tests below
+/// regardless.
+@MainActor
+final class AppleTTSBackendTests: XCTestCase {
+
+    // MARK: - Unit: utterance mapping (deterministic, no render)
+
+    func test_makeUtterance_honoursRateAndPitch() {
+        let config = SpeechGenerationConfig(text: "hi", rate: 0.4, pitch: 1.5)
+        let utterance = AppleTTSBackend.makeUtterance(text: "hi", config: config)
+        XCTAssertEqual(utterance.speechString, "hi")
+        XCTAssertEqual(utterance.rate, 0.4, accuracy: 0.0001)
+        XCTAssertEqual(utterance.pitchMultiplier, 1.5, accuracy: 0.0001)
+    }
+
+    func test_makeUtterance_resolvesLanguageTagVoice() {
+        // A BCP-47 language tag should resolve to an installed voice when one
+        // exists for that language. If the test host has no en-US voice at all
+        // (unusual), the voice stays nil — assert only that mapping does not
+        // crash and leaves the text intact.
+        let config = SpeechGenerationConfig(text: "hi", voice: "en-US")
+        let utterance = AppleTTSBackend.makeUtterance(text: "hi", config: config)
+        XCTAssertEqual(utterance.speechString, "hi")
+        if AVSpeechSynthesisVoice(language: "en-US") != nil {
+            XCTAssertNotNil(utterance.voice, "Expected en-US to resolve to an installed voice")
+        }
+    }
+
+    func test_makeOutputURL_honoursOutputDirectory() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tts-out-\(UUID().uuidString)", isDirectory: true)
+        let url = AppleTTSBackend.makeOutputURL(directory: dir)
+        XCTAssertEqual(url.deletingLastPathComponent().standardizedFileURL, dir.standardizedFileURL)
+        XCTAssertEqual(url.pathExtension, "caf")
+    }
+
+    func test_makeOutputURL_defaultsToTemporaryDirectory() {
+        let url = AppleTTSBackend.makeOutputURL(directory: nil)
+        XCTAssertEqual(url.pathExtension, "caf")
+        // Lives under the temp directory when no output directory is supplied.
+        XCTAssertTrue(
+            url.path.hasPrefix(FileManager.default.temporaryDirectory.path),
+            "Expected default URL under the temp directory; got \(url.path)"
+        )
+    }
+
+    // MARK: - Unit: empty prompt rejected synchronously
+
+    func test_generate_emptyPrompt_throwsSynchronously() {
+        let backend = AppleTTSBackend()
+        XCTAssertThrowsError(try backend.generate(config: SpeechGenerationConfig(text: "   "))) { error in
+            XCTAssertEqual(error as? AppleTTSBackend.BackendError, .noAudioProduced)
+        }
+        XCTAssertFalse(backend.isGenerating)
+    }
+
+    // MARK: - Integration: real render to a file (tolerant)
+
+    /// Renders a short phrase with the real `AVSpeechSynthesizer` and asserts a
+    /// non-empty audio file when the synthesiser produces audio. Tolerant of
+    /// headless environments that decline to render: skips rather than fails if
+    /// no `.completed` event arrives within the deadline.
+    func test_generate_realSynthesizer_producesAudioFile() async throws {
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tts-itest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let backend = AppleTTSBackend()
+        let config = SpeechGenerationConfig(
+            text: "Hello from ManifoldKit.",
+            outputDirectory: outputDir
+        )
+
+        let stream = try backend.generate(config: config)
+
+        // Collect events with a deadline so a non-rendering host can't hang.
+        var completedURL: URL?
+        var sawProgress = false
+        let collected: Result<Void, Error> = await withTaskGroup(of: Result<(URL?, Bool), Error>.self) { group in
+            group.addTask {
+                do {
+                    var url: URL?
+                    var progress = false
+                    for try await event in stream {
+                        switch event {
+                        case .progress: progress = true
+                        case .completed(let u): url = u
+                        }
+                    }
+                    return .success((url, progress))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(20))
+                return .success((nil, false))
+            }
+            let first = await group.next()
+            group.cancelAll()
+            switch first {
+            case .success(let (url, progress)):
+                completedURL = url
+                sawProgress = progress
+                return .success(())
+            case .failure(let error):
+                return .failure(error)
+            case .none:
+                return .success(())
+            }
+        }
+
+        if case .failure(let error) = collected {
+            throw error
+        }
+
+        guard let url = completedURL else {
+            throw XCTSkip("AVSpeechSynthesizer produced no audio in this environment (no installed voices / headless sandbox); deterministic mapping is covered by the unit tests")
+        }
+
+        XCTAssertTrue(sawProgress, "Expected at least one progress tick before completion")
+
+        // The file must exist, be non-empty, and be a readable audio file.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path), "Expected audio file at \(url.path)")
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attrs[.size] as? Int) ?? 0
+        XCTAssertGreaterThan(size, 0, "Expected a non-empty audio file")
+
+        // It must open as a real audio file with a non-zero frame count.
+        let audioFile = try AVAudioFile(forReading: url)
+        XCTAssertGreaterThan(audioFile.length, 0, "Expected rendered audio frames")
+
+        // Backend returns to idle after completion.
+        XCTAssertFalse(backend.isGenerating, "Expected backend idle after completion")
+    }
+}

--- a/Tests/ManifoldRuntimeTests/AudioGenerationRuntimeTests.swift
+++ b/Tests/ManifoldRuntimeTests/AudioGenerationRuntimeTests.swift
@@ -1,0 +1,417 @@
+@preconcurrency import XCTest
+import Foundation
+import os
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+
+/// Coverage for ``AudioGenerationRuntime`` — the audio-side sibling to
+/// ``ImageGenerationRuntime`` / ``VideoGenerationRuntime``. Drives a mock
+/// ``AudioGenerationBackend`` through the service + runtime and asserts events
+/// and persistence into an in-memory ``MessageStore``.
+@MainActor
+final class AudioGenerationRuntimeTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class RuntimeMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessage] = [:]
+        var updateError: (any Error)?
+
+        func insertMessage(_ message: ChatMessage) async throws {
+            messages[message.id] = message
+        }
+
+        func updateMessage(_ message: ChatMessage) async throws {
+            if let error = updateError {
+                updateError = nil
+                throw error
+            }
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+
+        func deleteMessage(_ messageID: UUID) async throws {
+            guard messages.removeValue(forKey: messageID) != nil else {
+                throw ChatPersistenceError.messageNotFound(messageID)
+            }
+        }
+
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessage] {
+            messages.values
+                .filter { $0.sessionID == sessionID }
+                .sorted { $0.timestamp < $1.timestamp }
+        }
+
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    // MARK: - Mock audio backend
+
+    /// Controllable ``AudioGenerationBackend`` for driving the runtime. The
+    /// `generate` entrypoint is synchronous-throw (a local synth), matching the
+    /// real backend's shape. State is guarded by `OSAllocatedUnfairLock` so the
+    /// off-actor producer task can update flags without a race.
+    final class MockAudioBackend: AudioGenerationBackend, @unchecked Sendable {
+
+        struct Plan: Sendable {
+            var events: [AudioGenerationEvent] = []
+            /// When non-nil the stream throws this after yielding all events.
+            var trailingError: (any Error)?
+            /// Thrown from `generate(config:)` before a stream is returned.
+            var submitError: (any Error)?
+            /// Per-event delay — set large to give cancellation time to interleave.
+            var delayPerEventNs: UInt64 = 1_000_000  // 1ms
+        }
+
+        private struct State: Sendable {
+            var plan = Plan()
+            var isGenerating = false
+            var stopCalled = false
+        }
+
+        private let lock = OSAllocatedUnfairLock(initialState: State())
+
+        var stopCalled: Bool { lock.withLock { $0.stopCalled } }
+        var isGenerating: Bool { lock.withLock { $0.isGenerating } }
+
+        func setPlan(_ plan: Plan) {
+            lock.withLock { $0.plan = plan }
+        }
+
+        func generate(
+            config: SpeechGenerationConfig
+        ) throws -> AsyncThrowingStream<AudioGenerationEvent, Error> {
+            let plan = lock.withLock { state -> Plan in
+                state.isGenerating = true
+                return state.plan
+            }
+
+            if let error = plan.submitError {
+                lock.withLock { $0.isGenerating = false }
+                throw error
+            }
+
+            return AsyncThrowingStream { continuation in
+                let task = Task<Void, Never> { [lock] in
+                    for event in plan.events {
+                        if Task.isCancelled { break }
+                        try? await Task.sleep(nanoseconds: plan.delayPerEventNs)
+                        if Task.isCancelled { break }
+                        continuation.yield(event)
+                    }
+                    lock.withLock { $0.isGenerating = false }
+                    if let trailing = plan.trailingError, !Task.isCancelled {
+                        continuation.finish(throwing: trailing)
+                    } else {
+                        continuation.finish()
+                    }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+
+        func stopGeneration() {
+            lock.withLock {
+                $0.stopCalled = true
+                $0.isGenerating = false
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRuntime(
+        backend: MockAudioBackend = MockAudioBackend(),
+        modelIdentifier: String = "test-tts-model"
+    ) -> (
+        runtime: AudioGenerationRuntime,
+        store: RuntimeMessageStore,
+        backend: MockAudioBackend
+    ) {
+        let store = RuntimeMessageStore()
+        let service = AudioGenerationService(backend: backend)
+        let runtime = AudioGenerationRuntime(
+            service: service,
+            messageStore: store,
+            modelIdentifier: { modelIdentifier }
+        )
+        return (runtime, store, backend)
+    }
+
+    private static let config = SpeechGenerationConfig(text: "hello world")
+
+    enum TestError: Error { case deadlineElapsed }
+
+    /// Drains ``AudioGenerationRuntime/events`` until `predicate` returns true
+    /// or `deadline` elapses.
+    private func collectEvents(
+        from runtime: AudioGenerationRuntime,
+        until predicate: @escaping @Sendable (AudioRuntimeEvent) -> Bool,
+        deadline: Duration = .seconds(5)
+    ) async throws -> [AudioRuntimeEvent] {
+        let task = Task {
+            var collected: [AudioRuntimeEvent] = []
+            for await event in runtime.events {
+                collected.append(event)
+                if predicate(event) { break }
+            }
+            return collected
+        }
+        return try await withThrowingTaskGroup(of: [AudioRuntimeEvent].self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: deadline)
+                task.cancel()
+                throw TestError.deadlineElapsed
+            }
+            let first = try await group.next()
+            group.cancelAll()
+            return first ?? []
+        }
+    }
+
+    private static let isTerminal: @Sendable (AudioRuntimeEvent) -> Bool = { event in
+        switch event {
+        case .completed, .failed, .cancelled: return true
+        default: return false
+        }
+    }
+
+    // MARK: - Test 1: Happy path persists .generatedMedia/audio
+
+    func test_generate_happyPath_persistsAudioAndEmitsEvents() async throws {
+        let audioURL = URL(fileURLWithPath: "/tmp/tts-\(UUID().uuidString).caf")
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(events: [
+            .progress(step: 1, total: 3),
+            .progress(step: 2, total: 3),
+            .completed(audioURL)
+        ]))
+
+        let (runtime, store, _) = makeRuntime(backend: backend)
+        let sessionID = UUID()
+
+        let messageID = try await runtime.generate(
+            config: SpeechGenerationConfig(text: "a spoken sentence"),
+            in: sessionID
+        )
+
+        let events = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        // started → progress → progress → completed
+        XCTAssertEqual(events.count, 4, "Expected started + 2× progress + completed; got \(events)")
+
+        guard case .started(let startID, let prompt) = events[0] else {
+            return XCTFail("Expected .started at index 0, got \(events[0])")
+        }
+        XCTAssertEqual(startID, messageID)
+        XCTAssertEqual(prompt, "a spoken sentence")
+
+        guard case .progress(let pid, let step, let total) = events[1] else {
+            return XCTFail("Expected .progress at index 1, got \(events[1])")
+        }
+        XCTAssertEqual(pid, messageID)
+        XCTAssertEqual(step, 1)
+        XCTAssertEqual(total, 3)
+
+        guard case .completed(let cid, let payload) = events[3] else {
+            return XCTFail("Expected .completed at index 3, got \(events[3])")
+        }
+        XCTAssertEqual(cid, messageID)
+        XCTAssertEqual(payload.kind, .audio)
+        XCTAssertEqual(payload.prompt, "a spoken sentence")
+        XCTAssertEqual(payload.url, audioURL)
+        XCTAssertEqual(payload.modelIdentifier, "test-tts-model")
+        XCTAssertEqual(payload.format, "audio/x-caf")
+
+        // Persistence: placeholder updated to carry a .generatedMedia audio part.
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.id, messageID)
+        XCTAssertEqual(stored.first?.contentParts.count, 1)
+        guard case .generatedMedia(let storedPayload) = stored.first?.contentParts.first else {
+            return XCTFail("Expected stored part to be .generatedMedia")
+        }
+        XCTAssertEqual(storedPayload.kind, .audio)
+        XCTAssertEqual(storedPayload.url, audioURL)
+        XCTAssertEqual(storedPayload.modelIdentifier, "test-tts-model")
+    }
+
+    // MARK: - Test 2: total==0 falls back to step
+
+    func test_generate_zeroTotal_fallsBackToStep() async throws {
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(events: [
+            .progress(step: 5, total: 0),
+            .completed(URL(fileURLWithPath: "/tmp/o.caf"))
+        ]))
+
+        let (runtime, _, _) = makeRuntime(backend: backend)
+        _ = try await runtime.generate(config: Self.config, in: UUID())
+
+        let events = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        let progress = events.compactMap { event -> (Int, Int)? in
+            if case .progress(_, let s, let t) = event { return (s, t) }
+            return nil
+        }
+        XCTAssertEqual(progress.first?.0, 5)
+        XCTAssertEqual(progress.first?.1, 5, "total==0 should fall back to step")
+    }
+
+    // MARK: - Test 3: backend submission failure emits .failed
+
+    func test_generate_submissionFailure_emitsFailed() async throws {
+        struct SynthError: Error {}
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(submitError: SynthError()))
+
+        let (runtime, store, _) = makeRuntime(backend: backend)
+        let sessionID = UUID()
+
+        // The runtime's `generate` does NOT rethrow a backend submit error
+        // (the synchronous-throw service path surfaces it through the stream);
+        // it inserts the placeholder and emits .failed on the event stream.
+        let messageID = try await runtime.generate(config: Self.config, in: sessionID)
+
+        let events = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 1, "Placeholder must be inserted even on submission failure")
+
+        guard case .failed(let fid, _) = events.last else {
+            return XCTFail("Expected terminal .failed event, got \(events.last as Any)")
+        }
+        XCTAssertEqual(fid, messageID)
+    }
+
+    // MARK: - Test 4: mid-stream error emits .failed, placeholder stays empty
+
+    func test_generate_streamError_emitsFailedAndLeavesPlaceholderEmpty() async throws {
+        struct RenderError: Error {}
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(
+            events: [.progress(step: 1, total: 4)],
+            trailingError: RenderError()
+        ))
+
+        let (runtime, store, _) = makeRuntime(backend: backend)
+        let sessionID = UUID()
+
+        let messageID = try await runtime.generate(config: Self.config, in: sessionID)
+        let events = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        guard case .failed(let fid, _) = events.last else {
+            return XCTFail("Expected .failed terminal, got \(events.last as Any)")
+        }
+        XCTAssertEqual(fid, messageID)
+
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertTrue(
+            stored.first?.contentParts.isEmpty ?? false,
+            "Expected placeholder contentParts empty on failure"
+        )
+    }
+
+    // MARK: - Test 5: cancellation tears down and leaves placeholder empty
+
+    func test_cancel_emitsCancelledAndLeavesPlaceholderEmpty() async throws {
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(
+            events: [
+                .progress(step: 1, total: 5),
+                .progress(step: 2, total: 5),
+                .progress(step: 3, total: 5),
+                .completed(URL(fileURLWithPath: "/tmp/never.caf"))
+            ],
+            delayPerEventNs: 50_000_000  // 50ms per event — lets cancel interleave
+        ))
+
+        let (runtime, store, mockBackend) = makeRuntime(backend: backend)
+        let sessionID = UUID()
+
+        let messageID = try await runtime.generate(config: Self.config, in: sessionID)
+
+        // Wait for the first progress event so the consumer task is running.
+        let preCancelTask = Task {
+            var seen: [AudioRuntimeEvent] = []
+            for await event in runtime.events {
+                seen.append(event)
+                if case .progress = event { break }
+            }
+            return seen
+        }
+        _ = await preCancelTask.value
+
+        await runtime.cancel(messageID: messageID)
+
+        let terminal = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        guard case .cancelled(let cid) = terminal.last else {
+            return XCTFail("Expected .cancelled terminal, got \(terminal.last as Any)")
+        }
+        XCTAssertEqual(cid, messageID)
+
+        // Backend was told to stop via the service's cancellation hook.
+        XCTAssertTrue(mockBackend.stopCalled, "Expected backend.stopGeneration() on cancel")
+
+        let stored = try await store.fetchMessages(for: sessionID)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertTrue(
+            stored.first?.contentParts.isEmpty ?? false,
+            "Expected placeholder contentParts empty on cancel; got \(stored.first?.contentParts as Any)"
+        )
+    }
+
+    // MARK: - Test 6: cancel for unknown ID is a no-op
+
+    func test_cancel_unknownMessageID_isNoOp() async {
+        let (runtime, _, _) = makeRuntime()
+        await runtime.cancel(messageID: UUID())
+    }
+
+    // MARK: - Test 7: store update failure on completion emits .failed
+
+    func test_generate_storeUpdateError_emitsFailedNotCompleted() async throws {
+        struct PersistenceFailure: Error {}
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(events: [.completed(URL(fileURLWithPath: "/tmp/ok.caf"))]))
+
+        let (runtime, store, _) = makeRuntime(backend: backend)
+        store.updateError = PersistenceFailure()
+
+        let sessionID = UUID()
+        let messageID = try await runtime.generate(config: Self.config, in: sessionID)
+        let events = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        guard case .failed(let fid, _) = events.last else {
+            return XCTFail("Expected .failed on store update error, got \(events.last as Any)")
+        }
+        XCTAssertEqual(fid, messageID)
+    }
+
+    // MARK: - Test 8: modelIdentifier injected into payload
+
+    func test_generate_modelIdentifier_appearsInPayload() async throws {
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(events: [.completed(URL(fileURLWithPath: "/tmp/v.caf"))]))
+
+        let (runtime, _, _) = makeRuntime(backend: backend, modelIdentifier: "apple-tts-v2")
+
+        _ = try await runtime.generate(config: Self.config, in: UUID())
+        let events = try await collectEvents(from: runtime, until: Self.isTerminal)
+
+        guard case .completed(_, let payload) = events.last else {
+            return XCTFail("Expected .completed, got \(events.last as Any)")
+        }
+        XCTAssertEqual(payload.modelIdentifier, "apple-tts-v2")
+    }
+}

--- a/docs/plans/audio-generation-modality.md
+++ b/docs/plans/audio-generation-modality.md
@@ -1,0 +1,89 @@
+# Audio-generation modality (the 3rd media modality for P4)
+
+**Status:** direction set 2026-06-14 · **Decision owner:** @roryford
+
+## Decision
+
+- **Core ships TTS** as the concrete audio-generation modality: text → spoken-audio
+  *artifact*, one-shot, riding the `MediaGeneration<Output>` seam (`.progress` → optional
+  `.preview` → `.completed`, stored as a `generatedMedia` `MessagePart`).
+- **Music gen is NOT shipped by core.** Too much surface (model zoo, licensing, diffusion
+  weights). Instead, **leave the door open**: the generic seam is the extension point, so a
+  **consumer or companion** can define a music backend (Stable Audio Open locally, Lyria via
+  cloud) without forking core.
+- **Real-time/duplex** music (Magenta RealTime 2) stays out — different live-session
+  lifecycle, belongs with the realtime-voice surface (#1415).
+- **Pushing impls to companions is fine** — core owns the contract + (optionally) a zero-dep
+  Apple reference backend; heavy model impls live in companions.
+
+## Why this *confirms* P4 (not shrinks it)
+
+"Let consumers define music" is only possible if `MessagePart` has a **generic**
+`generatedMedia(GeneratedMediaPayload)` case rather than hardcoded per-modality cases. A
+fixed `generatedAudio` case would leave a consumer's music output nowhere to persist/render.
+So:
+
+- **TTS is the in-core proof** of the generic seam.
+- **Music is the out-of-tree modality** that exercises the acceptance metric *"a new modality
+  lands in ≤3 EDGE files"* — now load-bearing, not theoretical.
+
+P4 proceeds. The seam (P4a) is the extensibility contract; the collapse (P4b/P4c) is what
+makes the extension point real.
+
+## Shape
+
+- `AudioGeneration = MediaGeneration<AudioOutput>` (one-shot), parallel to `ImageGeneration`
+  / `VideoGeneration`. A real typealias, not a stub.
+- `GeneratedMediaPayload` carries audio (file URL + format + duration + sample rate). This is
+  the shape a consumer's music backend reuses — same payload, different backend + config.
+- `SpeechGenerationConfig` (text, voice, rate, pitch…) is the core-shipped config. Music
+  config is defined by whoever ships the music backend.
+
+## TTS model picks (local-first; companions OK)
+
+| Tier | Option | License | Platform | Placement |
+|------|--------|---------|----------|-----------|
+| Zero-dep reference | **Apple `AVSpeechSynthesizer`** (+ Personal Voice) | none (OS) | macOS + iOS | could ship **in core** — no external dep |
+| High-quality local | **Kokoro** via `Blaizzy/mlx-audio-swift` | Apache-2.0 (clean) | macOS + iOS | **companion** (mlx-audio dep) |
+| Conversational | **CSM** via mlx-audio-swift | ⚠️ verify | macOS + iOS | companion |
+| Cloud | a cloud TTS provider | n/a | all | `ManifoldCloudSaaS` |
+
+Apple `AVSpeechSynthesizer` is the natural zero-dependency reference backend (proves the seam
+end-to-end with no model download); Kokoro/CSM via mlx-audio-swift are the quality upgrades
+and live in a companion.
+
+## TTS / ManifoldVoice boundary — RESOLVED (2026-06-14)
+
+There are **three distinct lanes**; they share TTS *engines* but not protocols. Resolved by
+reading the actual `ManifoldVoice` surface (`SpeechSynthesizing.speak(_:) async` /
+`stopSpeaking()` — ephemeral playback, no output, driven by `VoiceConversationController`).
+
+| Lane | Surface | Output | Lifecycle | Owner |
+|------|---------|--------|-----------|-------|
+| **1 — Live voice I/O** | `ManifoldVoice` (`SpeechSynthesizing`, `SpeechTranscribing`, wake word, `VoiceConversationController`) | none — plays to speaker | `speak`/`stop`, fire-and-forget | exists today, **stays** |
+| **2 — Audio artifact gen** | **P4** `AudioGeneration = MediaGeneration<AudioOutput>` (TTS + consumer music) | persisted file (`GeneratedMediaPayload`) | `.progress` → `.completed` stream, stored as `generatedMedia` | **new (this design)** |
+| **3 — Realtime full-duplex voice agent** | a `VoiceBackend`-style streaming protocol (OpenAI-Realtime-style) | live bidirectional stream | continuous duplex session | **#1415** (parking-lot) |
+
+**Resolution:** P4 TTS does **not** absorb or supersede `ManifoldVoice`. Lane 1 (interact)
+and Lane 2 (generate-artifact) are different contracts — one plays audio, one renders audio
+to a file with a progress stream. **Share the engine, not the protocol:** a single TTS engine
+adapter (Apple `AVSpeechSynthesizer`, Kokoro, …) can back *both* `SpeechSynthesizing.speak`
+(Lane 1, via `AVSpeechSynthesizer` playback) *and* the Lane 2 media backend (via
+`AVSpeechSynthesizer.write(_:toBufferCallback:)` → file). The protocols stay separate because
+the roles differ. Lane 3 (#1415) is a third surface, unrelated to both.
+
+### Remaining sub-decisions (resolve before P4 implementation)
+- [ ] **Core reference backend?** Ship Apple `AVSpeechSynthesizer` as an in-core audio backend
+  (zero-dep, proves the seam), or keep core contract-only and put even the Apple backend in a
+  module/companion?
+- [ ] **Companion home for mlx-audio TTS** — add to `manifold-mlx`, or a new `manifold-audio`
+  companion (keeps mlx-audio-swift out of the diffusion package).
+- [ ] **Music extension example** — ship a doc/sample showing a consumer wiring a music
+  backend onto the seam (proves the ≤3-EDGE-files claim), even though core doesn't ship music.
+
+## Consequence for the cleanup train
+
+P4 is **not deferred** (see `pre-1.0-api-cleanup-train.md` §B1). P4a (additive seam, real
+`AudioGeneration` typealias + `SpeechGenerationConfig`) lands non-breaking; P4b/P4c (collapse
++ delete clones) ship as a **lockstep ManifoldKit + manifold-mlx release**. Core's only audio
+*backend* is optionally Apple `AVSpeechSynthesizer`; everything heavier is companion/consumer.


### PR DESCRIPTION
Closes #1904. Builds the **producer end** of the `AudioGeneration` seam end-to-end, proving the 3rd media modality. The seam (`AudioGeneration = MediaGeneration<SpeechGenerationConfig>`) and persistence (`MediaKind.audio` / `GeneratedMediaPayload` / `MessagePart.generatedMedia`) already shipped; before this PR nothing **produced** an audio stream and there was no `AudioGenerationRuntime`. This adds the missing backend + service + runtime, mirroring the Image/Video layering exactly.

**One PR, no phased split** (per repo hygiene). Backend + runtime + service + tests + design doc ship together.

## What was built

| Layer | Type | Module | Notes |
|-------|------|--------|-------|
| Backend event | `AudioGenerationEvent` | `ManifoldModelCatalog` | `.progress` / `.completed`; sibling to Image/VideoGenerationEvent. One-shot, no preview. |
| Backend protocol | `AudioGenerationBackend` | `ManifoldContract` | `AnyObject + Sendable`, sync-throw `generate(config:)` + `stopGeneration()` + `isGenerating`. **No `loadModel`** — system voices are always resident. |
| Reference backend | `AppleTTSBackend` | `ManifoldInference` | Zero-dependency, in-core. Uses `AVSpeechSynthesizer.write(_:toBufferCallback:)` to render text → CAF file (Lane 2 / artifact-gen, **not** speaker playback). Honours `SpeechGenerationConfig` (text, voice, rate, pitch, outputDirectory). `NSLock` isolation per `ImageGenerationBackend`'s rationale. macOS + iOS. |
| Service | `AudioGenerationService` | `ManifoldInference` | `@MainActor @Observable`, `idle → generating → idle`. Sync-throw `generate` (like image service), holds-backend-directly (like video service). Defaults to `AppleTTSBackend()`. |
| Runtime event | `AudioRuntimeEvent` | `ManifoldRuntime` | `.started/.progress/.completed/.failed/.cancelled`; parallel enum so other consumers' switches stay closed. |
| Runtime | `AudioGenerationRuntime` | `ManifoldRuntime` | Mirrors `Video`/`ImageGenerationRuntime`: placeholder → progress events → terminal persist via `MessageStore`, event taps, per-message `Task` tracking, cancel tear-down. |

### Files added
- `Sources/ManifoldModelCatalog/AudioGenerationEvent.swift`
- `Sources/ManifoldContract/AudioGenerationBackend.swift`
- `Sources/ManifoldInference/Services/AppleTTSBackend.swift`
- `Sources/ManifoldInference/Services/AudioGenerationService.swift`
- `Sources/ManifoldRuntime/Services/AudioRuntimeEvent.swift`
- `Sources/ManifoldRuntime/Services/AudioGenerationRuntime.swift`
- `Tests/ManifoldRuntimeTests/AudioGenerationRuntimeTests.swift`
- `Tests/ManifoldInferenceTests/AppleTTSBackendTests.swift`
- `docs/plans/audio-generation-modality.md` (design source, committed with the PR)

## Decisions
- **Module placement** follows the Image/Video siblings: event enum in `ManifoldModelCatalog`, backend protocol in `ManifoldContract` (the pure kernel — image's protocol lives here), the concrete `AVFoundation` impl + service in `ManifoldInference` (the engine), runtime + runtime-event in `ManifoldRuntime`. No new target, **no `Package.swift` / `Package.resolved` change**.
- **`.completed` carries `GeneratedMediaPayload` directly** (not a typed `AudioMessagePayload`) — audio has no legacy typed payload, and the unified payload (with `MediaKind.audio`) is exactly the shape the persisted `.generatedMedia` part already uses. The runtime sets `format` from the file extension (`audio/x-caf`).
- **No `loadModel` on the audio backend** — the reference engine needs no model download, so the protocol omits the load lifecycle to keep the seam minimal. A heavier companion backend (Kokoro/CSM via mlx-audio) loads weights internally.
- **CAF output** — the native format `AVAudioFile` writes from the synthesiser's buffer format with no re-encode.

## Headless rendering
`AVSpeechSynthesizer.write(...)` **renders headless on macOS** in this environment — the real-synthesizer integration test rendered a non-empty audio file with audio frames in ~0.35s and the `XCTSkip` fallback was not hit. The test is written to tolerate non-rendering sandboxes (skips rather than fails if no `.completed` arrives within the deadline); the deterministic mapping logic is unit-tested regardless.

## Test coverage
- `AudioGenerationRuntimeTests` (8, XCTest, in-memory `MessageStore`): happy-path persists `.generatedMedia`/audio; `total==0` falls back to step; backend submit failure → `.failed`; mid-stream error → `.failed` + empty placeholder; cancel → `.cancelled` + `stopGeneration()` called + empty placeholder; unknown-ID cancel no-op; store-update failure → `.failed` not `.completed`; `modelIdentifier` in payload.
- `AppleTTSBackendTests` (6, XCTest): utterance rate/pitch/voice mapping, output-URL directory honouring + temp fallback, empty-prompt synchronous throw, and the tolerant real-render integration test.
- Sabotage-verified (`.audio → .video` fails the happy-path assertion) then reverted.

## Gate
- `swift build` ✅
- `swift build --build-tests` ✅ (no exhaustive-switch breakage anywhere — `MediaKind.audio` and the unified payload already existed)
- `swift test --filter AudioGenerationRuntimeTests` ✅ 8/8
- `swift test --filter AppleTTSBackendTests` ✅ 6/6

## Out of scope (per #1904)
Music generation, mlx-audio companion backend, realtime/duplex (#1415), UI views — backend + runtime only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)