### PR TITLE
feat: bounded validation-reask loop for structured output (#1916)

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -118,3 +118,4 @@ API breakage: constructor RAGService.init(documentStore:vectorStore:embeddingBac
 API breakage: func CloudMessageEncoder.encodeTools(_:) has been renamed to func encodeTools(_:strict:)
 API breakage: func CloudMessageEncoder.claudeEncodeToolDefinition(_:) has been renamed to func claudeEncodeToolDefinition(_:strict:)
 API breakage: func OpenAIToolEncoding.encodeToolDefinition(_:) has been renamed to func encodeToolDefinition(_:strict:)
+API breakage: enumelement StructuredOutputError.reaskBudgetExhausted has been added as a new enum case

--- a/Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+StructuredOutput.swift
@@ -69,6 +69,41 @@ public enum StructuredOutputError: Error, Sendable {
 
     /// The JSON schema for the requested type could not be encoded to a string.
     case schemaEncodingFailure(String)
+
+    /// The bounded validation-reask loop (#1916) exhausted its retry budget
+    /// without producing output that both decoded into `T` and satisfied the
+    /// schema. Carries the last failure message (decode or validator) and the
+    /// number of generation attempts that ran.
+    case reaskBudgetExhausted(lastError: String, attempts: Int)
+}
+
+// MARK: - Reask policy
+
+/// Budget for the bounded validation-reask loop on structured output (#1916).
+///
+/// When a typed ``InferenceService/respond(_:to:config:reask:)`` round-trip
+/// produces output that fails to decode into `T` **or** fails
+/// ``JSONSchemaValidator`` schema validation, the loop re-prompts the model
+/// with the failure message inside this budget before throwing
+/// ``StructuredOutputError/reaskBudgetExhausted(lastError:attempts:)``.
+///
+/// This is a **distinct** failure class from transport-level retry
+/// (``RetryPolicy``, which handles HTTP transient backoff): a reask is a fresh
+/// generation that carries the conversation of prior failed attempts, asking
+/// the model to correct semantically invalid output. v1 re-runs only the final
+/// structured-output turn, not the full tool loop.
+public struct ReaskPolicy: Sendable {
+    /// Total number of generation attempts, including the first. `1` disables
+    /// reask (one attempt, then throw on failure).
+    public var maxAttempts: Int
+    /// When `true`, the model's bad output is echoed back as an assistant turn
+    /// in the reask conversation so it can see what it produced.
+    public var includeRawOutput: Bool
+
+    public init(maxAttempts: Int = 2, includeRawOutput: Bool = true) {
+        self.maxAttempts = maxAttempts
+        self.includeRawOutput = includeRawOutput
+    }
 }
 
 // MARK: - respond<T>
@@ -108,20 +143,125 @@ extension InferenceService {
         config: GenerationConfig = .init()
     ) async throws -> StructuredOutput<T> {
         let schema = T.jsonSchema
+        let schemaString = try Self.encodeSchema(schema)
+        let (rawText, strategy) = try await runStructuredGeneration(
+            messages: [.user(prompt)],
+            schemaString: schemaString,
+            config: config
+        )
+        return try await Self.decodeAndValidate(
+            T.self,
+            rawText: rawText,
+            strategy: strategy,
+            schema: schema
+        )
+    }
 
-        // Encode the schema to a string. The queue stages this on config and
-        // lowers it to GBNF (for grammar-capable backends) or injects it as a
-        // prompt instruction (weak backends) when the router runs.
-        let schemaString: String
+    /// Bounded validation-reask variant of ``respond(_:to:config:)`` (#1916).
+    ///
+    /// Runs the structured-output round-trip, and when the produced text fails
+    /// to decode into `T` **or** fails ``JSONSchemaValidator`` schema
+    /// validation, re-prompts the model with the failure message inside the
+    /// ``ReaskPolicy`` budget. Each reask carries the conversation of prior
+    /// failed attempts: optionally the model's bad output (when
+    /// ``ReaskPolicy/includeRawOutput``) plus a user turn naming the violation
+    /// and demanding valid JSON.
+    ///
+    /// This reask budget is **distinct** from transport-level retry
+    /// (``RetryPolicy``): it re-runs the final structured-output turn for a
+    /// *semantic* failure (bad decode / schema violation), not an HTTP
+    /// transient. v1 re-runs only that final turn, not the full tool loop.
+    ///
+    /// - Parameters:
+    ///   - type: The type to decode the response into.
+    ///   - prompt: The user prompt.
+    ///   - config: Sampling/generation configuration; `structuredOutput` is
+    ///     overwritten with the schema derived from `T` on every attempt.
+    ///   - reask: The retry budget. `maxAttempts: 1` disables reask.
+    /// - Returns: The decoded, schema-valid value, raw text, and strategy.
+    /// - Throws: ``StructuredOutputError/reaskBudgetExhausted(lastError:attempts:)``
+    ///   when the budget is exhausted without a valid response;
+    ///   ``StructuredOutputError/schemaEncodingFailure(_:)`` when the schema
+    ///   cannot be encoded; or any generation error from the backend.
+    public func respond<T: Decodable & Sendable & SchemaProviding>(
+        _ type: T.Type,
+        to prompt: String,
+        config: GenerationConfig = .init(),
+        reask: ReaskPolicy = .init()
+    ) async throws -> StructuredOutput<T> {
+        let schema = T.jsonSchema
+        let schemaString = try Self.encodeSchema(schema)
+
+        // The conversation grows across attempts: it starts with the user
+        // prompt and, on each failure, gains the model's (bad) output plus a
+        // corrective user turn. A reask is a fresh generation over this
+        // conversation — NOT a transport retry of the same request.
+        var messages: [Message] = [.user(prompt)]
+        let attemptBudget = max(1, reask.maxAttempts)
+        var lastError = "no attempt ran"
+
+        for attempt in 1...attemptBudget {
+            let (rawText, strategy) = try await runStructuredGeneration(
+                messages: messages,
+                schemaString: schemaString,
+                config: config
+            )
+
+            do {
+                return try await Self.decodeAndValidate(
+                    T.self,
+                    rawText: rawText,
+                    strategy: strategy,
+                    schema: schema
+                )
+            } catch let error as StructuredOutputError {
+                lastError = Self.reaskMessage(for: error)
+                Log.inference.warning(
+                    "structured-output attempt \(attempt, privacy: .public)/\(attemptBudget, privacy: .public) failed: \(lastError, privacy: .public)"
+                )
+
+                // Budget exhausted — stop before staging another turn.
+                if attempt >= attemptBudget { break }
+
+                if reask.includeRawOutput {
+                    messages.append(.assistant(rawText))
+                }
+                messages.append(.user(
+                    "Your previous response failed validation: \(lastError). "
+                    + "Return only valid JSON matching the schema."
+                ))
+            }
+        }
+
+        throw StructuredOutputError.reaskBudgetExhausted(
+            lastError: lastError,
+            attempts: attemptBudget
+        )
+    }
+
+    // MARK: - Shared round-trip steps
+
+    /// Encodes a ``JSONSchemaValue`` to a sorted-keys JSON string for staging
+    /// on the generation config. Throws ``StructuredOutputError/schemaEncodingFailure(_:)``.
+    private static func encodeSchema(_ schema: JSONSchemaValue) throws -> String {
         do {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
             let data = try encoder.encode(schema)
-            schemaString = String(decoding: data, as: UTF8.self)
+            return String(decoding: data, as: UTF8.self)
         } catch {
             throw StructuredOutputError.schemaEncodingFailure(String(describing: error))
         }
+    }
 
+    /// Stages the schema on config, enqueues a single generation over
+    /// `messages`, and drains the content tokens to a string. Returns the raw
+    /// text and the router-selected strategy.
+    private func runStructuredGeneration(
+        messages: [Message],
+        schemaString: String,
+        config: GenerationConfig
+    ) async throws -> (rawText: String, strategy: StructuredOutputStrategy) {
         // Stage the schema on config. The queue's router wiring (#1915) reads
         // `structuredOutput`, lowers the schema to GBNF when the active backend
         // supports grammar-constrained sampling, and selects the strongest
@@ -130,10 +270,7 @@ extension InferenceService {
         var routedConfig = config
         routedConfig.structuredOutput = .jsonSchema(schemaString)
 
-        let (_, stream) = try enqueue(
-            messages: [.user(prompt)],
-            config: routedConfig
-        )
+        let (_, stream) = try enqueue(messages: messages, config: routedConfig)
 
         // Drain to a string. Collect only content tokens — thinking and tool
         // events are not part of the structured payload.
@@ -144,14 +281,42 @@ extension InferenceService {
             }
         }
 
-        let rawText = collected
-
         // The strategy the router actually chose for the serving backend, set
         // on the stream by the queue at enqueue time. Reading it back is the
         // single source of truth — no recomputation against a capability set
         // that might differ from the one the queue dispatched to. `nil` means
         // the request carried no resolvable target (treated as prompt-level).
         let strategy = stream.structuredOutputStrategy ?? .jsonPrompting
+        return (collected, strategy)
+    }
+
+    /// Decodes `rawText` into `T` and validates it against `schema`.
+    ///
+    /// A decode failure surfaces ``StructuredOutputError/decodeFailure(rawText:underlying:)``;
+    /// schema-valid-but-rule-violating JSON (enum/required/bounds) surfaces a
+    /// `decodeFailure` carrying the validator's model-readable message. Both
+    /// are the reask triggers for ``respond(_:to:config:reask:)``.
+    private static func decodeAndValidate<T: Decodable & Sendable>(
+        _ type: T.Type,
+        rawText: String,
+        strategy: StructuredOutputStrategy,
+        schema: JSONSchemaValue
+    ) async throws -> StructuredOutput<T> {
+        // Validate the extracted JSON against the schema BEFORE decoding so the
+        // model gets the rich, model-readable violation message (enum/required/
+        // bounds) rather than an opaque Swift decoding error. The validator
+        // fails closed on unsupported keywords; treat that as "skip validation"
+        // and let the decoder be the authority, since refusing here would block
+        // any schema the decoder itself handles fine.
+        let jsonText = extractJSON(from: rawText)
+        let validator = JSONSchemaValidator()
+        if let failure = validator.validate(arguments: jsonText, against: schema),
+           !failure.modelReadableMessage.contains("unsupported schema feature") {
+            throw StructuredOutputError.decodeFailure(
+                rawText: rawText,
+                underlying: failure.modelReadableMessage
+            )
+        }
 
         // Decode off the main actor — small payloads, but no reason to block UI.
         do {
@@ -164,6 +329,19 @@ extension InferenceService {
                 rawText: rawText,
                 underlying: String(describing: error)
             )
+        }
+    }
+
+    /// Extracts a concise, model-readable message from a structured-output
+    /// error for embedding in the reask prompt.
+    private static func reaskMessage(for error: StructuredOutputError) -> String {
+        switch error {
+        case let .decodeFailure(_, underlying):
+            return underlying
+        case let .schemaEncodingFailure(message):
+            return message
+        case let .reaskBudgetExhausted(lastError, _):
+            return lastError
         }
     }
 

--- a/Tests/ManifoldInferenceTests/InferenceServiceStructuredOutputTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceStructuredOutputTests.swift
@@ -160,4 +160,146 @@ final class InferenceServiceStructuredOutputTests: XCTestCase {
             XCTAssertFalse(underlying.isEmpty, "underlying decode error must be surfaced")
         }
     }
+
+    // MARK: - (#1916) Bounded validation-reask loop
+
+    /// JSON that is schema-valid but violates an enum constraint — exercises the
+    /// validator-failure reask path (not just decode failures).
+    private struct Unit: Decodable, Sendable, SchemaProviding, Equatable {
+        let units: String
+
+        static var jsonSchema: JSONSchemaValue {
+            .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "units": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("metric"), .string("imperial")]),
+                    ]),
+                ]),
+                "required": .array([.string("units")]),
+            ])
+        }
+    }
+
+    // (a) invalid attempt 1, valid attempt 2 → succeeds in exactly 2 generations.
+    func test_reask_invalidThenValid_succeedsInTwoGenerations() async throws {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        // Per-turn scripting: turn 1 = garbage (decode fails), turn 2 = valid.
+        backend.tokensToYieldPerTurn = [
+            ["not json"],
+            tokens(#"{"city":"Paris","celsius":21}"#),
+        ]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(
+            Weather.self,
+            to: "Weather in Paris?",
+            reask: ReaskPolicy(maxAttempts: 2)
+        )
+
+        XCTAssertEqual(result.value, Weather(city: "Paris", celsius: 21))
+        XCTAssertEqual(backend.generateCallCount, 2, "exactly two generations should have run (one reask)")
+    }
+
+    // (b) always-invalid → throws reaskBudgetExhausted after maxAttempts generations.
+    func test_reask_alwaysInvalid_throwsBudgetExhausted() async throws {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["never valid json"]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        do {
+            _ = try await service.respond(
+                Weather.self,
+                to: "Weather?",
+                reask: ReaskPolicy(maxAttempts: 3)
+            )
+            XCTFail("expected reaskBudgetExhausted")
+        } catch let error as StructuredOutputError {
+            guard case .reaskBudgetExhausted(let lastError, let attempts) = error else {
+                return XCTFail("expected .reaskBudgetExhausted, got \(error)")
+            }
+            XCTAssertEqual(attempts, 3, "should report the full budget it burned")
+            XCTAssertFalse(lastError.isEmpty, "must carry the last failure message")
+        }
+        XCTAssertEqual(backend.generateCallCount, 3, "should run exactly maxAttempts generations")
+    }
+
+    // (c) the reask follow-up prompt carries the ValidationFailure message.
+    func test_reask_followUpPromptContainsValidationFailureMessage() async throws {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        // Turn 1: enum-violating but otherwise schema-valid JSON. Turn 2: valid.
+        backend.tokensToYieldPerTurn = [
+            tokens(#"{"units":"celsius"}"#),
+            tokens(#"{"units":"metric"}"#),
+        ]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        _ = try await service.respond(
+            Unit.self,
+            to: "Pick units",
+            reask: ReaskPolicy(maxAttempts: 2, includeRawOutput: true)
+        )
+
+        // The second generation's prompt (the assembled conversation) must
+        // contain the validator's model-readable message about the enum.
+        let lastPrompt = try XCTUnwrap(backend.lastPrompt, "no prompt reached the backend")
+        XCTAssertTrue(
+            lastPrompt.contains("must be one of: metric, imperial"),
+            "reask follow-up should embed the validator failure message; got: \(lastPrompt)"
+        )
+        // includeRawOutput echoes the bad output back as an assistant turn.
+        XCTAssertTrue(
+            lastPrompt.contains("celsius"),
+            "includeRawOutput should echo the bad output into the reask conversation"
+        )
+    }
+
+    // (d) schema-valid-but-enum-violating JSON triggers reask via the validator
+    // path (decode would succeed — only the validator catches it).
+    func test_reask_schemaValidButEnumViolating_triggersReask() async throws {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYieldPerTurn = [
+            tokens(#"{"units":"kelvin"}"#),   // decodes fine, violates enum
+            tokens(#"{"units":"imperial"}"#), // valid
+        ]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let result = try await service.respond(
+            Unit.self,
+            to: "Pick units",
+            reask: ReaskPolicy(maxAttempts: 2)
+        )
+
+        XCTAssertEqual(result.value, Unit(units: "imperial"))
+        XCTAssertEqual(backend.generateCallCount, 2, "validator failure must trigger a reask, not pass through")
+    }
+
+    // (e) maxAttempts:1 disables reask — a single failed attempt throws immediately
+    // with no retry. Confirms the budget gate is live.
+    func test_reask_maxAttemptsOne_throwsImmediatelyWithoutRetry() async throws {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["not json"]
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        do {
+            _ = try await service.respond(
+                Weather.self,
+                to: "Weather?",
+                reask: ReaskPolicy(maxAttempts: 1)
+            )
+            XCTFail("expected immediate failure")
+        } catch let error as StructuredOutputError {
+            guard case .reaskBudgetExhausted(_, let attempts) = error else {
+                return XCTFail("expected .reaskBudgetExhausted, got \(error)")
+            }
+            XCTAssertEqual(attempts, 1)
+        }
+        XCTAssertEqual(backend.generateCallCount, 1, "maxAttempts:1 must not retry")
+    }
 }


### PR DESCRIPTION
## Summary

Adds a bounded validation-reask loop for typed structured output. When the typed `respond<T>()` round-trip produces output that fails to **decode** into `T` **or** fails **`JSONSchemaValidator`** schema validation, the loop re-prompts the model with the failure message inside a bounded retry budget, then throws a typed error on exhaustion.

Closes #1916.

## New API

```swift
public struct ReaskPolicy: Sendable {
    public var maxAttempts: Int       // total attempts incl. the first (default 2; 1 disables reask)
    public var includeRawOutput: Bool // echo the model's bad output back (default true)
    public init(maxAttempts: Int = 2, includeRawOutput: Bool = true)
}

extension InferenceService {
    public func respond<T: Decodable & Sendable & SchemaProviding>(
        _ type: T.Type, to prompt: String,
        config: GenerationConfig = .init(),
        reask: ReaskPolicy = .init()
    ) async throws -> StructuredOutput<T>
}
```

New error case:
```swift
case reaskBudgetExhausted(lastError: String, attempts: Int)
```

### Behaviour
- Loop: generate → decode + validate → on failure append (optional) assistant turn with the raw output + a user turn `"Your previous response failed validation: <message>. Return only valid JSON matching the schema."` and retry within budget.
- Validator failures (schema-valid JSON violating enum/required/bounds) trigger reask just like decode failures — the validator runs **before** decode so the model gets the rich model-readable message. Validator fail-closed (unsupported keywords) is treated as "skip validation" and lets the decoder be the authority.
- **v1 scope:** reask re-runs only the final structured-output turn (carrying the conversation of prior failed attempts), NOT the full tool loop.
- The reask budget is **distinct** from transport-level `RetryPolicy` (HTTP backoff) — this is a decode/validator semantic-failure class.
- Stays on `@MainActor`; no `Task.detached`. Shared single-attempt generation + `decodeAndValidate` path is factored out so the original non-reask `respond` reuses it. `do/catch` + `Log.inference.warning` (no `try?`).

## API-break gate

Adding the new (non-`@frozen`) enum case is the only flagged change. The brief anticipated a `respond` *rename*, but the new overload is **additive** — the original `respond(_:to:config:)` signature is preserved as a distinct overload, so the digester flags only the enum case, not a rename.

Exact digester text emitted by `swift package diagnose-api-breaking-changes origin/main --breakage-allowlist-path .github/api-breakage-allowlist.txt`:

```
💔 API breakage: enumelement StructuredOutputError.reaskBudgetExhausted has been added as a new enum case
```

Line added to `.github/api-breakage-allowlist.txt` (verbatim, no `#` comments):
```
API breakage: enumelement StructuredOutputError.reaskBudgetExhausted has been added as a new enum case
```
Digester exits 0 with the line added.

## Tests (`Tests/ManifoldInferenceTests/InferenceServiceStructuredOutputTests.swift`)
- (a) invalid attempt 1, valid attempt 2 → succeeds; asserts exactly 2 generations ran.
- (b) always-invalid → throws `reaskBudgetExhausted` after `maxAttempts`; asserts generation count == `maxAttempts` (3).
- (c) reask follow-up prompt contains the `ValidationFailure` message text (and the echoed raw output).
- (d) schema-valid-but-enum-violating JSON triggers reask via the validator path (not just decode).
- (e) `maxAttempts:1` → immediate throw, no retry (budget gate live).

## Verification
- `swift build --build-tests --traits Server,Macros` → **Build complete!** (only pre-existing deprecation warnings).
- `swift test --filter ManifoldInferenceTests` → **1539 tests, 0 failures** (includes `SilentCatchAuditTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)