### PR TITLE
feat: configurable RAG retrieval threshold + top-K

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -106,3 +106,7 @@ API breakage: class InMemoryMetricSink has been removed
 API breakage: enumelement UnloadReason.idleTimeout has been added as a new enum case
 API breakage: constructor ManifoldBootstrap.init(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:isInMemory:) has been removed
 API breakage: func ManifoldBootstrap.build(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:) has been renamed to func build(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:audioGenerationService:)
+API breakage: func RAGService.retrieve(query:limit:) has parameter 1 type change from Swift.Int to Swift.Int?
+API breakage: func RAGService.retrieveSlots(query:limit:) has parameter 1 type change from Swift.Int to Swift.Int?
+API breakage: constructor RAGService.init(documentStore:vectorStore:embeddingBackend:reranker:chunker:parsers:) has been removed
+API breakage: constructor RAGConfiguration.init(embeddingBackend:reranker:chunkSize:chunkOverlap:topK:vectorStoreURL:) has been removed

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -51,6 +51,13 @@ public struct RAGConfiguration: Sendable {
     public var chunkOverlap: Int
     /// Number of chunks to retrieve per turn. Default: 5.
     public var topK: Int
+    /// Minimum cosine similarity a retrieved chunk must score to be injected.
+    /// Hits scoring strictly below this are dropped. Range `0...1`; the default
+    /// of `0` disables the floor (preserving the historical behaviour — the
+    /// vector store already excludes non-positive scores). Raise it (e.g. `0.3`)
+    /// to suppress weakly-related passages at the cost of occasionally returning
+    /// fewer than ``topK`` chunks.
+    public var similarityThreshold: Float
     /// URL for the flat-file vector index. Defaults to
     /// `<Application Support>/<bundleIdentifier>/ragvectors.bin`.
     public var vectorStoreURL: URL?
@@ -61,6 +68,7 @@ public struct RAGConfiguration: Sendable {
         chunkSize: Int = 1800,
         chunkOverlap: Int = 200,
         topK: Int = 5,
+        similarityThreshold: Float = 0,
         vectorStoreURL: URL? = nil
     ) {
         self.embeddingBackend = embeddingBackend
@@ -68,6 +76,7 @@ public struct RAGConfiguration: Sendable {
         self.chunkSize = chunkSize
         self.chunkOverlap = chunkOverlap
         self.topK = topK
+        self.similarityThreshold = similarityThreshold
         self.vectorStoreURL = vectorStoreURL
     }
 }
@@ -480,7 +489,9 @@ public final class ManifoldBootstrap {
             vectorStore: vectorStore,
             embeddingBackend: resolveEmbeddingBackend(ragConfig.embeddingBackend),
             reranker: ragConfig.reranker,
-            chunker: chunker
+            chunker: chunker,
+            defaultLimit: ragConfig.topK,
+            similarityThreshold: ragConfig.similarityThreshold
         )
     }
 

--- a/Sources/ManifoldRuntime/Services/RAGService.swift
+++ b/Sources/ManifoldRuntime/Services/RAGService.swift
@@ -29,6 +29,18 @@ public actor RAGService {
     private let chunker: DocumentChunker
     private let parsers: [any DocumentParser]
 
+    /// Default number of passages retrieved per turn when a caller does not pass
+    /// an explicit `limit`. Threaded from ``RAGConfiguration/topK`` at bootstrap;
+    /// the turn loop calls ``retrieve(query:)`` without a `limit`, so this is the
+    /// value that actually governs production retrieval width.
+    private let defaultLimit: Int
+
+    /// Cosine-similarity floor: hits scoring strictly below this are dropped
+    /// before injection. Threaded from ``RAGConfiguration/similarityThreshold``.
+    /// The default of `0` preserves the historical behaviour — the vector store
+    /// already excludes non-positive scores, so a `0` threshold is a no-op.
+    private let similarityThreshold: Float
+
     /// How much wider than `limit` the first-stage candidate set is fetched
     /// when a reranker is active. A 3× pool gives the cross-encoder enough
     /// candidates to recover relevant passages the bi-encoder cosine stage
@@ -43,7 +55,9 @@ public actor RAGService {
         embeddingBackend: (any EmbeddingBackend)? = nil,
         reranker: (any Reranker)? = nil,
         chunker: DocumentChunker = DocumentChunker(),
-        parsers: [any DocumentParser] = [TextDocumentParser(), PDFDocumentParser()]
+        parsers: [any DocumentParser] = [TextDocumentParser(), PDFDocumentParser()],
+        defaultLimit: Int = 5,
+        similarityThreshold: Float = 0
     ) {
         self.documentStore = documentStore
         self.vectorStore = vectorStore
@@ -51,6 +65,11 @@ public actor RAGService {
         self.reranker = reranker
         self.chunker = chunker
         self.parsers = parsers
+        // Clamp at the boundary: a non-positive limit would retrieve nothing
+        // (or trap the vector store's `.prefix`), and a negative threshold is
+        // meaningless for cosine scores in [-1, 1].
+        self.defaultLimit = max(1, defaultLimit)
+        self.similarityThreshold = max(0, similarityThreshold)
     }
 
     // MARK: - Ingestion
@@ -153,10 +172,15 @@ public actor RAGService {
     /// Called by ``ConversationRuntime`` before each generation turn. Empty
     /// results (whitespace-only query, no above-zero scores) round-trip as
     /// ``RetrievalResult/empty``.
-    public func retrieve(query: String, limit: Int = 5) async throws -> RetrievalResult {
+    public func retrieve(query: String, limit: Int? = nil) async throws -> RetrievalResult {
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return .empty
         }
+
+        // No explicit caller override falls back to the configured top-K
+        // (``RAGConfiguration/topK``). Clamp to a positive width so the
+        // vector-store `.prefix` and reranker pool math stay well-defined.
+        let limit = max(1, limit ?? defaultLimit)
 
         // Embedding models can hang or OOM on very long inputs. Truncate to
         // the configured byte cap before handing off — a shorter query loses
@@ -221,7 +245,17 @@ public actor RAGService {
 
         guard !rankedHits.isEmpty else { return .empty }
 
-        let content = rankedHits.map { hit in
+        // Similarity-threshold cutoff. Applied after reranking so the floor is
+        // checked against the final score the user sees in citations. A `0`
+        // threshold (the default) is a no-op since the vector store already
+        // excludes non-positive scores.
+        let filteredHits = similarityThreshold > 0
+            ? rankedHits.filter { $0.score >= similarityThreshold }
+            : rankedHits
+
+        guard !filteredHits.isEmpty else { return .empty }
+
+        let content = filteredHits.map { hit in
             "[\(hit.documentTitle)]\n\(hit.chunk.text)"
         }.joined(separator: "\n\n---\n\n")
 
@@ -233,7 +267,7 @@ public actor RAGService {
             label: "Retrieved Documents"
         )
 
-        let citations = rankedHits.map { hit in
+        let citations = filteredHits.map { hit in
             Citation(
                 documentID: hit.chunk.documentID,
                 documentTitle: hit.documentTitle,
@@ -251,7 +285,7 @@ public actor RAGService {
     ///
     /// Compatibility shim retained for callers that don't need the citation
     /// metadata — internally just calls ``retrieve(query:limit:)``.
-    public func retrieveSlots(query: String, limit: Int = 5) async throws -> [PromptSlot] {
+    public func retrieveSlots(query: String, limit: Int? = nil) async throws -> [PromptSlot] {
         try await retrieve(query: query, limit: limit).slots
     }
 }

--- a/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
+++ b/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
@@ -586,6 +586,117 @@ final class RAGServiceTests: XCTestCase {
                        "rerank failure must preserve the first-stage cosine ordering")
     }
 
+    // MARK: - #1939 item 6: configurable top-K + similarity threshold
+
+    /// `defaultLimit` (threaded from `RAGConfiguration.topK`) must govern the
+    /// first-stage fetch width when the caller passes no explicit `limit` — the
+    /// production turn loop calls `retrieve(query:)` with no limit.
+    func test_retrieve_defaultLimit_drivesFetchWidthWhenNoExplicitLimit() async throws {
+        let vectorStore = FakeVectorStore()
+        let hit = VectorSearchHit(chunk: DocumentChunk(documentID: UUID(), text: "x", chunkIndex: 0), documentTitle: "Doc", score: 0.9)
+        await vectorStore.setKeywordResults([hit])
+
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            defaultLimit: 9
+        )
+
+        _ = try await sut.retrieve(query: "anything")
+
+        let requested = await vectorStore.lastKeywordLimit
+        XCTAssertEqual(requested, 9, "configured defaultLimit (topK) must drive the fetch width")
+
+        // Sabotage: the old hardcoded `limit: 5` would have requested 5, not 9.
+        XCTAssertNotEqual(requested, 5)
+    }
+
+    /// An explicit `limit` argument still overrides the configured default.
+    func test_retrieve_explicitLimit_overridesDefaultLimit() async throws {
+        let vectorStore = FakeVectorStore()
+        let hit = VectorSearchHit(chunk: DocumentChunk(documentID: UUID(), text: "x", chunkIndex: 0), documentTitle: "Doc", score: 0.9)
+        await vectorStore.setKeywordResults([hit])
+
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            defaultLimit: 9
+        )
+
+        _ = try await sut.retrieve(query: "anything", limit: 3)
+
+        let requested = await vectorStore.lastKeywordLimit
+        XCTAssertEqual(requested, 3, "explicit limit must override the configured default")
+    }
+
+    /// The similarity threshold drops hits scoring strictly below the floor from
+    /// both the injected slot and the citation list.
+    func test_retrieve_similarityThreshold_filtersLowScoringHits() async throws {
+        let docID = UUID()
+        let hits = [
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "strong hit", chunkIndex: 0), documentTitle: "Doc", score: 0.80),
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "borderline hit", chunkIndex: 1), documentTitle: "Doc", score: 0.50),
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "weak hit", chunkIndex: 2), documentTitle: "Doc", score: 0.20),
+        ]
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setKeywordResults(hits)
+
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            similarityThreshold: 0.5
+        )
+
+        let result = try await sut.retrieve(query: "q")
+
+        // Only the two hits at-or-above 0.5 survive; the 0.20 hit is dropped.
+        XCTAssertEqual(result.citations.map(\.chunkIndex), [0, 1],
+                       "hits below the similarity threshold must be filtered out")
+        XCTAssertFalse(result.slots[0].content.contains("weak hit"),
+                       "below-threshold passage must not reach the injected slot")
+
+        // Sabotage: with the default (0) threshold all three would survive.
+        XCTAssertNotEqual(result.citations.map(\.chunkIndex), [0, 1, 2])
+    }
+
+    /// A threshold of 0 (the default) is a no-op: every hit the vector store
+    /// returns flows through, preserving the historical behaviour.
+    func test_retrieve_zeroThreshold_preservesAllHits() async throws {
+        let docID = UUID()
+        let hits = [
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "a", chunkIndex: 0), documentTitle: "Doc", score: 0.80),
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "b", chunkIndex: 1), documentTitle: "Doc", score: 0.10),
+        ]
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setKeywordResults(hits)
+
+        let sut = RAGService(documentStore: FakeDocumentStore(), vectorStore: vectorStore)
+
+        let result = try await sut.retrieve(query: "q")
+        XCTAssertEqual(result.citations.map(\.chunkIndex), [0, 1],
+                       "default (0) threshold must not drop any hit")
+    }
+
+    /// If every hit falls below the threshold, retrieval round-trips as empty
+    /// rather than injecting an empty slot.
+    func test_retrieve_allHitsBelowThreshold_returnsEmpty() async throws {
+        let hits = [
+            VectorSearchHit(chunk: DocumentChunk(documentID: UUID(), text: "weak", chunkIndex: 0), documentTitle: "Doc", score: 0.1),
+        ]
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setKeywordResults(hits)
+
+        let sut = RAGService(
+            documentStore: FakeDocumentStore(),
+            vectorStore: vectorStore,
+            similarityThreshold: 0.9
+        )
+
+        let result = try await sut.retrieve(query: "q")
+        XCTAssertTrue(result.slots.isEmpty)
+        XCTAssertTrue(result.citations.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func writeTempFile(content: String) throws -> URL {


### PR DESCRIPTION
Implements #1939 item 6 (adjustable RAG retrieval knobs — threshold + top-K).

## Problem
`RAGService.retrieve` hardcoded `limit: 5`. `RAGConfiguration.topK` already existed but was never threaded into the service, and there was no similarity-threshold field at all.

## Changes
- **`RAGService`** (`Sources/ManifoldRuntime/Services/RAGService.swift`): adds `defaultLimit` + `similarityThreshold` init params (clamped at the boundary). `retrieve(query:limit:)` now takes `limit: Int? = nil` and falls back to `defaultLimit` when no explicit limit is passed — the turn loop calls `retrieve(query:)` with no limit, so this is the value governing production retrieval. A post-rerank threshold filter drops hits scoring strictly below the cosine floor from both the injected slot and citations.
- **`RAGConfiguration`** (`Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift`): new `similarityThreshold: Float` field (default `0` = disabled). `makeRAGService` threads `topK` + `similarityThreshold` into the service.

## Behaviour preservation
Default `similarityThreshold = 0` is a no-op (the vector store already excludes non-positive scores), and `topK` already defaulted to 5 — so the out-of-box pipeline is byte-for-byte unchanged.

## UI
Scoped out. `DocumentLibraryView` is ingest/delete only; `RAGService` is built once at bootstrap with immutable knobs, so a live UI control needs a mutable view→bootstrap→service-rebuild path that doesn't exist today. Noted as a follow-up.

## Test plan
5 new XCTest cases in `RAGServiceTests` (in-memory fakes, deterministic, sabotage-verified during dev):
- `defaultLimit` drives fetch width when no explicit limit
- explicit `limit` overrides the configured default
- threshold filters low-scoring hits (slot + citations)
- zero threshold preserves all hits
- all-hits-below-threshold returns empty

Scoped gate: `swift build --build-tests` (green) + `swift test --filter RAGServiceTests` → 27/27 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)