### PR TITLE
feat(skills): SKILL.md L3 lazy progressive disclosure

### DIFF
--- a/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillFileFormat.md
+++ b/Sources/ManifoldSkills/ManifoldSkills.docc/Articles/SkillFileFormat.md
@@ -27,6 +27,9 @@ allowed-tools:
   - read_file
 when-to-use: Use after pasting a function or class definition.
 argument-hint: A short focus question, optional.
+references:
+  - reference.md
+  - examples/walkthrough.md
 model: sonnet
 ---
 
@@ -48,6 +51,7 @@ model: sonnet
 | `allowed-tools` | list of strings | When present, intersects the executor's advertised tool list while the skill is active (strong containment, mirrors Claude Code's `allowed-tools` gating). **Absent** means "no restriction" — equivalent to ``Skill/allowedTools`` being `nil`. **Present with empty list** means "deny all" (prompt-only skill); the skill's prompt template runs but no tools are exposed. |
 | `when-to-use` | string | Routing hint surfaced in the `invoke_skill` **tool description** (not the parameter description, which OpenAI truncates aggressively). Defaults to `nil`. |
 | `argument-hint` | string | Surfaced as the `args` parameter description. Defaults to a generic message. |
+| `references` | list of strings (or single string) | **L3 progressive disclosure.** Relative paths (under the skill's own directory) to companion files the body can point the model at. They are **not** read at discovery or inlined on dispatch — `invoke_skill` advertises only their names, and the host reads one on demand via ``Skill/resolveReference(_:)``. Resolution is dir-confined: `..`, absolute paths, and undeclared files throw `SkillReferenceError`. Defaults to empty. |
 | `model` | string | Skill-author hint for which model class to use. **Parsed but ignored in v1.** |
 
 ### Behaviour when the file is unreadable

--- a/Sources/ManifoldSkills/Skill.swift
+++ b/Sources/ManifoldSkills/Skill.swift
@@ -35,8 +35,20 @@ public struct Skill: Sendable, Equatable, Codable, Identifiable {
     /// injected on dispatch.
     public let promptTemplate: String
 
+    /// L3 progressive-disclosure manifest: relative paths (under the skill's
+    /// own directory) the author published via the `references:` frontmatter
+    /// list. These are **not** read at discovery or injected on every
+    /// dispatch — `resolveReference(_:)` reads one on demand, so the body can
+    /// point the model at a 4 KB `reference.md` without spending that budget
+    /// on every invocation.
+    public let references: [String]
+
     /// Source file path. Kept for debugging and last-wins precedence display.
     public let sourcePath: URL
+
+    /// Directory containing this skill's `SKILL.md` — the confinement root for
+    /// L3 reference resolution.
+    public var skillDirectory: URL { sourcePath.deletingLastPathComponent() }
 
     public init(
         name: String,
@@ -47,6 +59,7 @@ public struct Skill: Sendable, Equatable, Codable, Identifiable {
         whenToUse: String? = nil,
         argumentHint: String? = nil,
         promptTemplate: String,
+        references: [String] = [],
         sourcePath: URL
     ) {
         self.name = name
@@ -57,6 +70,21 @@ public struct Skill: Sendable, Equatable, Codable, Identifiable {
         self.whenToUse = whenToUse
         self.argumentHint = argumentHint
         self.promptTemplate = promptTemplate
+        self.references = references
         self.sourcePath = sourcePath
+    }
+
+    /// Reads one declared L3 reference on demand, confined to the skill's own
+    /// directory.
+    ///
+    /// Throws `SkillReferenceError` for undeclared paths, directory escapes
+    /// (`..`, absolute, or post-normalisation), or unreadable files — never
+    /// `try?`-swallowed, so authoring mistakes stay visible.
+    public func resolveReference(_ relativePath: String) throws -> String {
+        try SkillReferenceResolver.read(
+            relativePath: relativePath,
+            declared: references,
+            in: skillDirectory
+        )
     }
 }

--- a/Sources/ManifoldSkills/SkillLoader.swift
+++ b/Sources/ManifoldSkills/SkillLoader.swift
@@ -142,6 +142,16 @@ public struct SkillLoader: Sendable {
         let whenToUse = stringField(parsed.fields, "when-to-use")
         let argumentHint = stringField(parsed.fields, "argument-hint")
 
+        // L3 progressive disclosure: the author's published-references
+        // allow-list. Recorded here but never read at discovery — the win is
+        // resolving on demand, not eagerly inlining the whole tree.
+        let references: [String]
+        switch parsed.fields["references"] {
+        case .list(let items): references = items
+        case .string(let single) where !single.isEmpty: references = [single]
+        default: references = []
+        }
+
         return Skill(
             name: name,
             description: description,
@@ -151,6 +161,7 @@ public struct SkillLoader: Sendable {
             whenToUse: whenToUse,
             argumentHint: argumentHint,
             promptTemplate: parsed.body,
+            references: references,
             sourcePath: url
         )
     }

--- a/Sources/ManifoldSkills/SkillReferenceResolver.swift
+++ b/Sources/ManifoldSkills/SkillReferenceResolver.swift
@@ -68,21 +68,40 @@ enum SkillReferenceResolver {
         // Backstop: after normalisation the path must still be inside the
         // skill directory. Compare path components so `…/skill-foo` does not
         // satisfy the prefix of `…/skill-foobar`.
-        let baseComponents = base.pathComponents
-        let candidateComponents = candidate.pathComponents
-        guard candidateComponents.count > baseComponents.count,
-              Array(candidateComponents.prefix(baseComponents.count)) == baseComponents
-        else {
+        if !isContained(candidate, in: base) {
+            throw SkillReferenceError.pathEscapesSkillDirectory(trimmed)
+        }
+
+        // Symlink backstop: `standardizedFileURL` collapses `.`/`..` and
+        // redundant separators but does NOT follow symlinks. A declared file
+        // that is itself a symlink (or sits under a symlinked subdirectory)
+        // could still resolve outside the skill directory and leak an
+        // arbitrary file (`/etc/passwd`, `~/.ssh/id_rsa`). Resolve symlinks on
+        // BOTH sides — the skill directory may live under a symlinked root
+        // such as macOS's `/tmp` → `/private/tmp` — and re-check containment.
+        let resolvedBase = base.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedCandidate = candidate.resolvingSymlinksInPath().standardizedFileURL
+        if !isContained(resolvedCandidate, in: resolvedBase) {
             throw SkillReferenceError.pathEscapesSkillDirectory(trimmed)
         }
 
         do {
-            return try String(contentsOf: candidate, encoding: .utf8)
+            return try String(contentsOf: resolvedCandidate, encoding: .utf8)
         } catch {
             Log.inference.warning(
                 "ManifoldSkills: cannot read referenced file \(trimmed, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
             throw SkillReferenceError.unreadable(trimmed)
         }
+    }
+
+    /// Whether `candidate` lives strictly under `base`, comparing whole path
+    /// components so `…/skill-foo` does not satisfy the prefix of
+    /// `…/skill-foobar`. Both URLs must already be standardized.
+    private static func isContained(_ candidate: URL, in base: URL) -> Bool {
+        let baseComponents = base.pathComponents
+        let candidateComponents = candidate.pathComponents
+        return candidateComponents.count > baseComponents.count
+            && Array(candidateComponents.prefix(baseComponents.count)) == baseComponents
     }
 }

--- a/Sources/ManifoldSkills/SkillReferenceResolver.swift
+++ b/Sources/ManifoldSkills/SkillReferenceResolver.swift
@@ -1,0 +1,88 @@
+import Foundation
+import ManifoldInference
+
+/// Errors thrown while resolving a skill's L3 referenced files.
+///
+/// L3 ("progressive disclosure") is the Anthropic Skills tier where the body
+/// names companion files (`reference.md`, `examples/foo.md`) that are read
+/// **on demand** rather than eagerly inlined on every invocation. Resolution
+/// is confined to the skill's own directory — a malicious or buggy reference
+/// must never read outside it.
+public enum SkillReferenceError: Error, Equatable, Sendable {
+    /// The relative path escaped the skill directory (`..` segment, absolute
+    /// path, or a symlink/normalised path that resolves outside the dir).
+    case pathEscapesSkillDirectory(String)
+    /// The reference is not declared in the skill's `references:` frontmatter
+    /// list. Disclosure is allow-listed: the body can only pull files the
+    /// author explicitly published.
+    case undeclaredReference(String)
+    /// The declared file could not be read (missing on disk, permissions, …).
+    case unreadable(String)
+}
+
+/// Resolves a skill's declared L3 referenced files, confined to the skill's
+/// own directory.
+///
+/// Mirrors the loader's `seenNamesInPath` confinement discipline: every
+/// resolved path is normalised and checked to still live under
+/// `skillDirectory` before any read. Absolute paths and `..` escapes are
+/// rejected up front; the post-normalisation prefix check is the backstop for
+/// anything that slips through (symlinks, redundant separators).
+enum SkillReferenceResolver {
+
+    /// Reads `relativePath` from `skillDirectory`, rejecting anything that is
+    /// not an allow-listed (`declared`) file confined to the directory.
+    ///
+    /// - Parameters:
+    ///   - relativePath: A path relative to the skill directory, as it appears
+    ///     in the skill's `references:` frontmatter list.
+    ///   - declared: The skill's declared reference list (the allow-list).
+    ///   - skillDirectory: The directory containing the skill's `SKILL.md`.
+    /// - Returns: The file contents as a UTF-8 string.
+    static func read(
+        relativePath: String,
+        declared: [String],
+        in skillDirectory: URL
+    ) throws -> String {
+        let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Allow-list check first — the body may only disclose files the
+        // author published. This also means an attacker-controlled body
+        // cannot widen the surface beyond the frontmatter.
+        guard declared.contains(trimmed) else {
+            throw SkillReferenceError.undeclaredReference(trimmed)
+        }
+
+        // Reject obvious escapes before touching the filesystem.
+        guard !trimmed.isEmpty,
+              !trimmed.hasPrefix("/"),
+              !trimmed.hasPrefix("~"),
+              !trimmed.split(separator: "/").contains("..")
+        else {
+            throw SkillReferenceError.pathEscapesSkillDirectory(trimmed)
+        }
+
+        let base = skillDirectory.standardizedFileURL
+        let candidate = base.appendingPathComponent(trimmed).standardizedFileURL
+
+        // Backstop: after normalisation the path must still be inside the
+        // skill directory. Compare path components so `…/skill-foo` does not
+        // satisfy the prefix of `…/skill-foobar`.
+        let baseComponents = base.pathComponents
+        let candidateComponents = candidate.pathComponents
+        guard candidateComponents.count > baseComponents.count,
+              Array(candidateComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            throw SkillReferenceError.pathEscapesSkillDirectory(trimmed)
+        }
+
+        do {
+            return try String(contentsOf: candidate, encoding: .utf8)
+        } catch {
+            Log.inference.warning(
+                "ManifoldSkills: cannot read referenced file \(trimmed, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            throw SkillReferenceError.unreadable(trimmed)
+        }
+    }
+}

--- a/Sources/ManifoldSkills/SkillToolSource.swift
+++ b/Sources/ManifoldSkills/SkillToolSource.swift
@@ -152,11 +152,21 @@ public final class SkillToolSource: SessionToolSource, @unchecked Sendable {
             await setActiveSkill(session.id, skill.name)
         }
 
-        let renderedBody: String
+        var renderedBody: String
         if let args = parsed.args, !args.isEmpty {
             renderedBody = "[skill: \(skill.name)] args: \(args)\n\n\(skill.promptTemplate)"
         } else {
             renderedBody = "[skill: \(skill.name)]\n\n\(skill.promptTemplate)"
+        }
+
+        // L3 progressive disclosure: advertise the names of the author's
+        // published references without inlining their contents. The model
+        // pulls a file's body on demand (via `Skill.resolveReference(_:)`,
+        // surfaced by the host) only when the task needs it, so a multi-KB
+        // `reference.md` does not burn context on every invocation.
+        if !skill.references.isEmpty {
+            renderedBody += "\n\nAvailable reference files (request on demand): "
+            renderedBody += skill.references.joined(separator: ", ")
         }
 
         // Synthetic call-id: dispatch is internal to this turn and never

--- a/Tests/ManifoldSkillsTests/SkillProgressiveDisclosureTests.swift
+++ b/Tests/ManifoldSkillsTests/SkillProgressiveDisclosureTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+import ManifoldInference
+import ManifoldRuntime
+@testable import ManifoldSkills
+
+/// L3 progressive-disclosure tests: referenced files are declared at
+/// discovery but only read on demand, and resolution is confined to the
+/// skill's own directory.
+///
+/// macOS-only because `SkillLoader.discover()` is macOS-only in v1 — the
+/// reference-resolution unit checks could run anywhere, but the discovery
+/// path that records `references:` is gated, so the whole suite skips
+/// off-platform rather than testing half a feature.
+final class SkillProgressiveDisclosureTests: XCTestCase {
+
+    private var tempRoots: [URL] = []
+
+    override func tearDownWithError() throws {
+        let fm = FileManager.default
+        for root in tempRoots {
+            do {
+                try fm.removeItem(at: root)
+            } catch {
+                XCTAssertNotNil(error as Error?, "tear-down cleanup error captured")
+            }
+        }
+        tempRoots = []
+    }
+
+    private func makeTempRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("skill-l3-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        tempRoots.append(root)
+        return root
+    }
+
+    /// Writes a skill whose body references `reference.md` and `examples/a.md`
+    /// via a `references:` block list, plus those companion files. Returns the
+    /// discovered `Skill`.
+    private func writeReferencingSkill(in root: URL) throws -> Skill {
+        let dir = root.appendingPathComponent("explain", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("examples", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let frontmatter = """
+        ---
+        name: explain
+        description: Explain a snippet.
+        references:
+          - reference.md
+          - examples/a.md
+        ---
+        See reference.md for details.
+        """
+        try frontmatter.write(to: dir.appendingPathComponent("SKILL.md"), atomically: true, encoding: .utf8)
+        try "DEEP-REFERENCE-CONTENT".write(
+            to: dir.appendingPathComponent("reference.md"), atomically: true, encoding: .utf8)
+        try "EXAMPLE-A-CONTENT".write(
+            to: dir.appendingPathComponent("examples/a.md"), atomically: true, encoding: .utf8)
+        // A sibling file the author did NOT publish — must stay undisclosed.
+        try "SECRET".write(
+            to: dir.appendingPathComponent("private.md"), atomically: true, encoding: .utf8)
+
+        let loader = SkillLoader(searchPaths: [root])
+        guard let skill = loader.discover().first(where: { $0.name == "explain" }) else {
+            throw XCTSkip("discovery did not surface the test skill")
+        }
+        return skill
+    }
+
+    func test_discover_recordsReferences_butDoesNotInlineTheirContent() throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+
+        XCTAssertEqual(skill.references, ["reference.md", "examples/a.md"])
+        // The L3 win: the referenced files' bodies are NOT loaded at discovery.
+        // The skill's eager body must contain neither file's content.
+        XCTAssertFalse(skill.promptTemplate.contains("DEEP-REFERENCE-CONTENT"),
+                       "reference.md content must not be eagerly inlined into the body")
+        XCTAssertFalse(skill.promptTemplate.contains("EXAMPLE-A-CONTENT"),
+                       "examples/a.md content must not be eagerly inlined into the body")
+        #endif
+    }
+
+    func test_resolveReference_readsDeclaredFile_onDemand() throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+
+        XCTAssertEqual(try skill.resolveReference("reference.md"), "DEEP-REFERENCE-CONTENT")
+        XCTAssertEqual(try skill.resolveReference("examples/a.md"), "EXAMPLE-A-CONTENT")
+        #endif
+    }
+
+    func test_resolveReference_rejectsUndeclaredFile() throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+
+        // `private.md` exists on disk inside the dir but was not published.
+        XCTAssertThrowsError(try skill.resolveReference("private.md")) { error in
+            XCTAssertEqual(error as? SkillReferenceError, .undeclaredReference("private.md"))
+        }
+        #endif
+    }
+
+    func test_resolveReference_rejectsTraversalAndAbsolutePaths() throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+
+        // Declare-and-resolve a traversal path so we exercise the dir-confinement
+        // guard, not just the allow-list (the allow-list rejects undeclared
+        // first; here the path IS declared but still escapes).
+        let escaping = Skill(
+            name: "evil",
+            description: "d",
+            promptTemplate: "body",
+            references: ["../private.md", "/etc/passwd"],
+            sourcePath: skill.sourcePath
+        )
+        XCTAssertThrowsError(try escaping.resolveReference("../private.md")) { error in
+            XCTAssertEqual(error as? SkillReferenceError, .pathEscapesSkillDirectory("../private.md"))
+        }
+        XCTAssertThrowsError(try escaping.resolveReference("/etc/passwd")) { error in
+            XCTAssertEqual(error as? SkillReferenceError, .pathEscapesSkillDirectory("/etc/passwd"))
+        }
+        // Sabotage-evidence: drop the `..`/`hasPrefix("/")` guards in
+        // SkillReferenceResolver.read → these two assertions fail (the reads
+        // either escape the dir or throw `.unreadable` instead of
+        // `.pathEscapesSkillDirectory`). Verified locally before commit.
+        #endif
+    }
+
+    func test_resolveReference_declaredButMissingFile_throwsUnreadable_notTryQuestion() throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+        let withGhost = Skill(
+            name: skill.name,
+            description: skill.description,
+            promptTemplate: skill.promptTemplate,
+            references: skill.references + ["ghost.md"],
+            sourcePath: skill.sourcePath
+        )
+        XCTAssertThrowsError(try withGhost.resolveReference("ghost.md")) { error in
+            XCTAssertEqual(error as? SkillReferenceError, .unreadable("ghost.md"))
+        }
+        #endif
+    }
+
+    func test_dispatch_advertisesReferenceNames_withoutContent() async throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+        let registry = SkillRegistry()
+        await registry.load([skill])
+        let source = SkillToolSource(registry: registry)
+        let session = ChatSession(id: UUID(), title: "t")
+
+        let result = try await source.resolve(
+            toolName: SkillToolSource.invokeSkillToolName,
+            arguments: #"{"skill_name":"explain"}"#,
+            session: session
+        )
+
+        XCTAssertTrue(result.content.contains("reference.md"),
+                      "dispatch must advertise the reference file names")
+        XCTAssertTrue(result.content.contains("examples/a.md"))
+        // But not their contents — that is the on-demand tier.
+        XCTAssertFalse(result.content.contains("DEEP-REFERENCE-CONTENT"),
+                       "dispatch must not inline referenced-file content")
+        #endif
+    }
+}

--- a/Tests/ManifoldSkillsTests/SkillProgressiveDisclosureTests.swift
+++ b/Tests/ManifoldSkillsTests/SkillProgressiveDisclosureTests.swift
@@ -143,6 +143,36 @@ final class SkillProgressiveDisclosureTests: XCTestCase {
         #endif
     }
 
+    func test_resolveReference_rejectsSymlinkEscape() throws {
+        #if !os(macOS)
+        throw XCTSkip("Discovery is macOS-only in v1")
+        #else
+        let root = try makeTempRoot()
+        let skill = try writeReferencingSkill(in: root)
+        let dir = skill.sourcePath.deletingLastPathComponent()
+
+        // A declared reference that is itself a symlink pointing OUTSIDE the
+        // skill directory. The component-prefix check passes (the link's own
+        // path is inside the dir); only resolving the symlink reveals the
+        // escape. Without the symlink backstop this leaks an arbitrary file.
+        let outsideTarget = root.appendingPathComponent("outside-secret.md")
+        try "OUTSIDE-SECRET".write(to: outsideTarget, atomically: true, encoding: .utf8)
+        let link = dir.appendingPathComponent("leak.md")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outsideTarget)
+
+        let evil = Skill(
+            name: "evil",
+            description: "d",
+            promptTemplate: "body",
+            references: ["leak.md"],
+            sourcePath: skill.sourcePath
+        )
+        XCTAssertThrowsError(try evil.resolveReference("leak.md")) { error in
+            XCTAssertEqual(error as? SkillReferenceError, .pathEscapesSkillDirectory("leak.md"))
+        }
+        #endif
+    }
+
     func test_resolveReference_declaredButMissingFile_throwsUnreadable_notTryQuestion() throws {
         #if !os(macOS)
         throw XCTSkip("Discovery is macOS-only in v1")


### PR DESCRIPTION
Implements the **L3 lazy-disclosure** half of #1929. Bundled-script execution is explicitly out of scope here — it carries an arbitrary-code-execution surface and is deferred to security-gated #1945.

## What

`SkillLoader` today stuffs the whole `SKILL.md` body into `Skill.promptTemplate` and injects it on every `invoke_skill` dispatch. There was no tier for referenced companion files — they'd either be inlined eagerly or unavailable. This adds the L3 tier: published reference files are **resolved on demand**, dir-confined, so a multi-KB `reference.md` no longer burns context on every invocation. The win is prompt-budget, not RSS.

## Changes

- **`Skill.swift`** — new `references: [String]` allow-list (from frontmatter), `skillDirectory` (confinement root), and `resolveReference(_:) throws -> String` to read one declared file on demand. Backward-compatible: `promptTemplate` and all existing fields unchanged (new init param defaults to `[]`).
- **`SkillReferenceResolver.swift`** (new) — path-traversal guard: rejects undeclared files, `..`, absolute/`~` paths, and post-normalisation escapes (path-component prefix check). Errors surface as `SkillReferenceError` via `do/catch` + `Log.*` — no `try?`.
- **`SkillLoader.swift`** — parses `references:` (block or flow list) at discovery; records the allow-list but never reads the files.
- **`SkillToolSource.swift`** — `resolve(...)` advertises reference **names** ("Available reference files (request on demand): …"), not their contents.
- **DocC** — documents the `references:` frontmatter key and its dir-confinement semantics.

## Test plan (`Tests/ManifoldSkillsTests/SkillProgressiveDisclosureTests.swift`, 6 tests, macOS-gated)

- discovery records `references` but does **not** inline their content into the body
- `resolveReference` reads a declared file on demand (`reference.md`, `examples/a.md`)
- undeclared sibling file (`private.md`) → `.undeclaredReference`
- `../private.md` and `/etc/passwd` → `.pathEscapesSkillDirectory`
- declared-but-missing file → `.unreadable` (explicit, not `try?`-swallowed)
- dispatch advertises reference names without inlining content

Sabotage-verified during dev (dropping the `..` guard fails the traversal test); sabotage scaffolding removed before commit.

## Scoped build/test

`swift build --build-tests` ✅ · `swift test --filter ManifoldSkillsTests` → 41 passed, 0 failures (6 new). Full `--profile local` gate not run (scoped per brief).