### PR TITLE
feat: full-context RAG mode (inject whole short docs under budget)

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -113,3 +113,5 @@ API breakage: constructor RAGConfiguration.init(embeddingBackend:reranker:chunkS
 API breakage: enumelement GenerationCompletion.Reason.runTokenBudget has been added as a new enum case
 API breakage: enumelement GenerationEvent.runTokenBudgetExceeded has been added as a new enum case
 API breakage: enumelement GenerationStreamConsumer.StreamAction.runTokenBudgetExceeded has been added as a new enum case
+API breakage: constructor RAGConfiguration.init(embeddingBackend:reranker:chunkSize:chunkOverlap:topK:similarityThreshold:vectorStoreURL:) has been removed
+API breakage: constructor RAGService.init(documentStore:vectorStore:embeddingBackend:reranker:chunker:parsers:defaultLimit:similarityThreshold:) has been removed

--- a/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
+++ b/Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift
@@ -58,6 +58,21 @@ public struct RAGConfiguration: Sendable {
     /// to suppress weakly-related passages at the cost of occasionally returning
     /// fewer than ``topK`` chunks.
     public var similarityThreshold: Float
+    /// When `true`, the retriever first tries to inject the *entire* ingested
+    /// corpus verbatim — skipping chunk retrieval — whenever the combined
+    /// document text fits within ``fullContextBudgetTokens``. When the corpus is
+    /// over budget (or the whole-document path fails to read its sources), it
+    /// falls back to normal chunked retrieval. Default: `false`, which preserves
+    /// the historical always-chunk behaviour. Mirrors LM Studio / Open WebUI's
+    /// "full context" toggle (#1939 item 7).
+    public var fullContextMode: Bool
+    /// Token ceiling for ``fullContextMode``. If the whole corpus estimates at or
+    /// below this many tokens it is injected verbatim; otherwise retrieval falls
+    /// back to chunking. Default: 8192 — a conservative slice of a typical local
+    /// context window that still leaves room for the system prompt, history, and
+    /// the response buffer (ties to the compression seam, #1885). Ignored unless
+    /// ``fullContextMode`` is `true`.
+    public var fullContextBudgetTokens: Int
     /// URL for the flat-file vector index. Defaults to
     /// `<Application Support>/<bundleIdentifier>/ragvectors.bin`.
     public var vectorStoreURL: URL?
@@ -69,6 +84,8 @@ public struct RAGConfiguration: Sendable {
         chunkOverlap: Int = 200,
         topK: Int = 5,
         similarityThreshold: Float = 0,
+        fullContextMode: Bool = false,
+        fullContextBudgetTokens: Int = 8192,
         vectorStoreURL: URL? = nil
     ) {
         self.embeddingBackend = embeddingBackend
@@ -77,6 +94,8 @@ public struct RAGConfiguration: Sendable {
         self.chunkOverlap = chunkOverlap
         self.topK = topK
         self.similarityThreshold = similarityThreshold
+        self.fullContextMode = fullContextMode
+        self.fullContextBudgetTokens = fullContextBudgetTokens
         self.vectorStoreURL = vectorStoreURL
     }
 }
@@ -491,7 +510,9 @@ public final class ManifoldBootstrap {
             reranker: ragConfig.reranker,
             chunker: chunker,
             defaultLimit: ragConfig.topK,
-            similarityThreshold: ragConfig.similarityThreshold
+            similarityThreshold: ragConfig.similarityThreshold,
+            fullContextMode: ragConfig.fullContextMode,
+            fullContextBudgetTokens: ragConfig.fullContextBudgetTokens
         )
     }
 

--- a/Sources/ManifoldRuntime/Services/RAGService.swift
+++ b/Sources/ManifoldRuntime/Services/RAGService.swift
@@ -41,6 +41,19 @@ public actor RAGService {
     /// already excludes non-positive scores, so a `0` threshold is a no-op.
     private let similarityThreshold: Float
 
+    /// When `true`, ``retrieve(query:limit:)`` first tries to inject the whole
+    /// corpus verbatim (skipping chunk retrieval) if it fits
+    /// ``fullContextBudgetTokens``, falling back to chunked retrieval otherwise.
+    /// Threaded from ``RAGConfiguration/fullContextMode``. The default of `false`
+    /// preserves the historical always-chunk behaviour.
+    private let fullContextMode: Bool
+
+    /// Token ceiling for the whole-document path. The corpus is injected verbatim
+    /// only when its estimated token count is at or below this value. Threaded
+    /// from ``RAGConfiguration/fullContextBudgetTokens``; ignored when
+    /// ``fullContextMode`` is `false`.
+    private let fullContextBudgetTokens: Int
+
     /// How much wider than `limit` the first-stage candidate set is fetched
     /// when a reranker is active. A 3× pool gives the cross-encoder enough
     /// candidates to recover relevant passages the bi-encoder cosine stage
@@ -57,7 +70,9 @@ public actor RAGService {
         chunker: DocumentChunker = DocumentChunker(),
         parsers: [any DocumentParser] = [TextDocumentParser(), PDFDocumentParser()],
         defaultLimit: Int = 5,
-        similarityThreshold: Float = 0
+        similarityThreshold: Float = 0,
+        fullContextMode: Bool = false,
+        fullContextBudgetTokens: Int = 8192
     ) {
         self.documentStore = documentStore
         self.vectorStore = vectorStore
@@ -70,6 +85,11 @@ public actor RAGService {
         // meaningless for cosine scores in [-1, 1].
         self.defaultLimit = max(1, defaultLimit)
         self.similarityThreshold = max(0, similarityThreshold)
+        self.fullContextMode = fullContextMode
+        // A non-positive budget would make the whole-doc path unreachable; clamp
+        // so a misconfigured `0` still admits trivially small corpora rather than
+        // silently disabling the feature it was meant to enable.
+        self.fullContextBudgetTokens = max(1, fullContextBudgetTokens)
     }
 
     // MARK: - Ingestion
@@ -177,6 +197,16 @@ public actor RAGService {
             return .empty
         }
 
+        // Full-context pre-retrieval branch. When enabled and the whole corpus
+        // fits the token budget, inject every document verbatim and skip chunk
+        // retrieval entirely — short knowledge bases benefit from the model
+        // seeing complete documents rather than top-K passages. A `nil` return
+        // means the corpus was over budget or unreadable, so we fall through to
+        // the normal chunked path below.
+        if fullContextMode, let wholeDocResult = try await retrieveWholeDocuments() {
+            return wholeDocResult
+        }
+
         // No explicit caller override falls back to the configured top-K
         // (``RAGConfiguration/topK``). Clamp to a positive width so the
         // vector-store `.prefix` and reranker pool math stay well-defined.
@@ -274,6 +304,78 @@ public actor RAGService {
                 chunkIndex: hit.chunk.chunkIndex,
                 fullText: hit.chunk.text,
                 score: hit.score
+            )
+        }
+
+        return RetrievalResult(slots: [slot], citations: citations)
+    }
+
+    /// Full-context path: reads every ingested document's source, estimates the
+    /// combined token cost, and — only if it fits ``fullContextBudgetTokens`` —
+    /// returns a single retrieval slot carrying all documents verbatim plus a
+    /// per-document citation.
+    ///
+    /// Returns `nil` (signalling the caller to fall back to chunked retrieval)
+    /// when there are no documents, when the corpus is over budget, or when no
+    /// document source could be read. Document text is re-parsed from each
+    /// record's `sourceURL` using the same parsers used at ingest, so this needs
+    /// no new vector-store surface.
+    private func retrieveWholeDocuments() async throws -> RetrievalResult? {
+        let documents = try await documentStore.fetchDocuments()
+        guard !documents.isEmpty else { return nil }
+
+        // Re-parse each document from its source. A source that has since moved
+        // or whose type lost its parser is skipped with a warning rather than
+        // failing the turn — partial corpora are still useful, and a fully empty
+        // result correctly falls back to chunking below.
+        var parsed: [(record: DocumentRecord, text: String)] = []
+        for record in documents {
+            let ext = record.fileType.lowercased()
+            guard let parser = parsers.first(where: { $0.supportedExtensions.contains(ext) }) else {
+                Log.inference.warning("RAGService: no parser for full-context document \(record.title, privacy: .public) (.\(ext, privacy: .public)); skipping")
+                continue
+            }
+            do {
+                let text = try await parser.parse(url: record.sourceURL)
+                parsed.append((record, text))
+            } catch {
+                Log.inference.warning("RAGService: failed to read full-context document \(record.title, privacy: .public): \(error.localizedDescription)")
+            }
+        }
+
+        guard !parsed.isEmpty else { return nil }
+
+        // Budget gate: estimate the combined token cost and bail out to chunked
+        // retrieval when the corpus does not fit. The estimate reuses the same
+        // context-budget primitive the trim/compaction path uses, so the
+        // "does this fit?" question is answered consistently across the engine.
+        let totalTokens = parsed.reduce(0) { running, doc in
+            running + ContextWindowManager.estimateTokenCount(doc.text)
+        }
+        guard totalTokens <= fullContextBudgetTokens else {
+            Log.inference.info("RAGService: full-context corpus (\(totalTokens) tokens) exceeds budget (\(self.fullContextBudgetTokens)); falling back to chunked retrieval")
+            return nil
+        }
+
+        let content = parsed.map { doc in
+            "[\(doc.record.title)]\n\(doc.text)"
+        }.joined(separator: "\n\n---\n\n")
+
+        let slot = PromptSlot(
+            id: "rag-retrieval",
+            content: content,
+            position: .contextSetup,
+            role: .retrieval,
+            label: "Full Documents"
+        )
+
+        let citations = parsed.map { doc in
+            Citation(
+                documentID: doc.record.id,
+                documentTitle: doc.record.title,
+                chunkIndex: 0,
+                fullText: doc.text,
+                score: 1.0
             )
         }
 

--- a/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
+++ b/Tests/ManifoldRuntimeTests/RAGServiceTests.swift
@@ -697,6 +697,143 @@ final class RAGServiceTests: XCTestCase {
         XCTAssertTrue(result.citations.isEmpty)
     }
 
+    // MARK: - #1939 item 7: full-context mode (whole-doc injection)
+
+    /// With `fullContextMode` on and a corpus that fits the token budget, the
+    /// retriever must inject the *whole* document verbatim — never touching the
+    /// chunk-retrieval path (no vector/keyword search at all).
+    func test_fullContextMode_underBudget_injectsWholeDocumentAndSkipsChunking() async throws {
+        let body = "The complete contents of a short document, injected verbatim."
+        let url = try writeTempFile(content: body)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let docStore = FakeDocumentStore()
+        let docID = UUID()
+        docStore.insertedRecords = [
+            DocumentRecord(id: docID, title: "ShortDoc", sourceURL: url, fileType: "txt", chunkCount: 1)
+        ]
+
+        // The keyword store would return a *different* string if the chunk path
+        // ran — its absence in the output proves the whole-doc branch won.
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setKeywordResults([
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "CHUNK PASSAGE", chunkIndex: 0), documentTitle: "ShortDoc", score: 1.0)
+        ])
+
+        let sut = RAGService(
+            documentStore: docStore,
+            vectorStore: vectorStore,
+            fullContextMode: true,
+            fullContextBudgetTokens: 8192
+        )
+
+        let result = try await sut.retrieve(query: "anything")
+
+        XCTAssertEqual(result.slots.count, 1)
+        XCTAssertTrue(result.slots[0].content.contains(body),
+                      "the whole document body must be injected verbatim")
+        XCTAssertFalse(result.slots[0].content.contains("CHUNK PASSAGE"),
+                       "the chunk-retrieval path must not run under full-context mode when under budget")
+        XCTAssertEqual(result.citations.count, 1)
+        XCTAssertEqual(result.citations[0].documentID, docID)
+
+        // The chunked path was never reached, so the vector store saw no query.
+        let keywordLimit = await vectorStore.lastKeywordLimit
+        XCTAssertNil(keywordLimit, "no keyword/vector search must happen on the under-budget whole-doc path")
+
+        // Sabotage: with full-context mode OFF this would be the CHUNK PASSAGE.
+        XCTAssertNotEqual(result.slots[0].content, "[ShortDoc]\nCHUNK PASSAGE")
+    }
+
+    /// With `fullContextMode` on but a corpus that *exceeds* the token budget,
+    /// the retriever must fall back to normal chunk retrieval.
+    func test_fullContextMode_overBudget_fallsBackToChunkedRetrieval() async throws {
+        // A document far larger than a tiny budget forces the fallback.
+        let body = String(repeating: "word ", count: 4000)
+        let url = try writeTempFile(content: body)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let docStore = FakeDocumentStore()
+        let docID = UUID()
+        docStore.insertedRecords = [
+            DocumentRecord(id: docID, title: "BigDoc", sourceURL: url, fileType: "txt", chunkCount: 10)
+        ]
+
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setKeywordResults([
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "CHUNK PASSAGE", chunkIndex: 0), documentTitle: "BigDoc", score: 1.0)
+        ])
+
+        let sut = RAGService(
+            documentStore: docStore,
+            vectorStore: vectorStore,
+            fullContextMode: true,
+            fullContextBudgetTokens: 16  // far below the ~5000-token corpus
+        )
+
+        let result = try await sut.retrieve(query: "anything")
+
+        XCTAssertEqual(result.slots.count, 1)
+        XCTAssertTrue(result.slots[0].content.contains("CHUNK PASSAGE"),
+                      "over-budget corpus must fall back to the chunk-retrieval path")
+        XCTAssertFalse(result.slots[0].content.contains(body),
+                       "the whole document must NOT be injected when over budget")
+
+        // The fallback chunked path actually ran a keyword search.
+        let keywordLimit = await vectorStore.lastKeywordLimit
+        XCTAssertNotNil(keywordLimit, "over-budget fallback must invoke the chunk-retrieval search")
+    }
+
+    /// The default (`fullContextMode == false`) must preserve the historical
+    /// chunked behaviour even when a corpus would fit a budget.
+    func test_fullContextMode_disabledByDefault_usesChunkedRetrieval() async throws {
+        let url = try writeTempFile(content: "Tiny doc that would fit any budget.")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let docStore = FakeDocumentStore()
+        let docID = UUID()
+        docStore.insertedRecords = [
+            DocumentRecord(id: docID, title: "TinyDoc", sourceURL: url, fileType: "txt", chunkCount: 1)
+        ]
+
+        let vectorStore = FakeVectorStore()
+        await vectorStore.setKeywordResults([
+            VectorSearchHit(chunk: DocumentChunk(documentID: docID, text: "CHUNK PASSAGE", chunkIndex: 0), documentTitle: "TinyDoc", score: 1.0)
+        ])
+
+        // No fullContextMode argument → defaults to off.
+        let sut = RAGService(documentStore: docStore, vectorStore: vectorStore)
+
+        let result = try await sut.retrieve(query: "anything")
+
+        XCTAssertTrue(result.slots[0].content.contains("CHUNK PASSAGE"),
+                      "with full-context mode off, retrieval must use chunks")
+        let keywordLimit = await vectorStore.lastKeywordLimit
+        XCTAssertNotNil(keywordLimit, "default mode must run the chunk-retrieval search")
+    }
+
+    /// An empty corpus under full-context mode must fall back to chunked
+    /// retrieval (which then round-trips empty) rather than injecting a blank
+    /// whole-document slot.
+    func test_fullContextMode_emptyCorpus_fallsBackToChunked() async throws {
+        let docStore = FakeDocumentStore()  // no documents
+        let vectorStore = FakeVectorStore()  // no hits
+
+        let sut = RAGService(
+            documentStore: docStore,
+            vectorStore: vectorStore,
+            fullContextMode: true
+        )
+
+        let result = try await sut.retrieve(query: "anything")
+        XCTAssertTrue(result.slots.isEmpty)
+        XCTAssertTrue(result.citations.isEmpty)
+
+        // The fallback chunked path ran (and found nothing).
+        let keywordLimit = await vectorStore.lastKeywordLimit
+        XCTAssertNotNil(keywordLimit, "empty corpus must fall through to the chunk-retrieval search")
+    }
+
     // MARK: - Helpers
 
     private func writeTempFile(content: String) throws -> URL {


### PR DESCRIPTION
Implements **#1939 item 7** — _"Full context mode" toggle: inject whole short docs, chunk only over budget_ (LM Studio / Open WebUI parity; ties to the compression seam #1885). Kept deliberately **separate from item 6** (retrieval threshold + top-K, already merged in #1947).

## What

A net-new **pre-retrieval budget branch** plus the config to drive it. No whole-document-injection path existed before — RAG always chunked.

- **`RAGConfiguration`**: `fullContextMode: Bool = false` + `fullContextBudgetTokens: Int = 8192`, threaded into `RAGService` at bootstrap.
- **`RAGService.retrieve`**: when `fullContextMode` is on, a pre-retrieval branch (`retrieveWholeDocuments`) re-parses every ingested document from its `sourceURL` (reusing the same ingest parsers — no new `VectorStore` surface), estimates the combined token cost with `ContextWindowManager.estimateTokenCount` (the same budget primitive the trim/compaction path uses), and:
  - **under budget** → injects all documents verbatim as a single retrieval slot (one citation per doc), skipping chunk retrieval entirely;
  - **over budget / empty / unreadable** → returns `nil` and falls through to the existing chunked path.
- **Default off** — preserves the historical always-chunk behaviour byte-for-byte.

## Tests (`RAGServiceTests`)

In-memory fakes, deterministic. Cover: whole-doc injection under budget (asserts the chunk path never ran), fallback-to-chunking over budget, default-off preserves chunking, and empty-corpus fallback. Sabotage-verified (removing the budget gate fails the over-budget test); inline sabotage asserts retained per the file's existing convention.

## api-digester

Adding fields to the two public inits changes their signatures (as #1947 did). The exact digester lines are appended to `.github/api-breakage-allowlist.txt` (bare `API breakage:` lines, `grep -c '^#'` = 0); local digester run exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)