### PR TITLE
feat(hardware): public conservative KV-cache fallback constant (#1963)

### DIFF
--- a/Sources/ManifoldHardware/ModelLoadPlan.swift
+++ b/Sources/ManifoldHardware/ModelLoadPlan.swift
@@ -8,6 +8,27 @@ import Foundation
 /// load path sees the same authoritative context and verdict.
 public struct ModelLoadPlan: Sendable {
 
+    /// Conservative per-token KV-cache cost (bytes) for callers that build ``Inputs``
+    /// directly without GGUF metadata to read.
+    ///
+    /// Most app-side fit checks should prefer the fully-public, canonical pre-download
+    /// entry point ``estimate(for:requestedContextSize:environment:absoluteContextCeiling:headroomFraction:)``,
+    /// which derives the ``MemoryStrategy`` from ``DownloadableModel/modelType`` and applies
+    /// this fallback internally. Reach for this constant only when constructing an ``Inputs``
+    /// value by hand (e.g. a host serving a curated/recommended shelf with only manifest-level
+    /// fields) — it lets callers stay on the public surface instead of importing the
+    /// `@_spi(BackendInternals)` ``GGUFKVCacheEstimator``.
+    ///
+    /// This is the legacy 8 KB/token heuristic: conservative versus real grouped-query-attention
+    /// architectures (which are typically cheaper per token), so a verdict computed with it is at
+    /// least as strict as the post-download `compute(...)` path for the same inputs.
+    ///
+    /// Single source of truth — this aliases the SPI estimator's
+    /// `GGUFKVCacheEstimator.legacyFallbackBytesPerToken` so the public constant and the
+    /// internal heuristic can never drift (a unit test asserts the two stay equal).
+    public static let conservativeFallbackBytesPerToken: UInt64 =
+        GGUFKVCacheEstimator.legacyFallbackBytesPerToken
+
     /// The raw inputs a plan was computed from. Captured on the plan so callers can
     /// log, diff, or re-evaluate with different parameters without re-querying state.
     public struct Inputs: Sendable, Equatable {
@@ -306,6 +327,13 @@ public struct ModelLoadPlan: Sendable {
     }
 
     /// Pre-flight fit verdict for a `DownloadableModel` (browse-time, pre-download).
+    ///
+    /// **This is the canonical public entry point for pre-download memory-fit checks.** It needs
+    /// only manifest-level fields (`sizeBytes`, `modelType`) — no GGUF header — and applies the
+    /// conservative KV fallback internally, so callers never have to construct ``Inputs`` by hand.
+    /// Only when you genuinely must build an ``Inputs`` directly should you reach for the public
+    /// ``conservativeFallbackBytesPerToken`` constant instead of the `@_spi(BackendInternals)`
+    /// estimator.
     ///
     /// Unlike ``compute(for:requestedContextSize:environment:absoluteContextCeiling:headroomFraction:)``
     /// which consumes an on-disk ``ModelInfo`` (with GGUF metadata, detected context length,

--- a/Tests/ManifoldHardwareTests/ConservativeFallbackBytesPerTokenTests.swift
+++ b/Tests/ManifoldHardwareTests/ConservativeFallbackBytesPerTokenTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+// SPI import is needed only here, in the test — the whole point of the public
+// `ModelLoadPlan.conservativeFallbackBytesPerToken` constant (#1963) is that app
+// code never has to do this.
+@_spi(BackendInternals) import ManifoldHardware
+
+/// Guards the single-source-of-truth invariant for the public conservative KV-cache
+/// fallback (#1963): `ModelLoadPlan.conservativeFallbackBytesPerToken` must alias the
+/// `@_spi(BackendInternals)` heuristic `GGUFKVCacheEstimator.legacyFallbackBytesPerToken`
+/// so the public constant and the internal estimator can never drift.
+final class ConservativeFallbackBytesPerTokenTests: XCTestCase {
+
+    func testPublicConstantMatchesSPIEstimatorFallback() {
+        XCTAssertEqual(
+            ModelLoadPlan.conservativeFallbackBytesPerToken,
+            GGUFKVCacheEstimator.legacyFallbackBytesPerToken,
+            "Public fallback must stay equal to the SPI estimator's legacy fallback — they share a definition, so divergence means the alias was broken."
+        )
+    }
+}


### PR DESCRIPTION
## Summary
`GGUFKVCacheEstimator.legacyFallbackBytesPerToken` is `@_spi(BackendInternals)`, so app code that builds `ModelLoadPlan.Inputs` directly (e.g. a host serving a curated/recommended model shelf with only manifest-level fields) couldn't reach the conservative per-token KV fallback without coupling to the internal backend seam.

This implements option (b) from the issue:

- Adds `public static let ModelLoadPlan.conservativeFallbackBytesPerToken` (in `ManifoldHardware`), sourced from the existing SPI constant so the two are a **single source of truth** and can't drift.
- Adds a unit test asserting `ModelLoadPlan.conservativeFallbackBytesPerToken == GGUFKVCacheEstimator.legacyFallbackBytesPerToken` (the SPI import lives only in the test).
- Also implements option (a): documents `ModelLoadPlan.estimate(for: DownloadableModel ...)` as the canonical public pre-download fit entry point, pointing direct-`Inputs` builders at the new constant.

```swift
// Direct Inputs construction now stays on the public surface — no @_spi import:
let inputs = ModelLoadPlan.Inputs(
    modelFileSize: curated.sizeBytes,
    memoryStrategy: .mappable,
    requestedContextSize: 4096,
    trainedContextLength: nil,
    kvBytesPerToken: ModelLoadPlan.conservativeFallbackBytesPerToken,
    availableMemoryBytes: device.physicalMemoryBytes,
    physicalMemoryBytes: device.physicalMemoryBytes,
    absoluteContextCeiling: 128_000,
    headroomFraction: 0.40
)
```

Additive public surface only (no breaking changes).

## Test status
- `swift build --target ManifoldHardware` — passes
- `swift test --filter ConservativeFallbackBytesPerTokenTests` — 1 test, 0 failures

Closes #1963

🤖 Generated with [Claude Code](https://claude.com/claude-code)