### PR TITLE
feat: cloud strict-schema emission (OpenAI + Anthropic) (#1918)

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -115,3 +115,6 @@ API breakage: enumelement GenerationEvent.runTokenBudgetExceeded has been added 
 API breakage: enumelement GenerationStreamConsumer.StreamAction.runTokenBudgetExceeded has been added as a new enum case
 API breakage: constructor RAGConfiguration.init(embeddingBackend:reranker:chunkSize:chunkOverlap:topK:similarityThreshold:vectorStoreURL:) has been removed
 API breakage: constructor RAGService.init(documentStore:vectorStore:embeddingBackend:reranker:chunker:parsers:defaultLimit:similarityThreshold:) has been removed
+API breakage: func CloudMessageEncoder.encodeTools(_:) has been renamed to func encodeTools(_:strict:)
+API breakage: func CloudMessageEncoder.claudeEncodeToolDefinition(_:) has been renamed to func claudeEncodeToolDefinition(_:strict:)
+API breakage: func OpenAIToolEncoding.encodeToolDefinition(_:) has been renamed to func encodeToolDefinition(_:strict:)

--- a/Sources/ManifoldCloudCore/CloudMessageEncoder.swift
+++ b/Sources/ManifoldCloudCore/CloudMessageEncoder.swift
@@ -114,13 +114,18 @@ public enum CloudMessageEncoder: Sendable {
 
     /// Encodes a list of ``ToolDefinition`` into the provider's
     /// `tools[]` envelope. Returns an empty array when `tools` is empty.
-    public func encodeTools(_ tools: [ToolDefinition]) -> [[String: Any]] {
+    ///
+    /// When `strict` is `true` the OpenAI/Claude encoders rewrite each tool's
+    /// schema into the provider strict shape and flag `strict: true`. Callers
+    /// must gate this on ``BackendCapabilities/supportsStrictSchema`` — Ollama
+    /// ignores it (no strict tool mode).
+    public func encodeTools(_ tools: [ToolDefinition], strict: Bool = false) -> [[String: Any]] {
         guard !tools.isEmpty else { return [] }
         switch self {
         case .openAI, .openAIResponses:
-            return tools.map(OpenAIToolEncoding.encodeToolDefinition)
+            return tools.map { OpenAIToolEncoding.encodeToolDefinition($0, strict: strict) }
         case .claude:
-            return tools.map(Self.claudeEncodeToolDefinition)
+            return tools.map { Self.claudeEncodeToolDefinition($0, strict: strict) }
         case .ollama:
             return tools.map(Self.ollamaEncodeToolDefinition)
         }
@@ -369,15 +374,27 @@ extension CloudMessageEncoder {
     }
 
     /// Inlined from `ClaudeMessageEncoder.encodeToolDefinition`.
-    package static func claudeEncodeToolDefinition(_ tool: ToolDefinition) -> [String: Any] {
+    ///
+    /// When `strict` is `true` (caller-gated on
+    /// ``BackendCapabilities/supportsStrictSchema``), the `input_schema` is
+    /// rewritten via ``StrictSchemaTransform/anthropicStrict(_:)`` and the tool
+    /// gains `"strict": true` — Anthropic's `structured-outputs-2025-11-13`
+    /// guarantee that tool inputs validate against the schema.
+    package static func claudeEncodeToolDefinition(_ tool: ToolDefinition, strict: Bool = false) -> [String: Any] {
         var entry: [String: Any] = [
             "name": tool.name,
             "description": tool.description,
         ]
-        if let schema = encodeJSONSchemaToFoundation(tool.parameters) {
+        let schemaValue = strict
+            ? StrictSchemaTransform.anthropicStrict(tool.parameters)
+            : tool.parameters
+        if let schema = encodeJSONSchemaToFoundation(schemaValue) {
             entry["input_schema"] = schema
         } else {
             entry["input_schema"] = ["type": "object", "properties": [String: Any]()]
+        }
+        if strict {
+            entry["strict"] = true
         }
         return entry
     }

--- a/Sources/ManifoldCloudCore/OpenAIToolEncoding.swift
+++ b/Sources/ManifoldCloudCore/OpenAIToolEncoding.swift
@@ -25,15 +25,27 @@ package enum OpenAIToolEncoding {
 
     /// Encodes a ``ToolDefinition`` into the `{type:"function", function:{...}}`
     /// envelope used by both Chat Completions and Responses.
-    package static func encodeToolDefinition(_ tool: ToolDefinition) -> [String: Any] {
+    ///
+    /// When `strict` is `true` (the caller has gated this on the backend's
+    /// ``BackendCapabilities/supportsStrictSchema``), the parameters are
+    /// rewritten via ``StrictSchemaTransform/openAIStrict(_:)`` and the
+    /// `function` object gains `"strict": true`, so OpenAI guarantees the
+    /// emitted arguments validate against the schema.
+    package static func encodeToolDefinition(_ tool: ToolDefinition, strict: Bool = false) -> [String: Any] {
         var function: [String: Any] = [
             "name": tool.name,
             "description": tool.description,
         ]
-        if let parameters = foundationJSON(from: tool.parameters) {
+        let parametersSchema = strict
+            ? StrictSchemaTransform.openAIStrict(tool.parameters)
+            : tool.parameters
+        if let parameters = foundationJSON(from: parametersSchema) {
             function["parameters"] = parameters
         } else {
             function["parameters"] = ["type": "object", "properties": [String: Any]()]
+        }
+        if strict {
+            function["strict"] = true
         }
         return [
             "type": "function",

--- a/Sources/ManifoldCloudCore/StrictSchemaTransform.swift
+++ b/Sources/ManifoldCloudCore/StrictSchemaTransform.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+/// Rewrites a caller-supplied JSON Schema into the *strict* shape each cloud
+/// provider requires when it guarantees the model's output will validate
+/// against the schema.
+///
+/// Both OpenAI (`strict: true` function tools, `response_format:
+/// {type: "json_schema", strict: true}`) and Anthropic
+/// (`structured-outputs-2025-11-13`: `strict: true` tools / `output_format`)
+/// impose two non-negotiable structural rules on every object level:
+///
+/// 1. `additionalProperties: false` — the model may not emit keys outside the
+///    declared `properties`.
+/// 2. Every declared property must appear in `required`.
+///
+/// That shared core lives in ``strictCore(_:)``. The two providers then diverge:
+///
+/// - **OpenAI** does not support *optional* fields the way ordinary JSON Schema
+///   does — under `strict` every property is required, so an optional `T?` must
+///   be expressed as a `{"type": ["T", "null"]}` *union* (the field is still in
+///   `required`, but may be `null`). OpenAI also rejects (`400 Bad Request`) a
+///   number of validation keywords inside a strict schema — `minLength`,
+///   `maxLength`, `pattern`, `format`, `minimum`, `maximum`, `minItems`,
+///   `maxItems`, etc. — so ``openAIStrict(_:)`` strips them.
+/// - **Anthropic**'s strict mode keeps the full JSON Schema validation
+///   vocabulary (it does not reject `format`/`minLength`/etc.) and does not
+///   require the OpenAI null-union rewrite for previously-optional fields.
+///   ``anthropicStrict(_:)`` therefore applies only the shared core.
+///
+/// Both entry points are kept distinct even though Anthropic's transform is the
+/// shared core today: the call sites differ (OpenAI threads through
+/// `OpenAIToolEncoding` + `response_format`; Anthropic through the Claude
+/// `input_schema`), and OpenAI's extra rules are likely to keep diverging.
+///
+/// The transform is capability-gated at the call site — it is only invoked when
+/// the backend advertises ``BackendCapabilities/supportsStrictSchema`` — so
+/// providers that reject `additionalProperties: false` never see a strict
+/// schema and keep emitting their legacy shape.
+public enum StrictSchemaTransform: Sendable {
+
+    /// JSON Schema validation keywords OpenAI's strict mode rejects with a
+    /// `400`. We strip these from every object/property level before sending.
+    private static let openAIUnsupportedKeywords: Set<String> = [
+        "minLength", "maxLength", "pattern", "format",
+        "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum",
+        "multipleOf",
+        "minItems", "maxItems", "uniqueItems",
+        "minProperties", "maxProperties",
+        "minContains", "maxContains",
+        "contentEncoding", "contentMediaType",
+        "default",
+    ]
+
+    /// Returns the JSON Schema string carried by a
+    /// ``StructuredOutputStrategy/jsonSchema(_:)`` strategy, or `nil` for any
+    /// other (or `nil`) strategy. The strict emission path only fires for the
+    /// json-schema case, so backends use this to decide whether a strict
+    /// request was made.
+    public static func jsonSchemaString(from strategy: StructuredOutputStrategy?) -> String? {
+        if case .jsonSchema(let schema) = strategy, !schema.isEmpty {
+            return schema
+        }
+        return nil
+    }
+
+    /// Produces the OpenAI strict shape: shared core + null-union rewrite for
+    /// the fields that were previously optional + unsupported-keyword stripping.
+    public static func openAIStrict(_ schema: JSONSchemaValue) -> JSONSchemaValue {
+        transform(schema, provider: .openAI)
+    }
+
+    /// Produces the Anthropic strict shape (`structured-outputs-2025-11-13`):
+    /// shared core only. Anthropic keeps the full validation vocabulary and does
+    /// not require the OpenAI null-union rewrite.
+    public static func anthropicStrict(_ schema: JSONSchemaValue) -> JSONSchemaValue {
+        transform(schema, provider: .anthropic)
+    }
+
+    // MARK: - Implementation
+
+    private enum Provider {
+        case openAI
+        case anthropic
+    }
+
+    private static func transform(_ value: JSONSchemaValue, provider: Provider) -> JSONSchemaValue {
+        switch value {
+        case .object(let dict):
+            return transformObject(dict, provider: provider)
+        case .array(let items):
+            // A bare array node (e.g. an `anyOf`/`prefixItems` list). Recurse
+            // element-wise; objects inside still get the strict core applied.
+            return .array(items.map { transform($0, provider: provider) })
+        default:
+            return value
+        }
+    }
+
+    private static func transformObject(
+        _ dict: [String: JSONSchemaValue],
+        provider: Provider
+    ) -> JSONSchemaValue {
+        var out = dict
+
+        // Strip keywords OpenAI's strict mode rejects. Anthropic keeps them.
+        if provider == .openAI {
+            for keyword in openAIUnsupportedKeywords {
+                out.removeValue(forKey: keyword)
+            }
+        }
+
+        let typeIsObject = isObjectType(out["type"])
+        let hasProperties = out["properties"] != nil
+
+        // Recurse into nested schema-bearing keywords regardless of `type` so
+        // composed schemas (anyOf/oneOf/allOf, array `items`, `$defs`) are
+        // transformed too.
+        for key in ["items", "additionalItems", "contains", "not", "if", "then", "else"] {
+            if let nested = out[key] {
+                out[key] = transform(nested, provider: provider)
+            }
+        }
+        for key in ["anyOf", "oneOf", "allOf", "prefixItems"] {
+            if case .array(let arr)? = out[key] {
+                out[key] = .array(arr.map { transform($0, provider: provider) })
+            }
+        }
+        for key in ["$defs", "definitions"] {
+            if case .object(let defs)? = out[key] {
+                out[key] = .object(defs.mapValues { transform($0, provider: provider) })
+            }
+        }
+
+        // Apply the strict-object core only to object-typed nodes (or nodes
+        // that declare `properties`), since the all-required +
+        // additionalProperties:false rules are object-level.
+        guard typeIsObject || hasProperties else {
+            return .object(out)
+        }
+
+        // Capture the originally-required set BEFORE we force everything
+        // required: OpenAI must express a previously-*optional* field as a
+        // `{"type": ["T", "null"]}` union (it stays in `required` but may be
+        // null). Anthropic keeps the field's type untouched.
+        let originallyRequired = requiredNameSet(out["required"])
+
+        var transformedProperties: [String: JSONSchemaValue] = [:]
+        var propertyNames: [String] = []
+        if case .object(let props)? = out["properties"] {
+            for (name, propSchema) in props {
+                propertyNames.append(name)
+                let wasOptional = !originallyRequired.contains(name)
+                transformedProperties[name] = strictProperty(
+                    propSchema,
+                    provider: provider,
+                    wasOptional: wasOptional
+                )
+            }
+            out["properties"] = .object(transformedProperties)
+        }
+
+        // Rule 1: additionalProperties: false on every object level.
+        out["additionalProperties"] = .bool(false)
+
+        // Rule 2: every declared property is required. Preserve any caller
+        // ordering already present, then append the rest deterministically.
+        out["required"] = .array(requiredList(existing: out["required"], allNames: propertyNames))
+
+        return .object(out)
+    }
+
+    /// Transforms a single property's schema, applying the OpenAI null-union
+    /// rewrite when that field was previously optional.
+    ///
+    /// For OpenAI a previously-optional `T` becomes a union `["T", "null"]` so
+    /// the field can still be marked `required` (OpenAI strict forbids absent
+    /// keys) while permitting `null`. Anthropic leaves the type unchanged.
+    private static func strictProperty(
+        _ schema: JSONSchemaValue,
+        provider: Provider,
+        wasOptional: Bool
+    ) -> JSONSchemaValue {
+        let transformed = transform(schema, provider: provider)
+        guard provider == .openAI, wasOptional else {
+            return transformed
+        }
+        return addNullToType(transformed)
+    }
+
+    /// Rewrites a schema node's `type` to include `"null"` (OpenAI optional
+    /// rewrite). Handles both the string form (`"type": "string"` →
+    /// `["string", "null"]`) and the array form (appending `"null"` if absent).
+    /// A node without a concrete `type` (e.g. a pure `anyOf`) is returned
+    /// unchanged — there is no scalar type to widen.
+    private static func addNullToType(_ value: JSONSchemaValue) -> JSONSchemaValue {
+        guard case .object(var dict) = value else { return value }
+        switch dict["type"] {
+        case .string(let s) where s != "null":
+            dict["type"] = .array([.string(s), .string("null")])
+        case .array(let arr):
+            let hasNull = arr.contains { if case .string(let s) = $0 { return s == "null" }; return false }
+            dict["type"] = hasNull ? .array(arr) : .array(arr + [.string("null")])
+        default:
+            break
+        }
+        return .object(dict)
+    }
+
+    /// Extracts the set of property names listed in a `required` array.
+    private static func requiredNameSet(_ value: JSONSchemaValue?) -> Set<String> {
+        guard case .array(let arr)? = value else { return [] }
+        var names = Set<String>()
+        for entry in arr {
+            if case .string(let name) = entry { names.insert(name) }
+        }
+        return names
+    }
+
+    /// Whether a `type` node denotes (or includes) `"object"`.
+    private static func isObjectType(_ value: JSONSchemaValue?) -> Bool {
+        switch value {
+        case .string(let s):
+            return s == "object"
+        case .array(let arr):
+            return arr.contains { if case .string(let s) = $0 { return s == "object" }; return false }
+        default:
+            return false
+        }
+    }
+
+    /// Builds the `required` array: every declared property, with any
+    /// already-present entries kept in their original order first.
+    private static func requiredList(
+        existing: JSONSchemaValue?,
+        allNames: [String]
+    ) -> [JSONSchemaValue] {
+        var ordered: [String] = []
+        var seen = Set<String>()
+        if case .array(let arr)? = existing {
+            for entry in arr {
+                if case .string(let name) = entry, !seen.contains(name) {
+                    ordered.append(name)
+                    seen.insert(name)
+                }
+            }
+        }
+        for name in allNames.sorted() where !seen.contains(name) {
+            ordered.append(name)
+            seen.insert(name)
+        }
+        return ordered.map { .string($0) }
+    }
+}

--- a/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
@@ -121,6 +121,9 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
         supportsVision: true,
         streamsToolCallArguments: true,
         supportsParallelToolCalls: true,
+        // Anthropic `structured-outputs-2025-11-13`: strict tools / output_format
+        // guarantee schema-valid output (#1918).
+        supportsStrictSchema: true,
         // Cloud Messages API sends a structured message array on the wire, so
         // `.promptRendered` carries only the latest user message, not the full
         // post-template prompt — a partial view (#1905).
@@ -234,6 +237,9 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             supportsVision: BackendVisionCapability.claudeMessagesSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true,
+            // Anthropic `structured-outputs-2025-11-13`: strict tools / output_format
+            // guarantee schema-valid output (#1918).
+            supportsStrictSchema: true,
             // Structured message array on the wire → partial `.promptRendered` (#1905).
             rendersFullPrompt: false
         )
@@ -401,7 +407,13 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
         // Anthropic's side; the framework-level `.none` suppresses the
         // tools field entirely so the model has nothing to call.
         if !config.tools.isEmpty, config.toolChoice != .none {
-            var toolEntries = CloudMessageEncoder.claude.encodeTools(config.tools)
+            // Strict structured output (#1918): when the caller passes an
+            // explicit `.jsonSchema(...)` strategy and this backend advertises
+            // strict-schema support, encode each tool's `input_schema` in
+            // Anthropic's strict shape and flag `strict: true`.
+            let strictRequested = capabilities.supportsStrictSchema
+                && StrictSchemaTransform.jsonSchemaString(from: config.structuredOutput) != nil
+            var toolEntries = CloudMessageEncoder.claude.encodeTools(config.tools, strict: strictRequested)
             // Tag the last tool entry with cache_control when automatic so
             // Anthropic caches the entire system+tools prefix. The breakpoint
             // applies to the last block in the tagged sequence — tagging every

--- a/Sources/ManifoldCloudSaaS/OpenAIBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIBackend.swift
@@ -162,10 +162,41 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             supportsVision: BackendVisionCapability.openAIChatCompletionsSupportsImageInput(modelName: modelName),
             streamsToolCallArguments: true,
             supportsParallelToolCalls: true,
+            // OpenAI honors `strict: true` function tools and
+            // `response_format: {type:"json_schema", strict:true}`, so it can
+            // emit a schema-valid output guarantee (#1918).
+            supportsStrictSchema: true,
             // Chat Completions sends a structured message array on the wire, so
             // `.promptRendered` carries only the latest user message — partial (#1905).
             rendersFullPrompt: false
         )
+    }
+
+    // MARK: - Strict structured-output helpers (#1918)
+
+    /// Parses a JSON Schema string into the strict OpenAI `response_format`
+    /// schema dictionary. Returns `nil` (caller falls back to legacy
+    /// `json_object`/no structured output) when the string is not valid JSON,
+    /// rather than throwing — a malformed caller-supplied schema must not abort
+    /// the whole request build.
+    static func strictResponseFormatSchema(from schemaString: String) -> [String: Any]? {
+        guard let data = schemaString.data(using: .utf8) else {
+            Log.inference.warning("OpenAIBackend strict schema: schema string was not valid UTF-8 — falling back to non-strict output.")
+            return nil
+        }
+        let decoded: JSONSchemaValue
+        do {
+            decoded = try JSONDecoder().decode(JSONSchemaValue.self, from: data)
+        } catch {
+            Log.inference.warning("OpenAIBackend strict schema: could not decode schema string into JSONSchemaValue — falling back to non-strict output. error=\(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        let strict = StrictSchemaTransform.openAIStrict(decoded)
+        guard let foundation = encodeJSONSchemaToFoundation(strict) as? [String: Any] else {
+            Log.inference.warning("OpenAIBackend strict schema: transformed schema was not a JSON object — falling back to non-strict output.")
+            return nil
+        }
+        return foundation
     }
 
     /// Throwing factory that propagates ``URLSessionProvider/networkDisabled``
@@ -334,7 +365,27 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             "top_p": config.topP,
             "max_tokens": config.maxOutputTokens ?? 2048
         ]
-        if config.jsonMode {
+        // Strict structured output (#1918): an explicit
+        // `.jsonSchema(schema)` request, gated on the backend's
+        // strict-schema capability, takes precedence over plain `jsonMode`.
+        // The schema is rewritten into OpenAI's strict shape
+        // (`additionalProperties:false` + all-required + null-unions) and
+        // emitted under `response_format: {type:"json_schema", strict:true}`,
+        // which guarantees the model's output validates against the schema.
+        let strictSchemaString = StrictSchemaTransform.jsonSchemaString(from: config.structuredOutput)
+        let strictRequested = capabilities.supportsStrictSchema && strictSchemaString != nil
+        if strictRequested,
+           let schemaString = strictSchemaString,
+           let strictSchema = Self.strictResponseFormatSchema(from: schemaString) {
+            body["response_format"] = [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": "response",
+                    "strict": true,
+                    "schema": strictSchema,
+                ] as [String: Any],
+            ]
+        } else if config.jsonMode {
             // OpenAI-native providers accept `response_format`; Ollama's
             // OpenAI-compatible adapter looks for the legacy top-level
             // `format: "json"` switch.
@@ -371,7 +422,7 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, EndpointB
         // applied via the shared encoding helper so the same logic powers
         // ``OpenAIResponsesBackend``.
         if !config.tools.isEmpty {
-            body["tools"] = CloudMessageEncoder.openAI.encodeTools(config.tools)
+            body["tools"] = CloudMessageEncoder.openAI.encodeTools(config.tools, strict: strictRequested)
             OpenAIToolEncoding.applyToolChoice(config.toolChoice, into: &body)
         }
 

--- a/Sources/ManifoldHardware/BackendCapabilities.swift
+++ b/Sources/ManifoldHardware/BackendCapabilities.swift
@@ -128,6 +128,22 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
     /// Whether the backend supports Foundation-style guided structured output.
     public let supportsGuidedStructuredOutput: Bool
 
+    /// Whether the backend can emit a *strict* JSON-Schema constraint that
+    /// guarantees schema-valid output — OpenAI `strict: true` function tools and
+    /// `response_format: {type: "json_schema", strict: true}`, Anthropic's
+    /// `structured-outputs-2025-11-13` strict tools / `output_format`.
+    ///
+    /// When `true`, callers that pass ``StructuredOutputStrategy/jsonSchema(_:)``
+    /// via ``GenerationConfig/structuredOutput`` get the schema rewritten into
+    /// the provider's strict shape (`additionalProperties: false` on every
+    /// object, all properties required) before it hits the wire. Backends that
+    /// report `false` (the default) reject `additionalProperties: false` and
+    /// keep their legacy structured-output behaviour (e.g. `json_object`).
+    ///
+    /// Defaults to `false` for source compatibility — only OpenAI and Claude
+    /// SaaS backends advertise `true` today.
+    public let supportsStrictSchema: Bool
+
     /// `true` when the backend uses MLX's process-global resources — the GPU
     /// buffer cache (`MLX.Memory.cacheLimit`), the Metal device, and the MLX
     /// runtime singleton — and must coordinate with `MLXResourceArbiter` for
@@ -219,6 +235,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         streamsToolCallArguments: Bool = false,
         supportsParallelToolCalls: Bool = false,
         supportsGuidedStructuredOutput: Bool = false,
+        supportsStrictSchema: Bool = false,
         sharesMLXProcessResources: Bool = false,
         rendersFullPrompt: Bool = false,
         maxAdvertisedToolCount: Int? = nil
@@ -243,6 +260,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.streamsToolCallArguments = streamsToolCallArguments
         self.supportsParallelToolCalls = supportsParallelToolCalls
         self.supportsGuidedStructuredOutput = supportsGuidedStructuredOutput
+        self.supportsStrictSchema = supportsStrictSchema
         self.sharesMLXProcessResources = sharesMLXProcessResources
         self.rendersFullPrompt = rendersFullPrompt
         self.maxAdvertisedToolCount = maxAdvertisedToolCount
@@ -269,6 +287,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         case streamsToolCallArguments
         case supportsParallelToolCalls
         case supportsGuidedStructuredOutput
+        case supportsStrictSchema
         case sharesMLXProcessResources
         case rendersFullPrompt
         case maxAdvertisedToolCount
@@ -299,6 +318,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         streamsToolCallArguments = (try c.decodeIfPresent(Bool.self, forKey: .streamsToolCallArguments)) ?? false
         supportsParallelToolCalls = (try c.decodeIfPresent(Bool.self, forKey: .supportsParallelToolCalls)) ?? false
         supportsGuidedStructuredOutput = (try c.decodeIfPresent(Bool.self, forKey: .supportsGuidedStructuredOutput)) ?? false
+        supportsStrictSchema = (try c.decodeIfPresent(Bool.self, forKey: .supportsStrictSchema)) ?? false
         sharesMLXProcessResources = (try c.decodeIfPresent(Bool.self, forKey: .sharesMLXProcessResources)) ?? false
         rendersFullPrompt = (try c.decodeIfPresent(Bool.self, forKey: .rendersFullPrompt)) ?? false
         maxAdvertisedToolCount = try c.decodeIfPresent(Int.self, forKey: .maxAdvertisedToolCount)
@@ -326,6 +346,7 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         try c.encode(streamsToolCallArguments, forKey: .streamsToolCallArguments)
         try c.encode(supportsParallelToolCalls, forKey: .supportsParallelToolCalls)
         try c.encode(supportsGuidedStructuredOutput, forKey: .supportsGuidedStructuredOutput)
+        try c.encode(supportsStrictSchema, forKey: .supportsStrictSchema)
         try c.encode(sharesMLXProcessResources, forKey: .sharesMLXProcessResources)
         try c.encode(rendersFullPrompt, forKey: .rendersFullPrompt)
         try c.encodeIfPresent(maxAdvertisedToolCount, forKey: .maxAdvertisedToolCount)

--- a/Tests/ManifoldBackendsTests/CloudStrictSchemaTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudStrictSchemaTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+import Foundation
+@testable import ManifoldCloudSaaS
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Wire-contract tests for cloud strict-schema emission (#1918):
+///
+/// - ``StrictSchemaTransform/openAIStrict(_:)`` injects
+///   `additionalProperties:false` at every object level, marks every property
+///   required, and rewrites previously-optional fields into `["T","null"]`
+///   unions.
+/// - ``StrictSchemaTransform/anthropicStrict(_:)`` applies the shared core
+///   without the OpenAI null-union rewrite or keyword stripping.
+/// - ``OpenAIBackend`` tool encoding under a strict request flags
+///   `function.strict==true` and transforms `parameters`.
+/// - ``OpenAIBackend/buildRequest`` with a `.jsonSchema` strategy emits a
+///   `response_format.type=="json_schema"` + `strict:true` block.
+/// - The capability gate: a backend without `supportsStrictSchema` keeps the
+///   legacy `json_object` shape.
+@MainActor
+final class CloudStrictSchemaTests: XCTestCase {
+
+    private var mockURL: URL!
+    private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        DNSRebindingGuard._resolverForTesting = { _ in ["93.184.216.34"] }
+        mockURL = URL(string: "https://openai-strict-\(UUID().uuidString).test")!
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+    }
+
+    override func tearDown() {
+        DNSRebindingGuard._resolverForTesting = nil
+        if let url = mockURL {
+            MockURLProtocol.unstub(url: url.appendingPathComponent("v1/chat/completions"))
+        }
+        session = nil
+        mockURL = nil
+        super.tearDown()
+    }
+
+    private func makeOpenAI() -> OpenAIBackend {
+        let backend = OpenAIBackend(urlSession: session)
+        backend.configure(baseURL: mockURL, apiKey: "sk-test", modelName: "gpt-4o-mini")
+        return backend
+    }
+
+    /// A nested object schema with one required (`city`) and one optional
+    /// (`units`) top-level field, plus a nested `coords` object with a
+    /// required `lat` and optional `lon`.
+    private func nestedSchema() -> JSONSchemaValue {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")]),
+                "units": .object(["type": .string("string")]),
+                "coords": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "lat": .object(["type": .string("number")]),
+                        "lon": .object(["type": .string("number")]),
+                    ]),
+                    "required": .array([.string("lat")]),
+                ]),
+            ]),
+            "required": .array([.string("city")]),
+        ])
+    }
+
+    // MARK: - StrictSchemaTransform.openAIStrict
+
+    func test_openAIStrict_addsAdditionalPropertiesFalse_atEveryLevel() throws {
+        let strict = StrictSchemaTransform.openAIStrict(nestedSchema())
+        guard case .object(let root) = strict else { return XCTFail("root not object") }
+        XCTAssertEqual(root["additionalProperties"], .bool(false), "root must forbid extra properties")
+
+        guard case .object(let props) = root["properties"],
+              case .object(let coords) = props["coords"] else {
+            return XCTFail("coords not object")
+        }
+        XCTAssertEqual(coords["additionalProperties"], .bool(false), "nested object must forbid extra properties")
+    }
+
+    func test_openAIStrict_marksEveryPropertyRequired() throws {
+        let strict = StrictSchemaTransform.openAIStrict(nestedSchema())
+        guard case .object(let root) = strict,
+              case .array(let required) = root["required"] else {
+            return XCTFail("required not array")
+        }
+        let names = Set(required.compactMap { if case .string(let s) = $0 { return s }; return nil })
+        XCTAssertEqual(names, ["city", "units", "coords"], "every declared property must be required")
+
+        guard case .object(let props) = root["properties"],
+              case .object(let coords) = props["coords"],
+              case .array(let coordsRequired) = coords["required"] else {
+            return XCTFail("coords.required not array")
+        }
+        let coordsNames = Set(coordsRequired.compactMap { if case .string(let s) = $0 { return s }; return nil })
+        XCTAssertEqual(coordsNames, ["lat", "lon"], "nested object's properties must all be required")
+    }
+
+    func test_openAIStrict_rewritesOptionalFieldToNullUnion() throws {
+        let strict = StrictSchemaTransform.openAIStrict(nestedSchema())
+        guard case .object(let root) = strict,
+              case .object(let props) = root["properties"] else {
+            return XCTFail("properties missing")
+        }
+
+        // `units` was NOT in the original required set → null union.
+        guard case .object(let units) = props["units"] else { return XCTFail("units missing") }
+        XCTAssertEqual(units["type"], .array([.string("string"), .string("null")]),
+                       "previously-optional field must become a [\"T\",\"null\"] union")
+
+        // `city` WAS required → plain type preserved.
+        guard case .object(let city) = props["city"] else { return XCTFail("city missing") }
+        XCTAssertEqual(city["type"], .string("string"), "required field keeps its scalar type")
+    }
+
+    func test_openAIStrict_stripsUnsupportedKeywords() throws {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object([
+                    "type": .string("string"),
+                    "minLength": .integer(1),
+                    "format": .string("email"),
+                ]),
+            ]),
+            "required": .array([.string("name")]),
+        ])
+        let strict = StrictSchemaTransform.openAIStrict(schema)
+        guard case .object(let root) = strict,
+              case .object(let props) = root["properties"],
+              case .object(let name) = props["name"] else {
+            return XCTFail("name property missing")
+        }
+        XCTAssertNil(name["minLength"], "minLength must be stripped for OpenAI strict")
+        XCTAssertNil(name["format"], "format must be stripped for OpenAI strict")
+        XCTAssertEqual(name["type"], .string("string"))
+    }
+
+    // MARK: - StrictSchemaTransform.anthropicStrict (divergence)
+
+    func test_anthropicStrict_keepsKeywordsAndDoesNotNullUnion() throws {
+        let schema = JSONSchemaValue.object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object([
+                    "type": .string("string"),
+                    "minLength": .integer(1),
+                ]),
+                "units": .object(["type": .string("string")]),
+            ]),
+            "required": .array([.string("name")]),
+        ])
+        let strict = StrictSchemaTransform.anthropicStrict(schema)
+        guard case .object(let root) = strict,
+              case .object(let props) = root["properties"],
+              case .object(let name) = props["name"],
+              case .object(let units) = props["units"] else {
+            return XCTFail("schema shape unexpected")
+        }
+        // Shared core: additionalProperties:false + all-required.
+        XCTAssertEqual(root["additionalProperties"], .bool(false))
+        guard case .array(let required) = root["required"] else { return XCTFail("required missing") }
+        let names = Set(required.compactMap { if case .string(let s) = $0 { return s }; return nil })
+        XCTAssertEqual(names, ["name", "units"])
+        // Divergence from OpenAI: keep keywords, no null union.
+        XCTAssertEqual(name["minLength"], .integer(1), "Anthropic keeps validation keywords")
+        XCTAssertEqual(units["type"], .string("string"), "Anthropic does NOT rewrite optionals to null unions")
+    }
+
+    // MARK: - OpenAI tool encoding under strict
+
+    func test_encodeToolDefinition_strict_setsStrictTrueAndTransformsParams() throws {
+        let tool = ToolDefinition(
+            name: "lookup",
+            description: "Look up a value.",
+            parameters: nestedSchema()
+        )
+        let encoded = OpenAIToolEncoding.encodeToolDefinition(tool, strict: true)
+        let function = try XCTUnwrap(encoded["function"] as? [String: Any])
+        XCTAssertEqual(function["strict"] as? Bool, true, "strict tool must carry strict:true")
+
+        let parameters = try XCTUnwrap(function["parameters"] as? [String: Any])
+        XCTAssertEqual(parameters["additionalProperties"] as? Bool, false,
+                       "strict tool parameters must forbid extra properties")
+        let required = try XCTUnwrap(parameters["required"] as? [String])
+        XCTAssertEqual(Set(required), ["city", "units", "coords"],
+                       "strict tool parameters must require every property")
+    }
+
+    func test_encodeToolDefinition_nonStrict_omitsStrictFlag() throws {
+        let tool = ToolDefinition(name: "lookup", description: "x", parameters: nestedSchema())
+        let encoded = OpenAIToolEncoding.encodeToolDefinition(tool, strict: false)
+        let function = try XCTUnwrap(encoded["function"] as? [String: Any])
+        XCTAssertNil(function["strict"], "non-strict tool must not carry the strict flag")
+        let parameters = try XCTUnwrap(function["parameters"] as? [String: Any])
+        XCTAssertNil(parameters["additionalProperties"],
+                     "non-strict parameters must be passed through verbatim")
+    }
+
+    // MARK: - OpenAIBackend.buildRequest response_format
+
+    private func jsonSchemaStrategy() throws -> StructuredOutputStrategy {
+        let data = try JSONEncoder().encode(nestedSchema())
+        return .jsonSchema(String(decoding: data, as: UTF8.self))
+    }
+
+    func test_buildRequest_jsonSchemaStrategy_emitsJsonSchemaResponseFormat() throws {
+        let backend = makeOpenAI()
+        var config = GenerationConfig()
+        config.structuredOutput = try jsonSchemaStrategy()
+
+        let request = try backend.buildRequest(prompt: "hi", systemPrompt: nil, config: config)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        let responseFormat = try XCTUnwrap(json["response_format"] as? [String: Any])
+        XCTAssertEqual(responseFormat["type"] as? String, "json_schema")
+        let jsonSchema = try XCTUnwrap(responseFormat["json_schema"] as? [String: Any])
+        XCTAssertEqual(jsonSchema["strict"] as? Bool, true)
+        let schema = try XCTUnwrap(jsonSchema["schema"] as? [String: Any])
+        XCTAssertEqual(schema["additionalProperties"] as? Bool, false,
+                       "emitted response_format schema must be in strict shape")
+        // Legacy json_object shape must NOT also be present.
+        XCTAssertNil(json["format"], "strict path must not emit the legacy `format: json` switch")
+    }
+
+    func test_buildRequest_jsonMode_withoutStructuredOutput_keepsLegacyJsonObject() throws {
+        let backend = makeOpenAI()
+        var config = GenerationConfig()
+        config.jsonMode = true
+
+        let request = try backend.buildRequest(prompt: "hi", systemPrompt: nil, config: config)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        let responseFormat = try XCTUnwrap(json["response_format"] as? [String: Any])
+        XCTAssertEqual(responseFormat["type"] as? String, "json_object",
+                       "plain jsonMode must keep the legacy json_object shape")
+    }
+
+    // MARK: - Capability gate regression guard
+
+    func test_capabilityGate_nonStrictBackend_emitsLegacyJsonObject() throws {
+        // A backend whose capabilities do NOT advertise strict schema must
+        // fall back to legacy json_object even when given a .jsonSchema
+        // strategy — otherwise it would 400 on additionalProperties:false.
+        let caps = BackendCapabilities(supportsStructuredOutput: true, supportsStrictSchema: false)
+        XCTAssertFalse(caps.supportsStrictSchema)
+
+        // Drive the gate exactly as OpenAIBackend.buildRequest does.
+        let strategy = try jsonSchemaStrategy()
+        let strictRequested = caps.supportsStrictSchema
+            && StrictSchemaTransform.jsonSchemaString(from: strategy) != nil
+        XCTAssertFalse(strictRequested,
+                       "a non-strict-capable backend must not enter the strict emission path")
+    }
+
+    func test_openAIBackend_advertisesStrictSchemaCapability() {
+        XCTAssertTrue(makeOpenAI().capabilities.supportsStrictSchema)
+    }
+
+    func test_claudeBackend_advertisesStrictSchemaCapability() {
+        XCTAssertTrue(ClaudeBackend().capabilities.supportsStrictSchema)
+    }
+}


### PR DESCRIPTION
## Summary

Adds cloud strict-schema emission so OpenAI (Chat Completions) and Anthropic/Claude can guarantee schema-valid structured output. Resolves the core of #1918 (ships BOTH provider strict shapes in v1).

- **New `StrictSchemaTransform`** (`Sources/ManifoldCloudCore/StrictSchemaTransform.swift`) — recursive `JSONSchemaValue` rewriter with two entry points (`openAIStrict`, `anthropicStrict`).
- **New `BackendCapabilities.supportsStrictSchema`** — additive, defaults `false` (so every existing initializer/conformance/Codable blob is unaffected). OpenAI + Claude SaaS backends advertise `true`.
- **First backend consumer of `config.structuredOutput`** — this is intended and independent of the router (#1915 wires the router separately). The trigger is an explicit `.jsonSchema(...)` strategy gated on `supportsStrictSchema`; otherwise legacy behaviour is preserved.
  - OpenAI tools: `function.strict = true` + `openAIStrict(parameters)`.
  - OpenAI response-format: `response_format: {type:"json_schema", json_schema:{name, strict:true, schema: openAIStrict(parsed)}}` instead of `json_object`.
  - Claude tools: `input_schema` rewritten via `anthropicStrict` + `strict:true`.

Does **not** close #1916 (reask) — strict guarantees schema-*valid* JSON, not semantically-correct values.

## OpenAI vs Anthropic strict-shape divergence

Both providers share a non-negotiable core: `additionalProperties:false` on every object level + every declared property in `required`. They diverge on two points, both verified and implemented faithfully:

1. **Optional fields.** OpenAI strict forbids absent keys, so a previously-*optional* `T` must become a `{"type":["T","null"]}` union (still in `required`, but nullable). Anthropic does **not** require this — it leaves the field's type untouched.
2. **Validation keywords.** OpenAI strict `400`s on `minLength`/`maxLength`/`pattern`/`format`/`minimum`/`maximum`/`minItems`/etc., so `openAIStrict` strips them. Anthropic keeps the full JSON Schema vocabulary, so `anthropicStrict` preserves them.

The shared core lives in one private implementation; the two named entry points are kept distinct because the call sites differ (OpenAI threads `OpenAIToolEncoding` + `response_format`; Claude threads `input_schema`) and OpenAI's extra rules are likely to keep diverging.

## Design decision: parse the schema string, don't transform at the dict level

`StructuredOutputStrategy.jsonSchema` carries a schema **string**. For the OpenAI `response_format` path I parse that string into `JSONSchemaValue` (`JSONDecoder`), run `openAIStrict`, then re-encode to the Foundation dict — so the transform operates on the typed recursive enum rather than ad-hoc `[String:Any]` walking. A malformed/non-JSON schema string logs via `Log.inference.warning` and falls back to non-strict output rather than throwing (no `try?`; do/catch). Tool schemas are already typed `JSONSchemaValue`, so those transform directly.

## Tests (`Tests/ManifoldBackendsTests/CloudStrictSchemaTests.swift`, 12 cases)

- `openAIStrict`: `additionalProperties:false` at every nested level; every property required (root + nested); optional field → `["T","null"]` union AND in `required`; unsupported keywords stripped.
- `anthropicStrict`: shared core applied; keywords kept; no null-union (divergence guard).
- `encodeToolDefinition(strict:)`: `function.strict==true` + transformed params; non-strict omits the flag and passes params verbatim.
- `OpenAIBackend.buildRequest` with `.jsonSchema` strategy: `response_format.type=="json_schema"` + `strict:true` + strict-shaped schema (decoded via `JSONSerialization`); plain `jsonMode` keeps legacy `json_object`.
- Capability gate regression: a non-strict-capable `BackendCapabilities` does not enter the strict path.
- OpenAI + Claude backends advertise the capability.

Each assertion was sabotage-verified (e.g. disabling the null-union rewrite fails `test_openAIStrict_rewritesOptionalFieldToNullUnion`); sabotage removed before commit. UUID-based mock hostnames per suite; no `MockURLProtocol.reset()`.

## Verification

- `swift build --build-tests --traits Server,Macros` — **success** (exit 0; only pre-existing deprecation warnings).
- `swift test --filter CloudStrictSchemaTests` — **12 passed, 0 failures**.
- `swift test --filter ManifoldBackendsTests` — **651 tests, 0 failures** (3 skipped), regression-clean.
- `swift test --filter BackendCapabilitiesTests` — **30 passed**, confirms the additive Codable field round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)