### PR TITLE
feat: surface device-fit verdict badge + recommended quant in model browser

### DIFF
--- a/Sources/ManifoldUIModelManagement/Views/Models/DownloadableModelRow.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/DownloadableModelRow.swift
@@ -80,6 +80,7 @@ public struct DownloadableModelRow: View {
                             .accessibilityLabel("Curated model")
                     }
 
+                    fitBadge
                     speedBadge
                 }
 
@@ -135,6 +136,38 @@ public struct DownloadableModelRow: View {
             trailingContent
         }
         .padding(.vertical, 4)
+    }
+
+    // MARK: - Fit Badge
+
+    /// Three-way device-fit verdict badge (Excellent / Good / Marginal / Not recommended)
+    /// rendered green / yellow / red for *this* device, before download.
+    ///
+    /// Shown only when `showFitGuidance` is set and the model has a usable size, alongside
+    /// the `SpeedClass` badge. Uses the `FitQuality` *word* and a tint, never a raw composite
+    /// score — the underlying figure is a coarse estimate and a bare number reads as fact.
+    @ViewBuilder
+    private var fitBadge: some View {
+        if showFitGuidance, model.sizeBytes > 0, let score = viewModel.fitScore(for: model) {
+            let quality = score.fitQuality
+            Text(quality.label)
+                .font(.caption2)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(Self.fitTint(quality).opacity(0.15), in: Capsule())
+                .foregroundStyle(Self.fitTint(quality))
+                .accessibilityLabel("Device fit: \(quality.label). Approximate guidance, not a guarantee.")
+        }
+    }
+
+    /// Maps a `FitQuality` verdict to its badge tint. Static + pure so the verdict→color
+    /// contract is unit-testable without standing up a SwiftUI hierarchy.
+    static func fitTint(_ quality: FitQuality) -> Color {
+        switch quality {
+        case .excellent, .good:  return .green
+        case .marginal:          return .yellow
+        case .notRecommended:    return .red
+        }
     }
 
     // MARK: - Speed Badge

--- a/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
+++ b/Sources/ManifoldUIModelManagement/Views/Models/HuggingFaceBrowserView.swift
@@ -277,7 +277,10 @@ struct HuggingFaceBrowserView: View {
                             : nil
                     )
                     if variant.id == recommended?.id {
-                        bestForDeviceBadge(noVariantFits: noVariantFits)
+                        bestForDeviceBadge(
+                            noVariantFits: noVariantFits,
+                            quantization: variant.quantization
+                        )
                     }
                 }
             }
@@ -286,8 +289,12 @@ struct HuggingFaceBrowserView: View {
         }
     }
 
-    private func bestForDeviceBadge(noVariantFits: Bool) -> some View {
-        Text(bestForDeviceLabel(noVariantFits: noVariantFits))
+    private func bestForDeviceBadge(noVariantFits: Bool, quantization: String?) -> some View {
+        Text(Self.bestForDeviceLabel(
+            noVariantFits: noVariantFits,
+            recommendedQuant: quantization,
+            isRecommendedSort: viewModel.sortMode == .recommended
+        ))
             .font(.caption2)
             .padding(.horizontal, 4)
             .padding(.vertical, 1)
@@ -467,9 +474,20 @@ struct HuggingFaceBrowserView: View {
         }
     }
 
-    private func bestForDeviceLabel(noVariantFits: Bool) -> String {
-        if noVariantFits { return "Smallest available" }
-        return viewModel.sortMode == .recommended ? "Best for your device" : "Recommended"
+    /// Label for the recommended-variant badge, naming the chosen quant tier when the
+    /// listing carries one ("Best for your device: Q4_K_M") so the user knows *which*
+    /// download to pick, not just that a recommendation exists. Static + pure so the
+    /// label contract is unit-testable without a SwiftUI hierarchy.
+    static func bestForDeviceLabel(
+        noVariantFits: Bool,
+        recommendedQuant: String?,
+        isRecommendedSort: Bool
+    ) -> String {
+        let base = noVariantFits
+            ? "Smallest available"
+            : (isRecommendedSort ? "Best for your device" : "Recommended")
+        guard let quant = recommendedQuant, !quant.isEmpty else { return base }
+        return "\(base): \(quant)"
     }
 
     private func handleImport(_ result: Result<[URL], Error>) {

--- a/Tests/ManifoldUIModelManagementTests/FitVerdictBadgeTests.swift
+++ b/Tests/ManifoldUIModelManagementTests/FitVerdictBadgeTests.swift
@@ -1,0 +1,84 @@
+@preconcurrency import XCTest
+import SwiftUI
+@testable import ManifoldUIModelManagement
+@testable import ManifoldInference
+
+/// Verifies the pure verdict→color and recommended-quant→label mappings that back the
+/// device-fit badges in the model browser. The SwiftUI layout itself is not unit-testable,
+/// but the mapping functions are deterministic and isolated here so the green/yellow/red
+/// contract and the quant-naming string cannot silently drift.
+@MainActor
+final class FitVerdictBadgeTests: XCTestCase {
+
+    // MARK: - FitQuality → tint
+
+    func test_fitTint_excellentAndGood_areGreen() {
+        XCTAssertEqual(DownloadableModelRow.fitTint(.excellent), .green)
+        XCTAssertEqual(DownloadableModelRow.fitTint(.good), .green)
+    }
+
+    func test_fitTint_marginal_isYellow() {
+        XCTAssertEqual(DownloadableModelRow.fitTint(.marginal), .yellow)
+    }
+
+    func test_fitTint_notRecommended_isRed() {
+        XCTAssertEqual(DownloadableModelRow.fitTint(.notRecommended), .red)
+        // Sabotage guard: a denied verdict must never read as green/yellow.
+        XCTAssertNotEqual(DownloadableModelRow.fitTint(.notRecommended), .green)
+    }
+
+    func test_fitTint_coversAllCases() {
+        // CaseIterable tripwire: a new FitQuality case must get an explicit tint.
+        for quality in FitQuality.allCases {
+            let tint = DownloadableModelRow.fitTint(quality)
+            XCTAssertTrue(
+                [.green, .yellow, .red].contains(tint),
+                "FitQuality.\(quality) mapped to an unexpected tint"
+            )
+        }
+    }
+
+    // MARK: - Recommended-quant naming
+
+    func test_bestForDeviceLabel_namesQuant_whenPresent() {
+        let label = HuggingFaceBrowserView.bestForDeviceLabel(
+            noVariantFits: false,
+            recommendedQuant: "Q4_K_M",
+            isRecommendedSort: true
+        )
+        XCTAssertEqual(label, "Best for your device: Q4_K_M")
+    }
+
+    func test_bestForDeviceLabel_omitsQuant_whenMissingOrEmpty() {
+        XCTAssertEqual(
+            HuggingFaceBrowserView.bestForDeviceLabel(
+                noVariantFits: false, recommendedQuant: nil, isRecommendedSort: true
+            ),
+            "Best for your device"
+        )
+        XCTAssertEqual(
+            HuggingFaceBrowserView.bestForDeviceLabel(
+                noVariantFits: false, recommendedQuant: "", isRecommendedSort: true
+            ),
+            "Best for your device"
+        )
+    }
+
+    func test_bestForDeviceLabel_nonRecommendedSort_usesRecommendedBase() {
+        XCTAssertEqual(
+            HuggingFaceBrowserView.bestForDeviceLabel(
+                noVariantFits: false, recommendedQuant: "Q5_K_M", isRecommendedSort: false
+            ),
+            "Recommended: Q5_K_M"
+        )
+    }
+
+    func test_bestForDeviceLabel_noVariantFits_usesSmallestBase() {
+        XCTAssertEqual(
+            HuggingFaceBrowserView.bestForDeviceLabel(
+                noVariantFits: true, recommendedQuant: "Q3_K_S", isRecommendedSort: true
+            ),
+            "Smallest available: Q3_K_S"
+        )
+    }
+}


### PR DESCRIPTION
Closes #1933.

## Summary
Surfaces the **device-fit verdict badge** + **recommended-quant naming** in the model browser. The load-plan math already ships (`ModelLoadPlan.estimate` → allow/warn/deny, `FitQuality`/`SpeedClass`, `recommendedVariant`); this is the residual UI work the issue's investigation plan descoped to.

- **FitQuality verdict badge** (`DownloadableModelRow.swift`): renders the three-way verdict (Excellent/Good/Marginal/Not recommended) as a green/yellow/red capsule beside the existing `SpeedClass` badge, gated behind the same `showFitGuidance` flag. Reuses `viewModel.fitScore(for:).fitQuality` — no recompute. Excellent/Good → green, Marginal → yellow, Not recommended (incl. `!willRun`) → red. Uses the verdict *word* + tint, never a raw composite (honest-presentation constraint from the DocC).
- **Recommended-quant naming** (`HuggingFaceBrowserView.swift`): the existing "Best for your device" badge on the recommended variant now names the chosen quant tier — `"Best for your device: Q4_K_M"` — so the user knows *which* download to pick. Degrades to the bare label when the listing carries no quant tag.

## Tests
`FitVerdictBadgeTests` (8 XCTest cases, deterministic, no hardware): asserts the verdict→tint mapping (incl. a `CaseIterable` tripwire + a sabotage guard that a denied verdict is never green) and the recommended-quant label string across all base/quant combinations. The verdict→color and label logic was extracted into pure static functions to make it unit-testable; pure-SwiftUI layout itself is not unit-tested (noted).

## Verification
- `swift build --target ManifoldUIModelManagement` — clean
- `swift build --build-tests` — clean
- `swift test --filter FitVerdictBadgeTests` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)