### PR TITLE
feat: partial/snapshot typed streaming via streamObject (#1917)

### DIFF
--- a/Sources/ManifoldInference/Services/InferenceService+StreamObject.swift
+++ b/Sources/ManifoldInference/Services/InferenceService+StreamObject.swift
@@ -1,0 +1,240 @@
+import Foundation
+import ManifoldModelCatalog
+
+// MARK: - PartialSnapshot
+
+/// A progressively-filled snapshot of a structured-output generation as it
+/// streams (#1917).
+///
+/// Each token delta produces a new snapshot. ``fields`` holds the best-effort
+/// parse of the accumulated buffer (after a lenient close step auto-terminates
+/// any open string/object/array), so SwiftUI can render a partial object as it
+/// arrives. ``decoded`` is `nil` until the *raw* buffer parses cleanly into `T`
+/// — i.e. once the model has emitted a complete, valid JSON document. The
+/// lenient close is only used to populate ``fields``; `T` is never decoded from
+/// a synthetically-closed buffer, so a final `decoded` value never reflects
+/// guessed structure.
+///
+/// This is a side-channel surface: the ``GenerationEvent`` vocabulary is frozen
+/// for 1.0 and gains no snapshot case. ``InferenceService/streamObject(_:to:config:)``
+/// drains the same token stream `respond` does and yields these snapshots on a
+/// dedicated `AsyncThrowingStream`.
+public struct PartialSnapshot<T: Decodable & Sendable>: Sendable {
+    /// Best-effort parse of the accumulated buffer so far, after a lenient
+    /// close step. Empty until the buffer contains enough to parse a partial
+    /// object. Keys appear incrementally as the model emits them.
+    public let fields: [String: JSONSchemaValue]
+
+    /// The decoded value, non-`nil` once the accumulated *raw* buffer (no
+    /// lenient close applied) decodes cleanly into `T`. Typically becomes
+    /// non-`nil` on the final snapshot.
+    public let decoded: T?
+
+    /// The accumulated buffer for this snapshot — every content token seen so
+    /// far, concatenated.
+    public let rawText: String
+
+    public init(fields: [String: JSONSchemaValue], decoded: T?, rawText: String) {
+        self.fields = fields
+        self.decoded = decoded
+        self.rawText = rawText
+    }
+}
+
+// MARK: - streamObject / streamEach
+
+extension InferenceService {
+
+    /// Streams progressively-filled snapshots of a structured-output generation.
+    ///
+    /// Mirrors ``respond(_:to:config:)`` — derives a JSON schema from `T`, stages
+    /// it on the config, and enqueues through the queue so the
+    /// ``StructuredOutputRouter`` selects the strongest constrained-decoding
+    /// mechanism the active backend supports. But instead of draining to a single
+    /// value, it yields a ``PartialSnapshot`` on **every content-token delta**:
+    /// the buffer is leniently closed, parsed into ``PartialSnapshot/fields``,
+    /// and decoded into `T` when the raw buffer is complete.
+    ///
+    /// This gives SwiftUI a stream of partial objects rather than raw token text,
+    /// so a view can render `name` before `age` arrives. The
+    /// ``GenerationEvent`` vocabulary is untouched (frozen for 1.0) — snapshots
+    /// travel on this dedicated stream.
+    ///
+    /// v1 uses the uniform lenient-reparse path for **all** backends. Foundation's
+    /// native Apple snapshot stream is a follow-up; this path works against every
+    /// backend that emits `.token` deltas.
+    ///
+    /// - Parameters:
+    ///   - type: The type each completed buffer should decode into.
+    ///   - prompt: The user prompt.
+    ///   - config: Sampling/generation configuration. Any `structuredOutput`
+    ///     already set is overwritten with the schema derived from `T`.
+    /// - Returns: A stream of ``PartialSnapshot`` values, one per token delta.
+    ///   The stream finishes when generation completes and throws on schema
+    ///   encoding failure or any backend/generation error.
+    public func streamObject<T: Decodable & Sendable & SchemaProviding>(
+        _ type: T.Type,
+        to prompt: String,
+        config: GenerationConfig = .init()
+    ) -> AsyncThrowingStream<PartialSnapshot<T>, Error> {
+        AsyncThrowingStream { continuation in
+            // `Task { }` inherits this @MainActor — the enqueue + stream drain
+            // must run on the actor that owns the queue. Never Task.detached
+            // (CLAUDE.md gotcha #5).
+            let task = Task { @MainActor in
+                do {
+                    let routedConfig = try Self.routedStructuredConfig(for: T.self, base: config)
+                    let (_, stream) = try self.enqueue(
+                        messages: [.user(prompt)],
+                        config: routedConfig
+                    )
+
+                    var buffer = ""
+                    for try await event in stream {
+                        if Task.isCancelled { break }
+                        guard case .token(let fragment) = event else { continue }
+                        buffer += fragment
+                        let snapshot = await Self.makeSnapshot(T.self, from: buffer)
+                        continuation.yield(snapshot)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Streams one decoded `T` per completed element of a top-level JSON array.
+    ///
+    /// Where ``streamObject(_:to:config:)`` snapshots a single object as it
+    /// fills, `streamEach` is the collection mode: the model is expected to emit
+    /// a JSON array of `T`, and each element is decoded and yielded the moment
+    /// its closing brace/bracket lands. Useful for "stream me a list" UIs that
+    /// want to append rows as they complete rather than waiting for the whole
+    /// array.
+    ///
+    /// The schema staged on the config describes `T` (the element), not the
+    /// array — backends that constrain on the element shape still produce a
+    /// valid stream of elements; weak backends get the element schema as a
+    /// prompt instruction. Element boundaries are detected structurally from the
+    /// raw token stream (brace/bracket depth, string-aware), so no lenient close
+    /// is involved: each element is decoded from its exact, complete text.
+    ///
+    /// - Parameters:
+    ///   - type: The element type to decode.
+    ///   - prompt: The user prompt.
+    ///   - config: Generation configuration; `structuredOutput` is overwritten
+    ///     with the schema for `T`.
+    /// - Returns: A stream of decoded `T` values, one per completed array
+    ///   element.
+    public func streamEach<T: Decodable & Sendable & SchemaProviding>(
+        _ type: T.Type,
+        to prompt: String,
+        config: GenerationConfig = .init()
+    ) -> AsyncThrowingStream<T, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { @MainActor in
+                do {
+                    let routedConfig = try Self.routedStructuredConfig(for: T.self, base: config)
+                    let (_, stream) = try self.enqueue(
+                        messages: [.user(prompt)],
+                        config: routedConfig
+                    )
+
+                    var extractor = TopLevelArrayElementExtractor()
+                    for try await event in stream {
+                        if Task.isCancelled { break }
+                        guard case .token(let fragment) = event else { continue }
+                        for elementText in extractor.consume(fragment) {
+                            let value = try await Self.decode(T.self, from: elementText)
+                            continuation.yield(value)
+                        }
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    // MARK: - Shared helpers
+
+    /// Builds the routed config that stages `T`'s schema on `structuredOutput`,
+    /// matching `respond`'s lowering so `streamObject`/`streamEach` route through
+    /// the same `StructuredOutputRouter` wiring at the queue chokepoint.
+    static func routedStructuredConfig<T: SchemaProviding>(
+        for type: T.Type,
+        base: GenerationConfig
+    ) throws -> GenerationConfig {
+        let schema = T.jsonSchema
+        let schemaString: String
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(schema)
+            schemaString = String(decoding: data, as: UTF8.self)
+        } catch {
+            throw StructuredOutputError.schemaEncodingFailure(String(describing: error))
+        }
+        var routed = base
+        routed.structuredOutput = .jsonSchema(schemaString)
+        return routed
+    }
+
+    /// Produces a snapshot from the accumulated buffer: lenient-close → parse
+    /// `fields`, and attempt a clean decode of `T` from the *raw* (un-closed)
+    /// buffer. `nonisolated` so the parse/decode runs off the main actor.
+    nonisolated static func makeSnapshot<T: Decodable & Sendable>(
+        _ type: T.Type,
+        from buffer: String
+    ) async -> PartialSnapshot<T> {
+        let fields = parseFields(from: buffer)
+        let decoded = decodeClean(T.self, from: buffer)
+        return PartialSnapshot(fields: fields, decoded: decoded, rawText: buffer)
+    }
+
+    /// Best-effort partial-field parse. Extracts the leading JSON object from the
+    /// buffer (tolerating prose/fences via ``extractJSON(from:)``), leniently
+    /// closes it, and decodes to a `[String: JSONSchemaValue]`. Returns empty
+    /// when nothing parses yet.
+    nonisolated static func parseFields(from buffer: String) -> [String: JSONSchemaValue] {
+        let candidate = extractJSON(from: buffer)
+        guard let closed = LenientJSONCloser.close(candidate),
+              let data = closed.data(using: .utf8) else {
+            return [:]
+        }
+        do {
+            let value = try JSONDecoder().decode(JSONSchemaValue.self, from: data)
+            if case .object(let dict) = value { return dict }
+            return [:]
+        } catch {
+            // Partial buffers frequently fail to parse mid-stream — that is the
+            // expected steady state, not an error worth logging on every token.
+            return [:]
+        }
+    }
+
+    /// Attempts a clean decode of `T` from the raw buffer with no lenient close.
+    /// Returns `nil` until the buffer holds a complete, valid document — so
+    /// ``PartialSnapshot/decoded`` never reflects guessed structure.
+    nonisolated static func decodeClean<T: Decodable & Sendable>(
+        _ type: T.Type,
+        from buffer: String
+    ) -> T? {
+        let candidate = extractJSON(from: buffer)
+        guard let data = candidate.data(using: .utf8) else { return nil }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/ManifoldInference/Services/LenientJSONCloser.swift
+++ b/Sources/ManifoldInference/Services/LenientJSONCloser.swift
@@ -1,0 +1,290 @@
+import Foundation
+
+/// Closes a possibly-truncated JSON string so a partial streaming buffer parses.
+///
+/// As structured output streams in token by token, the accumulated buffer is
+/// almost always mid-document: an unterminated string, a trailing `:` or `,`, a
+/// half-written number, or unbalanced `{`/`[`. ``close(_:)`` walks the buffer
+/// once, tracking string/escape state and the open-container stack, then appends
+/// the minimal suffix that makes it valid JSON — dropping any dangling partial
+/// token first.
+///
+/// This is the core of partial/snapshot typed streaming (#1917): the closed
+/// string is parsed into ``PartialSnapshot/fields`` so SwiftUI can render the
+/// object as it fills. It is deliberately *not* used to decode the final typed
+/// value — that always comes from the raw, complete buffer — so a synthetically
+/// closed string never produces a misleading `decoded` value.
+enum LenientJSONCloser {
+
+    /// Returns a parseable JSON string for `partial`, or `nil` when not even a
+    /// best-effort close yields something parseable (e.g. empty input, or a
+    /// buffer that has not yet reached an opening `{`/`[`).
+    ///
+    /// Handles:
+    /// - open string → close the quote;
+    /// - trailing `:` (key with no value) → drop the key and its quote;
+    /// - trailing `,` → drop it;
+    /// - mid-number / mid-literal (`true`/`false`/`null` prefix) → drop the
+    ///   partial token;
+    /// - unbalanced `{`/`[` → close in LIFO order.
+    static func close(_ partial: String) -> String? {
+        let trimmed = partial.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let firstOpen = trimmed.firstIndex(where: { $0 == "{" || $0 == "[" }) else {
+            // Nothing structural yet — a bare partial scalar isn't a useful
+            // snapshot. Let the caller treat it as "no fields yet".
+            return nil
+        }
+
+        // Scan from the first opener so leading prose/fence text is ignored.
+        let scanRegion = String(trimmed[firstOpen...])
+
+        var stack: [Character] = []        // open containers, '{' or '['
+        var inString = false
+        var escaped = false
+        // Index (into `chars`) just past the last byte we want to keep. We may
+        // rewind it to drop a dangling partial token.
+        let chars = Array(scanRegion)
+        var keepCount = chars.count
+
+        // Track where the current top-level-ish value token started so we can
+        // drop a half-written number/literal. We only need the last value-start
+        // outside of strings; reset on structural punctuation.
+        var lastValueStart: Int? = nil
+        // True once we've seen a ':' or container-open or ',' and are awaiting a
+        // value (so a trailing partial scalar there is droppable).
+        var awaitingValue = false
+
+        var i = 0
+        while i < chars.count {
+            let c = chars[i]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if c == "\\" {
+                    escaped = true
+                } else if c == "\"" {
+                    inString = false
+                }
+                i += 1
+                continue
+            }
+            switch c {
+            case "\"":
+                inString = true
+                lastValueStart = i
+                awaitingValue = false
+            case "{":
+                stack.append("{")
+                lastValueStart = nil
+                awaitingValue = false
+            case "[":
+                stack.append("[")
+                lastValueStart = nil
+                awaitingValue = true
+            case "}", "]":
+                if !stack.isEmpty { stack.removeLast() }
+                lastValueStart = nil
+                awaitingValue = false
+            case ":":
+                lastValueStart = nil
+                awaitingValue = true
+            case ",":
+                lastValueStart = nil
+                awaitingValue = true
+            case " ", "\t", "\n", "\r":
+                break
+            default:
+                // Start of a number / literal value token.
+                if lastValueStart == nil { lastValueStart = i }
+            }
+            i += 1
+        }
+
+        var result = ""
+
+        if inString {
+            // Unterminated string: close the quote. If a backslash was pending,
+            // drop it first so we don't emit a dangling escape.
+            if escaped {
+                keepCount = chars.count - 1
+            }
+            result = String(chars[0..<keepCount]) + "\""
+        } else {
+            // If we're sitting on a half-written number/literal that isn't a
+            // complete value, drop it. A value token is "complete enough" only
+            // if it parses as a JSON scalar on its own.
+            if let start = lastValueStart, start < chars.count {
+                let tokenText = String(chars[start...]).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !tokenText.isEmpty && !isCompleteScalar(tokenText) {
+                    keepCount = start
+                }
+            }
+            var kept = String(chars[0..<keepCount])
+            // Drop trailing structural punctuation that can't be followed by a
+            // close: a dangling key-colon or comma.
+            kept = dropTrailingDanglingPunctuation(kept)
+            result = kept
+        }
+
+        // Close any still-open containers in LIFO order.
+        for opener in stack.reversed() {
+            result.append(opener == "{" ? "}" : "]")
+        }
+
+        _ = awaitingValue  // documented intent; punctuation drop covers the cases
+        return result
+    }
+
+    /// Removes a trailing `:` (with its key) or `,` left dangling by a partial
+    /// buffer, so the close suffix produces valid JSON.
+    private static func dropTrailingDanglingPunctuation(_ s: String) -> String {
+        var chars = Array(s)
+        // Strip trailing whitespace first.
+        while let last = chars.last, last == " " || last == "\n" || last == "\t" || last == "\r" {
+            chars.removeLast()
+        }
+        guard let last = chars.last else { return String(chars) }
+        if last == "," {
+            chars.removeLast()
+        } else if last == ":" {
+            // Drop the colon, then the preceding string key (its quotes too) so
+            // we don't leave a key with no value.
+            chars.removeLast()
+            while let c = chars.last, c == " " || c == "\n" || c == "\t" || c == "\r" {
+                chars.removeLast()
+            }
+            // Remove the quoted key.
+            if chars.last == "\"" {
+                chars.removeLast()
+                var escaped = false
+                while let c = chars.last {
+                    chars.removeLast()
+                    if escaped {
+                        escaped = false
+                    } else if c == "\\" {
+                        escaped = true
+                    } else if c == "\"" {
+                        break
+                    }
+                }
+            }
+            // Drop a now-dangling comma left before the removed key.
+            while let c = chars.last, c == " " || c == "\n" || c == "\t" || c == "\r" {
+                chars.removeLast()
+            }
+            if chars.last == "," { chars.removeLast() }
+        }
+        return String(chars)
+    }
+
+    /// Whether `token` is a complete JSON scalar (number, `true`/`false`/`null`).
+    /// A bare prefix like `4` or `tr` mid-stream returns the same way `4` does —
+    /// so we only treat it as complete when it parses as a standalone scalar.
+    private static func isCompleteScalar(_ token: String) -> Bool {
+        if token == "true" || token == "false" || token == "null" { return true }
+        // A number is "complete" only if it's a fully-formed numeric literal and
+        // not obviously mid-token (no trailing '.', 'e', '+', '-', 'E').
+        if let last = token.last, ".eE+-".contains(last) { return false }
+        guard let data = token.data(using: .utf8) else { return false }
+        // JSONSerialization with .fragmentsAllowed accepts a bare scalar.
+        do {
+            _ = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+/// Detects completed elements of a top-level JSON array from a streaming token
+/// feed and yields each element's exact text.
+///
+/// Drives ``InferenceService/streamEach(_:to:config:)``: the model emits a JSON
+/// array, and this extractor — fed each token via ``consume(_:)`` — returns the
+/// substring of every element the moment its matching close lands. Tracks the
+/// top-level `[`, then per-element brace/bracket depth, string state, and
+/// escapes so commas/brackets inside strings or nested objects don't split an
+/// element early.
+struct TopLevelArrayElementExtractor {
+    private var buffer: [Character] = []
+    private var sawArrayOpen = false
+    private var depth = 0          // depth INSIDE the array (nested containers)
+    private var inString = false
+    private var escaped = false
+    private var elementStart: Int? = nil
+
+    /// Feeds a token fragment and returns the text of any elements completed by
+    /// it. Usually empty; non-empty when one or more closing delimiters arrive.
+    mutating func consume(_ fragment: String) -> [String] {
+        var completed: [String] = []
+        for c in fragment {
+            buffer.append(c)
+            let idx = buffer.count - 1
+
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if c == "\\" {
+                    escaped = true
+                } else if c == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            switch c {
+            case "\"":
+                inString = true
+                if sawArrayOpen && depth == 0 && elementStart == nil {
+                    elementStart = idx
+                }
+            case "[":
+                if !sawArrayOpen {
+                    sawArrayOpen = true
+                } else {
+                    if depth == 0 && elementStart == nil { elementStart = idx }
+                    depth += 1
+                }
+            case "{":
+                if sawArrayOpen {
+                    if depth == 0 && elementStart == nil { elementStart = idx }
+                    depth += 1
+                }
+            case "}":
+                if sawArrayOpen && depth > 0 { depth -= 1 }
+            case "]":
+                if sawArrayOpen {
+                    if depth > 0 {
+                        depth -= 1
+                    } else {
+                        // Closing the top-level array — flush any element in
+                        // progress (a trailing scalar without a comma).
+                        if let start = elementStart {
+                            let text = String(buffer[start..<idx])
+                                .trimmingCharacters(in: .whitespacesAndNewlines)
+                            if !text.isEmpty { completed.append(text) }
+                            elementStart = nil
+                        }
+                        sawArrayOpen = false
+                    }
+                }
+            case ",":
+                if sawArrayOpen && depth == 0 {
+                    if let start = elementStart {
+                        let text = String(buffer[start..<idx])
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !text.isEmpty { completed.append(text) }
+                    }
+                    elementStart = nil
+                }
+            default:
+                // Start of a scalar element (number / literal).
+                if sawArrayOpen && depth == 0 && elementStart == nil
+                    && c != " " && c != "\n" && c != "\t" && c != "\r" {
+                    elementStart = idx
+                }
+            }
+        }
+        return completed
+    }
+}

--- a/Tests/ManifoldInferenceTests/InferenceServiceStreamObjectTests.swift
+++ b/Tests/ManifoldInferenceTests/InferenceServiceStreamObjectTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for partial/snapshot typed streaming via `streamObject` / `streamEach`
+/// and the `LenientJSONCloser` core (#1917).
+@MainActor
+final class InferenceServiceStreamObjectTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private struct Person: Decodable, Sendable, SchemaProviding, Equatable {
+        let name: String
+        let age: Int
+
+        static var jsonSchema: JSONSchemaValue {
+            .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "name": .object(["type": .string("string")]),
+                    "age": .object(["type": .string("integer")]),
+                ]),
+                "required": .array([.string("name"), .string("age")]),
+            ])
+        }
+    }
+
+    /// Weak caps so the router takes the prompt-fallback path and the backend
+    /// just streams `tokensToYield` verbatim.
+    private func weakCapabilities() -> BackendCapabilities {
+        BackendCapabilities(
+            supportsStructuredOutput: false,
+            supportsGrammarConstrainedSampling: false,
+            supportsGuidedStructuredOutput: false
+        )
+    }
+
+    private func charTokens(_ s: String) -> [String] { s.map { String($0) } }
+
+    private func makeService(tokens: [String]) -> (InferenceService, MockInferenceBackend) {
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = tokens
+        let service = InferenceService(backend: backend, name: "Mock")
+        return (service, backend)
+    }
+
+    // MARK: - (a) Incremental snapshot fill
+
+    func test_streamObject_fillsFieldsIncrementally_andDecodesFinal() async throws {
+        let json = #"{"name":"Ada","age":42}"#
+        let (service, _) = makeService(tokens: charTokens(json))
+
+        var snapshots: [PartialSnapshot<Person>] = []
+        for try await snap in service.streamObject(Person.self, to: "Who?") {
+            snapshots.append(snap)
+        }
+
+        XCTAssertFalse(snapshots.isEmpty, "expected at least one snapshot")
+
+        // `name` must appear in fields before `age` ever does — the whole point
+        // of partial snapshots.
+        let firstNameIdx = snapshots.firstIndex { $0.fields["name"] != nil }
+        let firstAgeIdx = snapshots.firstIndex { $0.fields["age"] != nil }
+        let nameIdx = try XCTUnwrap(firstNameIdx, "name never parsed into fields")
+        let ageIdx = try XCTUnwrap(firstAgeIdx, "age never parsed into fields")
+        XCTAssertLessThan(nameIdx, ageIdx, "name should fill before age")
+
+        // No intermediate snapshot decodes; only the final, complete buffer does.
+        let decodedCount = snapshots.filter { $0.decoded != nil }.count
+        XCTAssertGreaterThanOrEqual(decodedCount, 1, "final snapshot must decode")
+
+        let final = try XCTUnwrap(snapshots.last)
+        XCTAssertEqual(final.decoded, Person(name: "Ada", age: 42))
+        XCTAssertEqual(final.rawText, json)
+        XCTAssertEqual(final.fields["name"], .string("Ada"))
+        XCTAssertEqual(final.fields["age"], .integer(42))
+    }
+
+    // MARK: - (b) Lenient close yields a partial, not a throw
+
+    func test_streamObject_midStringAndMidNumber_yieldPartialFieldsNoThrow() async throws {
+        // Buffer ends mid-string then mid-number across the token feed; the
+        // stream must produce snapshots and not throw.
+        let json = #"{"name":"Grace","age":85}"#
+        let (service, _) = makeService(tokens: charTokens(json))
+
+        var midStringHadName = false
+        var snapshots: [PartialSnapshot<Person>] = []
+        for try await snap in service.streamObject(Person.self, to: "Who?") {
+            snapshots.append(snap)
+            // After "Gra (open string), lenient close should still surface name.
+            if snap.rawText == #"{"name":"Gra"# || snap.rawText.hasPrefix(#"{"name":"Gra"#) {
+                if snap.fields["name"] != nil { midStringHadName = true }
+            }
+        }
+
+        XCTAssertTrue(midStringHadName, "mid-string buffer should leniently close to a parseable partial")
+        XCTAssertEqual(snapshots.last?.decoded, Person(name: "Grace", age: 85))
+    }
+
+    func test_lenientCloser_handlesTruncations() {
+        // Open string → closed quote, parseable.
+        let openString = LenientJSONCloser.close(#"{"name":"Ad"#)
+        XCTAssertNotNil(openString)
+        XCTAssertEqual(openString, #"{"name":"Ad"}"#)
+
+        // Trailing colon (key, no value) → key dropped.
+        let danglingColon = LenientJSONCloser.close(#"{"name":"Ada","age":"#)
+        XCTAssertEqual(danglingColon, #"{"name":"Ada"}"#)
+
+        // Trailing comma → dropped.
+        let danglingComma = LenientJSONCloser.close(#"{"name":"Ada","#)
+        XCTAssertEqual(danglingComma, #"{"name":"Ada"}"#)
+
+        // Mid-number → partial token dropped, then key dropped (no value left).
+        let midNumber = LenientJSONCloser.close(#"{"name":"Ada","age":4"#)
+        let mn = try? JSONSerialization.jsonObject(with: Data((midNumber ?? "").utf8))
+        XCTAssertNotNil(mn, "mid-number close must be parseable; got \(midNumber ?? "nil")")
+
+        // Unbalanced nested containers close in order.
+        let nested = LenientJSONCloser.close(#"{"a":[1,2,{"b":"c"#)
+        let n = try? JSONSerialization.jsonObject(with: Data((nested ?? "").utf8))
+        XCTAssertNotNil(n, "nested close must be parseable; got \(nested ?? "nil")")
+
+        // Pre-structural buffer → nil.
+        XCTAssertNil(LenientJSONCloser.close("Sure, here you go"))
+    }
+
+    // MARK: - (c) streamEach collection mode
+
+    func test_streamEach_yieldsOneDecodedObjectPerElement() async throws {
+        let arr = #"[{"name":"Ada","age":42},{"name":"Grace","age":85},{"name":"Bob","age":7}]"#
+        let (service, _) = makeService(tokens: charTokens(arr))
+
+        var collected: [Person] = []
+        for try await person in service.streamEach(Person.self, to: "List people") {
+            collected.append(person)
+        }
+
+        XCTAssertEqual(collected, [
+            Person(name: "Ada", age: 42),
+            Person(name: "Grace", age: 85),
+            Person(name: "Bob", age: 7),
+        ])
+    }
+
+    func test_streamEach_handlesCommasInsideStrings() async throws {
+        // A comma inside a string value must NOT split the element early.
+        let arr = #"[{"name":"Ada, Lovelace","age":42},{"name":"Bob","age":7}]"#
+        let (service, _) = makeService(tokens: charTokens(arr))
+
+        var collected: [Person] = []
+        for try await person in service.streamEach(Person.self, to: "List") {
+            collected.append(person)
+        }
+
+        XCTAssertEqual(collected, [
+            Person(name: "Ada, Lovelace", age: 42),
+            Person(name: "Bob", age: 7),
+        ])
+    }
+
+    // MARK: - (d) Cancellation mid-stream stops cleanly
+
+    func test_streamObject_cancellationMidStream_stopsCleanly() async throws {
+        let json = #"{"name":"Ada","age":42}"#
+        let backend = MockInferenceBackend(capabilities: weakCapabilities())
+        backend.isModelLoaded = true
+        backend.tokensToYield = charTokens(json)
+        let gate = TokenEmissionGate()
+        backend.tokenEmissionGate = gate
+        let service = InferenceService(backend: backend, name: "Mock")
+
+        let stream = service.streamObject(Person.self, to: "Who?")
+        var iterator = stream.makeAsyncIterator()
+
+        // Release one token deterministically, then pull exactly one snapshot.
+        await gate.advance()
+        let first = try await iterator.next()
+        XCTAssertNotNil(first, "expected first snapshot after one token")
+
+        // Drop the iterator → onTermination cancels the driving task. Releasing
+        // the gate lets the backend's emission task observe cancellation and
+        // exit without yielding the rest.
+        iterator = stream.makeAsyncIterator()  // detach from the original
+        await gate.release()
+
+        // No crash / hang — the producing task tears down cleanly. Reaching here
+        // is the assertion.
+        XCTAssertTrue(true)
+    }
+
+    // MARK: - (e) Sabotage (run manually, then keep disabled)
+
+    /// SABOTAGE (verified, then disabled): replacing the lenient-close call in
+    /// `parseFields` with a no-op (`return [:]` before parsing) makes every
+    /// intermediate snapshot carry empty `fields` — only the final, complete
+    /// buffer parses cleanly into fields, so `firstNameIdx < firstAgeIdx` in
+    /// `test_streamObject_fillsFieldsIncrementally_andDecodesFinal` collapses
+    /// (both nil → XCTUnwrap fails). Confirmed the incremental path is live.
+    /// Likewise, breaking `TopLevelArrayElementExtractor.consume` to never flush
+    /// on `,` yields the whole array as one (undecodable) element →
+    /// `test_streamEach_yieldsOneDecodedObjectPerElement` collects 0 objects.
+    func test_sabotage_documentation_only() {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary

Partial/snapshot typed streaming for structured output (#1917). As a structured-output generation streams, callers get progressively-filled typed snapshots instead of raw token deltas — better SwiftUI DX for "render the object as it fills in."

## New public surface (`Sources/ManifoldInference/Services/InferenceService+StreamObject.swift`)

```swift
public struct PartialSnapshot<T: Decodable & Sendable>: Sendable {
    public let fields: [String: JSONSchemaValue]  // best-effort parsed-so-far
    public let decoded: T?                         // non-nil once the raw buffer decodes cleanly
    public let rawText: String                     // accumulated buffer
}

extension InferenceService {
    public func streamObject<T: Decodable & Sendable & SchemaProviding>(
        _ type: T.Type, to prompt: String, config: GenerationConfig = .init()
    ) -> AsyncThrowingStream<PartialSnapshot<T>, Error>

    public func streamEach<T: Decodable & Sendable & SchemaProviding>(
        _ type: T.Type, to prompt: String, config: GenerationConfig = .init()
    ) -> AsyncThrowingStream<T, Error>
}
```

- **`streamObject`**: on each `.token` delta, append to a JSON buffer, run a lenient-close step, parse `fields`, attempt a clean decode of `T` from the *raw* (un-closed) buffer; yield a `PartialSnapshot`. `decoded` becomes non-nil once the raw buffer parses cleanly — never from a synthetically-closed buffer, so it never reflects guessed structure.
- **`streamEach`**: detects top-level JSON array element boundaries (string-aware, brace/bracket depth) and yields one decoded `T` per completed element.

Both reuse `respond`'s schema-staging (`routedStructuredConfig`) so they route through the same `StructuredOutputRouter` wiring at the queue chokepoint. v1 uses the uniform lenient-reparse path for **all** backends.

## How the lenient JSON closer works (`LenientJSONCloser.swift`)

`LenientJSONCloser.close(_:)` walks a possibly-truncated buffer once, tracking string/escape state and the open-container stack, then appends the minimal valid suffix. Handles: open string (close quote), trailing `:` (drop key + colon), trailing `,` (drop), mid-number/mid-literal (drop the partial token unless it's already a complete scalar), unbalanced `{`/`[` (close LIFO). Returns `nil` before the buffer reaches an opening `{`/`[`. The companion `TopLevelArrayElementExtractor` drives `streamEach`.

## Frozen `GenerationEvent` NOT touched

The `GenerationEvent` enum is frozen for 1.0 (documented at `GenerationEvent.swift:9-24`). **No case was added.** Snapshots travel on a dedicated side-channel `AsyncThrowingStream` returned by `streamObject`/`streamEach`. The driving `Task` inherits `@MainActor` (never `Task.detached`); parse/decode run `nonisolated` off-actor.

The fully-typed, macro-synthesized `PartiallyGenerated<T>` (all-optional fields) is explicitly **out of scope** — a v2 follow-up. v1 ships the untyped `PartialSnapshot<T>` with `decoded: T?`. Foundation's native Apple snapshot stream is also a follow-up; v1 uses the uniform path.

## Tests (`Tests/ManifoldInferenceTests/InferenceServiceStreamObjectTests.swift`)

- (a) char-by-char `{\"name\":\"Ada\",\"age\":42}` → `name` fills before `age`; final snapshot `decoded == Person(name:\"Ada\", age:42)`.
- (b) lenient-close: mid-string / mid-number / trailing colon / trailing comma / nested unbalanced → parseable partials, no throw; pre-structural buffer → `nil`.
- (c) `streamEach`: streamed array → one decoded object per element; comma-inside-string does not split early.
- (d) cancellation mid-stream (gated token emission) tears down cleanly.
- (e) sabotage documented (verified, then disabled): no-op lenient close collapses incremental fill; non-flushing extractor yields 0 objects.

## Verification

- `swift build --build-tests --traits Server,Macros` — **Build complete**.
- `swift test --filter ManifoldInferenceTests` — **1541 tests, 0 failures** (includes `SilentCatchAuditTest`; all error paths use do/catch).
- New public types are additive → API-break gate safe (no allowlist entry).

Closes #1917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)