### PR TITLE
feat: typed respond<T>() structured-output round-trip + wire StructuredOutputRouter (#1915)

### DIFF
--- a/Sources/ManifoldContract/GenerationStream.swift
+++ b/Sources/ManifoldContract/GenerationStream.swift
@@ -37,6 +37,13 @@ public final class GenerationStream: Sendable {
     /// ``InferenceError/idleTimeout(_:)`` if no event arrives within this duration.
     public nonisolated let idleTimeout: Duration?
 
+    /// The structured-output strategy the generation queue selected for the
+    /// serving backend, or `nil` when the request carried no structured-output
+    /// target. Set once by the queue at enqueue time; the single source of
+    /// truth that ``InferenceService/respond(_:to:config:)`` reports back so it
+    /// never recomputes the selection against a different capability set.
+    public package(set) var structuredOutputStrategy: StructuredOutputStrategy?
+
     // MARK: - Phase
 
     /// Lifecycle phases for a generation stream.

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -657,6 +657,52 @@ final class GenerationQueue {
             config.grammar = derived
         }
 
+        // Structured-output routing (#1915). When a caller has staged a
+        // structured-output target on the config, this is where it gets lowered
+        // into the strongest mechanism the *active* backend supports — the
+        // first production caller of `StructuredOutputRouter`. `respond(_:to:)`
+        // stages the target; the queue resolves it here because only the queue
+        // knows which backend will actually serve the request.
+        var systemPrompt = systemPrompt
+        if let staged = config.structuredOutput,
+           let target = Self.structuredOutputTarget(
+               from: staged,
+               capabilities: backend.capabilities
+           ) {
+            let strategy = StructuredOutputRouter.selectStrategy(
+                capabilities: backend.capabilities,
+                target: target
+            )
+            switch strategy {
+            case .gbnf(let grammar):
+                // An explicit caller grammar always wins; only lower when the
+                // slot is free so we never clobber a host-authored string.
+                if config.grammar == nil { config.grammar = grammar }
+                // The grammar is the constraint — drop the strategy hint so a
+                // cloud encoder downstream doesn't also try to apply a schema.
+                config.structuredOutput = nil
+            case .jsonSchema(let schema):
+                // Leave the strategy on config so the cloud strict-schema
+                // encoder (sibling #1918) honors it on the wire.
+                config.structuredOutput = .jsonSchema(schema)
+            case .jsonPrompting:
+                // No backend-level constraint available — fall back to a
+                // prompt-level instruction so weak backends still get steered.
+                if let schema = target.jsonSchema, !schema.isEmpty {
+                    systemPrompt = Self.appendingJSONSchemaInstruction(
+                        to: systemPrompt,
+                        schema: schema
+                    )
+                }
+                config.structuredOutput = nil
+            case .guided:
+                // Foundation guided generation is deferred (#1915 follow-up).
+                // Keep the strategy intact for the guided-capable backend to
+                // pick up; no config lowering happens here yet.
+                break
+            }
+        }
+
         let token = GenerationRequestToken(rawValue: nextGenerationToken.rawValue + 1)
         nextGenerationToken = token
 
@@ -690,6 +736,64 @@ final class GenerationQueue {
         lastActivityTimestamp = Date()
         drainQueue()
         return (token: token, stream: stream)
+    }
+
+    /// Reconstructs a ``StructuredOutputTarget`` from a strategy a caller staged
+    /// on ``GenerationConfig/structuredOutput``.
+    ///
+    /// `respond(_:to:)` stages only the JSON schema (as `.jsonSchema`). When the
+    /// active backend supports grammar-constrained sampling, the schema is
+    /// lowered to GBNF here so the router can upgrade to the strongest
+    /// mechanism. Doing the lowering inside the queue (rather than staging a
+    /// grammar on `config.grammar`) keeps the caller's `config.grammar` slot
+    /// untouched — a schema-only backend never sees a stray grammar it would
+    /// reject. Returns `nil` for `.gbnf` (already a grammar, nothing to
+    /// re-route) and `.jsonPrompting` / `.guided` (no re-routable payload).
+    static func structuredOutputTarget(
+        from strategy: StructuredOutputStrategy,
+        capabilities: BackendCapabilities
+    ) -> StructuredOutputTarget? {
+        switch strategy {
+        case .jsonSchema(let schema):
+            let grammar: String?
+            if capabilities.supportsGrammarConstrainedSampling,
+               let schemaValue = Self.decodeSchema(schema) {
+                grammar = ToolGrammarBuilder().buildSchemaGrammar(for: schemaValue)
+            } else {
+                grammar = nil
+            }
+            return StructuredOutputTarget(gbnfGrammar: grammar, jsonSchema: schema)
+        case .gbnf, .jsonPrompting, .guided:
+            return nil
+        }
+    }
+
+    /// Decodes a staged JSON-schema string back into a ``JSONSchemaValue`` for
+    /// GBNF lowering. Returns `nil` on malformed input so the caller falls back
+    /// to a non-grammar strategy rather than crashing.
+    private static func decodeSchema(_ schema: String) -> JSONSchemaValue? {
+        guard let data = schema.data(using: .utf8) else { return nil }
+        do {
+            return try JSONDecoder().decode(JSONSchemaValue.self, from: data)
+        } catch {
+            Log.inference.warning(
+                "StructuredOutputRouter: failed to decode staged JSON schema for GBNF lowering: \(String(describing: error), privacy: .public)"
+            )
+            return nil
+        }
+    }
+
+    /// Appends a JSON-schema instruction to a system prompt for the
+    /// prompt-level structured-output fallback (`.jsonPrompting`).
+    static func appendingJSONSchemaInstruction(to systemPrompt: String?, schema: String) -> String {
+        let instruction = """
+        You must respond with a single JSON object that conforms exactly to this JSON Schema. \
+        Output only the JSON object — no prose, no code fences.
+        JSON Schema:
+        \(schema)
+        """
+        guard let existing = systemPrompt, !existing.isEmpty else { return instruction }
+        return existing + "\n\n" + instruction
     }
 
     /// Assembles a ``GenerationConfig`` from the individual sampling parameters

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -664,6 +664,11 @@ final class GenerationQueue {
         // stages the target; the queue resolves it here because only the queue
         // knows which backend will actually serve the request.
         var systemPrompt = systemPrompt
+        // The strategy the router actually chose for the serving backend, so it
+        // can be surfaced on the returned stream as the single source of truth
+        // (`respond(_:to:)` reads it rather than recomputing against a possibly
+        // different capability set).
+        var selectedStructuredStrategy: StructuredOutputStrategy?
         if let staged = config.structuredOutput,
            let target = Self.structuredOutputTarget(
                from: staged,
@@ -673,6 +678,7 @@ final class GenerationQueue {
                 capabilities: backend.capabilities,
                 target: target
             )
+            selectedStructuredStrategy = strategy
             switch strategy {
             case .gbnf(let grammar):
                 // An explicit caller grammar always wins; only lower when the
@@ -710,6 +716,7 @@ final class GenerationQueue {
         let rawStream = AsyncThrowingStream<GenerationEvent, Error> { continuation = $0 }
         let stream = GenerationStream(rawStream)
         stream.setPhase(.queued)
+        stream.structuredOutputStrategy = selectedStructuredStrategy
         continuations[token] = continuation
 
         Self.warnIfThinkingUnsupported(backend: backend, config: config)

--- a/Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift
@@ -86,6 +86,12 @@ extension InferenceService {
     /// The macro is optional: any `Decodable & Sendable & SchemaProviding` type
     /// works, so this is usable in default builds where the `Macros` trait is off.
     ///
+    /// This shares the generation queue with chat turns — the request is
+    /// enqueued and serializes behind any in-flight generation rather than
+    /// dispatching out-of-band. The router wiring lives at the queue's enqueue
+    /// chokepoint, which is the only place the serving backend's capabilities
+    /// are known.
+    ///
     /// - Parameters:
     ///   - type: The type to decode the response into.
     ///   - prompt: The user prompt.
@@ -140,20 +146,12 @@ extension InferenceService {
 
         let rawText = collected
 
-        // Report the strategy the router actually chose for the active backend.
-        // The queue runs the same selection internally to lower config; we
-        // recompute it here (read-only, via the same queue helper) purely to
-        // surface it on the result.
-        let strategy: StructuredOutputStrategy
-        if let caps = currentEndpointBackend?.capabilities,
-           let target = GenerationQueue.structuredOutputTarget(
-               from: .jsonSchema(schemaString),
-               capabilities: caps
-           ) {
-            strategy = StructuredOutputRouter.selectStrategy(capabilities: caps, target: target)
-        } else {
-            strategy = .jsonPrompting
-        }
+        // The strategy the router actually chose for the serving backend, set
+        // on the stream by the queue at enqueue time. Reading it back is the
+        // single source of truth — no recomputation against a capability set
+        // that might differ from the one the queue dispatched to. `nil` means
+        // the request carried no resolvable target (treated as prompt-level).
+        let strategy = stream.structuredOutputStrategy ?? .jsonPrompting
 
         // Decode off the main actor — small payloads, but no reason to block UI.
         do {

--- a/Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+// MARK: - Schema Providing
+
+/// A type that can describe itself as a JSON Schema for structured-output
+/// generation.
+///
+/// Conformance is the only requirement of ``InferenceService/respond(_:to:config:)``
+/// beyond `Decodable`. The `@ToolSchema` macro (trait-gated behind `Macros`)
+/// synthesizes `static var jsonSchema` for you, but it is **not** required —
+/// any type can conform by hand, which keeps `respond` usable in default builds
+/// where the macro is off.
+///
+/// ```swift
+/// struct Weather: Decodable, Sendable, SchemaProviding {
+///     let city: String
+///     let celsius: Double
+///     static var jsonSchema: JSONSchemaValue {
+///         .object([
+///             "type": .string("object"),
+///             "properties": .object([
+///                 "city": .object(["type": .string("string")]),
+///                 "celsius": .object(["type": .string("number")]),
+///             ]),
+///             "required": .array([.string("city"), .string("celsius")]),
+///         ])
+///     }
+/// }
+/// ```
+public protocol SchemaProviding {
+    /// The JSON Schema describing the decoded shape of this type.
+    static var jsonSchema: JSONSchemaValue { get }
+}
+
+// MARK: - Result
+
+/// The result of a typed structured-output round-trip.
+public struct StructuredOutput<T: Decodable & Sendable>: Sendable {
+    /// The decoded value.
+    public let value: T
+    /// The raw text the model produced before decoding. Useful for logging,
+    /// debugging, and reask loops (#1916).
+    public let rawText: String
+    /// The structured-output strategy the router selected for the active
+    /// backend. `.jsonPrompting` indicates the backend offered no constrained
+    /// decoding and the schema was injected as a prompt instruction.
+    public let strategy: StructuredOutputStrategy
+
+    public init(value: T, rawText: String, strategy: StructuredOutputStrategy) {
+        self.value = value
+        self.rawText = rawText
+        self.strategy = strategy
+    }
+}
+
+// MARK: - Errors
+
+/// Failures specific to the typed structured-output round-trip.
+///
+/// Surfaced by ``InferenceService/respond(_:to:config:)``. A clean, public
+/// typed error is the precondition for the structured-output reask loop
+/// (#1916) — callers inspect ``decodeFailure`` to decide whether to retry with
+/// the raw text fed back to the model.
+public enum StructuredOutputError: Error, Sendable {
+    /// The model produced text that did not decode into the requested type.
+    /// Carries the raw text and the underlying decoding error so a reask loop
+    /// can include both in its retry prompt.
+    case decodeFailure(rawText: String, underlying: String)
+
+    /// The JSON schema for the requested type could not be encoded to a string.
+    case schemaEncodingFailure(String)
+}
+
+// MARK: - respond<T>
+
+extension InferenceService {
+
+    /// Generates a single response constrained to decode into `T`.
+    ///
+    /// Derives a JSON schema from `T`, stages it on the generation config, and
+    /// routes through the queue where ``StructuredOutputRouter`` selects the
+    /// strongest constrained-decoding mechanism the active backend supports
+    /// (GBNF grammar → JSON-schema strict mode → prompt-level instruction).
+    /// Runs one generation, drains the stream to a string, and decodes into `T`.
+    ///
+    /// The macro is optional: any `Decodable & Sendable & SchemaProviding` type
+    /// works, so this is usable in default builds where the `Macros` trait is off.
+    ///
+    /// - Parameters:
+    ///   - type: The type to decode the response into.
+    ///   - prompt: The user prompt.
+    ///   - config: Sampling/generation configuration. Any `structuredOutput`
+    ///     already set is overwritten with the schema derived from `T`.
+    /// - Returns: The decoded value, the raw model text, and the strategy used.
+    /// - Throws: ``StructuredOutputError/decodeFailure(rawText:underlying:)`` when
+    ///   the produced text does not decode into `T`;
+    ///   ``StructuredOutputError/schemaEncodingFailure(_:)`` when the schema
+    ///   cannot be encoded; or any generation error from the backend.
+    public func respond<T: Decodable & Sendable & SchemaProviding>(
+        _ type: T.Type,
+        to prompt: String,
+        config: GenerationConfig = .init()
+    ) async throws -> StructuredOutput<T> {
+        let schema = T.jsonSchema
+
+        // Encode the schema to a string. The queue stages this on config and
+        // lowers it to GBNF (for grammar-capable backends) or injects it as a
+        // prompt instruction (weak backends) when the router runs.
+        let schemaString: String
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(schema)
+            schemaString = String(decoding: data, as: UTF8.self)
+        } catch {
+            throw StructuredOutputError.schemaEncodingFailure(String(describing: error))
+        }
+
+        // Stage the schema on config. The queue's router wiring (#1915) reads
+        // `structuredOutput`, lowers the schema to GBNF when the active backend
+        // supports grammar-constrained sampling, and selects the strongest
+        // mechanism — leaving `config.grammar` untouched for schema-only
+        // backends so they never see a grammar they'd reject.
+        var routedConfig = config
+        routedConfig.structuredOutput = .jsonSchema(schemaString)
+
+        let (_, stream) = try enqueue(
+            messages: [.user(prompt)],
+            config: routedConfig
+        )
+
+        // Drain to a string. Collect only content tokens — thinking and tool
+        // events are not part of the structured payload.
+        var collected = ""
+        for try await event in stream {
+            if case .token(let fragment) = event {
+                collected += fragment
+            }
+        }
+
+        let rawText = collected
+
+        // Report the strategy the router actually chose for the active backend.
+        // The queue runs the same selection internally to lower config; we
+        // recompute it here (read-only, via the same queue helper) purely to
+        // surface it on the result.
+        let strategy: StructuredOutputStrategy
+        if let caps = currentEndpointBackend?.capabilities,
+           let target = GenerationQueue.structuredOutputTarget(
+               from: .jsonSchema(schemaString),
+               capabilities: caps
+           ) {
+            strategy = StructuredOutputRouter.selectStrategy(capabilities: caps, target: target)
+        } else {
+            strategy = .jsonPrompting
+        }
+
+        // Decode off the main actor — small payloads, but no reason to block UI.
+        do {
+            let value = try await Self.decode(T.self, from: rawText)
+            return StructuredOutput(value: value, rawText: rawText, strategy: strategy)
+        } catch let error as StructuredOutputError {
+            throw error
+        } catch {
+            throw StructuredOutputError.decodeFailure(
+                rawText: rawText,
+                underlying: String(describing: error)
+            )
+        }
+    }
+
+    /// Decodes JSON text into `T` off the main actor.
+    ///
+    /// `nonisolated` so the JSON parse runs on the cooperative pool rather than
+    /// the `@MainActor`. Tolerates surrounding prose / code fences from
+    /// prompt-level fallbacks by extracting the first balanced JSON object.
+    nonisolated static func decode<T: Decodable & Sendable>(
+        _ type: T.Type,
+        from text: String
+    ) async throws -> T {
+        let jsonText = extractJSON(from: text)
+        guard let data = jsonText.data(using: .utf8) else {
+            throw StructuredOutputError.decodeFailure(
+                rawText: text,
+                underlying: "Response was not valid UTF-8."
+            )
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw StructuredOutputError.decodeFailure(
+                rawText: text,
+                underlying: String(describing: error)
+            )
+        }
+    }
+
+    /// Extracts the first balanced top-level JSON object/array from `text`,
+    /// stripping markdown code fences and surrounding prose that weak backends
+    /// emit alongside the JSON in the prompt-fallback path. Returns the input
+    /// unchanged when no object/array delimiter is found (let the decoder
+    /// produce the authoritative error).
+    nonisolated static func extractJSON(from text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let start = trimmed.firstIndex(where: { $0 == "{" || $0 == "[" }) else {
+            return trimmed
+        }
+        let opener = trimmed[start]
+        let closer: Character = opener == "{" ? "}" : "]"
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var endIndex: String.Index?
+        var idx = start
+        while idx < trimmed.endIndex {
+            let ch = trimmed[idx]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if ch == "\\" {
+                    escaped = true
+                } else if ch == "\"" {
+                    inString = false
+                }
+            } else if ch == "\"" {
+                inString = true
+            } else if ch == opener {
+                depth += 1
+            } else if ch == closer {
+                depth -= 1
+                if depth == 0 {
+                    endIndex = trimmed.index(after: idx)
+                    break
+                }
+            }
+            idx = trimmed.index(after: idx)
+        }
+        guard let endIndex else { return trimmed }
+        return String(trimmed[start..<endIndex])
+    }
+}

--- a/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
+++ b/Sources/ManifoldInference/Services/ToolGrammarBuilder.swift
@@ -152,6 +152,42 @@ public struct ToolGrammarBuilder: Sendable {
         return lines.joined(separator: "\n")
     }
 
+    /// Builds a GBNF grammar string whose `root` constrains output to a single
+    /// JSON value matching `schema` (no tool-call envelope), or `nil` when the
+    /// schema carries no structural information to constrain (a bare scalar /
+    /// unmodeled node lowers to the generic JSON `value`, which is no
+    /// constraint at all — the caller should fall back rather than ship a
+    /// grammar that accepts anything).
+    ///
+    /// Reuses the same recursive lowerer as ``buildGrammar(for:)`` so a typed
+    /// structured-output request gets exactly the constraint surface a tool's
+    /// `arguments` would. The first production caller is
+    /// `InferenceService.respond(_:to:)` (#1915).
+    public func buildSchemaGrammar(for schema: JSONSchemaValue) -> String? {
+        var emittedOrder: [String] = []
+        var rules: [String: String] = [:]
+        func emit(_ name: String, _ rhs: String) {
+            if rules[name] == nil { emittedOrder.append(name) }
+            rules[name] = rhs
+        }
+
+        // toolIndex 0 keeps helper rule names stable/deterministic.
+        var ctx = LoweringContext(toolIndex: 0, suffix: 0)
+        lower(schema, into: &ctx, ruleName: "root", emit: emit)
+
+        // If `root` lowered straight to the generic `value` rule the schema
+        // constrained nothing — signal "no grammar" so the caller can pick a
+        // weaker-but-honest strategy instead of a vacuous grammar.
+        if rules["root"] == "value" { return nil }
+
+        var lines: [String] = []
+        for name in emittedOrder {
+            lines.append("\(name) ::= \(rules[name]!)")
+        }
+        lines.append(contentsOf: Self.genericRuleLines)
+        return lines.joined(separator: "\n")
+    }
+
     // MARK: - Diagnostics (pre-flight advisory)
 
     /// A non-binding prediction of how fully a tool's parameter schema will be

--- a/Tests/ManifoldInferenceTests/InferenceServiceStructuredOutputTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceStructuredOutputTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for the typed `respond<T>()` structured-output round-trip and its
+/// `StructuredOutputRouter` wiring in `GenerationQueue` (#1915).
+@MainActor
+final class InferenceServiceStructuredOutputTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Hand-written conformance — no `@ToolSchema` macro required (Macros trait
+    /// is off in default builds; the API must work without it).
+    private struct Weather: Decodable, Sendable, SchemaProviding, Equatable {
+        let city: String
+        let celsius: Int
+
+        static var jsonSchema: JSONSchemaValue {
+            .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "city": .object(["type": .string("string")]),
+                    "celsius": .object(["type": .string("integer")]),
+                ]),
+                "required": .array([.string("city"), .string("celsius")]),
+            ])
+        }
+    }
+
+    /// Capabilities for a backend with no constrained-decoding support — forces
+    /// the router down to `.jsonPrompting`.
+    private func weakCapabilities() -> BackendCapabilities {
+        BackendCapabilities(
+            supportsStructuredOutput: false,
+            supportsGrammarConstrainedSampling: false,
+            supportsGuidedStructuredOutput: false
+        )
+    }
+
+    /// Tokenises a string into single-character fragments so the mock streams
+    /// it like real token output rather than one blob.
+    private func tokens(_ s: String) -> [String] { s.map { String($0) } }
+
+    // MARK: - (a) Happy path
+
+    func test_respond_decodesValidJSON_andPreservesRawText() async throws {
+        let json = #"{"city":"Paris","celsius":21}"#
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens(json)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(Weather.self, to: "Weather in Paris?")
+
+        XCTAssertEqual(result.value, Weather(city: "Paris", celsius: 21))
+        XCTAssertEqual(result.rawText, json)
+    }
+
+    func test_respond_extractsJSONFromSurroundingProse() async throws {
+        // Weak backends append prose / code fences around the object on the
+        // prompt-fallback path; respond must still decode.
+        let wrapped = "Sure! Here you go:\n```json\n{\"city\":\"Oslo\",\"celsius\":3}\n```"
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = [wrapped]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(Weather.self, to: "Weather in Oslo?")
+
+        XCTAssertEqual(result.value, Weather(city: "Oslo", celsius: 3))
+    }
+
+    // MARK: - (b) Router wiring — the previously-untested path
+
+    func test_respond_invokesRouter_lowersSchemaToGrammar_onGrammarBackend() async throws {
+        // A grammar-capable backend must end up with config.grammar set by the
+        // router lowering, and structuredOutput cleared.
+        let caps = BackendCapabilities(supportsGrammarConstrainedSampling: true)
+        let backend = MockInferenceBackend(capabilities: caps)
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens(#"{"city":"Rome","celsius":30}"#)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(Weather.self, to: "Weather in Rome?")
+
+        let config = try XCTUnwrap(backend.lastConfig, "generate() was not called")
+        // Router selected GBNF: grammar lowered onto config, strategy hint cleared.
+        XCTAssertNotNil(config.grammar, "router did not lower the schema to a GBNF grammar")
+        XCTAssertNil(config.structuredOutput, "grammar path should clear the strategy hint")
+        XCTAssertEqual(result.strategy, .gbnf(try XCTUnwrap(config.grammar)))
+
+        // Sabotage check (run manually before commit, then remove): breaking the
+        // `StructuredOutputRouter.selectStrategy` call in GenerationQueue's
+        // enqueue chokepoint (e.g. forcing the `.guided` arm) leaves
+        // config.grammar nil here and fails this assertion — confirming the
+        // test actually exercises the wiring. Verified failing, then restored.
+    }
+
+    func test_respond_routerSelectsJSONSchema_onStructuredOutputBackend() async throws {
+        // A backend that supports json-schema but NOT grammar keeps the
+        // .jsonSchema strategy on config for the downstream cloud encoder.
+        let caps = BackendCapabilities(supportsStructuredOutput: true)
+        let backend = MockInferenceBackend(capabilities: caps)
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens(#"{"city":"Bern","celsius":12}"#)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(Weather.self, to: "Weather in Bern?")
+
+        let config = try XCTUnwrap(backend.lastConfig)
+        XCTAssertNil(config.grammar, "non-grammar backend must not receive a grammar")
+        guard case .jsonSchema = config.structuredOutput else {
+            return XCTFail("expected .jsonSchema strategy to remain on config, got \(String(describing: config.structuredOutput))")
+        }
+        guard case .jsonSchema = result.strategy else {
+            return XCTFail("expected reported strategy .jsonSchema, got \(result.strategy)")
+        }
+    }
+
+    // MARK: - (c) jsonPrompting fallback
+
+    func test_respond_jsonPromptingFallback_injectsSchemaIntoSystemPrompt() async throws {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens(#"{"city":"Lima","celsius":18}"#)
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(Weather.self, to: "Weather in Lima?")
+
+        let systemPrompt = try XCTUnwrap(backend.lastSystemPrompt, "no system prompt was passed to the backend")
+        XCTAssertTrue(
+            systemPrompt.contains("JSON Schema"),
+            "expected the schema instruction to be injected into the system prompt"
+        )
+        XCTAssertTrue(
+            systemPrompt.contains(#""city""#),
+            "expected the actual schema properties in the injected instruction"
+        )
+        XCTAssertEqual(result.strategy, .jsonPrompting)
+        XCTAssertNil(backend.lastConfig?.grammar)
+    }
+
+    // MARK: - (d) Decode failure → typed error (precondition for #1916)
+
+    func test_respond_decodeFailure_surfacesTypedError() async throws {
+        let garbage = "this is not json at all"
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = [garbage]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        do {
+            _ = try await service.respond(Weather.self, to: "Weather?")
+            XCTFail("expected a decode failure")
+        } catch let error as StructuredOutputError {
+            guard case .decodeFailure(let rawText, let underlying) = error else {
+                return XCTFail("expected .decodeFailure, got \(error)")
+            }
+            XCTAssertEqual(rawText, garbage, "raw text must be preserved for the reask loop (#1916)")
+            XCTAssertFalse(underlying.isEmpty, "underlying decode error must be surfaced")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ships an ergonomic typed structured-output round-trip on `InferenceService` and wires the previously-dead `StructuredOutputRouter` into the generation path as its **first production caller** (#1915).

`respond<T>()` derives a JSON schema from a Swift type, routes to the strongest constrained-decoding mechanism the active backend supports, runs one generation, and decodes the result into `T`.

## Public surface added

- `protocol SchemaProviding { static var jsonSchema: JSONSchemaValue { get } }` — macro-**optional**: conform by hand or let `@ToolSchema` synthesize it. Usable in default builds (the `Macros` trait stays off).
- `struct StructuredOutput<T: Decodable & Sendable>` — `value` + `rawText` + the chosen `strategy`.
- `enum StructuredOutputError` — `.decodeFailure(rawText:underlying:)` / `.schemaEncodingFailure(_:)`. Clean public typed error, the precondition for the #1916 reask loop (carries raw text + underlying error for retry prompts).
- `InferenceService.respond(_:to:config:)` — async throwing, returns `StructuredOutput<T>`.
- `ToolGrammarBuilder.buildSchemaGrammar(for:)` — lowers a bare `JSONSchemaValue` to a `root`-anchored GBNF grammar (returns `nil` when the schema constrains nothing, so callers downgrade honestly).

All additive → API-break gate safe. No existing public signatures changed.

## How the router is now wired

The first production caller of `StructuredOutputRouter.selectStrategy` lives at the `GenerationQueue` enqueue chokepoint, alongside the existing `config.grammar` tool-grammar derivation:

- `Sources/ManifoldInference/Services/GenerationQueue.swift:666-700` — when `config.structuredOutput` carries a staged schema, the queue reconstructs a `StructuredOutputTarget` (lowering the schema to GBNF via `buildSchemaGrammar` **only** when `backend.capabilities.supportsGrammarConstrainedSampling`), runs the router, and lowers the chosen strategy into the backend-honored field:
  - `.gbnf` → `config.grammar` (never clobbers a caller-authored grammar), clears the strategy hint
  - `.jsonSchema` → kept on `config.structuredOutput` for the sibling cloud encoder (#1918)
  - `.jsonPrompting` → appends a schema instruction to the system prompt
  - `.guided` → left intact (deferred)
- `respond()` (`Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift`) stages only the schema on `config.structuredOutput` and routes through `enqueue(messages:config:)`, so the queue wiring is exercised on the real generation path. It then drains the stream to text and decodes `T` off the `@MainActor` (`nonisolated static decode`).

Design note: schema→GBNF lowering happens **inside the queue** (not by staging a grammar on `config.grammar` in `respond`) so a schema-only backend never sees a stray grammar it would reject with `unsupportedGrammar`.

## Tests (`Tests/ManifoldInferenceTests/InferenceServiceStructuredOutputTests.swift`)

- **(a) happy path** — valid JSON from `MockInferenceBackend` decodes to the instance; `.rawText` preserved. Plus a prose/code-fence extraction case.
- **(b) router wiring** — grammar-capable backend ends up with `config.grammar` set + strategy cleared (the previously-untested wiring). **Sabotage-verified**: forcing empty caps into the router call leaves `config.grammar` nil and fails the test; reverted. A second test covers a json-schema-only backend keeping `.jsonSchema` on config.
- **(c) jsonPrompting fallback** — weak backend gets the schema injected into the system prompt (asserts prompt contains the schema + properties).
- **(d) decode failure** — surfaces `StructuredOutputError.decodeFailure` with raw text + underlying error preserved.

## Verification

- `swift build --build-tests --traits Server,Macros` → **Build complete!** (full all-traits sweep green).
- `swift test --filter ManifoldInferenceTests` → **1530 tests, 0 failures** (includes the 6 new tests, existing `StructuredOutputRouterTests`, and `SilentCatchAuditTest`).

## Out of scope

- **Cloud `.jsonSchema` wire-honoring** — owned by sibling PR #1918 (cloud strict-schema encoder). Cloud encoders were deliberately **not** touched to avoid merge conflicts.
- **Foundation `.guided`** — deferred to a follow-up; the router's `.guided` arm is left intact and the queue passes it through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)