### PR TITLE
feat(ui): wire audio generation into ChatViewModel + message rendering (#1904)

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -104,3 +104,5 @@ API breakage: struct InferenceMetric has been removed
 API breakage: protocol InferenceMetricSink has been removed
 API breakage: class InMemoryMetricSink has been removed
 API breakage: enumelement UnloadReason.idleTimeout has been added as a new enum case
+API breakage: constructor ManifoldBootstrap.init(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:isInMemory:) has been removed
+API breakage: func ManifoldBootstrap.build(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:) has been renamed to func build(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:audioGenerationService:)

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -228,7 +228,6 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         videoGenerationService videoService: VideoGenerationService? = nil,
-        audioGenerationService: AudioGenerationService? = nil,
         webSearchRuntime: (any WebSearchRuntime)? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
@@ -236,7 +235,11 @@ public final class ManifoldBootstrap {
         hookRegistry: HookRegistry? = nil,
         enableResumableRuns: Bool = false,
         makeModelContainer: @MainActor () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() },
-        isInMemory: Bool = false
+        isInMemory: Bool = false,
+        // Appended at the tail to keep the existing parameter positions stable
+        // for the API source-compat digester (#1904 UI fast-follow). Grouped
+        // with the other *GenerationService params at the call site by label.
+        audioGenerationService: AudioGenerationService? = nil
     ) throws {
         // Capture the previous configuration before any mutation so a failure
         // partway through bootstrap leaves `ManifoldConfiguration.shared`
@@ -508,14 +511,16 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         videoGenerationService: VideoGenerationService? = nil,
-        audioGenerationService: AudioGenerationService? = nil,
         webSearchRuntime: (any WebSearchRuntime)? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
         sessionToolSources: [any SessionToolSource] = [],
         hookRegistry: HookRegistry? = nil,
         enableResumableRuns: Bool = false,
-        makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() }
+        makeModelContainer: @MainActor @escaping () throws -> ModelContainer = { try ModelContainerFactory.makeContainer() },
+        // Appended at the tail to keep existing parameter positions stable for
+        // the API source-compat digester (#1904 UI fast-follow).
+        audioGenerationService: AudioGenerationService? = nil
     ) -> (progress: AsyncStream<RuntimeBootstrapMilestone>, task: Task<ManifoldBootstrap, any Error>) {
         let (stream, continuation) = AsyncStream.makeStream(
             of: RuntimeBootstrapMilestone.self,

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -179,6 +179,17 @@ public final class ManifoldBootstrap {
     /// `nil` when ``videoGenerationService`` is `nil`.
     public let videoRuntime: VideoGenerationRuntime?
 
+    /// The audio-generation (TTS) service, when the host opted in to audio
+    /// generation. `nil` when ``ManifoldBootstrap`` was constructed without an
+    /// `audioGenerationService` parameter.
+    public let audioGenerationService: AudioGenerationService?
+
+    /// The audio-generation runtime, pre-wired against ``audioGenerationService``
+    /// and ``persistence``. Pass to ``ChatViewModel/configure(audioRuntime:)``
+    /// to enable audio generation in the chat view model.
+    /// `nil` when ``audioGenerationService`` is `nil`.
+    public let audioRuntime: AudioGenerationRuntime?
+
     /// The web-search runtime, when the host opted in to web search.
     ///
     /// Unlike image/video, the concrete implementation
@@ -217,6 +228,7 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         videoGenerationService videoService: VideoGenerationService? = nil,
+        audioGenerationService: AudioGenerationService? = nil,
         webSearchRuntime: (any WebSearchRuntime)? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
@@ -297,6 +309,10 @@ public final class ManifoldBootstrap {
             self.videoRuntime = videoService.map {
                 VideoGenerationRuntime(service: $0, messageStore: resolvedPersistence)
             }
+            self.audioGenerationService = audioGenerationService
+            self.audioRuntime = audioGenerationService.map {
+                AudioGenerationRuntime(service: $0, messageStore: resolvedPersistence)
+            }
             self.webSearchRuntime = webSearchRuntime
             self._isInMemory = isInMemory
         } catch {
@@ -316,6 +332,7 @@ public final class ManifoldBootstrap {
         usageStore: SwiftDataUsageStore,
         imageGenerationService: ImageGenerationService? = nil,
         videoGenerationService: VideoGenerationService? = nil,
+        audioGenerationService: AudioGenerationService? = nil,
         webSearchRuntime: (any WebSearchRuntime)? = nil,
         ragService: RAGService? = nil,
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
@@ -365,6 +382,15 @@ public final class ManifoldBootstrap {
             )
         } else {
             self.videoRuntime = nil
+        }
+        self.audioGenerationService = audioGenerationService
+        if let audioGenerationService {
+            self.audioRuntime = AudioGenerationRuntime(
+                service: audioGenerationService,
+                messageStore: persistence
+            )
+        } else {
+            self.audioRuntime = nil
         }
         self.webSearchRuntime = webSearchRuntime
     }
@@ -482,6 +508,7 @@ public final class ManifoldBootstrap {
         inferenceService: InferenceService? = nil,
         imageGenerationService: ImageGenerationService? = nil,
         videoGenerationService: VideoGenerationService? = nil,
+        audioGenerationService: AudioGenerationService? = nil,
         webSearchRuntime: (any WebSearchRuntime)? = nil,
         diagnostics: DiagnosticsService = DiagnosticsService(),
         runtimeOptions: ConversationRuntimeOptions = ConversationRuntimeOptions(),
@@ -541,6 +568,7 @@ public final class ManifoldBootstrap {
                     usageStore: usageStore,
                     imageGenerationService: imageGenerationService,
                     videoGenerationService: videoGenerationService,
+                    audioGenerationService: audioGenerationService,
                     webSearchRuntime: webSearchRuntime,
                     ragService: ragService,
                     runtimeOptions: runtimeOptions,
@@ -665,5 +693,6 @@ extension ManifoldBootstrap: ChatRuntimeBootstrap {
     public var diagnosticsService: DiagnosticsService { diagnostics }
     public var imageGenerationRuntime: ImageGenerationRuntime? { imageRuntime }
     public var videoGenerationRuntime: VideoGenerationRuntime? { videoRuntime }
+    public var audioGenerationRuntime: AudioGenerationRuntime? { audioRuntime }
     public var webSearchRuntimePort: (any WebSearchRuntime)? { webSearchRuntime }
 }

--- a/Sources/ManifoldRuntime/Services/ChatRuntimeBootstrap.swift
+++ b/Sources/ManifoldRuntime/Services/ChatRuntimeBootstrap.swift
@@ -11,5 +11,12 @@ public protocol ChatRuntimeBootstrap: AnyObject {
     var diagnosticsService: DiagnosticsService { get }
     var imageGenerationRuntime: ImageGenerationRuntime? { get }
     var videoGenerationRuntime: VideoGenerationRuntime? { get }
+    var audioGenerationRuntime: AudioGenerationRuntime? { get }
     var webSearchRuntimePort: (any WebSearchRuntime)? { get }
+}
+
+public extension ChatRuntimeBootstrap {
+    /// Audio generation is opt-in; bootstraps that don't wire a TTS runtime
+    /// inherit this `nil` default so existing conformers stay source-compatible.
+    var audioGenerationRuntime: AudioGenerationRuntime? { nil }
 }

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+AudioGeneration.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+AudioGeneration.swift
@@ -1,0 +1,254 @@
+import Foundation
+import ManifoldRuntime
+import ManifoldInference
+
+// MARK: - ChatViewModel + AudioGeneration
+//
+// Host-facing entry surface for `AudioGenerationRuntime` (TTS). Mirrors the role
+// `ChatViewModel+VideoGeneration` plays for `VideoGenerationRuntime`: forwards
+// commands to the runtime and maps `AudioRuntimeEvent` back to `@Observable`
+// state on `@MainActor`.
+//
+// The runtime is **optional** — chat-only hosts never call
+// `configure(audioRuntime:)` and the audio methods throw `.notConfigured`.
+// The text, image, and video paths on `ChatViewModel` are unchanged.
+//
+// Two shape differences from the video sibling, both following the
+// already-shipped runtime (PR #1908):
+//   - The submit config (`SpeechGenerationConfig`) carries the text itself, so
+//     `generateSpeech` takes no separate prompt argument and mirrors the
+//     runtime's `generate(config:in:)`.
+//   - `AudioRuntimeEvent.completed` carries a `GeneratedMediaPayload` directly
+//     (audio has no legacy typed payload), and progress is reported as
+//     `step`/`totalSteps` rather than a `fractionComplete` Double, so the
+//     handler derives the fraction.
+
+/// Per-message progress snapshot for in-flight or completed audio generations.
+///
+/// Populated by ``ChatViewModel/audioGenerationProgress`` from
+/// ``AudioRuntimeEvent`` values. Hosts subscribe via `@Observable` to render
+/// progress UIs keyed off the placeholder message ID returned by
+/// ``ChatViewModel/generateSpeech(config:)``.
+public struct AudioGenerationProgress: Sendable, Equatable {
+
+    /// The placeholder ``ChatMessage/ID`` the generation is writing to.
+    public let messageID: UUID
+
+    /// User-supplied prompt (the synthesised text) the generation was started
+    /// with.
+    public let prompt: String
+
+    /// Backend-estimated fraction complete, 0.0–1.0. `0` while queued or
+    /// waiting for the first progress event. Derived from the runtime's
+    /// `step`/`totalSteps` progress events.
+    public let fractionComplete: Double
+
+    /// `true` once a terminal event (completed / failed / cancelled) has been
+    /// observed. UI can stop animating progress affordances at this point.
+    public let isComplete: Bool
+
+    /// Localized error description if the generation failed; `nil` otherwise.
+    /// Set independently of ``isComplete`` so cancellation surfaces as
+    /// `isComplete = true, error = nil`.
+    public let error: String?
+
+    public init(
+        messageID: UUID,
+        prompt: String,
+        fractionComplete: Double,
+        isComplete: Bool,
+        error: String?
+    ) {
+        self.messageID = messageID
+        self.prompt = prompt
+        self.fractionComplete = fractionComplete
+        self.isComplete = isComplete
+        self.error = error
+    }
+}
+
+/// Errors thrown by ``ChatViewModel`` audio-generation entry methods.
+public enum ChatViewModelAudioError: Error, LocalizedError, Equatable {
+
+    /// ``ChatViewModel/configure(audioRuntime:)`` was never called.
+    case notConfigured
+
+    /// ``ChatViewModel/activeSession`` is `nil` — there is no conversation
+    /// to insert the placeholder audio message into.
+    case noActiveConversation
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Audio generation is not configured. Install an AudioGenerationRuntime via configure(audioRuntime:)."
+        case .noActiveConversation:
+            return "No active conversation. Create or select a session before generating audio."
+        }
+    }
+}
+
+@MainActor
+extension ChatViewModel {
+
+    // MARK: - Runtime install
+
+    /// The audio-generation runtime, if the host wired one up. `nil` for
+    /// chat-only hosts; audio methods throw ``ChatViewModelAudioError/notConfigured``
+    /// in that case.
+    public var audioRuntime: AudioGenerationRuntime? {
+        _audioRuntime
+    }
+
+    /// Install an ``AudioGenerationRuntime``. Typically called by
+    /// ``ManifoldBootstrap`` when the host opts in to audio generation;
+    /// app code can also call it directly.
+    ///
+    /// Latest-wins: a prior runtime's event-drain task is cancelled before
+    /// the new one starts, so reconfiguring at runtime is safe. The view
+    /// model holds the runtime strongly for the rest of its lifetime — same
+    /// ownership model as ``videoRuntime``.
+    public func configure(audioRuntime: AudioGenerationRuntime) {
+        _audioRuntime = audioRuntime
+        startAudioRuntimeEventDrain(runtime: audioRuntime)
+    }
+
+    /// Cancels the existing audio-runtime drain task (if any) and starts a
+    /// fresh one for `runtime`.
+    ///
+    /// Weak capture mirrors the video-runtime drain: the host owns the view
+    /// model, and the drain task must not keep old test or preview instances
+    /// alive after their bootstrap and SwiftData container tear down.
+    private func startAudioRuntimeEventDrain(runtime: AudioGenerationRuntime) {
+        audioRuntimeEventDrainTask?.cancel()
+        audioRuntimeEventDrainTask = Task { [weak self] in
+            for await event in runtime.events {
+                if Task.isCancelled { return }
+                guard let self else { return }
+                self.handle(audioRuntimeEvent: event)
+            }
+        }
+    }
+
+    // MARK: - Commands
+
+    /// Begin an audio (text-to-speech) generation in the active conversation.
+    ///
+    /// Inserts a placeholder ``ChatMessage`` immediately (via the
+    /// runtime's `MessageStore` port) and dispatches a consumer task that
+    /// updates ``audioGenerationProgress`` from runtime events. Returns the
+    /// placeholder message ID synchronously so the caller can pair UI state
+    /// with the in-flight generation.
+    ///
+    /// Unlike ``generateVideo(prompt:config:)``, there is no separate prompt
+    /// argument — ``SpeechGenerationConfig/text`` carries the text to
+    /// synthesise. This mirrors the runtime's `generate(config:in:)`.
+    ///
+    /// - Parameter config: TTS generation parameters (text, voice, rate, …).
+    /// - Returns: The placeholder ``ChatMessage/ID``.
+    /// - Throws: ``ChatViewModelAudioError/notConfigured`` if no runtime is
+    ///   installed, ``ChatViewModelAudioError/noActiveConversation`` if
+    ///   there is no active session, or any persistence / backend error from
+    ///   the generation submit.
+    @discardableResult
+    public func generateSpeech(
+        config: SpeechGenerationConfig
+    ) async throws -> UUID {
+        guard let runtime = _audioRuntime else {
+            throw ChatViewModelAudioError.notConfigured
+        }
+        guard let sessionID = activeSessionID else {
+            throw ChatViewModelAudioError.noActiveConversation
+        }
+        return try await runtime.generate(
+            config: config,
+            in: sessionID
+        )
+    }
+
+    /// Cancel an in-flight audio generation by its placeholder message ID.
+    ///
+    /// Idempotent — cancelling an unknown or already-finished generation is
+    /// a no-op. The terminal ``AudioRuntimeEvent/cancelled(messageID:)``
+    /// event flips ``AudioGenerationProgress/isComplete`` to `true` once the
+    /// underlying stream observes the cancellation.
+    public func cancelAudioGeneration(messageID: UUID) async {
+        guard let runtime = _audioRuntime else { return }
+        await runtime.cancel(messageID: messageID)
+    }
+
+    // MARK: - Event drain
+
+    /// Maps an incoming ``AudioRuntimeEvent`` to mutations on
+    /// ``audioGenerationProgress``. Sibling to
+    /// ``handle(videoRuntimeEvent:)`` for ``AudioRuntimeEvent``.
+    func handle(audioRuntimeEvent event: AudioRuntimeEvent) {
+        switch event {
+        case .started(let messageID, let prompt):
+            audioGenerationProgress[messageID] = AudioGenerationProgress(
+                messageID: messageID,
+                prompt: prompt,
+                fractionComplete: 0.0,
+                isComplete: false,
+                error: nil
+            )
+            if let sessionID = activeSessionID {
+                let placeholder = ChatMessage(
+                    id: messageID,
+                    role: .assistant,
+                    contentParts: [],
+                    sessionID: sessionID
+                )
+                messages.append(placeholder)
+            }
+
+        case .progress(let messageID, let step, let totalSteps):
+            // A `progress` for an unknown ID would mean we missed `started`;
+            // create the entry with what we know rather than dropping the
+            // event silently.
+            let prompt = audioGenerationProgress[messageID]?.prompt ?? ""
+            let fraction = totalSteps > 0
+                ? min(max(Double(step) / Double(totalSteps), 0.0), 1.0)
+                : 0.0
+            audioGenerationProgress[messageID] = AudioGenerationProgress(
+                messageID: messageID,
+                prompt: prompt,
+                fractionComplete: fraction,
+                isComplete: false,
+                error: nil
+            )
+
+        case .completed(let messageID, let payload):
+            let existing = audioGenerationProgress[messageID]
+            audioGenerationProgress[messageID] = AudioGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? payload.prompt,
+                fractionComplete: 1.0,
+                isComplete: true,
+                error: nil
+            )
+            if let idx = messages.firstIndex(where: { $0.id == messageID }) {
+                messages[idx].contentParts = [.generatedMedia(payload)]
+            }
+
+        case .failed(let messageID, let error):
+            let existing = audioGenerationProgress[messageID]
+            audioGenerationProgress[messageID] = AudioGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? "",
+                fractionComplete: existing?.fractionComplete ?? 0.0,
+                isComplete: true,
+                error: error.localizedDescription
+            )
+
+        case .cancelled(let messageID):
+            let existing = audioGenerationProgress[messageID]
+            audioGenerationProgress[messageID] = AudioGenerationProgress(
+                messageID: messageID,
+                prompt: existing?.prompt ?? "",
+                fractionComplete: existing?.fractionComplete ?? 0.0,
+                isComplete: true,
+                error: nil
+            )
+        }
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -690,6 +690,29 @@ public final class ChatViewModel {
     /// generations. Driven by the `VideoGenerationRuntime` event drain.
     public internal(set) var videoGenerationProgress: [UUID: VideoGenerationProgress] = [:]
 
+    // MARK: - AudioGenerationRuntime
+    //
+    // Optional sibling to `_videoRuntime` for the audio-generation (TTS) path.
+    // Hosts that opt in to audio generation install one via
+    // `configure(audioRuntime:)` (typically through `ManifoldBootstrap`);
+    // chat-only hosts leave this nil and the public audio-generation methods
+    // throw `.notConfigured`. Storage lives on the main type because
+    // extensions cannot add stored properties — all behavior lives in
+    // `ChatViewModel+AudioGeneration.swift`.
+
+    /// Backing storage for ``audioRuntime``. Internal so the
+    /// `ChatViewModel+AudioGeneration` extension can mutate it.
+    var _audioRuntime: AudioGenerationRuntime?
+
+    /// Drain task for the audio runtime event stream. Cancelled when the
+    /// runtime is replaced (latest-wins) or the view model is torn down.
+    @ObservationIgnored
+    var audioRuntimeEventDrainTask: Task<Void, Never>?
+
+    /// Per-message-ID progress dictionary for in-flight or completed audio
+    /// generations. Driven by the `AudioGenerationRuntime` event drain.
+    public internal(set) var audioGenerationProgress: [UUID: AudioGenerationProgress] = [:]
+
     // MARK: - WebSearchRuntime
     //
     // Optional sibling to `_imageRuntime` / `_videoRuntime` for the web-search
@@ -904,6 +927,7 @@ public final class ChatViewModel {
     deinit {
         imageRuntimeEventDrainTask?.cancel()
         videoRuntimeEventDrainTask?.cancel()
+        audioRuntimeEventDrainTask?.cancel()
         endpointRefreshTask?.cancel()
     }
 

--- a/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
+++ b/Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift
@@ -22,6 +22,9 @@ extension ChatViewModel {
         if let videoRuntime = bootstrap.videoGenerationRuntime {
             configure(videoRuntime: videoRuntime)
         }
+        if let audioRuntime = bootstrap.audioGenerationRuntime {
+            configure(audioRuntime: audioRuntime)
+        }
         if let webSearchRuntime = bootstrap.webSearchRuntimePort {
             configure(webSearchRuntime: webSearchRuntime)
         }

--- a/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
@@ -178,7 +178,21 @@ struct MessagePartsView: View {
                 generatedMediaFallback(media)
             }
         case .audio:
-            generatedMediaFallback(media)
+            // Bridge the unified payload onto the existing Lane-1 audio player
+            // (`AudioMessageView`, which renders `MessagePart.audio`). It only
+            // needs url/duration/waveform/role, so reuse it rather than ship a
+            // second player. The generated payload carries no waveform samples;
+            // `AudioMessageView` degrades to a flat strip when `waveform` is nil.
+            if FileManager.default.fileExists(atPath: media.url.path) {
+                AudioMessageView(
+                    url: media.url,
+                    duration: media.durationSeconds ?? 0,
+                    waveform: nil,
+                    role: role
+                )
+            } else {
+                generatedMediaFallback(media)
+            }
         }
     }
 

--- a/Tests/ManifoldUITests/ChatViewModelAudioGenerationTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelAudioGenerationTests.swift
@@ -1,0 +1,323 @@
+@preconcurrency import XCTest
+import Foundation
+import os
+@testable import ManifoldUI
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+
+/// Coverage for ``ChatViewModel`` audio-generation (TTS) entry surface — runtime
+/// install, command forwarding, and event-to-progress mapping. Sibling to
+/// ``ChatViewModelImageGenerationTests``. The shape differs from the image/video
+/// siblings only where the shipped runtime differs: `generateSpeech` takes the
+/// config alone (the text lives in ``SpeechGenerationConfig``), and the
+/// completion event carries a ``GeneratedMediaPayload`` directly.
+@MainActor
+final class ChatViewModelAudioGenerationTests: XCTestCase {
+
+    // MARK: - In-memory MessageStore
+
+    @MainActor
+    final class TestMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessage] = [:]
+
+        func insertMessage(_ message: ChatMessage) async throws {
+            messages[message.id] = message
+        }
+        func updateMessage(_ message: ChatMessage) async throws {
+            guard messages[message.id] != nil else {
+                throw ChatPersistenceError.messageNotFound(message.id)
+            }
+            messages[message.id] = message
+        }
+        func deleteMessage(_ messageID: UUID) async throws {
+            messages.removeValue(forKey: messageID)
+        }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessage] {
+            messages.values.filter { $0.sessionID == sessionID }.sorted { $0.timestamp < $1.timestamp }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    // MARK: - Mock backend (driven by a configurable plan)
+
+    final class MockAudioBackend: AudioGenerationBackend, @unchecked Sendable {
+        struct Plan: Sendable {
+            var events: [AudioGenerationEvent] = []
+            var trailingError: (any Error)?
+            var delayPerEventNs: UInt64 = 1_000_000
+        }
+
+        private struct State: Sendable {
+            var isGenerating = false
+            var plan = Plan()
+        }
+
+        private let state = OSAllocatedUnfairLock(initialState: State())
+
+        var isGenerating: Bool { state.withLock { $0.isGenerating } }
+
+        func setPlan(_ plan: Plan) { state.withLock { $0.plan = plan } }
+
+        func generate(
+            config: SpeechGenerationConfig
+        ) throws -> AsyncThrowingStream<AudioGenerationEvent, Error> {
+            let plan: Plan = state.withLock { snap in
+                snap.isGenerating = true
+                return snap.plan
+            }
+            return AsyncThrowingStream { continuation in
+                let task = Task<Void, Never> { [self] in
+                    for event in plan.events {
+                        if Task.isCancelled { break }
+                        try? await Task.sleep(nanoseconds: plan.delayPerEventNs)
+                        if Task.isCancelled { break }
+                        continuation.yield(event)
+                    }
+                    if let trailingError = plan.trailingError, !Task.isCancelled {
+                        continuation.finish(throwing: trailingError)
+                    } else {
+                        continuation.finish()
+                    }
+                    self.state.withLock { $0.isGenerating = false }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+
+        func stopGeneration() { state.withLock { $0.isGenerating = false } }
+    }
+
+    // MARK: - Builders
+
+    private func makeRuntime(backend: MockAudioBackend) -> (AudioGenerationRuntime, TestMessageStore) {
+        let service = AudioGenerationService(backend: backend)
+        let store = TestMessageStore()
+        let runtime = AudioGenerationRuntime(service: service, messageStore: store)
+        return (runtime, store)
+    }
+
+    private func makeViewModel() -> ChatViewModel {
+        ChatViewModel(
+            inferenceService: InferenceService(),
+            userDefaults: UserDefaults(suiteName: "ChatViewModelAudioGenerationTests-\(UUID().uuidString)")!
+        )
+    }
+
+    /// Spin until `predicate(vm.audioGenerationProgress[messageID])` becomes
+    /// `true`, or fail after `timeout`. The progress dict is updated from a
+    /// detached `@MainActor` task so we yield in a tight loop rather than
+    /// using a one-shot expectation — events arrive in batches.
+    private func awaitProgress(
+        _ vm: ChatViewModel,
+        for messageID: UUID,
+        until predicate: (AudioGenerationProgress) -> Bool,
+        timeout: TimeInterval = 5.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            if let progress = vm.audioGenerationProgress[messageID], predicate(progress) {
+                return
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("Timed out waiting for progress predicate on \(messageID)", file: file, line: line)
+    }
+
+    // MARK: - Test 1: not configured
+
+    func test_generateSpeech_withoutConfiguredRuntime_throwsNotConfigured() async {
+        let vm = makeViewModel()
+        vm.activeSession = ChatSession(title: "Test")
+        do {
+            _ = try await vm.generateSpeech(config: SpeechGenerationConfig(text: "hello"))
+            XCTFail("Expected throw")
+        } catch let error as ChatViewModelAudioError {
+            XCTAssertEqual(error, .notConfigured)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Test 2: no active conversation
+
+    func test_generateSpeech_withoutActiveSession_throwsNoActiveConversation() async throws {
+        let backend = MockAudioBackend()
+        let (runtime, _) = makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(audioRuntime: runtime)
+        // No session set — activeSessionID is nil.
+        XCTAssertNil(vm.activeSessionID)
+        do {
+            _ = try await vm.generateSpeech(config: SpeechGenerationConfig(text: "hello"))
+            XCTFail("Expected throw")
+        } catch let error as ChatViewModelAudioError {
+            XCTAssertEqual(error, .noActiveConversation)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Test 3: happy path — placeholder inserted, ID returned, completion sets media
+
+    func test_generateSpeech_happyPath_insertsPlaceholderAndSetsGeneratedMedia() async throws {
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("avm-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outDir) }
+
+        let audioURL = outDir.appendingPathComponent("out.caf")
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: audioURL)
+
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(events: [
+            .progress(step: 1, total: 4),
+            .progress(step: 2, total: 4),
+            .progress(step: 3, total: 4),
+            .progress(step: 4, total: 4),
+            .completed(audioURL)
+        ]))
+
+        let (runtime, _) = makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(audioRuntime: runtime)
+        vm.activeSession = ChatSession(title: "Audio Test")
+
+        let messageID = try await vm.generateSpeech(
+            config: SpeechGenerationConfig(text: "read this aloud", outputDirectory: outDir)
+        )
+
+        // A placeholder message must be appended for the returned ID.
+        await awaitProgress(vm, for: messageID) { p in
+            p.prompt == "read this aloud" && !p.isComplete
+        }
+        XCTAssertTrue(
+            vm.messages.contains(where: { $0.id == messageID }),
+            "A placeholder message should be inserted for the returned ID"
+        )
+
+        // Wait for terminal completion.
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error == nil }
+
+        let final = vm.audioGenerationProgress[messageID]
+        XCTAssertNotNil(final)
+        XCTAssertEqual(final?.prompt, "read this aloud")
+        XCTAssertTrue(final?.isComplete ?? false)
+        XCTAssertNil(final?.error)
+
+        // The completion event must rewrite the placeholder's parts to a single
+        // `.generatedMedia` of kind `.audio`.
+        let message = try XCTUnwrap(vm.messages.first(where: { $0.id == messageID }))
+        XCTAssertEqual(message.contentParts.count, 1)
+        guard case .generatedMedia(let media) = message.contentParts.first else {
+            return XCTFail("Expected a .generatedMedia part, got \(String(describing: message.contentParts.first))")
+        }
+        XCTAssertEqual(media.kind, .audio)
+        XCTAssertEqual(media.url, audioURL)
+    }
+
+    // MARK: - Test 4: failed generation surfaces error
+
+    func test_generateSpeech_failure_surfacesErrorInProgress() async throws {
+        struct BoomError: LocalizedError { var errorDescription: String? { "boom" } }
+
+        let backend = MockAudioBackend()
+        backend.setPlan(.init(events: [.progress(step: 1, total: 4)], trailingError: BoomError()))
+
+        let (runtime, _) = makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(audioRuntime: runtime)
+        vm.activeSession = ChatSession(title: "Fail Test")
+
+        let messageID = try await vm.generateSpeech(
+            config: SpeechGenerationConfig(text: "broken")
+        )
+
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error != nil }
+        XCTAssertEqual(vm.audioGenerationProgress[messageID]?.error, "boom")
+    }
+
+    // MARK: - Test 5: cancel marks progress complete
+
+    func test_cancelAudioGeneration_marksProgressComplete() async throws {
+        let backend = MockAudioBackend()
+        // Long-running plan so we can cancel mid-flight.
+        backend.setPlan(.init(
+            events: (1...20).map { .progress(step: $0, total: 20) },
+            delayPerEventNs: 20_000_000  // 20ms each
+        ))
+
+        let (runtime, _) = makeRuntime(backend: backend)
+        let vm = makeViewModel()
+        vm.configure(audioRuntime: runtime)
+        vm.activeSession = ChatSession(title: "Cancel Test")
+
+        let messageID = try await vm.generateSpeech(
+            config: SpeechGenerationConfig(text: "slow")
+        )
+
+        // Wait for at least one progress event.
+        await awaitProgress(vm, for: messageID) { !$0.isComplete }
+
+        await vm.cancelAudioGeneration(messageID: messageID)
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error == nil }
+    }
+
+    // MARK: - Test 6: cancel is a no-op when unconfigured
+
+    func test_cancelAudioGeneration_whenUnconfigured_isNoOp() async {
+        let vm = makeViewModel()
+        XCTAssertNil(vm.audioRuntime)
+        // Must not throw or trap — just return.
+        await vm.cancelAudioGeneration(messageID: UUID())
+    }
+
+    // MARK: - Test 7: reconfigure cancels prior subscription
+
+    func test_configure_reconfigureCancelsPriorSubscription() async throws {
+        let backend1 = MockAudioBackend()
+        backend1.setPlan(.init(events: [.progress(step: 1, total: 4)]))
+        let (runtime1, _) = makeRuntime(backend: backend1)
+
+        let backend2 = MockAudioBackend()
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("avm-reconf-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outDir) }
+        let audioURL = outDir.appendingPathComponent("out.caf")
+        try Data([0x00]).write(to: audioURL)
+        backend2.setPlan(.init(events: [
+            .progress(step: 1, total: 1),
+            .completed(audioURL)
+        ]))
+        let (runtime2, _) = makeRuntime(backend: backend2)
+
+        let vm = makeViewModel()
+        vm.configure(audioRuntime: runtime1)
+        // Capture the first drain task to assert it's been cancelled after
+        // reconfigure.
+        let firstDrain = vm.audioRuntimeEventDrainTask
+        XCTAssertNotNil(firstDrain)
+
+        vm.configure(audioRuntime: runtime2)
+        XCTAssertTrue(firstDrain?.isCancelled ?? false, "Prior drain task should be cancelled")
+        XCTAssertNotNil(vm.audioRuntimeEventDrainTask)
+        XCTAssertNotIdentical(
+            vm.audioRuntime as AnyObject,
+            runtime1 as AnyObject
+        )
+
+        vm.activeSession = ChatSession(title: "Reconf Test")
+        let messageID = try await vm.generateSpeech(
+            config: SpeechGenerationConfig(text: "second", outputDirectory: outDir)
+        )
+
+        // The new runtime's events feed the dict.
+        await awaitProgress(vm, for: messageID) { $0.isComplete && $0.error == nil }
+    }
+}


### PR DESCRIPTION
UI fast-follow to **PR #1908** (the in-core TTS backend + `AudioGenerationRuntime`, issue #1904). The runtime persists `MessagePart.generatedMedia` with `MediaKind.audio` but nothing in the UI drove or rendered it. This wires the host-facing surface end-to-end, mirroring the **video** generation path (the closest sibling — cloud-style submit, no in-UI model picker).

## Files

**Added**
- `Sources/ManifoldUI/ViewModels/ChatViewModel+AudioGeneration.swift` — `AudioGenerationProgress`, `ChatViewModelAudioError` (`.notConfigured`/`.noActiveConversation`), `audioRuntime` + `configure(audioRuntime:)` (weak-capture drain), `generateSpeech(config:)`, `cancelAudioGeneration(messageID:)`, `handle(audioRuntimeEvent:)`.
- `Tests/ManifoldUITests/ChatViewModelAudioGenerationTests.swift` — 7 tests mirroring the image VM suite.

**Changed**
- `Sources/ManifoldUI/ViewModels/ChatViewModel.swift` — `_audioRuntime` / `audioRuntimeEventDrainTask` (`@ObservationIgnored`) / `audioGenerationProgress`, plus deinit cancel.
- `Sources/ManifoldUI/Views/Chat/MessagePartsView.swift` — `.generatedMedia` kind `.audio` rendering.
- `Sources/ManifoldRuntime/Services/ChatRuntimeBootstrap.swift` — `audioGenerationRuntime` protocol member (nil default for source-compat).
- `Sources/ManifoldUI/ViewModels/RuntimeConfiguration.swift` — wire `configure(audioRuntime:)` from the bootstrap.
- `Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift` — `audioGenerationService` opt-in parameter + `audioRuntime` construction.

## Runtime method signature mirrored
`AudioGenerationRuntime.generate(config:in:)` — the text lives in `SpeechGenerationConfig`, so `generateSpeech(config:)` takes **no separate prompt arg** (differs from `generateVideo(prompt:config:)`). The `.completed(messageID:payload:)` event carries a `GeneratedMediaPayload` **directly** (audio has no legacy typed payload), so the handler writes `.generatedMedia(payload)` without a wrapping bridge. Progress is `step`/`totalSteps`; the handler derives `fractionComplete`.

## Rendering-bridge decision
**Reuse `AudioMessageView`** (option a). It already renders the Lane-1 `MessagePart.audio` player from url/duration/waveform/role, so the `.generatedMedia` `.audio` branch extracts `media.url` + `media.durationSeconds` and presents it (waveform nil → flat strip). No second player shipped. Falls back to the existing file-presence row when the artifact is missing.

## Bootstrap opt-in shape
Same as video: an optional `audioGenerationService: AudioGenerationService?` parameter on `ManifoldBootstrap.init` / `.build()`. When supplied, the bootstrap constructs an `AudioGenerationRuntime(service:messageStore:)`, exposes it via the `audioGenerationRuntime` protocol accessor, and `configure(bootstrap:)` wires it onto the view model. Chat-only hosts pass nothing and the audio methods throw `.notConfigured`.

## Gate
- `swift build` and `swift build --build-tests` both pass.
- Force-unwrap lint: "No unreviewed force-unwraps in Sources".
- `ChatViewModelAudioGenerationTests` (7) + `BootstrapConfigureImageWiringTests` (2) pass. Sabotage-verified the happy-path test catches a broken media-write bridge, then reverted.

No change to the shipped audio backend/runtime/service. Backend-family imports avoided — the extension imports `ManifoldRuntime` + `ManifoldInference` like the video sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)