### PR TITLE
fix: harden turn loop — multimodal trim budget, tool-dispatch budget + event symmetry, v1.0 tripwires

### DIFF
--- a/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
+++ b/Sources/ManifoldInference/Services/GenerationToolDispatchLoop.swift
@@ -208,7 +208,21 @@ struct GenerationToolDispatchLoop {
                                 content: "Tool call blocked by pre-tool-use hook: \(reason ?? "no reason given")",
                                 errorKind: .permissionDenied
                             )
+                            // Keep the dispatch event stream symmetric: consumers
+                            // pair every `.toolDispatchStarted` with a
+                            // `.toolDispatchCompleted`. A hook-blocked call still
+                            // emits the pair (with the denied error kind) so those
+                            // consumers don't desync waiting for a completion that
+                            // never arrives.
+                            yieldEvent(.toolDispatchStarted(callId: call.id, name: call.toolName, attempt: 1))
                             yieldEvent(.toolResult(denied))
+                            yieldEvent(
+                                .toolDispatchCompleted(
+                                    callId: call.id,
+                                    durationMilliseconds: 0,
+                                    errorKind: .permissionDenied
+                                )
+                            )
                             continue
                         case .proceed(let sanitized):
                             if sanitized != call.arguments {
@@ -246,14 +260,56 @@ struct GenerationToolDispatchLoop {
                         }
                     )
 
-                    toolResultByteTotal += result.content.utf8.count
+                    let dispatchDurationNs = DispatchTime.now().uptimeNanoseconds &- dispatchStart.uptimeNanoseconds
+                    let dispatchDurationMs = Int(dispatchDurationNs / 1_000_000)
+
+                    if result.errorKind == .cancelled {
+                        // Cancellation completes the dispatch pair but is not
+                        // recorded as turn history — the loop unwinds immediately.
+                        yieldEvent(.toolResult(result))
+                        yieldEvent(
+                            .toolDispatchCompleted(
+                                callId: call.id,
+                                durationMilliseconds: dispatchDurationMs,
+                                errorKind: result.errorKind
+                            )
+                        )
+                        return .cancelled
+                    }
+
+                    // Byte-budget guard, checked BEFORE persisting/yielding the
+                    // result as a successful completion. A result that pushes the
+                    // cumulative total over budget must not be recorded as success
+                    // or threaded into the next turn's history — instead substitute
+                    // a synthetic permanent error so the model sees the truncation
+                    // and the loop stops without ever logging the oversized payload
+                    // as a `.toolDispatchCompleted` success.
+                    let prospectiveTotal = toolResultByteTotal + result.content.utf8.count
+                    if prospectiveTotal >= Self.toolResultByteBudget {
+                        Log.inference.warning(
+                            "GenerationQueue: tool-result byte budget (\(Self.toolResultByteBudget, privacy: .public)) exceeded by '\(call.toolName, privacy: .public)' (\(prospectiveTotal, privacy: .public) bytes); dropping oversized result and terminating loop."
+                        )
+                        let overflow = ToolResult(
+                            callId: call.id,
+                            content: "tool result exceeded the cumulative byte budget and was dropped",
+                            errorKind: .permanent
+                        )
+                        yieldEvent(.toolResult(overflow))
+                        yieldEvent(
+                            .toolDispatchCompleted(
+                                callId: call.id,
+                                durationMilliseconds: dispatchDurationMs,
+                                errorKind: .permanent
+                            )
+                        )
+                        return .stop
+                    }
+
+                    toolResultByteTotal = prospectiveTotal
                     lastCallSignature = (toolName: effectiveCall.toolName, arguments: effectiveCall.arguments)
                     dispatchedInThisTurn.append((effectiveCall, result))
 
                     yieldEvent(.toolResult(result))
-
-                    let dispatchDurationNs = DispatchTime.now().uptimeNanoseconds &- dispatchStart.uptimeNanoseconds
-                    let dispatchDurationMs = Int(dispatchDurationNs / 1_000_000)
                     yieldEvent(
                         .toolDispatchCompleted(
                             callId: call.id,
@@ -272,14 +328,6 @@ struct GenerationToolDispatchLoop {
                             "error_kind": result.errorKind?.rawValue ?? "none"
                         ]
                     )
-
-                    if result.errorKind == .cancelled {
-                        return .cancelled
-                    }
-
-                    if toolResultByteTotal >= Self.toolResultByteBudget {
-                        return .stop
-                    }
 
                 // Token usage lands once per generation (terminal `.usage`
                 // event). Fold it into the run-level accumulator so the

--- a/Sources/ManifoldInference/Services/PromptAssembler.swift
+++ b/Sources/ManifoldInference/Services/PromptAssembler.swift
@@ -224,19 +224,35 @@ public enum PromptAssembler {
     ) -> (messages: [ChatMessage], totalTokens: Int) {
         guard !messages.isEmpty else { return ([], 0) }
 
+        // Count whole messages via ``ContextWindowManager/estimateTokenCount(_:tokenizer:)``
+        // rather than `tokenizer.tokenCount(message.content)`: `.content` is a
+        // text-only projection (`contentParts.compactMap(\.textContent)`), so the
+        // string overload silently counts image/audio/tool parts as zero. A
+        // multimodal turn would then underestimate its cost, sail past this trim
+        // budget, and overflow the context window at generation time.
+        //
+        // Wrapping the tokenizer in ``CachingTokenizer`` memoizes per-text-part
+        // counts for the duration of this trim, so identical message content
+        // re-counted across the budget-zero fallback and the main loop is
+        // tokenized at most once.
+        let memoizingTokenizer = CachingTokenizer(wrapping: tokenizer)
+        func messageTokens(_ message: ChatMessage) -> Int {
+            ContextWindowManager.estimateTokenCount(message, tokenizer: memoizingTokenizer)
+        }
+
         if budget <= 0 {
             if let lastUser = messages.last(where: { $0.role == .user }) {
-                return ([lastUser], tokenizer.tokenCount(lastUser.content))
+                return ([lastUser], messageTokens(lastUser))
             }
             let last = messages.suffix(1)
-            return (Array(last), last.reduce(0) { $0 + tokenizer.tokenCount($1.content) })
+            return (Array(last), last.reduce(0) { $0 + messageTokens($1) })
         }
 
         var kept: [ChatMessage] = []
         var usedTokens = 0
 
         for message in messages.reversed() {
-            let count = tokenizer.tokenCount(message.content)
+            let count = messageTokens(message)
             if usedTokens + count > budget && !kept.isEmpty { break }
             kept.append(message)
             usedTokens += count

--- a/Tests/ManifoldInferenceTests/GenerationQueueToolLoopTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueueToolLoopTests.swift
@@ -486,6 +486,190 @@ final class GenerationQueueToolLoopTests: XCTestCase {
         XCTAssertEqual(results.first?.callId, "g1")
     }
 
+    // MARK: - Iteration cap boundary (the (limit+1)th call is not dispatched)
+
+    /// The dispatch loop checks the iteration ceiling BEFORE generating the
+    /// next turn, so the model never gets to emit the (limit+1)th tool call.
+    /// With `maxToolIterations: 2` and a backend that *would* keep calling
+    /// tools forever, the executor runs exactly twice — never a third time.
+    func test_iterationCap_doesNotDispatchOneBeyondLimit() async throws {
+        let executor = RecordingExecutor(name: "spam") { _ in
+            ToolResult(callId: "", content: "ok", errorKind: nil)
+        }
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        // Distinct args per turn so the repeat-call short-circuit never masks
+        // a real dispatch — every turn would invoke the executor if reached.
+        provider.backend.scriptedToolCallsPerTurn = (0..<10).map { idx in
+            [makeCall(id: "s-\(idx)", name: "spam", arguments: #"{"i":\#(idx)}"#)]
+        }
+
+        let coordinator = makeCoordinator(registry: registry)
+        let (_, stream) = try coordinator.enqueueCustomConfig(
+            messages: [("user", "go")],
+            config: GenerationConfig(maxOutputTokens: 8, maxToolIterations: 2)
+        )
+        let events = try await collectEvents(stream)
+
+        // Exactly `limit` dispatches — the (limit+1)th is never generated.
+        XCTAssertEqual(executor.callCount, 2, "executor must run exactly maxToolIterations times")
+
+        // No dispatch event for a hypothetical third call id ("s-2"): the limit
+        // fires before that turn is generated, so it never reaches dispatch.
+        let dispatchStartedIds = events.compactMap { event -> String? in
+            if case .toolDispatchStarted(let id, _, _) = event { return id } else { return nil }
+        }
+        XCTAssertEqual(dispatchStartedIds, ["s-0", "s-1"])
+        XCTAssertFalse(dispatchStartedIds.contains("s-2"), "the (limit+1)th call must never be dispatched")
+
+        let limits = events.compactMap { event -> Int? in
+            if case .toolIterationLimitExceeded(let n) = event { return n } else { return nil }
+        }
+        XCTAssertEqual(limits, [2])
+    }
+
+    // MARK: - Over-budget result is not recorded as a successful completion
+
+    /// A result that pushes the cumulative tool-result byte total over budget
+    /// must be detected BEFORE it is persisted/yielded as a success. The loop
+    /// substitutes a synthetic `.permanent` overflow result (so the oversized
+    /// content never lands as success or in the next turn's history) and stops.
+    func test_overBudgetResult_notRecordedAsSuccess_loopStops() async throws {
+        // Budget is 512 KiB. First result is small (well under); the second
+        // returns 1 MiB which crosses the budget. The over-budget detection
+        // must fire on the *second* dispatch, replacing it with an overflow
+        // error rather than logging the giant payload as a success.
+        let smallContent = "small-ok"
+        let giantContent = String(repeating: "x", count: 1_048_576)
+        // Two distinct executors so neither closure mutates shared state: the
+        // first dispatch stays under budget, the second crosses it.
+        let smallExecutor = RecordingExecutor(name: "small") { _ in
+            ToolResult(callId: "", content: smallContent, errorKind: nil)
+        }
+        let giantExecutor = RecordingExecutor(name: "giant") { _ in
+            ToolResult(callId: "", content: giantContent, errorKind: nil)
+        }
+        let registry = ToolRegistry()
+        // Opt out of registry-level oversize enforcement so the giant payload
+        // reaches the coordinator's own byte-budget guard (the unit under test).
+        registry.outputPolicy = ToolOutputPolicy(maxBytes: .max, onOversize: .allow)
+        registry.register(smallExecutor)
+        registry.register(giantExecutor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [makeCall(id: "b1", name: "small", arguments: #"{"i":0}"#)],
+            [makeCall(id: "b2", name: "giant", arguments: #"{"i":1}"#)],
+            [makeCall(id: "b3", name: "small", arguments: #"{"i":2}"#)],
+        ]
+
+        let coordinator = makeCoordinator(registry: registry)
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "go")],
+            maxOutputTokens: 8
+        )
+        let events = try await collectEvents(stream)
+
+        let results = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }
+        // Two results: the small success and the over-budget substitute.
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].callId, "b1")
+        XCTAssertEqual(results[0].content, smallContent)
+        XCTAssertNil(results[0].errorKind)
+
+        // The oversized result must NOT be recorded as success — the giant
+        // payload never appears, and the substitute carries `.permanent`.
+        XCTAssertEqual(results[1].callId, "b2")
+        XCTAssertEqual(results[1].errorKind, .permanent)
+        XCTAssertNotEqual(results[1].content, giantContent, "oversized content must not be recorded as a successful result")
+
+        // The paired completion for the over-budget call carries `.permanent`,
+        // not a success (`nil`) error kind.
+        let completedKinds = events.compactMap { event -> (String, ToolResult.ErrorKind?)? in
+            if case .toolDispatchCompleted(let id, _, let kind) = event { return (id, kind) }
+            return nil
+        }
+        let b2Completion = completedKinds.first { $0.0 == "b2" }
+        XCTAssertEqual(b2Completion?.1, .permanent, "over-budget dispatch must not complete as success")
+
+        // The loop stops after the over-budget result — the third call is never
+        // dispatched.
+        XCTAssertFalse(
+            completedKinds.contains { $0.0 == "b3" },
+            "loop must stop after the over-budget result; the third call must not dispatch"
+        )
+
+        // Completion reason is `.stop`.
+        let completions = events.compactMap { event -> GenerationCompletion? in
+            if case .generationCompleted(let c) = event { return c } else { return nil }
+        }
+        XCTAssertEqual(completions.first?.reason, .stop)
+    }
+
+    // MARK: - Hook-blocked call keeps the dispatch event stream symmetric
+
+    /// When a pre-tool-use hook blocks a call, consumers that pair every
+    /// `.toolDispatchStarted` with a `.toolDispatchCompleted` must still see a
+    /// matched pair (plus the denied `.toolResult`) — otherwise they desync
+    /// waiting for a completion that never lands.
+    func test_hookBlockedCall_emitsMatchedDispatchPairAndDeniedResult() async throws {
+        let executor = RecordingExecutor(name: "danger") { _ in
+            ToolResult(callId: "", content: "should-not-run", errorKind: nil)
+        }
+        let registry = ToolRegistry()
+        registry.register(executor)
+
+        provider.backend.scriptedToolCallsPerTurn = [
+            [makeCall(id: "h1", name: "danger", arguments: "{}")],
+            [],
+        ]
+        provider.backend.tokensToYieldPerTurn = [[], ["done"]]
+
+        let coordinator = makeCoordinator(registry: registry)
+        // Block every call before it dispatches.
+        coordinator.preToolUseHook = { @Sendable _, _, _ in .block(reason: "not allowed") }
+
+        let (_, stream) = try coordinator.enqueue(
+            messages: [("user", "go")],
+            maxOutputTokens: 8
+        )
+        let events = try await collectEvents(stream)
+
+        // The blocked tool must never execute.
+        XCTAssertEqual(executor.callCount, 0, "a blocked call must not invoke the executor")
+
+        // Matched dispatch pair for the blocked call.
+        let started = events.compactMap { event -> String? in
+            if case .toolDispatchStarted(let id, _, _) = event { return id } else { return nil }
+        }
+        let completed = events.compactMap { event -> (String, ToolResult.ErrorKind?)? in
+            if case .toolDispatchCompleted(let id, _, let kind) = event { return (id, kind) }
+            return nil
+        }
+        XCTAssertEqual(started, ["h1"], "blocked call must emit toolDispatchStarted")
+        XCTAssertEqual(completed.map(\.0), ["h1"], "blocked call must emit a paired toolDispatchCompleted")
+        XCTAssertEqual(completed.first?.1, .permissionDenied, "the paired completion carries the denied error kind")
+
+        // The denied result is surfaced, and it sits between the started and
+        // completed events (event-stream symmetry).
+        let results = events.compactMap { event -> ToolResult? in
+            if case .toolResult(let r) = event { return r } else { return nil }
+        }
+        let denied = try XCTUnwrap(results.first { $0.callId == "h1" })
+        XCTAssertEqual(denied.errorKind, .permissionDenied)
+        XCTAssertTrue(denied.content.contains("blocked by pre-tool-use hook"))
+
+        let startedIdx = try XCTUnwrap(events.firstIndex { if case .toolDispatchStarted = $0 { return true } else { return false } })
+        let resultIdx = try XCTUnwrap(events.firstIndex { event in
+            if case .toolResult(let r) = event { return r.callId == "h1" } else { return false }
+        })
+        let completedIdx = try XCTUnwrap(events.firstIndex { if case .toolDispatchCompleted = $0 { return true } else { return false } })
+        XCTAssertLessThan(startedIdx, resultIdx)
+        XCTAssertLessThan(resultIdx, completedIdx)
+    }
+
     // MARK: - Terminal completion event (#1832)
 
     /// A plain text turn (no tool calls) must end with exactly one

--- a/Tests/ManifoldInferenceTests/PromptAssemblerUtilizationTests.swift
+++ b/Tests/ManifoldInferenceTests/PromptAssemblerUtilizationTests.swift
@@ -108,4 +108,44 @@ final class PromptAssemblerUtilizationTests: XCTestCase {
         let expected = min(1.0, Double(assembled.totalTokens) / Double(caps.contextWindowSize))
         XCTAssertEqual(assembled.contextUtilization, expected, accuracy: 1e-9)
     }
+
+    // MARK: - Test 5: multimodal message counts non-text parts (#1885)
+
+    /// A message carrying an image part must contribute a non-zero token cost.
+    /// Previously `trimMessagesToFit` counted via `tokenizer.tokenCount(message.content)`,
+    /// which is a text-only projection — image/audio/tool parts counted as zero,
+    /// so a multimodal turn would underestimate and overflow the window.
+    func test_imagePart_isCountedWithNonZeroTokens() {
+        // A user message with a trivial text caption plus an image part.
+        let multimodal = ChatMessage(
+            role: .user,
+            contentParts: [
+                .text("look"),
+                .image(data: Data(repeating: 0, count: 8), mimeType: "image/png")
+            ],
+            sessionID: Self.sessionID
+        )
+
+        let assembled = PromptAssembler.assemble(
+            slots: [],
+            messages: [multimodal],
+            systemPrompt: nil,
+            contextSize: 4096
+        )
+
+        // The image part alone contributes ContextWindowManager.imagePartTokenEstimate,
+        // so the history total must exceed what the text caption costs on its own.
+        let textOnlyCost = ContextWindowManager.estimateTokenCount("look")
+        XCTAssertGreaterThan(
+            assembled.budgetBreakdown["history"] ?? 0,
+            textOnlyCost,
+            "Image part must add token cost beyond the text-only projection"
+        )
+        // Concretely, the history must include the fixed image estimate.
+        XCTAssertGreaterThanOrEqual(
+            assembled.budgetBreakdown["history"] ?? 0,
+            ContextWindowManager.imagePartTokenEstimate,
+            "Multimodal history should reserve at least the image-part estimate"
+        )
+    }
 }

--- a/Tests/ManifoldPersistenceSwiftDataTests/RunStoreV10ReadBackTests.swift
+++ b/Tests/ManifoldPersistenceSwiftDataTests/RunStoreV10ReadBackTests.swift
@@ -1,0 +1,179 @@
+// Read-back integration test for the V9→V10 RunStore schema migration (#1795 /
+// P3b #1784). SwiftDataRunStore shipped its resumable-run tables (ConversationRun /
+// RunStep) without a read-back test exercising a *partially-completed* run — a run
+// that was interrupted mid-step. Schema corruption (a dropped table, a renamed
+// column, a botched migration stage) would silently break run resumption for anyone
+// who started a run under v0.48 and upgraded.
+//
+// This mirrors SchemaMigrationReadBackTests' pattern: seed a fixture under the older
+// schema (here, a V9 store), re-open it through the full ModelContainerFactory
+// migration plan (which runs the lightweight V9→V10 stage), then write a
+// dangling/incomplete run through SwiftDataRunStore and re-read it from a fresh store
+// instance over the same on-disk container. We assert the run status, step ordering,
+// and the incomplete-final-step flag all round-trip cleanly.
+//
+// In-memory / on-disk SwiftData throughout — the persistence layer is never mocked
+// (CLAUDE.md rule). The on-disk file is required to prove the data survives a fresh
+// container, not just an in-process context.
+
+import XCTest
+import SwiftData
+@testable import ManifoldPersistenceSwiftData
+import ManifoldInference
+import ManifoldRuntime
+
+@MainActor
+final class RunStoreV10ReadBackTests: XCTestCase {
+
+    private var tempStoreDirectory: URL?
+
+    override func tearDown() async throws {
+        if let tempStoreDirectory {
+            try? FileManager.default.removeItem(at: tempStoreDirectory)
+        }
+        tempStoreDirectory = nil
+        try await super.tearDown()
+    }
+
+    private func makeStoreDirectory(named prefix: String) throws -> URL {
+        let storeDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+        tempStoreDirectory = storeDirectory
+        return storeDirectory
+    }
+
+    /// Seeds a V9 store with a legacy session, migrates it to V10 through the
+    /// real `ModelContainerFactory`, writes a *partially-completed* run (two
+    /// completed steps followed by a dangling, never-completed final step), then
+    /// re-opens the same on-disk file with a brand-new container + store and
+    /// asserts the whole shape round-trips:
+    ///   - run status preserved (`.running` — the run was interrupted, not done),
+    ///   - steps returned in ascending `stepIndex` order,
+    ///   - the two leading steps marked completed,
+    ///   - the dangling final step preserved as *incomplete* (the resumption point).
+    ///
+    /// Sabotage-evidence: if the V9→V10 stage were dropped, `makeContainer`
+    /// halts with a schema-mismatch before any assert; if the final step's
+    /// `isCompleted` flag were clobbered to `true` during round-trip, the
+    /// incomplete-final-step assertion fails and resumable runs would silently
+    /// skip the interrupted step.
+    func test_v9StoreMigratesToV10_andPartialRunRoundTripsAcrossFreshStore() async throws {
+        let storeDirectory = try makeStoreDirectory(named: "RunStoreV10ReadBack")
+        let storeURL = storeDirectory.appendingPathComponent("Manifold.sqlite")
+
+        let legacySessionID: UUID
+
+        // --- Step 1: seed a V9 store (the v0.48-era on-disk shape) ---
+        do {
+            let v9Container = try ModelContainer(
+                for: Schema(versionedSchema: ManifoldSchemaV9.self),
+                configurations: [ModelConfiguration(url: storeURL)]
+            )
+            let ctx = ModelContext(v9Container)
+            let session = ManifoldSchemaV9.ChatSession(title: "Pre-V10 run session")
+            session.systemPrompt = "resume me"
+            ctx.insert(session)
+            legacySessionID = session.id
+            try ctx.save()
+            // Container released here — WAL lock freed before the V10 re-open.
+        }
+
+        // --- Step 2: migrate V9 -> V10 via the real factory, write a partial run ---
+        let runID: UUID
+        let completedStepIDs: [UUID]
+        let danglingStepID: UUID
+        do {
+            let migratedContainer = try ModelContainerFactory.makeContainer(
+                configurations: [ModelConfiguration(url: storeURL)]
+            )
+            let store = SwiftDataRunStore(modelContext: ModelContext(migratedContainer))
+
+            let now = Date(timeIntervalSince1970: 1_700_000_000)
+            // `.running` — the run is interrupted mid-flight, not completed.
+            let run = ConversationRun(
+                id: UUID(),
+                sessionID: legacySessionID,
+                goal: "Draft, review, and ship the post",
+                status: .running,
+                stepCount: 2,
+                maxSteps: 8,
+                createdAt: now,
+                updatedAt: now
+            )
+            try await store.insertRun(run)
+            runID = run.id
+
+            // Two completed steps...
+            var ids: [UUID] = []
+            for index in 0..<2 {
+                let step = RunStep(
+                    id: UUID(),
+                    runID: run.id,
+                    stepIndex: index,
+                    turnInput: nil,
+                    messageID: UUID(),
+                    isCompleted: true,
+                    isFailed: false,
+                    failureReason: nil,
+                    createdAt: now,
+                    updatedAt: now
+                )
+                try await store.insertStep(step)
+                ids.append(step.id)
+            }
+            completedStepIDs = ids
+
+            // ...followed by a dangling, never-completed final step — the
+            // resumption point. No messageID, isCompleted == false.
+            let dangling = RunStep(
+                id: UUID(),
+                runID: run.id,
+                stepIndex: 2,
+                turnInput: nil,
+                messageID: nil,
+                isCompleted: false,
+                isFailed: false,
+                failureReason: nil,
+                createdAt: now,
+                updatedAt: now
+            )
+            try await store.insertStep(dangling)
+            danglingStepID = dangling.id
+            // Container released — forces the read-back below to go through a
+            // genuinely fresh container over the same file.
+        }
+
+        // --- Step 3: re-open with a FRESH container + store, assert round-trip ---
+        let reopenedContainer = try ModelContainerFactory.makeContainer(
+            configurations: [ModelConfiguration(url: storeURL)]
+        )
+        let reopenedStore = SwiftDataRunStore(modelContext: ModelContext(reopenedContainer))
+
+        let reopenedRun = try await reopenedStore.fetchRun(runID)
+        let run = try XCTUnwrap(reopenedRun, "Partial run vanished across the V10 migration + fresh store")
+        XCTAssertEqual(run.status, .running, "Interrupted run must stay .running after round-trip")
+        XCTAssertEqual(run.sessionID, legacySessionID, "Run must remain bound to its (migrated) session")
+        XCTAssertEqual(run.stepCount, 2)
+        XCTAssertEqual(run.maxSteps, 8)
+
+        let steps = try await reopenedStore.fetchSteps(for: runID)
+        XCTAssertEqual(steps.map(\.stepIndex), [0, 1, 2], "Steps must round-trip in ascending stepIndex order")
+        XCTAssertEqual(steps.map(\.id), completedStepIDs + [danglingStepID], "Step identities must round-trip")
+
+        // Leading steps completed; final step preserved as the incomplete
+        // resumption point — the whole point of the fixture.
+        XCTAssertTrue(steps[0].isCompleted)
+        XCTAssertTrue(steps[1].isCompleted)
+        XCTAssertNotNil(steps[0].messageID)
+        XCTAssertNotNil(steps[1].messageID)
+
+        let finalStep = steps[2]
+        XCTAssertEqual(finalStep.id, danglingStepID)
+        XCTAssertFalse(finalStep.isCompleted, "Dangling final step must round-trip as incomplete (resumption point)")
+        XCTAssertFalse(finalStep.isFailed, "Dangling final step is incomplete, not failed")
+        XCTAssertNil(finalStep.messageID, "Incomplete final step produced no assistant message")
+        XCTAssertNil(finalStep.failureReason)
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ConversationEventClosedSwitchAuditTest.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationEventClosedSwitchAuditTest.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import ManifoldRuntime
+import ManifoldInference
+
+/// Compile-time tripwire enforcing invariant 6 from target-architecture.md:
+///
+/// > "New modality/run-level events ride their own event types — never new
+/// > `GenerationEvent` cases on the text path."
+///
+/// Run-level lifecycle events (`runStarted`, `stepFailed`, `runCompleted`, …)
+/// belong on ``RunEvent``, a sibling of ``ConversationEvent``. Adding a
+/// run/step-shaped case to ``ConversationEvent`` would push unreachable arms
+/// into the ~14 exhaustive `switch` consumers on the text path and silently
+/// break the closed-switch contract.
+///
+/// The sibling ``GenerationEventClosedAuditTest`` checks the string-keyed
+/// ``ConversationEventKind`` mirror. This file is the *structural* counterpart:
+/// it forces a compile error on the `switch` in `caseName(for:)` whenever a
+/// case is added to, removed from, or renamed on ``ConversationEvent`` itself —
+/// so this file is the checkpoint a contributor must visit before any case
+/// change lands. The asserted allowlist (`expectedCaseNames`) then documents
+/// the exact surface and fails at runtime if a run/step-shaped name slips in.
+///
+/// What a failure means:
+/// - **Compile error in `caseName(for:)` / `sampleEvents()`**: ``ConversationEvent``
+///   changed. If the change adds a *run-level* case, move it to ``RunEvent``
+///   instead. If it is a legitimate text-path case, add an arm + sample here
+///   AND add the name to `expectedCaseNames`.
+/// - **`test_noRunLevelShapedCaseNames` fails**: a run/step-lifecycle-shaped
+///   name leaked onto the text path. Relocate it to ``RunEvent``.
+final class ConversationEventClosedSwitchAuditTest: XCTestCase {
+
+    // MARK: Reserved run-level vocabulary (owned by RunEvent, never ConversationEvent)
+
+    /// Prefixes reserved for run-level lifecycle events. A ``ConversationEvent``
+    /// case name starting with any of these is an invariant-6 violation.
+    private let reservedRunPrefixes = ["run", "step"]
+
+    /// The exact, asserted set of ``ConversationEvent`` case names. This is the
+    /// text-path event contract. It must stay in lock-step with the closed
+    /// `switch` in `caseName(for:)` below.
+    private let expectedCaseNames: Set<String> = [
+        // Lifecycle
+        "messageInserted",
+        "messageRemoved",
+        "messageUpdated",
+        "sessionBranched",
+        "streamStarted",
+        "tokenEmitted",
+        "tokenUsageRecorded",
+        "thinkingStarted",
+        "thinkingUpdated",
+        "thinkingFinalized",
+        "loopDetected",
+        "streamFinished",
+        "errorRaised",
+        "sessionTouchFailed",
+        // Context pipeline
+        "beforeContextAssembly",
+        "historyShaped",
+        "contextAssembled",
+        "afterGeneration",
+        "compressionTriggered",
+        "historyCompressed",
+        // Tool calls
+        "toolCallRequested",
+        "toolCallApproved",
+        "toolCallCompleted",
+        // Multi-agent / skills / hooks
+        "agentHandoff",
+        "skillInvoked",
+        "hookFired",
+    ]
+
+    // MARK: Closed-switch checkpoint
+    //
+    // Exhaustive over EVERY current ``ConversationEvent`` case. Adding a case to
+    // the enum without adding an arm here is a COMPILE ERROR — that is the
+    // tripwire. The returned string is the case name, validated below.
+    private func caseName(for event: ConversationEvent) -> String {
+        switch event {
+        case .messageInserted:       return "messageInserted"
+        case .messageRemoved:        return "messageRemoved"
+        case .messageUpdated:        return "messageUpdated"
+        case .sessionBranched:       return "sessionBranched"
+        case .streamStarted:         return "streamStarted"
+        case .tokenEmitted:          return "tokenEmitted"
+        case .tokenUsageRecorded:    return "tokenUsageRecorded"
+        case .thinkingStarted:       return "thinkingStarted"
+        case .thinkingUpdated:       return "thinkingUpdated"
+        case .thinkingFinalized:     return "thinkingFinalized"
+        case .loopDetected:          return "loopDetected"
+        case .streamFinished:        return "streamFinished"
+        case .errorRaised:           return "errorRaised"
+        case .sessionTouchFailed:    return "sessionTouchFailed"
+        case .beforeContextAssembly: return "beforeContextAssembly"
+        case .historyShaped:         return "historyShaped"
+        case .contextAssembled:      return "contextAssembled"
+        case .afterGeneration:       return "afterGeneration"
+        case .compressionTriggered:  return "compressionTriggered"
+        case .historyCompressed:     return "historyCompressed"
+        case .toolCallRequested:     return "toolCallRequested"
+        case .toolCallApproved:      return "toolCallApproved"
+        case .toolCallCompleted:     return "toolCallCompleted"
+        case .agentHandoff:          return "agentHandoff"
+        case .skillInvoked:          return "skillInvoked"
+        case .hookFired:             return "hookFired"
+        }
+    }
+
+    /// One sample value per ``ConversationEvent`` case. The closed `switch` in
+    /// `caseName(for:)` plus this exhaustive sample list together force any enum
+    /// change to surface here.
+    private func sampleEvents() -> [ConversationEvent] {
+        let messageID = UUID()
+        let sessionID = UUID()
+        return [
+            .messageInserted(ChatMessage(role: .assistant, content: "", sessionID: sessionID)),
+            .messageRemoved(messageID: messageID),
+            .messageUpdated(ChatMessage(role: .assistant, content: "", sessionID: sessionID)),
+            .sessionBranched(newSessionID: sessionID, copiedCount: 0),
+            .streamStarted(messageID: messageID),
+            .tokenEmitted(messageID: messageID, delta: ""),
+            .tokenUsageRecorded(messageID: messageID, promptTokens: 0, completionTokens: 0),
+            .thinkingStarted(messageID: messageID),
+            .thinkingUpdated(messageID: messageID, partialText: ""),
+            .thinkingFinalized(messageID: messageID, text: "", signature: nil),
+            .loopDetected(messageID: messageID),
+            .streamFinished(messageID: messageID, reason: .stop),
+            .errorRaised(.cancelled),
+            .sessionTouchFailed(sessionID: sessionID),
+            .beforeContextAssembly(
+                prompt: nil,
+                request: PromptContextRequest(sessionID: sessionID, messageCount: 0, userInput: nil)
+            ),
+            .historyShaped(sessionID: sessionID, diagnostics: []),
+            .contextAssembled(slots: []),
+            .afterGeneration(messageID: messageID, finalText: ""),
+            .compressionTriggered(removed: [], reason: .contextWindowExceeded),
+            .historyCompressed(sessionID: sessionID, insertedRecords: []),
+            .toolCallRequested(ToolCall(id: "t", toolName: "noop", arguments: "{}")),
+            .toolCallApproved("t"),
+            .toolCallCompleted("t", ToolResult(callId: "t", content: "")),
+            .agentHandoff(from: nil, to: UUID()),
+            .skillInvoked(name: "s", sessionID: sessionID),
+            .hookFired(event: "preToolUse", sessionID: sessionID),
+        ]
+    }
+
+    // MARK: Tests
+
+    /// The asserted allowlist must exactly match the closed switch's universe.
+    /// If the enum gains a case, the switch forces a new arm + sample value;
+    /// this test then fails until `expectedCaseNames` is updated, keeping the
+    /// documented contract honest.
+    func test_caseNameSurfaceMatchesAssertedAllowlist() {
+        let observed = Set(sampleEvents().map(caseName(for:)))
+        XCTAssertEqual(
+            observed, expectedCaseNames,
+            "ConversationEvent case surface drifted from the asserted allowlist. " +
+            "If you added a text-path case, add it to expectedCaseNames AND the sample list. " +
+            "If you added a run-level case, move it to RunEvent (invariant 6)."
+        )
+    }
+
+    /// No ``ConversationEvent`` case name may be run/step-lifecycle-shaped —
+    /// that vocabulary is reserved for ``RunEvent``.
+    func test_noRunLevelShapedCaseNames() {
+        for name in expectedCaseNames {
+            for prefix in reservedRunPrefixes {
+                XCTAssertFalse(
+                    name.hasPrefix(prefix),
+                    "ConversationEvent case '\(name)' uses reserved run-level prefix '\(prefix)'. " +
+                    "Run-lifecycle events ride RunEvent, not the text path (invariant 6)."
+                )
+            }
+        }
+    }
+
+    /// The mirror ``ConversationEventKind`` must enumerate the same surface as
+    /// the closed switch — they are two views of one contract and must not drift.
+    func test_kindMirrorMatchesClosedSwitchSurface() {
+        let switchSurface = Set(sampleEvents().map(caseName(for:)))
+        let kindSurface = Set(ConversationEventKind.allCases.map(\.rawValue))
+        XCTAssertEqual(
+            switchSurface, kindSurface,
+            "ConversationEvent and its ConversationEventKind mirror have drifted apart."
+        )
+    }
+}


### PR DESCRIPTION
Tier 1 of the turn-loop audit (reliability + output-quality fixes) plus two v1.0-blocker tripwire tests. One PR to keep CI run-count down; all changes touch disjoint files and the full `scripts/test.sh --profile local` gate is green (5098 XCTest + 87 Swift Testing, 0 failures).

## Correctness fixes
- **Tool-result byte budget checked before overshoot** (`GenerationToolDispatchLoop.swift`): an over-budget result is now detected *before* it is recorded into `dispatchedInThisTurn`, yielded as a success, or threaded into next-turn history — it yields a synthetic `.permanent` overflow result + `.toolDispatchCompleted(errorKind: .permanent)` and stops. Previously the oversized result was persisted/logged as success, then the budget was checked.
- **Hook-blocked tool calls now emit a matched event pair** (`GenerationToolDispatchLoop.swift`): the `.block` branch emits `.toolDispatchStarted` → `.toolResult(denied)` → `.toolDispatchCompleted(errorKind: .permissionDenied)`, restoring started/completed symmetry for consumers that pair them. Previously only the denied result was yielded.
- **Iteration-limit boundary** (`GenerationToolDispatchLoop.swift`): verified already correct on `main` (check precedes generation; exactly `limit` calls dispatch). Added a regression test guarding the contract — no code change needed (the audit finding was stale against current `main`).

## Output-quality fix
- **PromptAssembler counts multimodal parts in the trim budget** (`PromptAssembler.swift`): `trimMessagesToFit()` routed all three token-count sites through `ContextWindowManager.estimateTokenCount(message:tokenizer:)` instead of the text-only `ChatMessage.content` projection, so image/audio/tool parts no longer count as zero tokens and silently overflow the context window. Memoized via the existing `CachingTokenizer`.

## v1.0-blocker tripwire tests (item 9)
- **`ConversationEventClosedSwitchAuditTest`** (ManifoldRuntimeTests): a compile-time closed `switch` over every `ConversationEvent` case + asserted case-name allowlist + reserved-prefix check (run/step belong to `RunEvent`, invariant 6). The pre-existing `GenerationEventClosedAuditTest` only checked `ConversationEventKind` rawValues — it had no structural tripwire over `ConversationEvent` itself.
- **`RunStoreV10ReadBackTests`** (ManifoldPersistenceSwiftDataTests): seeds a V9 store, migrates to V10, and round-trips a partially-completed `ConversationRun` with a dangling incomplete final `RunStep` across a fresh on-disk container — coverage the existing `SwiftDataRunStoreTests` lacked.

## Audit corrections surfaced while implementing
Two architecture-audit claims were partially stale: the iteration-limit bug (already fixed on `main`) and "those tripwire tests are missing" (partial coverage already existed). The new tests fill the genuine structural gaps rather than duplicating.

## Not in this PR
Tier 2 (concurrency races), Tier 3 (Jinja fallback, compression seam), and Tier 4 (architecture) are tracked in #1957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)