### PR TITLE
feat: quality-aware TTS voice selection + voice picker

### DIFF
--- a/Sources/ManifoldInference/Services/AppleTTSBackend+VoiceSelection.swift
+++ b/Sources/ManifoldInference/Services/AppleTTSBackend+VoiceSelection.swift
@@ -21,9 +21,11 @@ extension AppleTTSBackend {
     /// - Parameter language: BCP-47 tag (or bare primary subtag like `"en"`)
     ///   to filter by. `nil` returns every installed voice.
     public static func availableVoices(language: String? = nil) -> [VoiceDescriptor] {
-        let descriptors = AVSpeechSynthesisVoice.speechVoices()
+        var descriptors = AVSpeechSynthesisVoice.speechVoices()
             .map(VoiceDescriptor.init)
-            .filter { language == nil || Self.languageMatches($0.language, language!) }
+        if let language {
+            descriptors = descriptors.filter { Self.languageMatches($0.language, language) }
+        }
         return Self.ranked(descriptors)
     }
 

--- a/Sources/ManifoldInference/Services/AppleTTSBackend+VoiceSelection.swift
+++ b/Sources/ManifoldInference/Services/AppleTTSBackend+VoiceSelection.swift
@@ -1,0 +1,98 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+// MARK: - Voice enumeration + quality-aware selection
+//
+// Why this exists: leaving `AVSpeechUtterance.voice` nil (or resolving a
+// language tag via `AVSpeechSynthesisVoice(language:)`) yields the *compact*
+// default — e.g. `com.apple.voice.compact.en-US.Samantha`, the robotic floor.
+// Worse, the legacy MacinTalk novelty voices (Zarvox, Bells, Boing…) share the
+// same `standard` quality tier as Samantha, so a naive `max(by: quality)` can
+// surface a joke voice. The ranking below prefers the modern Siri-family voices
+// and the highest installed quality tier (premium → enhanced → compact), so the
+// backend automatically uses a downloaded Premium voice the moment one exists.
+
+extension AppleTTSBackend {
+
+    /// Installed speech voices as framework-free ``VoiceDescriptor`` values,
+    /// sorted best-first (premium → enhanced → standard; modern Siri voices
+    /// ahead of legacy/novelty voices at equal quality).
+    ///
+    /// - Parameter language: BCP-47 tag (or bare primary subtag like `"en"`)
+    ///   to filter by. `nil` returns every installed voice.
+    public static func availableVoices(language: String? = nil) -> [VoiceDescriptor] {
+        let descriptors = AVSpeechSynthesisVoice.speechVoices()
+            .map(VoiceDescriptor.init)
+            .filter { language == nil || Self.languageMatches($0.language, language!) }
+        return Self.ranked(descriptors)
+    }
+
+    /// Resolves the concrete `AVSpeechSynthesisVoice` for a config, applying the
+    /// quality-aware fallback. An explicit voice *identifier* always wins; a
+    /// language tag (or nil) resolves to the best installed voice for that
+    /// language (or the device language when nil).
+    static func resolveVoice(config: SpeechGenerationConfig) -> AVSpeechSynthesisVoice? {
+        guard let requested = config.voice, !requested.isEmpty else {
+            return bestVoice(forLanguage: nil)
+        }
+        // A real identifier resolves directly; a language tag does not, so it
+        // falls through to the quality-aware language path.
+        if let exact = AVSpeechSynthesisVoice(identifier: requested) {
+            return exact
+        }
+        return bestVoice(forLanguage: requested)
+            ?? AVSpeechSynthesisVoice(language: requested)
+    }
+
+    /// Highest-ranked installed voice for a language, or the device language
+    /// when `language` is nil. Returns nil only when no voice is installed.
+    static func bestVoice(forLanguage language: String?) -> AVSpeechSynthesisVoice? {
+        let target = language ?? AVSpeechSynthesisVoice.currentLanguageCode()
+        let voices = AVSpeechSynthesisVoice.speechVoices()
+
+        // Prefer an exact language match; fall back to the primary subtag
+        // (e.g. device "en-AU" can borrow a premium "en-US" before settling for
+        // a compact "en-AU").
+        let exact = voices.filter { $0.language.caseInsensitiveCompare(target) == .orderedSame }
+        let pool = exact.isEmpty
+            ? voices.filter { Self.languageMatches($0.language, target) }
+            : exact
+
+        return pool.max { Self.score(VoiceDescriptor($0)) < Self.score(VoiceDescriptor($1)) }
+    }
+
+    // MARK: - Pure ranking (unit-testable without AVFoundation voices)
+
+    /// Sorts descriptors best-first using ``score(_:)``, with a stable
+    /// alphabetical tie-break so equal-scoring voices order deterministically.
+    static func ranked(_ descriptors: [VoiceDescriptor]) -> [VoiceDescriptor] {
+        descriptors.sorted { lhs, rhs in
+            let sl = score(lhs), sr = score(rhs)
+            if sl != sr { return sl > sr }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    /// Heuristic desirability score. Quality dominates; within a tier the modern
+    /// Siri family (`com.apple.voice.*`) is preferred over super-compact, legacy
+    /// MacinTalk novelty (`com.apple.speech.synthesis.voice.*`), and Eloquence
+    /// voices — so a compact Samantha outranks Zarvox despite equal quality.
+    static func score(_ voice: VoiceDescriptor) -> Int {
+        var s = voice.quality.rawValue * 1000
+        let id = voice.id
+        if id.contains(".voice.") { s += 100 }                       // modern Siri family
+        if id.contains(".super-compact.") { s -= 60 }                // lower fidelity than compact
+        if id.hasPrefix("com.apple.eloquence.") { s -= 200 }         // robotic
+        if id.hasPrefix("com.apple.speech.synthesis.voice.") { s -= 500 } // MacinTalk novelty
+        return s
+    }
+
+    /// True when `voiceLanguage` matches `query` exactly or shares its primary
+    /// subtag (so `"en"` matches `"en-US"` and `"en-GB"`).
+    static func languageMatches(_ voiceLanguage: String, _ query: String) -> Bool {
+        if voiceLanguage.caseInsensitiveCompare(query) == .orderedSame { return true }
+        let primary: (String) -> String = { $0.split(separator: "-").first.map(String.init)?.lowercased() ?? "" }
+        let pv = primary(voiceLanguage)
+        return !pv.isEmpty && pv == primary(query)
+    }
+}

--- a/Sources/ManifoldInference/Services/AppleTTSBackend.swift
+++ b/Sources/ManifoldInference/Services/AppleTTSBackend.swift
@@ -256,6 +256,11 @@ public final class AppleTTSBackend: AudioGenerationBackend, @unchecked Sendable 
 
     /// Maps a ``SpeechGenerationConfig`` onto an `AVSpeechUtterance`. Honours
     /// `voice`, `rate`, and `pitch`; ignores knobs the engine does not expose.
+    ///
+    /// Voice resolution is quality-aware (see ``resolveVoice(config:)``): an
+    /// explicit identifier is used verbatim, while a language tag or a nil voice
+    /// resolves to the *best installed* voice rather than the compact default —
+    /// so a downloaded Enhanced/Premium voice is picked up automatically.
     static func makeUtterance(
         text: String,
         config: SpeechGenerationConfig
@@ -267,16 +272,7 @@ public final class AppleTTSBackend: AudioGenerationBackend, @unchecked Sendable 
         if let pitch = config.pitch {
             utterance.pitchMultiplier = pitch
         }
-        if let voiceID = config.voice {
-            // Try an explicit voice identifier first, then a BCP-47 language
-            // tag (callers commonly pass e.g. "en-US"). Leaving `voice` nil
-            // lets the system pick the default voice.
-            if let voice = AVSpeechSynthesisVoice(identifier: voiceID) {
-                utterance.voice = voice
-            } else if let voice = AVSpeechSynthesisVoice(language: voiceID) {
-                utterance.voice = voice
-            }
-        }
+        utterance.voice = resolveVoice(config: config)
         return utterance
     }
 }

--- a/Sources/ManifoldInference/Services/VoiceDescriptor.swift
+++ b/Sources/ManifoldInference/Services/VoiceDescriptor.swift
@@ -1,0 +1,80 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+/// A selectable text-to-speech voice, decoupled from `AVFoundation` so UI and
+/// tests can reason about voices without importing the speech framework.
+///
+/// Produced by ``AppleTTSBackend/availableVoices(language:)`` and consumed by
+/// voice pickers. The ``id`` is the platform voice identifier a caller stores
+/// in ``SpeechGenerationConfig/voice`` to pin a specific voice.
+public struct VoiceDescriptor: Sendable, Codable, Hashable, Identifiable {
+
+    /// Render quality tier. Apple ships three tiers; the higher two
+    /// (`enhanced`, `premium`) are downloadable on-device and dramatically more
+    /// natural than the always-resident `standard` (compact) voices.
+    public enum Quality: Int, Sendable, Codable, Hashable, Comparable, CaseIterable {
+        /// Always-resident "compact" voice — the robotic floor.
+        case standard = 1
+        /// Downloadable higher-fidelity voice.
+        case enhanced = 2
+        /// Downloadable neural voice — the most natural tier.
+        case premium = 3
+
+        public static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+
+        /// Human-facing label for grouping in a picker.
+        public var displayName: String {
+            switch self {
+            case .standard: return "Standard"
+            case .enhanced: return "Enhanced"
+            case .premium: return "Premium"
+            }
+        }
+    }
+
+    /// Platform voice identifier (e.g. `com.apple.voice.premium.en-US.Ava`).
+    /// Store this in ``SpeechGenerationConfig/voice`` to pin the voice.
+    public let id: String
+
+    /// Human-readable voice name (e.g. `Ava`).
+    public let name: String
+
+    /// BCP-47 language tag the voice speaks (e.g. `en-US`).
+    public let language: String
+
+    /// Render-quality tier.
+    public let quality: Quality
+
+    public init(id: String, name: String, language: String, quality: Quality) {
+        self.id = id
+        self.name = name
+        self.language = language
+        self.quality = quality
+    }
+}
+
+extension VoiceDescriptor.Quality {
+    /// Maps Apple's `AVSpeechSynthesisVoiceQuality` onto our tier. Unknown
+    /// future raw values fall back to `standard` rather than trapping.
+    init(_ avQuality: AVSpeechSynthesisVoiceQuality) {
+        switch avQuality {
+        case .premium: self = .premium
+        case .enhanced: self = .enhanced
+        default: self = .standard
+        }
+    }
+}
+
+extension VoiceDescriptor {
+    /// Bridges an `AVSpeechSynthesisVoice` into the framework-free descriptor.
+    init(_ voice: AVSpeechSynthesisVoice) {
+        self.init(
+            id: voice.identifier,
+            name: voice.name,
+            language: voice.language,
+            quality: Quality(voice.quality)
+        )
+    }
+}

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+AudioGeneration.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+AudioGeneration.swift
@@ -165,6 +165,40 @@ extension ChatViewModel {
         )
     }
 
+    /// Installed text-to-speech voices, ranked best-first, for populating a
+    /// voice picker. Thin pass-through to ``AppleTTSBackend/availableVoices(language:)``.
+    ///
+    /// - Parameter language: BCP-47 tag (or bare primary subtag like `"en"`) to
+    ///   filter by; `nil` returns every installed voice.
+    public func availableSpeechVoices(language: String? = nil) -> [VoiceDescriptor] {
+        AppleTTSBackend.availableVoices(language: language)
+    }
+
+    /// Convenience over ``generateSpeech(config:)`` that synthesises `text`
+    /// using ``selectedSpeechVoiceID`` (auto-selecting the best installed voice
+    /// when nil). The entry point used by `GenerativeContextMenuItems`.
+    ///
+    /// - Parameters:
+    ///   - text: The text to synthesise.
+    ///   - rate: Optional speaking-rate multiplier.
+    ///   - pitch: Optional pitch multiplier.
+    /// - Returns: The placeholder ``ChatMessage/ID``.
+    @discardableResult
+    public func generateSpeech(
+        forText text: String,
+        rate: Float? = nil,
+        pitch: Float? = nil
+    ) async throws -> UUID {
+        try await generateSpeech(
+            config: SpeechGenerationConfig(
+                text: text,
+                voice: selectedSpeechVoiceID,
+                rate: rate,
+                pitch: pitch
+            )
+        )
+    }
+
     /// Cancel an in-flight audio generation by its placeholder message ID.
     ///
     /// Idempotent — cancelling an unknown or already-finished generation is

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel.swift
@@ -713,6 +713,12 @@ public final class ChatViewModel {
     /// generations. Driven by the `AudioGenerationRuntime` event drain.
     public internal(set) var audioGenerationProgress: [UUID: AudioGenerationProgress] = [:]
 
+    /// Identifier of the voice the user picked for text-to-speech, or `nil` to
+    /// let the backend auto-select the best installed voice. Bound by
+    /// `VoicePickerView` and read by ``generateSpeech(forText:)`` /
+    /// `GenerativeContextMenuItems`. See `ChatViewModel+AudioGeneration`.
+    public var selectedSpeechVoiceID: String?
+
     // MARK: - WebSearchRuntime
     //
     // Optional sibling to `_imageRuntime` / `_videoRuntime` for the web-search

--- a/Sources/ManifoldUI/Views/Chat/GenerativeContextMenuItems.swift
+++ b/Sources/ManifoldUI/Views/Chat/GenerativeContextMenuItems.swift
@@ -48,6 +48,23 @@ public struct GenerativeContextMenuItems: View {
         let hasImage = generatedImage != nil
         let hasImageRuntime = viewModel.imageRuntime != nil
         let hasVideoRuntime = viewModel.videoRuntime != nil
+        let hasAudioRuntime = viewModel.audioRuntime != nil
+
+        // "Generate Speech from This" — text message + audio runtime. Uses the
+        // user's selected voice (or the best installed voice when unset).
+        if hasText && hasAudioRuntime {
+            Button {
+                Task {
+                    do {
+                        try await viewModel.generateSpeech(forText: text)
+                    } catch {
+                        Log.ui.warning("GenerativeContextMenuItems: speech generation failed: \(error)")
+                    }
+                }
+            } label: {
+                Label("Generate Speech from This", systemImage: "waveform")
+            }
+        }
 
         // "Generate Image from This" — text message + image runtime
         if hasText && hasImageRuntime {

--- a/Sources/ManifoldUI/Views/Settings/VoicePickerView.swift
+++ b/Sources/ManifoldUI/Views/Settings/VoicePickerView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import ManifoldInference
+
+/// A picker for the text-to-speech voice used by ``ChatViewModel/generateSpeech(forText:)``.
+///
+/// Lists installed voices grouped by quality tier (Premium → Enhanced →
+/// Standard), best-first within each tier, plus an **Automatic** option that
+/// lets the backend pick the best installed voice. The selection is bound to
+/// ``ChatViewModel/selectedSpeechVoiceID``.
+///
+/// ```swift
+/// VoicePickerView(viewModel: viewModel)        // all installed voices
+/// VoicePickerView(viewModel: viewModel, language: "en")  // English only
+/// ```
+///
+/// > Tip: The higher-quality (Enhanced/Premium) voices are downloaded by the
+/// > user in *System Settings → Accessibility → Spoken Content → System Voice →
+/// > Manage Voices*. Until then only Standard voices appear.
+public struct VoicePickerView: View {
+
+    @Bindable private var viewModel: ChatViewModel
+    private let language: String?
+
+    public init(viewModel: ChatViewModel, language: String? = nil) {
+        self.viewModel = viewModel
+        self.language = language
+    }
+
+    public var body: some View {
+        let grouped = Dictionary(
+            grouping: viewModel.availableSpeechVoices(language: language),
+            by: \.quality
+        )
+
+        Picker("Voice", selection: $viewModel.selectedSpeechVoiceID) {
+            Text("Automatic (best available)")
+                .tag(String?.none)
+
+            // Highest tier first so the most natural voices sit at the top.
+            ForEach(VoiceDescriptor.Quality.allCases.sorted(by: >), id: \.self) { tier in
+                if let voices = grouped[tier], !voices.isEmpty {
+                    Section(tier.displayName) {
+                        ForEach(voices) { voice in
+                            Text("\(voice.name) · \(voice.language)")
+                                .tag(String?.some(voice.id))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/ManifoldInferenceTests/VoiceSelectionTests.swift
+++ b/Tests/ManifoldInferenceTests/VoiceSelectionTests.swift
@@ -1,0 +1,121 @@
+@preconcurrency import AVFoundation
+import XCTest
+@testable import ManifoldInference
+
+/// Coverage for the quality-aware voice ranking and resolution added to
+/// ``AppleTTSBackend``. The ranking is exercised through pure ``VoiceDescriptor``
+/// values so the assertions are deterministic on any host — installed voices
+/// vary by machine, but the *ordering rules* must not.
+final class VoiceSelectionTests: XCTestCase {
+
+    private func v(_ id: String, _ name: String, _ lang: String, _ q: VoiceDescriptor.Quality) -> VoiceDescriptor {
+        VoiceDescriptor(id: id, name: name, language: lang, quality: q)
+    }
+
+    // MARK: - Quality dominates
+
+    func test_ranking_prefersPremiumOverEnhancedOverStandard() {
+        let premium = v("com.apple.voice.premium.en-US.Ava", "Ava", "en-US", .premium)
+        let enhanced = v("com.apple.voice.enhanced.en-US.Evan", "Evan", "en-US", .enhanced)
+        let standard = v("com.apple.voice.compact.en-US.Samantha", "Samantha", "en-US", .standard)
+
+        let ranked = AppleTTSBackend.ranked([standard, premium, enhanced])
+
+        XCTAssertEqual(ranked.map(\.name), ["Ava", "Evan", "Samantha"])
+    }
+
+    // MARK: - Novelty trap
+
+    func test_ranking_compactSamanthaBeatsNoveltyAtEqualQuality() {
+        // Zarvox / Bells are legacy MacinTalk voices at the SAME standard tier
+        // as compact Samantha — a naive max(by: quality) could surface them.
+        let samantha = v("com.apple.voice.compact.en-US.Samantha", "Samantha", "en-US", .standard)
+        let zarvox = v("com.apple.speech.synthesis.voice.Zarvox", "Zarvox", "en-US", .standard)
+        let bells = v("com.apple.speech.synthesis.voice.Bells", "Bells", "en-US", .standard)
+
+        let ranked = AppleTTSBackend.ranked([zarvox, bells, samantha])
+
+        XCTAssertEqual(ranked.first?.name, "Samantha", "Modern Siri voice must outrank novelty voices")
+        XCTAssertEqual(Set(ranked.suffix(2).map(\.name)), ["Zarvox", "Bells"])
+    }
+
+    func test_ranking_compactBeatsSuperCompactAtEqualQuality() {
+        let compact = v("com.apple.voice.compact.en-US.Samantha", "Samantha", "en-US", .standard)
+        let superCompact = v("com.apple.voice.super-compact.en-AU.Karen", "Karen", "en-AU", .standard)
+
+        let ranked = AppleTTSBackend.ranked([superCompact, compact])
+
+        XCTAssertEqual(ranked.first?.name, "Samantha")
+    }
+
+    func test_ranking_enhancedNoveltyStillLosesToPremiumSiri() {
+        // Quality must dominate the family bonus: a premium Siri voice beats an
+        // (implausible) enhanced novelty voice.
+        let premiumSiri = v("com.apple.voice.premium.en-US.Ava", "Ava", "en-US", .premium)
+        let enhancedNovelty = v("com.apple.speech.synthesis.voice.Zarvox", "Zarvox", "en-US", .enhanced)
+
+        let ranked = AppleTTSBackend.ranked([enhancedNovelty, premiumSiri])
+
+        XCTAssertEqual(ranked.first?.name, "Ava")
+    }
+
+    func test_ranking_tieBreaksAlphabeticallyAndStably() {
+        let a = v("com.apple.voice.compact.en-US.Aaron", "Aaron", "en-US", .standard)
+        let z = v("com.apple.voice.compact.en-US.Zoe", "Zoe", "en-US", .standard)
+
+        XCTAssertEqual(AppleTTSBackend.ranked([z, a]).map(\.name), ["Aaron", "Zoe"])
+        XCTAssertEqual(AppleTTSBackend.ranked([a, z]).map(\.name), ["Aaron", "Zoe"])
+    }
+
+    // MARK: - Language matching
+
+    func test_languageMatches_exactAndPrimarySubtag() {
+        XCTAssertTrue(AppleTTSBackend.languageMatches("en-US", "en-US"))
+        XCTAssertTrue(AppleTTSBackend.languageMatches("en-US", "EN-us"))   // case-insensitive
+        XCTAssertTrue(AppleTTSBackend.languageMatches("en-GB", "en"))      // primary subtag
+        XCTAssertFalse(AppleTTSBackend.languageMatches("fr-FR", "en-US"))
+        XCTAssertFalse(AppleTTSBackend.languageMatches("en-US", "es"))
+    }
+
+    // MARK: - Quality bridging
+
+    func test_quality_bridgesAVQuality() {
+        XCTAssertEqual(VoiceDescriptor.Quality(.premium), .premium)
+        XCTAssertEqual(VoiceDescriptor.Quality(.enhanced), .enhanced)
+        XCTAssertEqual(VoiceDescriptor.Quality(.default), .standard)
+    }
+
+    // MARK: - Host enumeration (smoke; host-dependent)
+
+    func test_availableVoices_returnsRankedNonEmptyAndSorted() {
+        let all = AppleTTSBackend.availableVoices()
+        // Every test host ships at least one voice.
+        XCTAssertFalse(all.isEmpty, "Expected installed system voices")
+        // Output must be in non-increasing score order.
+        let scores = all.map(AppleTTSBackend.score)
+        XCTAssertEqual(scores, scores.sorted(by: >), "availableVoices must be ranked best-first")
+    }
+
+    func test_availableVoices_languageFilterRestrictsToPrimarySubtag() {
+        let english = AppleTTSBackend.availableVoices(language: "en")
+        // Filter is honoured: nothing outside the en-* family leaks in.
+        XCTAssertTrue(english.allSatisfy { $0.language.lowercased().hasPrefix("en") },
+                      "Language filter must restrict to the requested primary subtag")
+    }
+
+    // MARK: - Resolution
+
+    func test_resolveVoice_nilVoice_picksAnInstalledVoice() {
+        // With no voice requested the backend now resolves a concrete voice
+        // rather than leaving the utterance on the bare system default.
+        let resolved = AppleTTSBackend.resolveVoice(config: SpeechGenerationConfig(text: "hi"))
+        XCTAssertNotNil(resolved, "Expected a resolved default voice on a host with installed voices")
+    }
+
+    func test_resolveVoice_explicitIdentifierWins() throws {
+        // Pick a real installed identifier and confirm it is honoured verbatim.
+        let some = try XCTUnwrap(AppleTTSBackend.availableVoices().first)
+        let resolved = AppleTTSBackend.resolveVoice(config: SpeechGenerationConfig(text: "hi", voice: some.id))
+        XCTAssertEqual(resolved?.identifier, some.id)
+    }
+}

--- a/Tests/ManifoldUITests/ChatViewModelVoiceSelectionTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelVoiceSelectionTests.swift
@@ -1,0 +1,135 @@
+@preconcurrency import XCTest
+import Foundation
+import os
+@testable import ManifoldUI
+@testable import ManifoldRuntime
+@testable import ManifoldInference
+
+/// Coverage for the ``ChatViewModel`` voice-selection surface added for the
+/// TTS voice picker: voice enumeration, the ``selectedSpeechVoiceID`` binding,
+/// and that ``ChatViewModel/generateSpeech(forText:)`` threads the selected
+/// voice into the ``SpeechGenerationConfig`` the backend receives.
+@MainActor
+final class ChatViewModelVoiceSelectionTests: XCTestCase {
+
+    // MARK: - Recording backend (captures the config it was handed)
+
+    final class RecordingAudioBackend: AudioGenerationBackend, @unchecked Sendable {
+        private let box = OSAllocatedUnfairLock<SpeechGenerationConfig?>(initialState: nil)
+        var lastConfig: SpeechGenerationConfig? { box.withLock { $0 } }
+
+        var isGenerating: Bool { false }
+        func stopGeneration() {}
+
+        func generate(
+            config: SpeechGenerationConfig
+        ) throws -> AsyncThrowingStream<AudioGenerationEvent, Error> {
+            box.withLock { $0 = config }
+            return AsyncThrowingStream { continuation in
+                continuation.yield(.progress(step: 1, total: 1))
+                continuation.yield(.completed(URL(fileURLWithPath: "/tmp/voice-test.caf")))
+                continuation.finish()
+            }
+        }
+    }
+
+    @MainActor
+    final class TestMessageStore: MessageStore {
+        private(set) var messages: [UUID: ChatMessage] = [:]
+        func insertMessage(_ message: ChatMessage) async throws { messages[message.id] = message }
+        func updateMessage(_ message: ChatMessage) async throws { messages[message.id] = message }
+        func deleteMessage(_ messageID: UUID) async throws { messages.removeValue(forKey: messageID) }
+        func fetchMessages(for sessionID: UUID) async throws -> [ChatMessage] {
+            messages.values.filter { $0.sessionID == sessionID }
+        }
+        func deleteMessages(for sessionID: UUID) async throws {
+            messages = messages.filter { $0.value.sessionID != sessionID }
+        }
+        func addPostWriteHook(_ hook: any MessageStorePostWriteHook) {}
+    }
+
+    private func makeViewModel() -> ChatViewModel {
+        ChatViewModel(
+            inferenceService: InferenceService(),
+            userDefaults: UserDefaults(suiteName: "ChatViewModelVoiceSelectionTests-\(UUID().uuidString)")!
+        )
+    }
+
+    @discardableResult
+    private func configure(_ vm: ChatViewModel, backend: RecordingAudioBackend) -> UUID {
+        let service = AudioGenerationService(backend: backend)
+        let runtime = AudioGenerationRuntime(service: service, messageStore: TestMessageStore())
+        vm.configure(audioRuntime: runtime)
+        let session = ChatSession(title: "Voice Test")
+        vm.activeSession = session
+        return session.id
+    }
+
+    /// Spin until the recording backend captures a config, or fail.
+    private func awaitConfig(
+        _ backend: RecordingAudioBackend,
+        timeout: TimeInterval = 5.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async -> SpeechGenerationConfig? {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            if let config = backend.lastConfig { return config }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("Timed out waiting for backend to receive a config", file: file, line: line)
+        return nil
+    }
+
+    // MARK: - Enumeration
+
+    func test_availableSpeechVoices_isNonEmptyAndRankedBestFirst() {
+        let vm = makeViewModel()
+        let voices = vm.availableSpeechVoices()
+        XCTAssertFalse(voices.isEmpty, "Expected installed system voices")
+        // Quality is the dominant ranking key, so qualities must be non-increasing.
+        let qualities = voices.map(\.quality.rawValue)
+        XCTAssertEqual(qualities, qualities.sorted(by: >), "Voices must be ranked best-first")
+    }
+
+    func test_availableSpeechVoices_languageFilterRestrictsResults() {
+        let vm = makeViewModel()
+        let english = vm.availableSpeechVoices(language: "en")
+        XCTAssertTrue(english.allSatisfy { $0.language.lowercased().hasPrefix("en") })
+    }
+
+    // MARK: - Selection threading
+
+    func test_selectedVoiceDefaultsToNil() {
+        XCTAssertNil(makeViewModel().selectedSpeechVoiceID)
+    }
+
+    func test_generateSpeechForText_threadsSelectedVoiceIntoConfig() async throws {
+        let vm = makeViewModel()
+        let backend = RecordingAudioBackend()
+        _ = configure(vm, backend: backend)
+
+        let chosen = try XCTUnwrap(vm.availableSpeechVoices().first)
+        vm.selectedSpeechVoiceID = chosen.id
+
+        try await vm.generateSpeech(forText: "Hello voices.")
+
+        let config = await awaitConfig(backend)
+        XCTAssertEqual(config?.voice, chosen.id, "Selected voice must be threaded into the config")
+        XCTAssertEqual(config?.text, "Hello voices.")
+    }
+
+    func test_generateSpeechForText_nilSelection_leavesVoiceNilForBackendAutoSelect() async throws {
+        let vm = makeViewModel()
+        let backend = RecordingAudioBackend()
+        _ = configure(vm, backend: backend)
+
+        XCTAssertNil(vm.selectedSpeechVoiceID)
+        try await vm.generateSpeech(forText: "Auto voice.")
+
+        let config = await awaitConfig(backend)
+        XCTAssertNil(config?.voice, "Nil selection must leave voice nil so the backend auto-selects")
+        XCTAssertEqual(config?.text, "Auto voice.")
+    }
+}


### PR DESCRIPTION
## Why

The TTS reference backend (`AppleTTSBackend`, #1908) left `AVSpeechUtterance.voice` nil, so the OS fell back to the **compact** default (`com.apple.voice.compact.en-US.Samantha`) — the robotic floor. Resolving a language tag via `AVSpeechSynthesisVoice(language:)` had the same problem, and a naive `max(by: quality)` could even surface a legacy MacinTalk **novelty** voice (Zarvox/Bells) since those share the `standard` quality tier.

This makes voice selection quality-aware and adds the first reachable TTS UI.

## Backend (`ManifoldInference`)

- **`VoiceDescriptor`** — framework-free `{id, name, language, quality}` value type so UI/tests reason about voices without importing AVFoundation (`ManifoldModelCatalog` stays a Foundation-only leaf).
- **`AppleTTSBackend.availableVoices(language:)`** — installed voices as ranked descriptors: premium → enhanced → standard, with modern Siri voices ahead of super-compact / Eloquence / MacinTalk novelty at equal quality.
- **Quality-aware `resolveVoice(config:)`** — an explicit identifier wins; a language tag or nil voice now resolves to the **best installed** voice, so a downloaded Enhanced/Premium voice is used automatically.

## UI (`ManifoldUI`)

- `ChatViewModel.selectedSpeechVoiceID` + `availableSpeechVoices(language:)` + `generateSpeech(forText:)` convenience that threads the selected voice.
- **`VoicePickerView`** — voices grouped by quality tier, plus an Automatic option.
- **"Generate Speech from This"** entry in `GenerativeContextMenuItems` — the first reachable TTS trigger.

## Tests

- `VoiceSelectionTests` (11) — pure-`VoiceDescriptor` ranking so assertions are deterministic on any host: premium>enhanced>standard, novelty/super-compact deprioritised, language match, resolution.
- `ChatViewModelVoiceSelectionTests` (5) — enumeration + selected-voice threading via a config-recording backend.
- Full `scripts/test.sh --profile local` gate: **5057 tests, 0 failures**. Existing audio suites unchanged.

## Note for users

Higher-fidelity voices are a one-time download (*System Settings → Accessibility → Spoken Content → System Voice → Manage Voices*). Until then only Standard voices are installed — but the backend now picks the best of whatever exists, and upgrades automatically once a Premium voice is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)