### PR TITLE
fix: auto-load persisted backends on quickStart relaunch

### DIFF
--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -434,16 +434,45 @@ public enum ManifoldKit {
                 Log.quickStart.warning("quickStart: model registry refresh failed; no model will be pre-selected: \(error, privacy: .public)")
             }
 
-            let effectivePolicy = selectionPolicy ?? ManifoldKit.defaultSelectionPolicy
-            let chosen = await effectivePolicy(viewModel.modelRegistry)
-            if let chosen {
-                viewModel.modelRegistry.selectModel(chosen)
-            } else {
-                // Neither the built-in policy nor the host-supplied policy found
-                // a model. Leave `selectedModel` nil so the UI can surface an
-                // explicit "No model available — add one to get started" state
-                // rather than a silent blank composer.
-                Log.quickStart.info("quickStart: no model selected — host UI should prompt the user to add a model")
+            // Per-session model/endpoint IDs restored by `switchToSession` must
+            // win over the global Foundation-first policy — otherwise relaunch
+            // would silently swap a persisted Ollama/cloud endpoint for Foundation.
+            if viewModel.selectedModel == nil, viewModel.selectedEndpoint == nil {
+                let effectivePolicy = selectionPolicy ?? ManifoldKit.defaultSelectionPolicy
+                let chosen = await effectivePolicy(viewModel.modelRegistry)
+                if let chosen {
+                    viewModel.modelRegistry.selectModel(chosen)
+                } else {
+                    // Neither the built-in policy nor the host-supplied policy found
+                    // a model. Leave `selectedModel` nil so the UI can surface an
+                    // explicit "No model available — add one to get started" state
+                    // rather than a silent blank composer.
+                    Log.quickStart.info("quickStart: no model selected — host UI should prompt the user to add a model")
+                }
+            }
+
+            // `switchToSession` may have restored a per-session cloud endpoint.
+            // When no local model was chosen, fall back to the first configured
+            // endpoint so cloud-only quickStart consumers are live without a
+            // separate `loadSelectedEndpoint()` call (#1473, DX 02).
+            if viewModel.selectedModel == nil, viewModel.selectedEndpoint == nil {
+                do {
+                    let endpoints = try await bootstrap.endpointStore.fetchEndpoints()
+                    viewModel.setAvailableEndpoints(endpoints)
+                    if let firstEndpoint = viewModel.availableEndpoints.first {
+                        viewModel.selectedEndpoint = firstEndpoint
+                    }
+                } catch {
+                    Log.quickStart.warning("quickStart: endpoint fetch failed during auto-select: \(error, privacy: .public)")
+                }
+            }
+
+            // Selection alone does not load — `ChatViewModel` requires an
+            // explicit dispatch. Mirror the manual-bootstrap recipe in
+            // BuildingAChatUI (dispatch after restore) so the facade path is
+            // generating when it returns.
+            if viewModel.selectedModel != nil || viewModel.selectedEndpoint != nil {
+                viewModel.dispatchSelectedLoad()
             }
 
             return QuickStartResult(bootstrap: bootstrap, viewModel: viewModel, sessionManager: sessionManager)

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -51,10 +51,10 @@ extension ChatViewModel {
         Log.ui.info("Switched to session: \(session.title, privacy: .private)")
 
         // Restoring a session re-applies the persisted model/endpoint selection
-        // but does not load it. Dispatch after the restoring flag clears so any
-        // coordinator/session guards see a settled surface (#1473, DX 02).
+        // but does not load it. The `defer` above clears `isRestoringSession`
+        // before the dispatched Task runs, so any coordinator/session guards
+        // see a settled surface when the load fires (#1473, DX 02).
         if teardownResult.resolvedModel != nil || teardownResult.resolvedEndpoint != nil {
-            sessionManager.isRestoringSession = false
             dispatchSelectedLoad()
         }
     }

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+SessionManagement.swift
@@ -47,7 +47,16 @@ extension ChatViewModel {
         clearDraftAttachments()
         await loadMessages()
         updateContextEstimate()
+
         Log.ui.info("Switched to session: \(session.title, privacy: .private)")
+
+        // Restoring a session re-applies the persisted model/endpoint selection
+        // but does not load it. Dispatch after the restoring flag clears so any
+        // coordinator/session guards see a settled surface (#1473, DX 02).
+        if teardownResult.resolvedModel != nil || teardownResult.resolvedEndpoint != nil {
+            sessionManager.isRestoringSession = false
+            dispatchSelectedLoad()
+        }
     }
 
     /// Saves the current generation settings back to the active session.

--- a/Tests/ManifoldKitTests/QuickStartTests.swift
+++ b/Tests/ManifoldKitTests/QuickStartTests.swift
@@ -144,12 +144,95 @@ final class QuickStartTests: XCTestCase {
             "sessionManager.sessions must reflect persisted sessions on relaunch immediately (#1447)")
     }
 
+    /// When the store already contains a cloud endpoint and no local model is
+    /// selected, `quickStart()` must select the first endpoint and dispatch a
+    /// load before returning — hosts should not need a separate
+    /// `loadSelectedEndpoint()` on every relaunch (DX 02-swiftui-chat).
+    func test_quickStart_selectsFirstEndpoint_whenPolicyReturnsNil() async throws {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let endpoint = APIEndpointRecord(
+            name: "Local Ollama",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.1:8b"
+        )
+
+        // Seed the shared container with an endpoint, then relaunch through
+        // quickStart() the way a consumer app would on second open.
+        let first = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { container },
+            selectionPolicy: { registry in
+                registry.foundationModelProvider = { false }
+                return nil
+            }
+        )
+        try await first.bootstrap.endpointStore.insertEndpoint(endpoint)
+
+        let second = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { container },
+            selectionPolicy: { registry in
+                registry.foundationModelProvider = { false }
+                return nil
+            }
+        )
+
+        XCTAssertEqual(
+            second.viewModel.selectedEndpoint?.id,
+            endpoint.id,
+            "quickStart() must select the first persisted endpoint when no local model is chosen"
+        )
+    }
+
+    /// A session that persisted a cloud endpoint must keep it on relaunch even
+    /// when the default Foundation-first policy would otherwise pre-select a
+    /// local model (DX 02-swiftui-chat).
+    func test_quickStart_preservesSessionEndpoint_overDefaultPolicy() async throws {
+        let container = try ModelContainerFactory.makeInMemoryContainer()
+        let endpoint = APIEndpointRecord(
+            name: "Local Ollama",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.1:8b"
+        )
+
+        let first = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { container }
+        )
+        try await first.bootstrap.endpointStore.insertEndpoint(endpoint)
+
+        var session = try XCTUnwrap(first.viewModel.activeSession)
+        session.selectedEndpointID = endpoint.id
+        try await first.bootstrap.persistence.updateSession(session)
+
+        let second = try await ManifoldKit._quickStart(
+            configuration: .default,
+            makeModelContainer: { container }
+        )
+
+        XCTAssertEqual(
+            second.viewModel.selectedEndpoint?.id,
+            endpoint.id,
+            "quickStart() must restore the session's persisted endpoint on relaunch"
+        )
+        XCTAssertNil(
+            second.viewModel.selectedModel,
+            "Restored session endpoint must not be replaced by the Foundation-first policy"
+        )
+    }
+
     /// Regression guard for #1473 — the documented quickStart cloud-endpoint
     /// recipe seeds `selectedEndpoint` and then activates it before first send.
     func test_quickStart_seededEndpoint_canLoadViaSelectedEndpoint() async throws {
         let result = try await ManifoldKit._quickStart(
             configuration: .default,
-            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() }
+            makeModelContainer: { try ModelContainerFactory.makeInMemoryContainer() },
+            selectionPolicy: { registry in
+                registry.foundationModelProvider = { false }
+                return nil
+            }
         )
         let cloudBackend = QuickStartCloudBackend()
         result.bootstrap.inferenceService.registerEndpointBackendFactory { provider in

--- a/Tests/ManifoldUITests/ViewModelEdgeCaseTests.swift
+++ b/Tests/ManifoldUITests/ViewModelEdgeCaseTests.swift
@@ -54,6 +54,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
         ) throws -> (ChatViewModel, MockInferenceBackend, ErrorInjectingPersistenceProvider) {
         mock.isModelLoaded = true
         let service = InferenceService(backend: mock, name: "Mock")
+        service.registerBackendFactory { _ in mock }
+        service.registerEndpointBackendFactory { _ in mock }
         let modelsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ViewModelEdgeCaseTests-\(UUID().uuidString)")
         addTeardownBlock { try? FileManager.default.removeItem(at: modelsDirectory) }
@@ -293,7 +295,8 @@ final class ViewModelEdgeCaseTests: XCTestCase {
     }
 
     func test_switchToSession_restoresSelectedEndpoint_whenEndpointExists() async throws {
-        let (vm, _, _) = try makeViewModelWithPersistence()
+        let (vm, mock, _) = try makeViewModelWithPersistence()
+        mock.isModelLoaded = false
         let endpoint = APIEndpointRecord(name: "OpenAI", provider: .openAI)
         vm.setAvailableEndpoints([endpoint])
         vm.selectedModel = ModelInfo.builtInFoundation
@@ -306,6 +309,30 @@ final class ViewModelEdgeCaseTests: XCTestCase {
 
         XCTAssertEqual(vm.selectedEndpoint?.id, endpoint.id)
         XCTAssertNil(vm.selectedModel, "Endpoint restore should not leak prior model selection")
+    }
+
+    func test_switchToSession_dispatchesLoad_whenRestoringLocalModel() async throws {
+        let (vm, mock, _) = try makeViewModelWithPersistence()
+        mock.isModelLoaded = false
+
+        vm.foundationModelProvider = { true }
+        vm.refreshModels()
+        let foundationModel = ModelInfo.builtInFoundation
+
+        var session = ManifoldInference.ChatSession(title: "Load On Restore")
+        session.selectedModelID = foundationModel.id
+
+        await vm.switchToSession(session)
+
+        XCTAssertEqual(vm.selectedModel?.id, foundationModel.id)
+
+        // `dispatchSelectedLoad()` runs the coordinated load on a Task — poll
+        // briefly so the mock backend has time to flip `isModelLoaded`.
+        for _ in 0..<30 where !mock.isModelLoaded {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTAssertTrue(mock.isModelLoaded,
+            "switchToSession must dispatch a load when restoring a persisted local model")
     }
 
     func test_switchToSession_clearsSelectedEndpoint_whenEndpointMissing() async throws {

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -215,7 +215,9 @@ struct MyChatApp: App {
 
 ### Seeding an Ollama endpoint
 
-For cloud / LAN backends (Ollama, OpenAI Chat Completions, OpenAI Responses, Anthropic Claude), the host inserts an `APIEndpointRecord` into the endpoint store *before* the view appears. `quickStart()` exposes the store on `result.bootstrap.endpointStore`; `ChatViewModel.refreshAvailableEndpointsFromStore()` is wired up automatically and will pick up the new endpoint. If you want a seeded endpoint to be live immediately (single-endpoint apps, scripted demos, kiosk flows), also set `selectedEndpoint` and call `loadSelectedEndpoint()` before exposing the view model.
+For cloud / LAN backends (Ollama, OpenAI Chat Completions, OpenAI Responses, Anthropic Claude), the host inserts an `APIEndpointRecord` into the endpoint store *before* the view appears. `quickStart()` exposes the store on `result.bootstrap.endpointStore`; `ChatViewModel.refreshAvailableEndpointsFromStore()` is wired up automatically and will pick up the new endpoint.
+
+On **relaunch**, when the endpoint is already in the store, `quickStart()` selects the first configured endpoint and dispatches a load before returning — no extra `loadSelectedEndpoint()` call is required. On **first launch**, when you seed the endpoint *after* `quickStart()` returns (the snippet below), you still need one explicit `loadSelectedEndpoint()` so the first session is live before the view appears.
 
 Ollama support is always compiled in since v0.48 (the `Ollama` trait was retired) — the seeded endpoint is the only configuration step.
 
@@ -246,7 +248,7 @@ struct MyChatApp: App {
                             let ollama = APIEndpointRecord(
                                 name: "Local Ollama",
                                 provider: .ollama,
-                                modelName: "llama3.2:3b"  // any model you've `ollama pull`-ed
+                                modelName: "llama3.1:8b"  // paste a tag from `ollama list`
                             )
                             try await r.bootstrap.endpointStore.insertEndpoint(ollama)
                             r.viewModel.setAvailableEndpoints([ollama])

--- a/docs/SWIFTUI-MULTI-SESSION.md
+++ b/docs/SWIFTUI-MULTI-SESSION.md
@@ -101,6 +101,24 @@ mints a fresh one if the store is empty). On every subsequent relaunch the
 sidebar comes back populated and the previously open chat is already
 selected — no host-side wait/restore heuristic required.
 
+**Model loading.** `quickStart()` also dispatches a load for whichever
+backend it selected: the built-in policy's local model (Foundation-first,
+then first on-disk GGUF), a per-session model/endpoint restored by
+``switchToSession(_:)``, or — when no local model is available — the first
+configured cloud endpoint in the endpoint store. You do **not** need a
+separate `loadSelectedEndpoint()` / `dispatchSelectedLoad()` call after
+`quickStart()` returns on relaunch. ``switchToSession(_:)`` performs the
+same dispatch when the user picks a different sidebar row, so the
+`onChange` handler above does not need an extra `dispatchSelectedLoad()`
+either.
+
+> **First-launch Ollama seeding.** If you insert an endpoint *after*
+> `quickStart()` returns (the pattern in [QUICKSTART.md → Seeding an Ollama
+> endpoint](QUICKSTART.md#seeding-an-ollama-endpoint)), you still need one
+> explicit `loadSelectedEndpoint()` on that first run — the endpoint did not
+> exist in the store when `quickStart()` ran. Every subsequent relaunch
+> picks it up automatically.
+
 ## 3. When to use the manual bootstrap path
 
 Drop down to `ManifoldBootstrap.build(...)` when you need:


### PR DESCRIPTION
## Problem

DX walkthrough scenario 02 (`02-swiftui-chat`) found that a persisted Ollama endpoint survives relaunch in SwiftData, but the backend is not loaded — generation fails until the host calls `loadSelectedEndpoint()` manually. Persisted endpoint ≠ loaded backend.

## Fix

**`quickStart()`**
- After `switchToSession`, auto-selects the first configured cloud endpoint when no local model or session selection exists
- Dispatches `dispatchSelectedLoad()` before returning so the facade path is generating-ready
- Skips the Foundation-first selection policy when the restored session already has a model or endpoint (prevents silently swapping Ollama → Foundation on relaunch)

**`switchToSession(_:)`**
- Dispatches load when a persisted model or endpoint is restored, so sidebar picks and relaunch restore are live without extra host glue

## Docs

- `QUICKSTART.md` and `SWIFTUI-MULTI-SESSION.md` clarify: relaunch is automatic; first-launch post-`quickStart()` Ollama seeding still needs one explicit `loadSelectedEndpoint()`

## Tests

- `test_quickStart_selectsFirstEndpoint_whenPolicyReturnsNil`
- `test_quickStart_preservesSessionEndpoint_overDefaultPolicy`
- `test_switchToSession_dispatchesLoad_whenRestoringLocalModel`
- `makeViewModelWithPersistence` registers mock backend factories so load dispatch is exercised

## Verification

```
swift test --filter 'QuickStartTests|ViewModelEdgeCaseTests'
```