### PR TITLE
fix: render tools natively through the Jinja prompt path so local tool calling works (#1909)

### DIFF
--- a/Sources/ManifoldInference/Services/GenerationPreflightTrimmer.swift
+++ b/Sources/ManifoldInference/Services/GenerationPreflightTrimmer.swift
@@ -59,22 +59,22 @@ struct GenerationPreflightTrimmer {
         var workingMessages = messages
         var attempt = 0
 
-        // Tools that the template renders natively (only `.gemma4` today) must be
-        // forwarded so the native tool block is emitted on this path too —
-        // otherwise the local TokenCounting path silently drops them. Templates
-        // that don't render tools natively ignore the argument; their tool
-        // guidance arrives folded into `systemPrompt` by the caller (#1856).
-        let nativeTools = renderer.template.rendersToolsNatively ? config.tools : []
-
+        // Forward the live tool definitions on every render so a native tool
+        // template emits its `{% if tools %}` block on this path too (#1909).
+        // The renderer threads them on whichever branch executes; the caller's
+        // `toolAugmentedSystemPrompt` decision (keyed on
+        // `PromptRenderer.rendersToolsNatively`) guarantees the preamble is folded
+        // only when the rendered prompt will *not* carry tools, so there is no
+        // double injection.
         while true {
             // Renders the model's real embedded Jinja when present, else the
             // detected enum (#1811). The same renderer feeds the final prompt
             // sent to the backend, so the token count and the decoded prompt
             // always agree.
             let prompt = renderer.render(
-                messages: GenerationHistoryInstaller.flatten(workingMessages),
+                messages: workingMessages,
                 systemPrompt: systemPrompt,
-                nativeTools: nativeTools
+                tools: config.tools
             )
             let promptTokens = try counter.countTokens(prompt)
 

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -457,7 +457,7 @@ final class GenerationQueue {
                 backend: backend,
                 messages: messages,
                 systemPrompt: Self.toolAugmentedSystemPrompt(
-                    template: selectedPromptTemplate,
+                    renderer: promptRenderer,
                     systemPrompt: systemPrompt,
                     backend: backend,
                     config: config
@@ -490,19 +490,21 @@ final class GenerationQueue {
             // models (#1811).
             let renderer = promptRenderer
             if backend.capabilities.supportsToolCalling && !config.tools.isEmpty {
-                // Templates that render `tools` natively (only `.gemma4` today)
-                // consume the array directly. Templates that discard it get the
-                // tool guidance folded into the system prompt instead (#1856) —
-                // see `toolAugmentedSystemPrompt`. Doing both would double-inject.
+                // A native tool template (embedded Jinja that references `tools`,
+                // or the `.gemma4` enum) renders the tool block directly; every
+                // other template gets the guidance folded into the system prompt
+                // instead (#1856). `toolAugmentedSystemPrompt` keys that choice on
+                // `renderer.rendersToolsNatively`, so passing `config.tools`
+                // unconditionally never double-injects (#1909).
                 let augmentedSystemPrompt = Self.toolAugmentedSystemPrompt(
-                    template: renderer.template,
+                    renderer: renderer,
                     systemPrompt: systemPrompt,
                     backend: backend,
                     config: config
                 )
-                assembledPrompt = renderer.render(messages: flattened, systemPrompt: augmentedSystemPrompt, nativeTools: config.tools)
+                assembledPrompt = renderer.render(messages: messages, systemPrompt: augmentedSystemPrompt, tools: config.tools)
             } else {
-                assembledPrompt = renderer.render(messages: flattened, systemPrompt: systemPrompt)
+                assembledPrompt = renderer.render(messages: messages, systemPrompt: systemPrompt)
             }
             effectiveSystemPrompt = nil
         } else {
@@ -564,18 +566,24 @@ final class GenerationQueue {
     /// the same `ToolSystemPromptBuilder.preferTools(for:)` preamble.
     ///
     /// Returns `systemPrompt` unchanged when: tools are empty, the backend does
-    /// not support tool calling, or the template renders tools natively (no
-    /// double-injection). Otherwise prepends the preamble — matching the
-    /// documented `preamble + "\n\n" + appSystemPrompt` shape.
+    /// not support tool calling, or the prompt that will actually be rendered
+    /// carries tools natively (no double-injection). Otherwise prepends the
+    /// preamble — matching the documented `preamble + "\n\n" + appSystemPrompt`
+    /// shape.
+    ///
+    /// The native-vs-fold decision is keyed on ``PromptRenderer/rendersToolsNatively``
+    /// rather than the bare enum flag: once an embedded Jinja template renders
+    /// tools (#1909), the enum's `.gemma4`-only flag is the wrong signal — the
+    /// renderer knows whether the executing path emits a native tool block.
     static func toolAugmentedSystemPrompt(
-        template: PromptTemplate,
+        renderer: PromptRenderer,
         systemPrompt: String?,
         backend: InferenceBackend,
         config: GenerationConfig
     ) -> String? {
         guard backend.capabilities.supportsToolCalling,
               !config.tools.isEmpty,
-              !template.rendersToolsNatively else {
+              !renderer.rendersToolsNatively else {
             return systemPrompt
         }
 

--- a/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
+++ b/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
@@ -95,7 +95,15 @@ struct GenerationToolDispatchLoop {
             registry.validator = JSONSchemaValidator()
         }
 
-        let currentMessages = messages
+        // Grows across iterations so each regeneration sees the prior turn's
+        // tool calls and results. Cloud backends receive that history through
+        // the structured `ToolCallingHistoryReceiver` wire (below); local
+        // prompt-template backends — which are *not* tool-aware receivers —
+        // instead need the tool turns threaded back into the structured
+        // messages so `PromptRenderer` re-renders them natively. Without this,
+        // a templated backend re-rendered the *identical* original prompt every
+        // iteration and never saw a single tool result (#1909, Ring 2).
+        var currentMessages = messages
         // `toolAwareHistory` is maintained in parallel for tool-call turns.
         // Seeded lazily on the first tool dispatch so plain-text turns keep
         // using the classic `setConversationHistory` path and existing
@@ -293,6 +301,27 @@ struct GenerationToolDispatchLoop {
                 )
             }
             toolAwareHistory = nextHistory
+
+            // Local prompt-template backends do not consume the tool-aware wire
+            // history — they re-render `currentMessages` through `PromptRenderer`.
+            // Thread the just-dispatched tool turn into that structured history so
+            // the next regeneration shows the model its own call and the result
+            // in the template's native format (#1909, Ring 2). Cloud backends
+            // (tool-aware receivers) already got this via `setToolAwareHistory`,
+            // so skip them to avoid duplicating the turn.
+            if (currentBackend() as? ToolCallingHistoryReceiver) == nil {
+                currentMessages.append(
+                    StructuredMessage(
+                        role: "assistant",
+                        parts: dispatchedInThisTurn.map { MessagePart.toolCall($0.0) }
+                    )
+                )
+                for (_, result) in dispatchedInThisTurn {
+                    currentMessages.append(
+                        StructuredMessage(role: "tool", parts: [.toolResult(result)])
+                    )
+                }
+            }
         }
     }
 

--- a/Sources/ManifoldInference/Services/JinjaPromptRenderer.swift
+++ b/Sources/ManifoldInference/Services/JinjaPromptRenderer.swift
@@ -19,6 +19,18 @@ import Jinja
 /// This renderer closes that gap: when a GGUF carries a usable Jinja chat
 /// template, render the *real* template. The enum remains the fallback for
 /// templateless models and for templates `swift-jinja` cannot evaluate.
+///
+/// ## Structured rendering (#1909)
+///
+/// A real chat template is a *structured* renderer: its `{% if tools %}` and
+/// `{% for tool_call in message.tool_calls %}` branches need the tool
+/// definitions and the per-message tool-call / tool-result structure. An
+/// earlier version of this renderer was fed the text-only `(role, content)`
+/// projection and hard-coded `tools: []`, so every tool-bearing template
+/// silently dropped its entire tool grammar — yielding a ~0% tool-call rate on
+/// gemma-4 and the generic-preamble fallback (never the native format) on every
+/// other templated model. This renderer now consumes ``StructuredMessage`` and
+/// the live ``ToolDefinition`` array, threading both into the template context.
 enum JinjaPromptRenderer {
 
     /// Roles that map onto a chat-template `messages` array. Anything else is
@@ -30,21 +42,29 @@ enum JinjaPromptRenderer {
     /// - Parameters:
     ///   - rawTemplate: the model's embedded `tokenizer.chat_template` Jinja
     ///     string (from ``ModelInfo/chatTemplateRaw``).
-    ///   - messages: ordered `(role, content)` pairs already flattened from the
-    ///     structured history.
+    ///   - messages: the structured conversation history. Tool-call and
+    ///     tool-result parts are threaded into the template context so a native
+    ///     tool template renders its `tool_calls` / `tool_call_id` blocks.
     ///   - systemPrompt: an optional system instruction. Prepended as a leading
     ///     `system` message when the history does not already start with one —
     ///     this matches what every chat template expects (a system turn at index
     ///     0) and lets the template's own "inject default system prompt" branch
     ///     fire only when the host supplied none.
+    ///   - tools: the tool definitions to expose to the template's `{% if tools %}`
+    ///     branch. Empty means "no tools" — the branch evaluates falsey. Each
+    ///     tool is exposed in both the OpenAI-style nested `function` shape and
+    ///     the flat `name`/`description`/`parameters` shape so templates written
+    ///     against either convention (e.g. gemma's `format_parameters` macro vs
+    ///     OpenAI's `tool.function.name`) both resolve.
     /// - Returns: the rendered prompt, or `nil` when the template cannot be
     ///   parsed or evaluated. A `nil` return is the signal for the caller to
     ///   fall back to the ``PromptTemplate`` enum — never a hard failure, since
     ///   a malformed embedded template must not block generation.
     static func render(
         rawTemplate: String,
-        messages: [(role: String, content: String)],
-        systemPrompt: String?
+        messages: [StructuredMessage],
+        systemPrompt: String?,
+        tools: [ToolDefinition] = []
     ) -> String? {
         let trimmed = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -61,7 +81,7 @@ enum JinjaPromptRenderer {
         }
 
         for message in messages where renderableRoles.contains(message.role) {
-            jinjaMessages.append(["role": message.role, "content": message.content])
+            jinjaMessages.append(jinjaMessage(from: message))
         }
 
         do {
@@ -69,10 +89,14 @@ enum JinjaPromptRenderer {
             let context: [String: Value] = [
                 "messages": try Value(any: jinjaMessages),
                 "add_generation_prompt": true,
-                // Many templates branch on tools/documents being defined; pass
-                // empty so `{%- if tools %}` evaluates falsey rather than raising
-                // an "undefined" error in stricter templates.
-                "tools": try Value(any: [Any]()),
+                // Native tool templates branch on `tools` being defined and
+                // non-empty; supply the real definitions (#1909). An empty array
+                // keeps `{%- if tools %}` falsey for tool-less turns.
+                "tools": try Value(any: toolsContext(tools)),
+                // Many templates also branch on `documents` (RAG retrieval). Pass
+                // an empty array so `{% if documents %}` is falsey rather than
+                // raising an "undefined" error in stricter templates.
+                "documents": try Value(any: [Any]()),
             ]
             let rendered = try template.render(context)
             // A template that evaluates to empty output is not usable — treat it
@@ -86,6 +110,92 @@ enum JinjaPromptRenderer {
                 "JinjaPromptRenderer: failed to render embedded chat template, falling back to enum: \(error.localizedDescription)"
             )
             return nil
+        }
+    }
+
+    /// Builds the per-message Jinja dictionary, threading the native tool-call /
+    /// tool-result structure that the text-only projection used to drop (#1909).
+    private static func jinjaMessage(from message: StructuredMessage) -> [String: Any] {
+        var dict: [String: Any] = [
+            "role": message.role,
+            "content": message.textContent,
+        ]
+
+        // Assistant tool calls → the OpenAI-style `tool_calls` array that a
+        // native template iterates with `{% for tool_call in message.tool_calls %}`.
+        let toolCalls: [[String: Any]] = message.parts.compactMap { part in
+            guard case .toolCall(let call) = part else { return nil }
+            let function: [String: Any] = [
+                "name": call.toolName,
+                "arguments": argumentsValue(call.arguments),
+            ]
+            return [
+                "id": call.id,
+                "type": "function",
+                "function": function,
+                // Flat aliases for templates that read `tool_call.name` / `.arguments`.
+                "name": call.toolName,
+                "arguments": argumentsValue(call.arguments),
+            ]
+        }
+        if !toolCalls.isEmpty {
+            dict["tool_calls"] = toolCalls
+        }
+
+        // Tool result → `tool_call_id` + `name` the template pairs with the call.
+        if let result = firstToolResult(in: message.parts) {
+            dict["tool_call_id"] = result.callId
+            // The text projection only carries `.text` parts; a tool turn whose
+            // payload lives in the `.toolResult` carries no text, so fold the
+            // result content in as the message content when text is empty.
+            if (dict["content"] as? String)?.isEmpty ?? true {
+                dict["content"] = result.content
+            }
+        }
+
+        return dict
+    }
+
+    private static func firstToolResult(in parts: [MessagePart]) -> ToolResult? {
+        for part in parts {
+            if case .toolResult(let result) = part { return result }
+        }
+        return nil
+    }
+
+    /// Tool-call arguments are stored as a raw JSON string. Most chat templates
+    /// (`format_parameters`, OpenAI-style) iterate the *parsed* object; parse
+    /// when possible and fall back to the raw string for the templates that
+    /// print the JSON verbatim.
+    private static func argumentsValue(_ raw: String) -> Any {
+        guard let data = raw.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) else {
+            return raw
+        }
+        return parsed
+    }
+
+    /// Converts the live ``ToolDefinition`` array into the template-facing tool
+    /// context, reusing ``encodeJSONSchemaToFoundation(_:)`` so the parameter
+    /// schema reaches the template in the exact JSON-Schema shape its
+    /// `format_parameters`-style macro consumes.
+    private static func toolsContext(_ tools: [ToolDefinition]) -> [[String: Any]] {
+        tools.map { tool in
+            let parameters = encodeJSONSchemaToFoundation(tool.parameters)
+                ?? ["type": "object", "properties": [String: Any]()]
+            let function: [String: Any] = [
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": parameters,
+            ]
+            return [
+                "type": "function",
+                "function": function,
+                // Flat aliases for gemma-style templates that read `tool.name`.
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": parameters,
+            ]
         }
     }
 }

--- a/Sources/ManifoldInference/Services/PromptRenderer.swift
+++ b/Sources/ManifoldInference/Services/PromptRenderer.swift
@@ -32,16 +32,91 @@ struct PromptRenderer {
     /// would be double-injected (#1856 / #1909).
     ///
     /// - When an embedded Jinja template is present, "native" means the template
-    ///   actually references `tools` (a template that branches on it must name
-    ///   it). The cheap textual probe is reliable: a template that renders tools
-    ///   cannot do so without referencing the variable, and a stray mention only
-    ///   costs a skipped preamble on a template that has no real tool block.
+    ///   references the `tools` *variable* inside a Jinja control/expression
+    ///   block (`{%- if tools %}`, `{% for t in tools %}`, `{{ tools | tojson }}`).
+    ///   A bare textual `.contains("tools")` is *not* sufficient: a template that
+    ///   only mentions the word in static prose (e.g. a system message reading
+    ///   "you have access to the following tools") or in literal output tokens
+    ///   (`<|tools|>`) renders no tool block, yet a substring probe would mark it
+    ///   native and skip the preamble — stranding the model with **zero** tool
+    ///   guidance (the substring sees the prose, the template ignores the array).
+    ///   Scoping the probe to Jinja-delimited regions keeps every genuine
+    ///   tool-rendering template (which *must* reference the variable in control
+    ///   flow) while rejecting prose/literal false positives.
     /// - For templateless models, only the `.gemma4` enum renders tools natively.
     var rendersToolsNatively: Bool {
         if let chatTemplateRaw, !chatTemplateRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return chatTemplateRaw.contains("tools")
+            return Self.templateReferencesToolsVariable(chatTemplateRaw)
         }
         return template.rendersToolsNatively
+    }
+
+    /// Whether `template` references the `tools` variable inside a Jinja
+    /// statement (`{% … %}`) or expression (`{{ … }}`) block — as opposed to a
+    /// bare textual occurrence in static prose or literal output tokens.
+    ///
+    /// A template can only *render* the tool grammar by branching on or iterating
+    /// the `tools` variable, which is always inside a Jinja delimiter pair. We
+    /// scan only the delimited regions for the bare identifier `tools`
+    /// (word-bounded, so `tool_calls` / `get_tools` / `<|tools|>` do not match)
+    /// and ignore static prose entirely. This is a heuristic, not a full parse,
+    /// but it cannot false-negative a template that genuinely renders tools.
+    ///
+    /// Implemented with a single forward scan rather than a regex so it stays off
+    /// the `NSRegularExpression` allocation path on the hot prompt-render route.
+    static func templateReferencesToolsVariable(_ template: String) -> Bool {
+        let scalars = Array(template.unicodeScalars)
+        var i = 0
+        while i < scalars.count - 1 {
+            // A Jinja block opens with `{%` (statement) or `{{` (expression).
+            guard scalars[i] == "{", scalars[i + 1] == "%" || scalars[i + 1] == "{" else {
+                i += 1
+                continue
+            }
+            let closer: Unicode.Scalar = scalars[i + 1] == "%" ? "%" : "}"
+            let blockStart = i + 2
+            var j = blockStart
+            // Find the matching closing delimiter (`%}` or `}}`). An unterminated
+            // block runs to end-of-string — scan its tail as the final region.
+            while j < scalars.count - 1, !(scalars[j] == closer && scalars[j + 1] == "}") {
+                j += 1
+            }
+            let blockEnd = min(j, scalars.count) // exclusive
+            if Self.scalarsContainToolsWord(scalars, from: blockStart, to: blockEnd) {
+                return true
+            }
+            i = j + 2
+        }
+        return false
+    }
+
+    /// Whether `scalars[from..<to]` contains the bare identifier `tools` on
+    /// identifier boundaries — i.e. not preceded or followed by an identifier
+    /// scalar, so `tool_calls`, `get_tools`, and `toolset` do not match.
+    private static func scalarsContainToolsWord(
+        _ scalars: [Unicode.Scalar],
+        from: Int,
+        to: Int
+    ) -> Bool {
+        let word: [Unicode.Scalar] = ["t", "o", "o", "l", "s"]
+        guard to - from >= word.count else { return false }
+        var k = from
+        while k <= to - word.count {
+            if Array(scalars[k..<k + word.count]) == word {
+                let prevIsIdent = k > from && Self.isIdentifierScalar(scalars[k - 1])
+                let nextIndex = k + word.count
+                let nextIsIdent = nextIndex < to && Self.isIdentifierScalar(scalars[nextIndex])
+                if !prevIsIdent && !nextIsIdent { return true }
+            }
+            k += 1
+        }
+        return false
+    }
+
+    /// Jinja identifier scalars: letters, digits, and `_` (matching Python/Jinja
+    /// name rules). Used to word-bound the `tools` probe.
+    private static func isIdentifierScalar(_ s: Unicode.Scalar) -> Bool {
+        s == "_" || (s.properties.isAlphabetic) || ("0"..."9").contains(s)
     }
 
     /// Renders `messages` into a single prompt string.

--- a/Sources/ManifoldInference/Services/PromptRenderer.swift
+++ b/Sources/ManifoldInference/Services/PromptRenderer.swift
@@ -26,28 +26,54 @@ struct PromptRenderer {
         self.chatTemplateRaw = chatTemplateRaw
     }
 
+    /// Whether the prompt the executing path will produce renders tool
+    /// definitions *natively* — i.e. the host must **not** also fold the
+    /// ``ToolSystemPromptBuilder`` preamble into the system prompt, or the tools
+    /// would be double-injected (#1856 / #1909).
+    ///
+    /// - When an embedded Jinja template is present, "native" means the template
+    ///   actually references `tools` (a template that branches on it must name
+    ///   it). The cheap textual probe is reliable: a template that renders tools
+    ///   cannot do so without referencing the variable, and a stray mention only
+    ///   costs a skipped preamble on a template that has no real tool block.
+    /// - For templateless models, only the `.gemma4` enum renders tools natively.
+    var rendersToolsNatively: Bool {
+        if let chatTemplateRaw, !chatTemplateRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return chatTemplateRaw.contains("tools")
+        }
+        return template.rendersToolsNatively
+    }
+
     /// Renders `messages` into a single prompt string.
     ///
     /// - Parameters:
-    ///   - messages: ordered `(role, content)` pairs.
+    ///   - messages: the structured conversation history. The Jinja path threads
+    ///     tool-call / tool-result structure into the template; the enum
+    ///     fallback collapses to its text projection.
     ///   - systemPrompt: optional system instruction.
-    ///   - nativeTools: tools to render natively. Only consumed on the enum
-    ///     fallback path (only `.gemma4` renders tools natively today); the
-    ///     Jinja path receives tools via the host-folded system prompt, matching
-    ///     the #1856 fold the queue already applies to non-native templates.
+    ///   - tools: tool definitions to render. The Jinja path exposes them to the
+    ///     template's `{% if tools %}` branch (#1909); the enum fallback consumes
+    ///     them only for `.gemma4`. Callers pass the live `config.tools` array
+    ///     unconditionally — ``rendersToolsNatively`` governs whether the host
+    ///     *also* folds the preamble, so there is never a double injection.
     func render(
-        messages: [(role: String, content: String)],
+        messages: [StructuredMessage],
         systemPrompt: String?,
-        nativeTools: [ToolDefinition] = []
+        tools: [ToolDefinition] = []
     ) -> String {
         if let chatTemplateRaw,
            let rendered = JinjaPromptRenderer.render(
                rawTemplate: chatTemplateRaw,
                messages: messages,
-               systemPrompt: systemPrompt
+               systemPrompt: systemPrompt,
+               tools: tools
            ) {
             return rendered
         }
-        return template.format(messages: messages, systemPrompt: systemPrompt, tools: nativeTools)
+        return template.format(
+            messages: GenerationHistoryInstaller.flatten(messages),
+            systemPrompt: systemPrompt,
+            tools: tools
+        )
     }
 }

--- a/Tests/ManifoldInferenceTests/GenerationQueueToolLoopTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueueToolLoopTests.swift
@@ -207,6 +207,62 @@ final class GenerationQueueToolLoopTests: XCTestCase {
         XCTAssertEqual(tokens.joined(), "The weather is sunny.")
     }
 
+    /// #1909, Ring 2: a backend that is **not** a `ToolCallingHistoryReceiver`
+    /// (every local prompt-template backend) re-renders its structured history
+    /// each turn. The dispatch loop must thread the prior tool call + result
+    /// back into that structured history, or the local backend re-renders the
+    /// identical original prompt every iteration and never sees the result.
+    ///
+    /// `MockInferenceBackend` is deliberately *not* tool-aware, so it stands in
+    /// for `LlamaBackend` here. We assert the second turn's structured history
+    /// carries the `.toolResult`.
+    func test_toolCall_threadsResultIntoNextTurnStructuredHistory_forNonToolAwareBackend() async throws {
+        let executor = RecordingExecutor(name: "get_weather") { _ in
+            ToolResult(callId: "", content: #"{"summary":"sunny"}"#, errorKind: nil)
+        }
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [makeCall(id: "c-1", name: "get_weather", arguments: #"{"city":"Rome"}"#)],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [
+            [],
+            ["done"],
+        ]
+
+        let coordinator = makeCoordinator(registry: registry)
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "What's the weather in Rome?")],
+            maxOutputTokens: 128
+        )
+        _ = try await collectEvents(stream)
+
+        // The second (and last) turn's structured history must include both the
+        // assistant tool-call turn and the tool result — the data a native
+        // template needs to render the round-trip.
+        let history = try XCTUnwrap(
+            provider.backend.lastReceivedStructuredHistory,
+            "non-tool-aware backend must receive structured history"
+        )
+        let toolResult = history
+            .flatMap(\.parts)
+            .compactMap { part -> ToolResult? in
+                if case .toolResult(let r) = part { return r }
+                return nil
+            }
+            .first
+        XCTAssertEqual(toolResult?.callId, "c-1", "tool result must be threaded into the next turn's history")
+        XCTAssertEqual(toolResult?.content, #"{"summary":"sunny"}"#)
+
+        let hasToolCall = history.flatMap(\.parts).contains { part in
+            if case .toolCall = part { return true }
+            return false
+        }
+        XCTAssertTrue(hasToolCall, "the assistant tool-call turn must also be threaded in")
+    }
+
     func test_streamingToolProgress_emitsBetweenDispatchStartedAndToolResult() async throws {
         let registry = ToolRegistry()
         registry.register(StreamingProgressExecutor())

--- a/Tests/ManifoldInferenceTests/JinjaPromptRendererTests.swift
+++ b/Tests/ManifoldInferenceTests/JinjaPromptRendererTests.swift
@@ -263,6 +263,40 @@ final class JinjaPromptRendererTests: XCTestCase {
         )
     }
 
+    /// A bare-substring probe (`chatTemplateRaw.contains("tools")`) marks this
+    /// template native and skips the preamble — but the template renders **no**
+    /// tool block, so the model would get zero tool guidance. The word `tools`
+    /// here lives only in static prose and a literal output token, never inside a
+    /// Jinja control/expression block, so `rendersToolsNatively` must be false and
+    /// the host must fold the preamble in.
+    func test_rendersToolsNatively_falseForProseOnlyMention() {
+        let proseOnly = """
+        {%- for message in messages %}
+        <|tools|>You have access to the following tools, but only via prose.
+        <|{{ message.role }}|>{{ message.content }}
+        {%- endfor %}
+        """
+        XCTAssertFalse(
+            PromptRenderer(template: .chatML, chatTemplateRaw: proseOnly).rendersToolsNatively,
+            "`tools` only in prose / literal output → NOT native; the preamble must still be folded"
+        )
+    }
+
+    /// Word-boundary guard: a template that references `tool_calls` (and prints
+    /// `tools` only as a literal token) but never the `tools` *variable* renders
+    /// no declaration block, so it must not be classified native.
+    func test_rendersToolsNatively_falseForToolCallsButNoToolsVariable() {
+        let toolCallsOnly = """
+        {%- for message in messages %}
+        {%- if message.tool_calls %}<|tool_call|>{% endif %}
+        {%- endfor %}
+        """
+        XCTAssertFalse(
+            PromptRenderer(template: .chatML, chatTemplateRaw: toolCallsOnly).rendersToolsNatively,
+            "`tool_calls` is not the `tools` variable; word-bounded probe must not match"
+        )
+    }
+
     // MARK: - PromptRenderer prefers Jinja, falls back to the enum
 
     func test_promptRenderer_prefersJinjaWhenTemplatePresent() {

--- a/Tests/ManifoldInferenceTests/JinjaPromptRendererTests.swift
+++ b/Tests/ManifoldInferenceTests/JinjaPromptRendererTests.swift
@@ -1,15 +1,23 @@
 import XCTest
 @testable import ManifoldInference
 
-/// Fixture tests for #1811: render a model's *real* embedded GGUF Jinja chat
-/// template via `swift-jinja` and confirm it produces ground-truth formatting
-/// the hand-rolled ``PromptTemplate`` enum cannot reproduce.
+/// Fixture tests for #1811 and #1909: render a model's *real* embedded GGUF
+/// Jinja chat template via `swift-jinja` and confirm it produces ground-truth
+/// formatting the hand-rolled ``PromptTemplate`` enum cannot reproduce —
+/// including the native tool grammar an earlier version silently dropped.
 ///
 /// Each fixture is a real, in-use model whose `tokenizer.chat_template` does NOT
 /// map cleanly onto the enum case the detector picks for it. The enum picks the
 /// nearest family (ChatML / Llama 3) and produces a *structurally different*
 /// prompt — the silent-correctness gap this issue closes.
 final class JinjaPromptRendererTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// A plain text turn in the structured shape the renderer now consumes.
+    private func msg(_ role: String, _ content: String) -> StructuredMessage {
+        StructuredMessage(role: role, content: content)
+    }
 
     // MARK: - Fixtures (abbreviated canonical HF chat templates)
 
@@ -57,17 +65,59 @@ final class JinjaPromptRendererTests: XCTestCase {
     {%- endif %}
     """
 
+    /// A native tool-calling template that exercises every structured field the
+    /// text-only projection used to drop (#1909): the `{% if tools %}`
+    /// declaration block, per-message `tool_calls`, and the paired
+    /// `tool_call_id` on the tool turn. Written against both the flat
+    /// (`tool.name`) and OpenAI-nested (`tool.function.name`) conventions the
+    /// renderer exposes, so it stands in for gemma-4 / Qwen / Hermes families.
+    private static let nativeToolTemplate = """
+    {%- if tools %}
+    <|tools|>
+    {%- for tool in tools %}
+    <|tool|>{{ tool.name }}:{{ tool.function.name }}<|/tool|>
+    {%- endfor %}
+    <|/tools|>
+    {%- endif %}
+    {%- for message in messages %}
+    <|{{ message.role }}|>{{ message.content }}
+    {%- if message.tool_calls %}
+        {%- for tc in message.tool_calls %}
+    <|call|>{{ tc.function.name }}<|/call|>
+        {%- endfor %}
+    {%- endif %}
+    {%- if message.tool_call_id %}
+    <|result_for|>{{ message.tool_call_id }}<|/result_for|>
+    {%- endif %}
+    {%- endfor %}
+    {%- if add_generation_prompt %}<|assistant|>{% endif %}
+    """
+
+    private static func weatherTool() -> ToolDefinition {
+        ToolDefinition(
+            name: "get_weather",
+            description: "Look up the weather for a city",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "city": .object(["type": .string("string")])
+                ]),
+                "required": .array([.string("city")]),
+            ])
+        )
+    }
+
     // MARK: - Model 1: Qwen2.5 default-system injection
 
     func test_qwen25_injectsDefaultSystemTurn_thatEnumDrops() throws {
-        let messages = [(role: "user", content: "What is 2+2?")]
+        let messages = [msg("user", "What is 2+2?")]
 
         let jinja = JinjaPromptRenderer.render(
             rawTemplate: Self.qwen25Template,
             messages: messages,
             systemPrompt: nil
         )
-        let enumOut = PromptTemplate.chatML.format(messages: messages, systemPrompt: nil)
+        let enumOut = PromptTemplate.chatML.format(messages: [(role: "user", content: "What is 2+2?")], systemPrompt: nil)
 
         let rendered = try XCTUnwrap(jinja, "swift-jinja should render the Qwen2.5 template")
 
@@ -87,14 +137,14 @@ final class JinjaPromptRendererTests: XCTestCase {
     // MARK: - Model 2: Llama-3.2 knowledge-date preamble
 
     func test_llama32_emitsKnowledgeDatePreamble_thatEnumDrops() throws {
-        let messages = [(role: "user", content: "Hi")]
+        let messages = [msg("user", "Hi")]
 
         let jinja = JinjaPromptRenderer.render(
             rawTemplate: Self.llama32Template,
             messages: messages,
             systemPrompt: nil
         )
-        let enumOut = PromptTemplate.llama3.format(messages: messages, systemPrompt: nil)
+        let enumOut = PromptTemplate.llama3.format(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
 
         let rendered = try XCTUnwrap(jinja, "swift-jinja should render the Llama-3.2 template")
 
@@ -113,7 +163,7 @@ final class JinjaPromptRendererTests: XCTestCase {
     // MARK: - Host system prompt is honoured (no double-injection)
 
     func test_qwen25_hostSystemPrompt_overridesDefault() throws {
-        let messages = [(role: "user", content: "Hi")]
+        let messages = [msg("user", "Hi")]
         let rendered = try XCTUnwrap(
             JinjaPromptRenderer.render(
                 rawTemplate: Self.qwen25Template,
@@ -128,17 +178,102 @@ final class JinjaPromptRendererTests: XCTestCase {
         )
     }
 
+    // MARK: - #1909 Ring 0/1: tool definitions reach the native template
+
+    func test_nativeToolTemplate_rendersToolDeclarations() throws {
+        // The bug: tools were hard-coded to [] in the Jinja context, so the
+        // entire `{% if tools %}` declaration block never rendered.
+        let withTools = try XCTUnwrap(
+            JinjaPromptRenderer.render(
+                rawTemplate: Self.nativeToolTemplate,
+                messages: [msg("user", "weather in Paris?")],
+                systemPrompt: nil,
+                tools: [Self.weatherTool()]
+            )
+        )
+        XCTAssertTrue(withTools.contains("<|tools|>"), "tools block must render when tools are present")
+        XCTAssertTrue(
+            withTools.contains("get_weather:get_weather"),
+            "both flat (tool.name) and nested (tool.function.name) shapes must resolve"
+        )
+
+        // Sabotage: with no tools the declaration block must be falsey/absent —
+        // proving the assertion above tracks the tools array, not a constant.
+        let noTools = try XCTUnwrap(
+            JinjaPromptRenderer.render(
+                rawTemplate: Self.nativeToolTemplate,
+                messages: [msg("user", "weather in Paris?")],
+                systemPrompt: nil,
+                tools: []
+            )
+        )
+        XCTAssertFalse(noTools.contains("<|tools|>"), "no tools → declaration block must not render")
+    }
+
+    func test_promptRenderer_threadsToolsThroughJinjaPath() {
+        let renderer = PromptRenderer(template: .gemma4, chatTemplateRaw: Self.nativeToolTemplate)
+        let out = renderer.render(
+            messages: [StructuredMessage(role: "user", content: "weather?")],
+            systemPrompt: nil,
+            tools: [Self.weatherTool()]
+        )
+        XCTAssertTrue(out.contains("get_weather"), "PromptRenderer must forward tools into the Jinja path (#1909)")
+    }
+
+    // MARK: - #1909 Ring 2: prior tool call + result render on the next turn
+
+    func test_nativeToolTemplate_rendersPriorToolCallAndResult() throws {
+        let call = ToolCall(id: "call_1", toolName: "get_weather", arguments: #"{"city":"Paris"}"#)
+        let messages: [StructuredMessage] = [
+            msg("user", "weather in Paris?"),
+            StructuredMessage(role: "assistant", parts: [.toolCall(call)]),
+            StructuredMessage(role: "tool", parts: [.toolResult(ToolResult(callId: "call_1", content: "18C and sunny"))]),
+        ]
+        let rendered = try XCTUnwrap(
+            JinjaPromptRenderer.render(
+                rawTemplate: Self.nativeToolTemplate,
+                messages: messages,
+                systemPrompt: nil,
+                tools: [Self.weatherTool()]
+            )
+        )
+        XCTAssertTrue(rendered.contains("<|call|>get_weather<|/call|>"), "prior assistant tool_call must render")
+        XCTAssertTrue(rendered.contains("<|result_for|>call_1<|/result_for|>"), "tool result must pair to its call id")
+        XCTAssertTrue(rendered.contains("18C and sunny"), "tool result content must reach the template as message content")
+    }
+
+    // MARK: - rendersToolsNatively governs the preamble-fold decision
+
+    func test_rendersToolsNatively_flag() {
+        XCTAssertTrue(
+            PromptRenderer(template: .chatML, chatTemplateRaw: Self.nativeToolTemplate).rendersToolsNatively,
+            "embedded template that references tools → native"
+        )
+        XCTAssertFalse(
+            PromptRenderer(template: .chatML, chatTemplateRaw: Self.qwen25Template).rendersToolsNatively,
+            "embedded template with no tools branch → not native (host folds the preamble)"
+        )
+        XCTAssertTrue(
+            PromptRenderer(template: .gemma4, chatTemplateRaw: nil).rendersToolsNatively,
+            "templateless gemma4 → enum renders tools natively"
+        )
+        XCTAssertFalse(
+            PromptRenderer(template: .chatML, chatTemplateRaw: nil).rendersToolsNatively,
+            "templateless non-gemma → not native"
+        )
+    }
+
     // MARK: - PromptRenderer prefers Jinja, falls back to the enum
 
     func test_promptRenderer_prefersJinjaWhenTemplatePresent() {
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: Self.qwen25Template)
-        let out = renderer.render(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
+        let out = renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
         XCTAssertTrue(out.contains("You are Qwen"), "Renderer must prefer the real embedded Jinja")
     }
 
     func test_promptRenderer_fallsBackToEnum_whenNoTemplate() {
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: nil)
-        let out = renderer.render(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
+        let out = renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
         let enumOut = PromptTemplate.chatML.format(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
         XCTAssertEqual(out, enumOut, "No embedded template → enum output verbatim")
     }
@@ -147,14 +282,14 @@ final class JinjaPromptRendererTests: XCTestCase {
         // A template swift-jinja cannot parse must not block generation — the
         // renderer falls back to the enum (a recoverable boundary condition).
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: "{%- if broken")
-        let out = renderer.render(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
+        let out = renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
         let enumOut = PromptTemplate.chatML.format(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
         XCTAssertEqual(out, enumOut, "Malformed embedded template → enum fallback, no crash")
     }
 
     func test_jinjaRenderer_returnsNil_forEmptyTemplate() {
         XCTAssertNil(
-            JinjaPromptRenderer.render(rawTemplate: "   \n  ", messages: [(role: "user", content: "Hi")], systemPrompt: nil),
+            JinjaPromptRenderer.render(rawTemplate: "   \n  ", messages: [msg("user", "Hi")], systemPrompt: nil),
             "Empty/whitespace template is a miss → nil so the caller falls back"
         )
     }


### PR DESCRIPTION
Fixes #1909. Companion E2E follow-up: roryford/manifold-llama#45.

## Problem (bigger than first reported)

The embedded-GGUF Jinja renderer added in #1898 was fed the **text-only** `(role, content)` projection and hard-coded `tools: []` into the template context. A real chat template is a *structured* renderer — its `{% if tools %}` and `{% for tool_call in message.tool_calls %}` branches need the tool definitions and per-message tool-call/result structure. The result was a silent-correctness gap with three concentric rings:

- **Ring 0 (reported):** a gemma-4 GGUF whose embedded `chat_template` is the native tool template had its tool definitions silently dropped → the model was never shown the tool-call grammar in any format → ~0% tool-call rate (3,400+ consecutive `toolCallParseFailed` observed).
- **Ring 1:** every *other* embedded-template model with a `{% if tools %}` block (Qwen2.5, Hermes, Llama-3.x tool variants, Mistral-tools) never used its trained native tool format — it silently fell back to the generic system-prompt preamble. #1898 reintroduced, for tools, the exact #1811-class silent gap it set out to close.
- **Ring 2:** multi-turn tool round-trips were **structurally impossible** on local prompt-template backends. `GenerationToolDispatchLoop` delivered tool results only via `ToolCallingHistoryReceiver` — a protocol only the Ollama/OpenAI wire adapters implement. `LlamaBackend` is not one, so each loop iteration re-rendered the *identical* original prompt and never saw a single tool result. (Masked because the only local tool-calling E2E runs against Ollama, which *is* tool-aware — see manifold-llama#45.)

## Fix — three cooperating defects

**A — structured render contract.** `JinjaPromptRenderer.render` / `PromptRenderer.render` now consume structured `[StructuredMessage]` + the live `[ToolDefinition]` instead of the text-only projection. Tool definitions (via the existing `encodeJSONSchemaToFoundation`), per-message `tool_calls`, and the paired `tool_call_id` are threaded into the Jinja context; `documents: []` is supplied so RAG templates don't fault on an undefined var. Tools/calls are exposed in both the OpenAI-nested (`tool.function.name`) and flat (`tool.name`) shapes so templates of either convention resolve. `GenerationPreflightTrimmer` (the live `LlamaBackend` `TokenCountingBackend` path) passes structured messages + `config.tools`; its stale "must forward natively" tombstone comment is gone.

**B — no double-injection.** `GenerationQueue.toolAugmentedSystemPrompt` keys the native-vs-fold-preamble decision on a new `PromptRenderer.rendersToolsNatively` — which knows whether the *executing* path emits a native tool block — instead of the enum's `.gemma4`-only flag. The probe is scoped to the `tools` variable referenced **inside Jinja `{% %}`/`{{ }}` delimiters** (word-bounded), so a template that mentions "tools" only in prose or a literal `<|tools|>` token is *not* misclassified native (which would skip the preamble *and* render no block, stranding the model with zero guidance — the #1909 failure relocated into the heuristic).

**C — local multi-turn (keystone).** `GenerationToolDispatchLoop` threads each dispatched tool call + result back into the structured `currentMessages` it re-renders, but only for backends that are **not** `ToolCallingHistoryReceiver`. Cloud backends keep the existing `setToolAwareHistory` wire path unchanged (no double-feed); non-tool-aware local backends now see the result on the next turn and render it natively.

## Tests

- Native tool-block rendering + sabotage (no tools → no block); tools-through-`PromptRenderer`.
- Multi-turn: prior assistant `tool_call` + paired tool result render on the next turn.
- `rendersToolsNatively` matrix incl. prose-only and `tool_calls`-only word-boundary false-positive guards (sabotage-verified: fail under the old `.contains` probe).
- Dispatch-loop **Ring-2 regression**: the non-tool-aware `MockInferenceBackend` (stands in for `LlamaBackend`) must receive the tool result in its next-turn structured history.
- The #1811 Jinja fixtures migrated to the structured signature.

All internal types — no public API change (digester clean). Local gate green (5193/5193; the lone failure was a live-Ollama-dependent `QuickStartTests`, unchanged on this branch, passes with Ollama up). Optional-traits sweep (`--traits Server,Macros`) green. Independently reviewed and hardened by a second pass (the `rendersToolsNatively` heuristic tightening above).

## Known follow-ups (out of scope, noted)
- `GenerationPreflightTrimmer` drops oldest non-system messages one at a time and can split a call/result pair for a strict template — degraded output, not a trap (the renderer catches and falls back to the enum). Pairing-aware trimming is a larger change.
- Image-in-template (vision GGUF) and full RAG `documents` population are deferred; local vision delivers image bytes via the backend's own install path, not the prompt string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)