### PR TITLE
feat: vendor-neutral GenAI TraceSink/GenSpan over InferenceMetricSink

### DIFF
--- a/Sources/ManifoldInference/Metrics/GenSpan.swift
+++ b/Sources/ManifoldInference/Metrics/GenSpan.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+// MARK: - Identifiers
+
+/// A 128-bit trace identifier shared by every span in a single Run.
+///
+/// Vendor-neutral by design: maps directly onto an OpenTelemetry `trace_id`
+/// (16 bytes) and onto OpenInference's trace correlation, but carries no
+/// dependency on either library. Hosts that link an OTLP exporter serialise
+/// the raw bytes; tests and in-memory sinks compare by value.
+public struct TraceID: Sendable, Hashable, CustomStringConvertible {
+    /// 16 raw bytes (128 bits), big-endian, matching the OTLP wire format.
+    public let bytes: [UInt8]
+
+    /// Wraps an explicit 16-byte identifier.
+    /// - Parameter bytes: Exactly 16 bytes. Shorter/longer arrays are accepted
+    ///   verbatim so callers controlling their own encoding are never blocked,
+    ///   but ``random()`` is the supported way to mint a conformant ID.
+    public init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    /// Mints a cryptographically-random 128-bit trace ID.
+    public static func random() -> TraceID {
+        TraceID(bytes: (0..<16).map { _ in UInt8.random(in: .min ... .max) })
+    }
+
+    /// Lowercase hex, the canonical OTLP/OpenInference string form.
+    public var description: String {
+        bytes.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// A 64-bit span identifier, unique within a Run.
+///
+/// Maps onto an OpenTelemetry `span_id` (8 bytes). See ``TraceID`` for the
+/// vendor-neutrality rationale.
+public struct SpanID: Sendable, Hashable, CustomStringConvertible {
+    /// 8 raw bytes (64 bits), big-endian, matching the OTLP wire format.
+    public let bytes: [UInt8]
+
+    public init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    /// Mints a cryptographically-random 64-bit span ID.
+    public static func random() -> SpanID {
+        SpanID(bytes: (0..<8).map { _ in UInt8.random(in: .min ... .max) })
+    }
+
+    /// Lowercase hex, the canonical OTLP/OpenInference string form.
+    public var description: String {
+        bytes.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Identifies a span and links it to its parent within a trace.
+///
+/// The `(traceID, spanID, parentSpanID)` triple is the minimal correlation
+/// structure needed to reconstruct a Run → Turn → span tree. A `nil`
+/// `parentSpanID` marks a trace root (typically the Run span).
+public struct SpanContext: Sendable, Hashable {
+    public let traceID: TraceID
+    public let spanID: SpanID
+    public let parentSpanID: SpanID?
+
+    public init(traceID: TraceID, spanID: SpanID, parentSpanID: SpanID? = nil) {
+        self.traceID = traceID
+        self.spanID = spanID
+        self.parentSpanID = parentSpanID
+    }
+
+    /// Creates a root span context (no parent) under a fresh or supplied trace.
+    public static func root(traceID: TraceID = .random()) -> SpanContext {
+        SpanContext(traceID: traceID, spanID: .random(), parentSpanID: nil)
+    }
+
+    /// Creates a child context that inherits this span's trace and points its
+    /// `parentSpanID` back at the receiver.
+    public func child(spanID: SpanID = .random()) -> SpanContext {
+        SpanContext(traceID: traceID, spanID: spanID, parentSpanID: self.spanID)
+    }
+}
+
+// MARK: - Span shape
+
+/// The semantic role of a span, aligned with OpenInference `span.kind` /
+/// OTel GenAI conventions but expressed vendor-neutrally.
+public enum SpanKind: Sendable, Hashable {
+    /// A multi-turn Run / agent loop (OpenInference `CHAIN`).
+    case chain
+    /// A single model generation call (OpenInference `LLM`).
+    case llm
+    /// A single tool invocation within a turn (OpenInference `TOOL`).
+    case tool
+    /// A retrieval / RAG step.
+    case retriever
+    /// Anything not covered above; `raw` is the exporter-facing kind string.
+    case other(String)
+
+    /// The OpenInference `openinference.span.kind` string for this kind.
+    public var openInferenceKind: String {
+        switch self {
+        case .chain: return "CHAIN"
+        case .llm: return "LLM"
+        case .tool: return "TOOL"
+        case .retriever: return "RETRIEVER"
+        case .other(let raw): return raw
+        }
+    }
+}
+
+/// A span's terminal status.
+public enum SpanStatus: Sendable, Hashable {
+    case unset
+    case ok
+    /// Failure; the associated value is the short error class (e.g.
+    /// "rateLimited"), mapped from ``InferenceMetric/errorClass``.
+    case error(String)
+}
+
+/// A vendor-neutral attribute value.
+///
+/// Deliberately small: the GenAI attribute set is strings, ints, doubles, and
+/// bools. Keeping the enum closed lets exporters switch exhaustively without an
+/// `Any`-typed escape hatch.
+public enum AttributeValue: Sendable, Hashable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+}
+
+/// A vendor-neutral span over the GenAI Run → Turn → span tree.
+///
+/// Maps cleanly to OpenInference / OTel GenAI conventions without importing
+/// either: an exporter product (kept out of core and the umbrella) serialises
+/// these to OTLP. The in-tree ``RecordingTraceSink`` collects them for tests
+/// and diagnostics.
+public struct GenSpan: Sendable {
+    public let context: SpanContext
+    public let kind: SpanKind
+    public let name: String
+    public let start: Date
+    public var end: Date?
+    public var attributes: [String: AttributeValue]
+    public var status: SpanStatus
+
+    public init(
+        context: SpanContext,
+        kind: SpanKind,
+        name: String,
+        start: Date,
+        end: Date? = nil,
+        attributes: [String: AttributeValue] = [:],
+        status: SpanStatus = .unset
+    ) {
+        self.context = context
+        self.kind = kind
+        self.name = name
+        self.start = start
+        self.end = end
+        self.attributes = attributes
+        self.status = status
+    }
+}
+
+// MARK: - Well-known attribute keys
+
+/// Canonical GenAI attribute keys, matching the OTel GenAI semantic
+/// conventions. Centralised so the adapter and any exporter agree on spelling.
+public enum GenAIAttributeKeys {
+    public static let system = "gen_ai.system"
+    public static let requestModel = "gen_ai.request.model"
+    public static let usagePromptTokens = "gen_ai.usage.prompt_tokens"
+    public static let usageCachedPromptTokens = "gen_ai.usage.cached_prompt_tokens"
+    public static let usageCompletionTokens = "gen_ai.usage.completion_tokens"
+    /// Non-standard but widely-ingested: per-call estimated cost in USD.
+    public static let costUSD = "gen_ai.usage.cost_usd"
+    public static let costApproximate = "gen_ai.usage.cost_is_approximate"
+    public static let costTableDate = "gen_ai.usage.cost_table_date"
+    /// Time-to-first-token in milliseconds.
+    public static let timeToFirstTokenMs = "gen_ai.latency.time_to_first_token_ms"
+    /// Mean inter-token latency in milliseconds.
+    public static let meanInterTokenLatencyMs = "gen_ai.latency.mean_inter_token_ms"
+    /// Wall-clock call duration in milliseconds.
+    public static let wallClockMs = "gen_ai.latency.wall_clock_ms"
+    public static let errorType = "error.type"
+}

--- a/Sources/ManifoldInference/Metrics/GenSpanTree.swift
+++ b/Sources/ManifoldInference/Metrics/GenSpanTree.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Helpers for constructing a Run → Turn → span tree with correct parent/child
+/// correlation, without threading IDs through every backend signature.
+///
+/// A host (or the turn loop, once IDs are threaded) opens a Run span, then a
+/// Turn span under it, then records one `.llm` span per model generation and
+/// one `.tool` span per tool invocation as children of the Turn. Each helper
+/// returns the child ``SpanContext`` so callers can keep building deeper.
+public enum GenSpanTree {
+    /// Opens a Run-level `.chain` span — the trace root.
+    /// - Parameter traceID: Trace to anchor the run under; defaults to a fresh one.
+    /// - Returns: The run span (status `.unset`; the caller closes it by setting
+    ///   `end`/`status`) and its context for parenting Turn spans.
+    public static func run(
+        name: String = "run",
+        traceID: TraceID = .random(),
+        start: Date = Date(),
+        attributes: [String: AttributeValue] = [:]
+    ) -> (span: GenSpan, context: SpanContext) {
+        let context = SpanContext.root(traceID: traceID)
+        let span = GenSpan(
+            context: context, kind: .chain, name: name, start: start, attributes: attributes
+        )
+        return (span, context)
+    }
+
+    /// Opens a Turn-level `.chain` span under a Run.
+    public static func turn(
+        under run: SpanContext,
+        name: String = "turn",
+        start: Date = Date(),
+        attributes: [String: AttributeValue] = [:]
+    ) -> (span: GenSpan, context: SpanContext) {
+        let context = run.child()
+        let span = GenSpan(
+            context: context, kind: .chain, name: name, start: start, attributes: attributes
+        )
+        return (span, context)
+    }
+
+    /// Records a model generation as an `.llm` child of a Turn, adapted from an
+    /// existing ``InferenceMetric`` so the attribute map stays lossless.
+    public static func generation(
+        _ metric: InferenceMetric,
+        under turn: SpanContext,
+        name: String? = nil
+    ) -> GenSpan {
+        metric.asGenSpan(context: turn.child(), name: name)
+    }
+
+    /// Opens a `.tool` child of a Turn.
+    public static func tool(
+        under turn: SpanContext,
+        name: String,
+        start: Date = Date(),
+        attributes: [String: AttributeValue] = [:]
+    ) -> (span: GenSpan, context: SpanContext) {
+        let context = turn.child()
+        let span = GenSpan(
+            context: context, kind: .tool, name: name, start: start, attributes: attributes
+        )
+        return (span, context)
+    }
+}

--- a/Sources/ManifoldInference/Metrics/InferenceMetric+GenSpan.swift
+++ b/Sources/ManifoldInference/Metrics/InferenceMetric+GenSpan.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+extension Duration {
+    /// Milliseconds as a `Double`, derived losslessly from the component
+    /// representation. Used to populate latency attributes in fractional ms.
+    fileprivate var inMilliseconds: Double {
+        let c = components
+        return Double(c.seconds) * 1_000 + Double(c.attoseconds) / 1_000_000_000_000_000
+    }
+}
+
+extension InferenceMetric {
+    /// Adapts this flat metric into a vendor-neutral ``GenSpan`` of kind
+    /// ``SpanKind/llm``.
+    ///
+    /// Lossless over the GenAI attribute set: every field on the metric is
+    /// surfaced either as a span field (start/end/status) or a `gen_ai.*`
+    /// attribute. This is the bridge that lets trace export work for hosts that
+    /// never touch the new Run/Turn correlation IDs — pass a freshly-minted
+    /// root context, or a child context built under a Turn span.
+    ///
+    /// - Parameters:
+    ///   - context: The span context placing this generation in the trace tree.
+    ///     Defaults to a fresh root span under a new trace.
+    ///   - name: Span name; defaults to the model identifier.
+    /// - Returns: A completed `.llm` span with start/end derived from
+    ///   ``timestamp`` and ``wallClockDuration``.
+    public func asGenSpan(
+        context: SpanContext = .root(),
+        name: String? = nil
+    ) -> GenSpan {
+        let end = timestamp.addingTimeInterval(wallClockDuration.inMilliseconds / 1_000)
+
+        var attributes: [String: AttributeValue] = [
+            GenAIAttributeKeys.system: .string(provider),
+            GenAIAttributeKeys.requestModel: .string(model),
+            GenAIAttributeKeys.usagePromptTokens: .int(promptTokens),
+            GenAIAttributeKeys.usageCachedPromptTokens: .int(cachedPromptTokens),
+            GenAIAttributeKeys.usageCompletionTokens: .int(completionTokens),
+            GenAIAttributeKeys.costUSD: .double(estimatedCostUSD),
+            GenAIAttributeKeys.costApproximate: .bool(isCostApproximate),
+            GenAIAttributeKeys.costTableDate: .string(costTableDate),
+            GenAIAttributeKeys.timeToFirstTokenMs: .double(timeToFirstToken.inMilliseconds),
+            GenAIAttributeKeys.meanInterTokenLatencyMs: .double(meanInterTokenLatency.inMilliseconds),
+            GenAIAttributeKeys.wallClockMs: .double(wallClockDuration.inMilliseconds),
+        ]
+
+        let status: SpanStatus
+        if let errorClass {
+            attributes[GenAIAttributeKeys.errorType] = .string(errorClass)
+            status = .error(errorClass)
+        } else {
+            status = .ok
+        }
+
+        return GenSpan(
+            context: context,
+            kind: .llm,
+            name: name ?? model,
+            start: timestamp,
+            end: end,
+            attributes: attributes,
+            status: status
+        )
+    }
+}

--- a/Sources/ManifoldInference/Metrics/TraceSink.swift
+++ b/Sources/ManifoldInference/Metrics/TraceSink.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Sink
+
+/// A type that receives ``GenSpan`` values forming a Run → Turn → span tree.
+///
+/// The vendor-neutral counterpart to ``InferenceMetricSink``: where a metric
+/// sink receives flat post-hoc snapshots, a trace sink receives correlated
+/// spans that reconstruct the call hierarchy. Conform to route spans into an
+/// OTLP exporter (kept out of core — see the issue's deferred-exporter note),
+/// Phoenix/Langfuse/LangSmith, or a local buffer.
+///
+/// Both sinks coexist: ``InferenceMetricSink`` stays the default backend output,
+/// and ``InferenceMetric/asGenSpan(context:)`` adapts any existing metric into
+/// a `.llm` span, so trace export works even before Run/Turn IDs are threaded
+/// through the turn loop.
+public protocol TraceSink: AnyObject, Sendable {
+    /// Called once per completed span (whether it succeeded or errored).
+    func record(_ span: GenSpan) async
+}
+
+// MARK: - In-memory recording sink
+
+/// A thread-safe in-memory ``TraceSink`` that retains every span it receives.
+///
+/// Intended for tests and debug diagnostics: assert on span tree shape and
+/// parent/child correlation without a live collector. Unbounded by design —
+/// for production buffering, prefer a bounded host implementation.
+public actor RecordingTraceSink: TraceSink {
+    private var spans: [GenSpan] = []
+
+    public init() {}
+
+    public func record(_ span: GenSpan) {
+        spans.append(span)
+    }
+
+    /// All recorded spans in insertion order.
+    public func recordedSpans() -> [GenSpan] { spans }
+
+    /// Spans whose `parentSpanID` matches `parent`, in insertion order.
+    public func children(of parent: SpanID) -> [GenSpan] {
+        spans.filter { $0.context.parentSpanID == parent }
+    }
+
+    /// The root spans (no parent) within `traceID`, in insertion order.
+    public func roots(in traceID: TraceID) -> [GenSpan] {
+        spans.filter { $0.context.traceID == traceID && $0.context.parentSpanID == nil }
+    }
+
+    /// Removes all recorded spans.
+    public func clear() { spans.removeAll() }
+}

--- a/Tests/ManifoldInferenceTests/TraceSinkTests.swift
+++ b/Tests/ManifoldInferenceTests/TraceSinkTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit tests for the vendor-neutral GenAI trace abstraction: the
+/// ``InferenceMetric`` → ``GenSpan`` adapter, span-tree correlation, and the
+/// in-memory ``RecordingTraceSink``. No SwiftData, no live collector.
+final class TraceSinkTests: XCTestCase {
+
+    private func metric(
+        provider: String = "Claude",
+        model: String = "claude-sonnet-4-6",
+        promptTokens: Int = 120,
+        cachedPromptTokens: Int = 40,
+        completionTokens: Int = 256,
+        cost: Double = 0.0042,
+        errorClass: String? = nil
+    ) -> InferenceMetric {
+        InferenceMetric(
+            provider: provider,
+            model: model,
+            promptTokens: promptTokens,
+            cachedPromptTokens: cachedPromptTokens,
+            completionTokens: completionTokens,
+            timeToFirstToken: .milliseconds(180),
+            meanInterTokenLatency: .milliseconds(12),
+            wallClockDuration: .milliseconds(900),
+            estimatedCostUSD: cost,
+            isCostApproximate: false,
+            costTableDate: "2026-06-20",
+            errorClass: errorClass,
+            timestamp: Date(timeIntervalSince1970: 1_000_000)
+        )
+    }
+
+    // MARK: - Adapter
+
+    func test_metricAdapter_isLosslessOverGenAIAttributes() throws {
+        let m = metric()
+        let span = m.asGenSpan()
+
+        XCTAssertEqual(span.kind, .llm)
+        XCTAssertEqual(span.name, m.model)
+        XCTAssertEqual(span.start, m.timestamp)
+        XCTAssertEqual(span.status, .ok)
+
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.system], .string("Claude"))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.requestModel], .string("claude-sonnet-4-6"))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.usagePromptTokens], .int(120))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.usageCachedPromptTokens], .int(40))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.usageCompletionTokens], .int(256))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.costUSD], .double(0.0042))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.costApproximate], .bool(false))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.costTableDate], .string("2026-06-20"))
+        // Latency attributes carry millisecond values.
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.timeToFirstTokenMs], .double(180))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.meanInterTokenLatencyMs], .double(12))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.wallClockMs], .double(900))
+
+        // end = start + wallClock (900ms).
+        let end = try XCTUnwrap(span.end)
+        XCTAssertEqual(end.timeIntervalSince1970, 1_000_000.9, accuracy: 0.001)
+    }
+
+    func test_erroredMetric_setsErrorStatusAndType() {
+        let span = metric(errorClass: "rateLimited").asGenSpan()
+        XCTAssertEqual(span.status, .error("rateLimited"))
+        XCTAssertEqual(span.attributes[GenAIAttributeKeys.errorType], .string("rateLimited"))
+    }
+
+    // MARK: - Single generation span
+
+    func test_singleGeneration_emitsOneLLMSpan() async {
+        let sink = RecordingTraceSink()
+        await sink.record(metric().asGenSpan())
+
+        let spans = await sink.recordedSpans()
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans.first?.kind, .llm)
+        XCTAssertNil(spans.first?.context.parentSpanID, "A bare generation span is a trace root.")
+    }
+
+    // MARK: - Tool-loop turn tree
+
+    func test_toolLoopTurn_emitsRunTurnLLMToolLLMTree() async {
+        let sink = RecordingTraceSink()
+
+        let (runSpan, runCtx) = GenSpanTree.run()
+        let (turnSpan, turnCtx) = GenSpanTree.turn(under: runCtx)
+        let llm1 = GenSpanTree.generation(metric(), under: turnCtx)
+        let (toolSpan, _) = GenSpanTree.tool(under: turnCtx, name: "get_weather")
+        let llm2 = GenSpanTree.generation(metric(completionTokens: 64), under: turnCtx)
+
+        for s in [runSpan, turnSpan, llm1, toolSpan, llm2] { await sink.record(s) }
+
+        // One trace shared by all spans.
+        let traceID = runCtx.traceID
+        let allSpans = await sink.recordedSpans()
+        XCTAssertTrue(allSpans.allSatisfy { $0.context.traceID == traceID })
+
+        // Run is the sole root.
+        let roots = await sink.roots(in: traceID)
+        XCTAssertEqual(roots.count, 1)
+        XCTAssertEqual(roots.first?.kind, .chain)
+
+        // Turn is the Run's only child.
+        let runChildren = await sink.children(of: runCtx.spanID)
+        XCTAssertEqual(runChildren.map(\.context.spanID), [turnCtx.spanID])
+
+        // Turn has exactly three children: llm, tool, llm in order.
+        let turnChildren = await sink.children(of: turnCtx.spanID)
+        XCTAssertEqual(turnChildren.map(\.kind), [.llm, .tool, .llm])
+        XCTAssertEqual(
+            turnChildren.map(\.context.spanID),
+            [llm1.context.spanID, toolSpan.context.spanID, llm2.context.spanID]
+        )
+
+        // Every child correctly parents back to the Turn.
+        XCTAssertTrue(turnChildren.allSatisfy { $0.context.parentSpanID == turnCtx.spanID })
+    }
+
+    func test_childContext_inheritsTraceAndLinksParent() {
+        let root = SpanContext.root()
+        let child = root.child()
+        XCTAssertEqual(child.traceID, root.traceID)
+        XCTAssertEqual(child.parentSpanID, root.spanID)
+        XCTAssertNotEqual(child.spanID, root.spanID)
+    }
+
+    func test_traceID_hexIsThirtyTwoChars() {
+        XCTAssertEqual(TraceID.random().description.count, 32)
+        XCTAssertEqual(SpanID.random().description.count, 16)
+    }
+}


### PR DESCRIPTION
Closes part of #1930.

## What this is

The dependency-free core half of the OpenTelemetry GenAI observability work: a vendor-neutral `Run → Turn → span` tree abstraction over the data `InferenceMetric` already collects, with no OTel/grpc dependency added to core.

### New types (all in `Sources/ManifoldInference/Metrics/`, additive)
- **`GenSpan.swift`** — `GenSpan`, `SpanContext`, `TraceID`/`SpanID` (16/8-byte OTLP-shaped IDs), `SpanKind` (`.chain`/`.llm`/`.tool`/`.retriever`/`.other`, with `openInferenceKind` strings), `SpanStatus`, `AttributeValue`, and `GenAIAttributeKeys` (canonical `gen_ai.*` keys).
- **`TraceSink.swift`** — the `TraceSink` protocol (the widening point #1930 names) plus `RecordingTraceSink`, an in-memory actor sink for tests/diagnostics. Coexists with the existing `InferenceMetricSink`.
- **`InferenceMetric+GenSpan.swift`** — `InferenceMetric.asGenSpan(context:)`, a lossless metric→`.llm`-span adapter so trace export works *before* correlation IDs are threaded through the turn loop.
- **`GenSpanTree.swift`** — helpers to build correlated Run/Turn/llm/tool spans with correct parent/child `SpanID` linkage.

### Tests
`Tests/ManifoldInferenceTests/TraceSinkTests.swift` (6 tests, XCTest, in-memory sink, no `try?`): adapter losslessness, error-status mapping, single `.llm` span, and the full `Run → Turn → [llm, tool, llm]` tree with parent/child correlation + ordering. Sabotage-verified (broke the Turn parent link → nesting test failed) and reverted.

## API gate
Purely additive — no existing public init/function signature changes, so the swift-api-digester gate is not triggered. **`.github/api-breakage-allowlist.txt` is untouched** (`grep -c '^#'` remains 0).

## Deferred to follow-ups
- **OTLP/OpenTelemetry wire exporter** — to ship as a separate optional product (`ManifoldTelemetryOTLP`), never re-exported by the umbrella, so core stays dependency-free (per the issue's investigation plan).
- **Threading Run/Turn correlation IDs** through `ConversationRuntime → InferenceService → backends → GenerationMetricTracker` so the turn loop auto-emits the tree. That change adds parameters to public signatures (digester + allowlist work) and is the genuinely load-bearing effort the plan flags; deferring keeps this PR additive and reviewable. Today, hosts/tests build the tree explicitly via `GenSpanTree` or adapt metrics via `asGenSpan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)