### PR TITLE
feat(mcp): emit Mcp-Method/Mcp-Name routing headers

### DIFF
--- a/Sources/ManifoldMCP/InternalMCPSession.swift
+++ b/Sources/ManifoldMCP/InternalMCPSession.swift
@@ -127,7 +127,7 @@ internal actor MCPSession {
         guard state != .closed else { throw MCPError.transportClosed }
         let message = MCPJSONRPCMessage.notification(method: method, params: params)
         let payload = try codec.encode(message)
-        try await transport.send(payload)
+        try await transport.send(payload, routing: routing(for: message))
         await stateHook.sessionDidSend(message)
     }
 
@@ -143,7 +143,7 @@ internal actor MCPSession {
             return
         }
         do {
-            try await transport.send(payload)
+            try await transport.send(payload, routing: routing(for: message))
         } catch {
             Log.inference.error("MCPSession: failed to send notification '\(method, privacy: .public)': \(error, privacy: .private)")
         }
@@ -263,7 +263,7 @@ internal actor MCPSession {
     ) async {
         pendingRequests[id] = continuation
         do {
-            try await transport.send(payload)
+            try await transport.send(payload, routing: routing(for: request))
             await stateHook.sessionDidSend(request)
         } catch {
             failPendingRequest(id: id, error: error)
@@ -319,6 +319,19 @@ internal actor MCPSession {
                 continuation.resume(throwing: MCPError.requestTimeout)
             }
         }
+    }
+}
+
+/// Derives the `Mcp-Method`/`Mcp-Name` routing metadata for a JSON-RPC message so the
+/// HTTP transport can emit the spec-mandated headers (2026-07-28). The tool name for a
+/// `tools/call` request lives in `params.name`; other methods carry no `Mcp-Name`.
+private func routing(for message: MCPJSONRPCMessage) -> MCPRouting? {
+    switch message {
+    case .request(_, let method, let params), .notification(let method, let params):
+        let name = method == "tools/call" ? stringValue(objectValue(params)?["name"]) : nil
+        return MCPRouting(method: method, name: name)
+    case .result, .error:
+        return nil
     }
 }
 

--- a/Sources/ManifoldMCP/InternalMCPTransport.swift
+++ b/Sources/ManifoldMCP/InternalMCPTransport.swift
@@ -3,11 +3,34 @@ import Foundation
 import Security
 import ManifoldInference
 
+/// Routing metadata threaded alongside a serialized JSON-RPC payload so the HTTP
+/// transport can emit the `Mcp-Method` / `Mcp-Name` headers the MCP spec mandates
+/// from 2026-07-28. The method/tool name are known up in `InternalMCPSession` but
+/// lost once the message is encoded to bytes, so they must travel beside the payload.
+internal struct MCPRouting: Sendable {
+    /// The JSON-RPC method (e.g. `tools/call`, `initialize`), emitted as `Mcp-Method`.
+    let method: String
+    /// The invocation target name — the tool name for `tools/call`, the prompt/resource
+    /// name where applicable — emitted as `Mcp-Name`. `nil` when the method carries none.
+    let name: String?
+
+    init(method: String, name: String? = nil) {
+        self.method = method
+        self.name = name
+    }
+}
+
 internal protocol MCPTransport: Sendable {
     var incomingMessages: AsyncThrowingStream<Data, Error> { get }
     func start() async throws
-    func send(_ payload: Data) async throws
+    func send(_ payload: Data, routing: MCPRouting?) async throws
     func close() async
+}
+
+extension MCPTransport {
+    func send(_ payload: Data) async throws {
+        try await send(payload, routing: nil)
+    }
 }
 
 internal struct MCPTransportConfiguration: Sendable {
@@ -151,11 +174,11 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
         }
     }
 
-    func send(_ payload: Data) async throws {
-        try await send(payload, allowRetry: true)
+    func send(_ payload: Data, routing: MCPRouting?) async throws {
+        try await send(payload, routing: routing, allowRetry: true)
     }
 
-    private func send(_ payload: Data, allowRetry: Bool) async throws {
+    private func send(_ payload: Data, routing: MCPRouting?, allowRetry: Bool) async throws {
         if payload.count > configuration.maxMessageBytes {
             throw MCPError.oversizeMessage(payload.count)
         }
@@ -166,6 +189,14 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
         request.httpBody = payload
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        // MCP routing headers (spec-mandated from 2026-07-28). Set before the
+        // caller-supplied custom headers so an explicit override still wins.
+        if let routing {
+            request.setValue(routing.method, forHTTPHeaderField: "Mcp-Method")
+            if let name = routing.name {
+                request.setValue(name, forHTTPHeaderField: "Mcp-Name")
+            }
+        }
         for (name, value) in configuration.headers {
             request.setValue(value, forHTTPHeaderField: name)
         }
@@ -196,7 +227,7 @@ internal actor MCPStreamableHTTPTransport: MCPTransport {
         if http.statusCode == 401 || http.statusCode == 403 {
             switch try await configuration.authorization.handleUnauthorized(statusCode: http.statusCode, body: data) {
             case .retry where allowRetry:
-                return try await send(payload, allowRetry: false)
+                return try await send(payload, routing: routing, allowRetry: false)
             case .retry:
                 throw MCPError.authorizationFailed("unauthorized")
             case .fail(let error):
@@ -323,7 +354,10 @@ internal actor MCPStdioTransport: MCPTransport {
         }
     }
 
-    func send(_ payload: Data) async throws {
+    func send(_ payload: Data, routing: MCPRouting?) async throws {
+        // Routing metadata has no representation in the stdio Content-Length framing;
+        // it exists purely for the HTTP transport's spec-mandated headers.
+        _ = routing
         if payload.count > maxMessageBytes {
             throw MCPError.oversizeMessage(payload.count)
         }

--- a/Tests/ManifoldMCPTests/Helpers/ChaosMCPTransport.swift
+++ b/Tests/ManifoldMCPTests/Helpers/ChaosMCPTransport.swift
@@ -146,7 +146,8 @@ final class ChaosMCPTransport: MCPTransport, @unchecked Sendable {
         }
     }
 
-    func send(_ payload: Data) async throws {
+    func send(_ payload: Data, routing: MCPRouting?) async throws {
+        _ = routing
         sendCallCount.wrappingAdd(1, ordering: .relaxed)
         captureSend(payload)
 

--- a/Tests/ManifoldMCPTests/MCPHardeningTests.swift
+++ b/Tests/ManifoldMCPTests/MCPHardeningTests.swift
@@ -798,7 +798,8 @@ private actor HangingSessionTransport: MCPTransport {
 
     func start() async throws {}
 
-    func send(_ payload: Data) async throws {
+    func send(_ payload: Data, routing: MCPRouting?) async throws {
+        _ = routing
         let message = try codec.decode(payload)
         guard case .request(let id, let method, let params) = message,
               let handler,

--- a/Tests/ManifoldMCPTests/MCPProviderFixtureContractTests.swift
+++ b/Tests/ManifoldMCPTests/MCPProviderFixtureContractTests.swift
@@ -243,7 +243,8 @@ private actor FixtureReplayTransport: MCPTransport {
 
     func start() async throws {}
 
-    func send(_ payload: Data) async throws {
+    func send(_ payload: Data, routing: MCPRouting?) async throws {
+        _ = routing
         let message = try codec.decode(payload)
         guard case .request(let id, let method, _) = message else {
             return

--- a/Tests/ManifoldMCPTests/MCPSessionTests.swift
+++ b/Tests/ManifoldMCPTests/MCPSessionTests.swift
@@ -110,6 +110,60 @@ final class MCPSessionTests: XCTestCase {
         await session.close()
     }
 
+    func test_sendRequestThreadsMcpRoutingHeadersForToolCall() async throws {
+        let descriptor = MCPServerDescriptor(
+            displayName: "Routing Test",
+            transport: .streamableHTTP(endpoint: URL(string: "https://example.com/mcp")!, headers: [:]),
+            dataDisclosure: "test"
+        )
+
+        let codec = MCPJSONRPCCodec(maxMessageBytes: 4096, maxJSONNestingDepth: 8)
+        let transport = MockSessionTransport(codec: codec)
+        await transport.setRequestHandler { id, method, _ in
+            switch method {
+            case "initialize":
+                return .result(id: id, result: .object([
+                    "protocolVersion": .string("2025-03-26"),
+                    "serverInfo": .object(["name": .string("Demo"), "version": .string("1")]),
+                    "capabilities": .object([:]),
+                ]))
+            case "tools/call":
+                return .result(id: id, result: .object(["content": .array([])]))
+            default:
+                return nil
+            }
+        }
+
+        let session = MCPSession(
+            descriptor: descriptor,
+            transport: transport,
+            codec: codec,
+            requestTimeout: .seconds(2),
+            maxConcurrentRequests: 4
+        )
+
+        _ = try await session.start()
+        _ = try await session.sendRequest(
+            method: "tools/call",
+            params: .object(["name": .string("search"), "arguments": .object([:])])
+        )
+
+        let routing = await transport.sentRoutingMetadata()
+        // The first send is the `initialized` notification from start(); the tools/call
+        // request is the one carrying a tool name.
+        let toolCallRouting = routing.compactMap { $0 }.first { $0.method == "tools/call" }
+        XCTAssertEqual(toolCallRouting?.method, "tools/call", "Mcp-Method must carry the JSON-RPC method")
+        XCTAssertEqual(toolCallRouting?.name, "search", "Mcp-Name must carry the tools/call tool name")
+
+        // A non-tools/call method carries a method but no name.
+        let initializeRouting = routing.compactMap { $0 }.first { $0.method == "initialize" }
+        XCTAssertEqual(initializeRouting?.method, "initialize")
+        XCTAssertNil(initializeRouting?.name, "Mcp-Name must be absent for methods without an invocation target")
+        // Sabotage: dropping `routing:` from the transport.send call in MCPSession.registerPendingAndSend (passing the no-routing default) makes toolCallRouting nil, failing the method/name assertions above.
+
+        await session.close()
+    }
+
     func test_sendRequestPropagatesJSONRPCError() async throws {
         let descriptor = MCPServerDescriptor(
             displayName: "Session Test",
@@ -331,6 +385,7 @@ private actor MockSessionTransport: MCPTransport {
     private let continuation: AsyncThrowingStream<Data, Error>.Continuation
     private var handler: (@Sendable (MCPRequestID, String, JSONSchemaValue?) -> MCPJSONRPCMessage?)?
     private var sent: [MCPJSONRPCMessage] = []
+    private var sentRouting: [MCPRouting?] = []
 
     init(codec: MCPJSONRPCCodec) {
         self.codec = codec
@@ -347,9 +402,10 @@ private actor MockSessionTransport: MCPTransport {
 
     func start() async throws {}
 
-    func send(_ payload: Data) async throws {
+    func send(_ payload: Data, routing: MCPRouting?) async throws {
         let message = try codec.decode(payload)
         sent.append(message)
+        sentRouting.append(routing)
 
         guard case .request(let id, let method, let params) = message,
               let handler else {
@@ -367,5 +423,9 @@ private actor MockSessionTransport: MCPTransport {
 
     func sentMessages() -> [MCPJSONRPCMessage] {
         sent
+    }
+
+    func sentRoutingMetadata() -> [MCPRouting?] {
+        sentRouting
     }
 }


### PR DESCRIPTION
Implements **item 5** of the #1939 quick-win checklist: pre-empt the MCP `Mcp-Method` / `Mcp-Name` routing headers ahead of the official 2026-07-28 spec requirement.

## What & why
Per the issue's investigation note, the header-add itself is trivial, but the JSON-RPC method/tool name are **not available** at the transport's `send(Data)` point — the payload is already serialized bytes. Adding empty/placeholder headers is near-worthless, so this threads the real values through:

- New internal `MCPRouting` value (`method` + optional `name`) travels beside the payload.
- `MCPTransport.send` gains a `routing:` parameter; a protocol extension keeps the bare `send(_:)` form working.
- `InternalMCPSession` derives routing from the `MCPJSONRPCMessage` (tool name pulled from `params.name` for `tools/call`) at all three send sites.
- `MCPStreamableHTTPTransport` emits `Mcp-Method` / `Mcp-Name` on the POST request (before caller-supplied custom headers, so an explicit override still wins). The stdio transport ignores routing — it has no header framing.

`MCPTransport` is `internal`, so **no public API breaks** — the api-breakage allowlist was not touched.

## Tests
New `test_sendRequestThreadsMcpRoutingHeadersForToolCall` in `ManifoldMCPTests` uses the in-module `MockSessionTransport` fake (no `MockURLProtocol`) to assert a `tools/call` carries method `tools/call` + name `search`, and that `initialize` carries a method but no name. Deterministic; sabotage-verified then documented inline.

Scoped run: `swift test --filter ManifoldMCPTests` → 226 tests, 0 failures.

Closes item 5 of #1939.