### PR TITLE
feat: user-settable stop sequences (GenerationConfig.stopSequences) honored by cloud backends

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -119,3 +119,4 @@ API breakage: func CloudMessageEncoder.encodeTools(_:) has been renamed to func 
 API breakage: func CloudMessageEncoder.claudeEncodeToolDefinition(_:) has been renamed to func claudeEncodeToolDefinition(_:strict:)
 API breakage: func OpenAIToolEncoding.encodeToolDefinition(_:) has been renamed to func encodeToolDefinition(_:strict:)
 API breakage: enumelement StructuredOutputError.reaskBudgetExhausted has been added as a new enum case
+API breakage: constructor GenerationConfig.init(temperature:topP:repeatPenalty:topK:typicalP:minP:repetitionPenalty:repetitionContextSize:presencePenalty:presenceContextSize:frequencyPenalty:frequencyContextSize:llamaDRY:llamaXTC:llamaMirostatV2:seed:maxOutputTokens:tools:toolChoice:maxThinkingTokens:jsonMode:streamPrefillProgress:thinkingMarkers:maxToolIterations:maxRunTokens:grammar:structuredOutput:yieldEveryNTokens:requiredCapabilities:) has been removed

--- a/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
+++ b/Sources/ManifoldCloudSaaS/ClaudeBackend.swift
@@ -365,6 +365,12 @@ public final class ClaudeBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             "temperature": config.temperature,
             "top_p": config.topP
         ]
+        // User-settable stop sequences (#1944). Anthropic uses `stop_sequences`;
+        // emit only when non-empty to preserve the prior payload shape for
+        // callers that never set stops.
+        if !config.stopSequences.isEmpty {
+            body["stop_sequences"] = config.stopSequences
+        }
 
         // Snapshot cache policy under the lock once so the rest of the build
         // is consistent even if another thread toggles it concurrently.

--- a/Sources/ManifoldCloudSaaS/OpenAIBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIBackend.swift
@@ -365,6 +365,11 @@ public final class OpenAIBackend: SSECloudBackend, TokenUsageProvider, EndpointB
             "top_p": config.topP,
             "max_tokens": config.maxOutputTokens ?? 2048
         ]
+        // User-settable stop sequences (#1944). Emit only when non-empty so
+        // callers that never set stops keep the prior payload shape.
+        if !config.stopSequences.isEmpty {
+            body["stop"] = config.stopSequences
+        }
         // Strict structured output (#1918): an explicit
         // `.jsonSchema(schema)` request, gated on the backend's
         // strict-schema capability, takes precedence over plain `jsonMode`.

--- a/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
@@ -267,12 +267,14 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             "top_p": config.topP,
             "max_output_tokens": config.maxOutputTokens ?? 2048
         ]
-        // User-settable stop sequences (#1944). The Responses API accepts a
-        // top-level `stop` array; emit only when non-empty to preserve the
-        // prior payload shape for callers that never set stops.
-        if !config.stopSequences.isEmpty {
-            body["stop"] = config.stopSequences
-        }
+        // User-settable stop sequences (#1944) are deliberately NOT emitted here.
+        // The OpenAI Responses API does not support a stop-sequence parameter:
+        // sending top-level `stop` returns 400 "Unknown parameter: 'stop'. Did you
+        // mean 'store'?" (verified against the OpenAI Responses reference + the
+        // "Does Responses API support `stop` parameter or not?" developer-forum
+        // thread, 2026-06). Chat Completions keeps `stop`; Responses callers that
+        // set GenerationConfig.stopSequences simply get no stop field on the wire
+        // rather than an invalid one that 400s on strict providers.
 
         // Tools — same `[{type:"function", function:{...}}]` envelope as Chat
         // Completions, plus the matching `tool_choice` policy.

--- a/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
+++ b/Sources/ManifoldCloudSaaS/OpenAIResponsesBackend.swift
@@ -267,6 +267,12 @@ public final class OpenAIResponsesBackend: SSECloudBackend, TokenUsageProvider, 
             "top_p": config.topP,
             "max_output_tokens": config.maxOutputTokens ?? 2048
         ]
+        // User-settable stop sequences (#1944). The Responses API accepts a
+        // top-level `stop` array; emit only when non-empty to preserve the
+        // prior payload shape for callers that never set stops.
+        if !config.stopSequences.isEmpty {
+            body["stop"] = config.stopSequences
+        }
 
         // Tools — same `[{type:"function", function:{...}}]` envelope as Chat
         // Completions, plus the matching `tool_choice` policy.

--- a/Sources/ManifoldContract/InferenceBackend.swift
+++ b/Sources/ManifoldContract/InferenceBackend.swift
@@ -286,6 +286,15 @@ public struct GenerationConfig: Sendable, Codable {
     /// Defaults to `nil` (no grammar constraint).
     public var grammar: String?
 
+    /// User-settable stop sequences: strings that, when generated, end the turn.
+    ///
+    /// Each backend that supports stop strings forwards these to its provider
+    /// (e.g. OpenAI `stop`, Anthropic `stop_sequences`, Ollama `options.stop`).
+    /// Empty (the default) means "use the model/backend defaults" — no stop
+    /// field is sent, preserving existing payload shapes for callers that never
+    /// set it.
+    public var stopSequences: [String] = []
+
     /// Routed structured-output strategy for this generation request.
     ///
     /// Runtime-only hint: callers can use ``StructuredOutputRouter`` to choose a
@@ -413,6 +422,7 @@ public struct GenerationConfig: Sendable, Codable {
         maxToolIterations: Int = 10,
         maxRunTokens: Int? = nil,
         grammar: String? = nil,
+        stopSequences: [String] = [],
         structuredOutput: StructuredOutputStrategy? = nil,
         yieldEveryNTokens: Int = 8,
         requiredCapabilities: Set<GenerationCapabilityRequirement> = []
@@ -443,6 +453,7 @@ public struct GenerationConfig: Sendable, Codable {
         self.maxToolIterations = max(1, maxToolIterations)
         self.maxRunTokens = maxRunTokens
         self.grammar = grammar
+        self.stopSequences = stopSequences
         self.structuredOutput = structuredOutput
         self.yieldEveryNTokens = yieldEveryNTokens
         self.requiredCapabilities = requiredCapabilities
@@ -452,7 +463,7 @@ public struct GenerationConfig: Sendable, Codable {
 
     private enum CodingKeys: String, CodingKey {
         case temperature, topP, repeatPenalty, topK, typicalP, maxOutputTokens
-        case tools, toolChoice, maxThinkingTokens, maxToolIterations, grammar
+        case tools, toolChoice, maxThinkingTokens, maxToolIterations, grammar, stopSequences
         case yieldEveryNTokens
         case streamPrefillProgress
         case minP, repetitionPenalty, seed
@@ -491,6 +502,8 @@ public struct GenerationConfig: Sendable, Codable {
         // thinkingMarkers is a per-request runtime hint; it is not persisted.
         thinkingMarkers = nil
         grammar = try c.decodeIfPresent(String.self, forKey: .grammar)
+        // stopSequences landed after the original shape; absent from older payloads.
+        stopSequences = (try c.decodeIfPresent([String].self, forKey: .stopSequences)) ?? []
         // structuredOutput is a per-request runtime hint; it is not persisted.
         structuredOutput = nil
         // yieldEveryNTokens landed after the original shape; default to 8 when absent.
@@ -533,6 +546,10 @@ public struct GenerationConfig: Sendable, Codable {
         try c.encode(streamPrefillProgress, forKey: .streamPrefillProgress)
         try c.encode(maxToolIterations, forKey: .maxToolIterations)
         try c.encodeIfPresent(grammar, forKey: .grammar)
+        // Empty stopSequences means "unset"; omit the key to preserve the prior payload shape.
+        if !stopSequences.isEmpty {
+            try c.encode(stopSequences, forKey: .stopSequences)
+        }
         try c.encode(yieldEveryNTokens, forKey: .yieldEveryNTokens)
         try c.encodeIfPresent(minP, forKey: .minP)
         try c.encodeIfPresent(repetitionPenalty, forKey: .repetitionPenalty)

--- a/Sources/ManifoldOllama/OllamaBackend.swift
+++ b/Sources/ManifoldOllama/OllamaBackend.swift
@@ -666,6 +666,10 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
         if let presence = config.presencePenalty { options["presence_penalty"] = presence }
         if let frequency = config.frequencyPenalty { options["frequency_penalty"] = frequency }
         if let repWindow = config.repetitionContextSize { options["repeat_last_n"] = repWindow }
+        // User-settable stop sequences (#1944). Ollama accepts `options.stop`
+        // (array). Emit only when non-empty to keep wire payloads identical for
+        // callers that never set stops.
+        if !config.stopSequences.isEmpty { options["stop"] = config.stopSequences }
 
         // Ollama's modern `/api/chat` returns `tool_calls` inside
         // `message.tool_calls` on streaming NDJSON lines. Earlier versions

--- a/Tests/ManifoldBackendsTests/CloudStopSequencesTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudStopSequencesTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import Foundation
+@testable import ManifoldCloudSaaS
+@testable import ManifoldCloudCore
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Wire-contract tests for user-settable stop sequences (#1944, D1).
+///
+/// Each cloud SaaS encoder forwards ``GenerationConfig/stopSequences`` to its
+/// provider under the provider's own key — OpenAI Chat Completions `stop`,
+/// OpenAI Responses `stop`, Anthropic `stop_sequences` — and OMITS the key
+/// entirely when the caller left stops unset (empty), so payloads for existing
+/// callers stay byte-identical.
+///
+/// We drive `buildRequest(...)` directly: the field insertion is a pure
+/// payload-construction concern, so no live HTTP round-trip is required.
+final class CloudStopSequencesTests: XCTestCase {
+
+    private func jsonBody(from request: URLRequest) throws -> [String: Any] {
+        let body = try XCTUnwrap(request.httpBody, "request must carry an httpBody")
+        return try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any],
+            "request body did not parse as JSON object"
+        )
+    }
+
+    // MARK: - OpenAI Chat Completions: "stop"
+
+    func test_openAI_includesStop_whenSet() throws {
+        let backend = OpenAIBackend()
+        backend.configure(
+            baseURL: URL(string: "https://openai.test")!,
+            apiKey: "sk-test",
+            modelName: "gpt-4o"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "Hi",
+            systemPrompt: nil,
+            config: GenerationConfig(stopSequences: ["</s>", "User:"])
+        )
+
+        let json = try jsonBody(from: request)
+        XCTAssertEqual(json["stop"] as? [String], ["</s>", "User:"])
+    }
+
+    func test_openAI_omitsStop_whenEmpty() throws {
+        let backend = OpenAIBackend()
+        backend.configure(
+            baseURL: URL(string: "https://openai.test")!,
+            apiKey: "sk-test",
+            modelName: "gpt-4o"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "Hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let json = try jsonBody(from: request)
+        XCTAssertNil(json["stop"], "unset stops must not appear on the wire")
+    }
+
+    // MARK: - OpenAI Responses: "stop"
+
+    func test_openAIResponses_includesStop_whenSet() throws {
+        let backend = OpenAIResponsesBackend()
+        backend.configure(
+            baseURL: URL(string: "https://openai-responses.test")!,
+            apiKey: "sk-test",
+            modelName: "gpt-5"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "Hi",
+            systemPrompt: nil,
+            config: GenerationConfig(stopSequences: ["END"])
+        )
+
+        let json = try jsonBody(from: request)
+        XCTAssertEqual(json["stop"] as? [String], ["END"])
+    }
+
+    func test_openAIResponses_omitsStop_whenEmpty() throws {
+        let backend = OpenAIResponsesBackend()
+        backend.configure(
+            baseURL: URL(string: "https://openai-responses.test")!,
+            apiKey: "sk-test",
+            modelName: "gpt-5"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "Hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let json = try jsonBody(from: request)
+        XCTAssertNil(json["stop"], "unset stops must not appear on the wire")
+    }
+
+    // MARK: - Anthropic Claude: "stop_sequences"
+
+    func test_claude_includesStopSequences_whenSet() throws {
+        let backend = ClaudeBackend()
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "sk-ant-test",
+            modelName: "claude-sonnet-4-20250514"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "Hi",
+            systemPrompt: nil,
+            config: GenerationConfig(stopSequences: ["</s>", "\n\nHuman:"])
+        )
+
+        let json = try jsonBody(from: request)
+        XCTAssertEqual(json["stop_sequences"] as? [String], ["</s>", "\n\nHuman:"])
+    }
+
+    func test_claude_omitsStopSequences_whenEmpty() throws {
+        let backend = ClaudeBackend()
+        backend.configure(
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "sk-ant-test",
+            modelName: "claude-sonnet-4-20250514"
+        )
+
+        let request = try backend.buildRequest(
+            prompt: "Hi",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let json = try jsonBody(from: request)
+        XCTAssertNil(json["stop_sequences"], "unset stops must not appear on the wire")
+    }
+}

--- a/Tests/ManifoldBackendsTests/CloudStopSequencesTests.swift
+++ b/Tests/ManifoldBackendsTests/CloudStopSequencesTests.swift
@@ -9,9 +9,12 @@ import ManifoldTestSupport
 ///
 /// Each cloud SaaS encoder forwards ``GenerationConfig/stopSequences`` to its
 /// provider under the provider's own key — OpenAI Chat Completions `stop`,
-/// OpenAI Responses `stop`, Anthropic `stop_sequences` — and OMITS the key
-/// entirely when the caller left stops unset (empty), so payloads for existing
-/// callers stay byte-identical.
+/// Anthropic `stop_sequences` — and OMITS the key entirely when the caller left
+/// stops unset (empty), so payloads for existing callers stay byte-identical.
+///
+/// The OpenAI **Responses** API is the exception: it does not support a
+/// stop-sequence parameter (sending `stop` returns 400 "Unknown parameter:
+/// 'stop'"), so `OpenAIResponsesBackend` never emits one — verified below.
 ///
 /// We drive `buildRequest(...)` directly: the field insertion is a pure
 /// payload-construction concern, so no live HTTP round-trip is required.
@@ -63,9 +66,13 @@ final class CloudStopSequencesTests: XCTestCase {
         XCTAssertNil(json["stop"], "unset stops must not appear on the wire")
     }
 
-    // MARK: - OpenAI Responses: "stop"
+    // MARK: - OpenAI Responses: stop is UNSUPPORTED — never emitted
 
-    func test_openAIResponses_includesStop_whenSet() throws {
+    /// The Responses API rejects a top-level `stop` parameter (400 "Unknown
+    /// parameter: 'stop'"), so the backend must NOT send one even when the
+    /// caller sets stopSequences — sending an invalid field 400s strict
+    /// providers. See OpenAIResponsesBackend's buildRequest comment.
+    func test_openAIResponses_neverEmitsStop_evenWhenSet() throws {
         let backend = OpenAIResponsesBackend()
         backend.configure(
             baseURL: URL(string: "https://openai-responses.test")!,
@@ -80,7 +87,14 @@ final class CloudStopSequencesTests: XCTestCase {
         )
 
         let json = try jsonBody(from: request)
-        XCTAssertEqual(json["stop"] as? [String], ["END"])
+        XCTAssertNil(
+            json["stop"],
+            "Responses API does not support `stop`; sending it 400s"
+        )
+        XCTAssertNil(
+            json["stop_sequences"],
+            "Responses API has no stop-sequence field under any name"
+        )
     }
 
     func test_openAIResponses_omitsStop_whenEmpty() throws {

--- a/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaBackendTests.swift
@@ -253,6 +253,36 @@ struct OllamaBackendTests {
         #expect(json["format"] == nil)
     }
 
+    // MARK: - Stop sequences (#1944)
+
+    @Test func buildRequest_stopSequencesSet_addsOptionsStop() throws {
+        let (backend, _) = makeConfiguredBackend()
+        let request = try backend.buildRequest(
+            prompt: "hello",
+            systemPrompt: nil,
+            config: GenerationConfig(stopSequences: ["</s>", "User:"])
+        )
+
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        #expect((options["stop"] as? [String]) == ["</s>", "User:"])
+    }
+
+    @Test func buildRequest_stopSequencesEmpty_omitsOptionsStop() throws {
+        let (backend, _) = makeConfiguredBackend()
+        let request = try backend.buildRequest(
+            prompt: "hello",
+            systemPrompt: nil,
+            config: GenerationConfig()
+        )
+
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let options = try #require(json["options"] as? [String: Any])
+        #expect(options["stop"] == nil)
+    }
+
     // MARK: - Streaming
 
     @Test func streaming_yieldsTokens() async throws {

--- a/Tests/ManifoldInferenceTests/GenerationConfigTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationConfigTests.swift
@@ -412,4 +412,57 @@ final class GenerationConfigTests: XCTestCase {
         XCTAssertEqual(backend.lastConfig?.llamaXTC, LlamaXTCSamplerOptions(probability: 0.3))
         XCTAssertEqual(backend.lastConfig?.llamaMirostatV2, LlamaMirostatV2SamplerOptions(tau: 4.5))
     }
+
+    // MARK: - Stop sequences (#1944)
+
+    func test_defaultInit_stopSequences_isEmpty() {
+        XCTAssertEqual(GenerationConfig().stopSequences, [])
+    }
+
+    func test_customInit_propagatesStopSequences() {
+        let config = GenerationConfig(stopSequences: ["</s>", "STOP"])
+        XCTAssertEqual(config.stopSequences, ["</s>", "STOP"])
+    }
+
+    func test_stopSequences_isMutable() {
+        var config = GenerationConfig()
+        config.stopSequences = ["\n\n"]
+        XCTAssertEqual(config.stopSequences, ["\n\n"])
+    }
+
+    func test_codableRoundtrip_preservesStopSequences() throws {
+        var original = GenerationConfig()
+        original.stopSequences = ["</s>", "User:"]
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertEqual(decoded.stopSequences, ["</s>", "User:"])
+    }
+
+    func test_codable_omitsStopSequencesWhenEmpty() throws {
+        // Empty means "unset" — keep it out of the wire payload to preserve the
+        // prior on-disk shape for callers that never set stops.
+        let data = try JSONEncoder().encode(GenerationConfig())
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNil(json["stopSequences"])
+    }
+
+    func test_codableDecode_legacyPayload_omittingStopSequences() throws {
+        let legacyJSON = """
+        {
+            "temperature": 0.7,
+            "topP": 0.9,
+            "repeatPenalty": 1.1,
+            "tools": [],
+            "toolChoice": {"type": "auto"},
+            "maxToolIterations": 10
+        }
+        """
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+
+        XCTAssertEqual(decoded.stopSequences, [])
+    }
 }


### PR DESCRIPTION
Advances #1944 (the D1 slice — does NOT close it).

## Problem
MK already declares a per-model `stopSequences` *capability*
(`SamplingParameterSet.stopSequences`), but there was no
`GenerationConfig.stopSequences` field for a user to set, and no backend sent
stop strings. The metadata advertised a capability the config layer couldn't
express. This closes that gap.

## What's covered (additive, non-breaking)
- **Contract:** new `public var stopSequences: [String]` on `GenerationConfig`
  (default `[]`; empty means "use the model/backend defaults"). Wired through
  the memberwise init (defaulted param — source-compatible), `CodingKeys`, and
  `Codable` (`decodeIfPresent ... ?? []`; omit-when-empty on encode so existing
  on-disk presets / wire payloads stay byte-identical).
- **Cloud encoders (core)** — each emits the field only when non-empty:
  - OpenAI Chat Completions (`OpenAIBackend`): `stop`
  - Anthropic Claude (`ClaudeBackend`): `stop_sequences` (top-level array)
  - Ollama (`OllamaBackend`): `options.stop`
  Each mirrors the existing conditional-field pattern in that adapter.
- **OpenAI Responses (`OpenAIResponsesBackend`): intentionally NOT emitted.**
  The Responses API does not support a stop-sequence parameter — sending a
  top-level `stop` returns 400 `Unknown parameter: 'stop'. Did you mean
  'store'?` (verified against the OpenAI Responses API reference and the
  "Does Responses API support `stop` parameter or not?" developer-forum
  thread, 2026-06). An earlier revision of this PR mirrored Chat Completions'
  `stop` on a guess; that field is dropped so Responses callers who set
  `stopSequences` get no stop field rather than a 400-inducing one. A test
  asserts the field is never sent under any name.

## Deferred
- **Local backends (llama.cpp / MLX)** live in the companion repos
  (manifold-llama / manifold-mlx) and are out of scope here. They already
  receive `stopSequences` via `GenerationConfig`; passing it to their samplers
  is an additive companion follow-up.
- **D2** (template-derived default stops) and **D3** (typed `Template`
  formatting consolidation) of #1944 remain open.

## Tests
- `GenerationConfig` Codable round-trips `stopSequences`, defaults to `[]`,
  omits the key when empty, and decodes legacy payloads to `[]`.
- Each cloud encoder includes the stop field with the right key/shape when set
  and omits it when empty (driven via `buildRequest`).
- Sabotage-checked per CLAUDE.md (Claude omit-when-empty + Contract round-trip
  both fail under sabotage), then removed before commit.

## Testing
Targeted suites only (`GenerationConfig`, `CloudStopSequences`, Ollama stop
tests) — all pass; `swift build --build-tests` succeeds. The orchestrator owns
the full gate.
