### PR TITLE
docs: competitive-research docs batch — RAG/migration/positioning/MCP (#1940)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,20 @@ For a complete walkthrough (descriptor setup, lifecycle, and built-in catalog), 
 
 ManifoldKit also supports running as an **MCP server** — exposing your app's live state and tools to external MCP clients such as Claude Desktop, other agents, or any MCP-aware host. Import `ManifoldMCPHost` and follow the setup guide at `Sources/ManifoldMCPHost/ManifoldMCPHost.docc/Articles/MCPHostServer.md`. This is the entry point for agent-platform builders who want to surface their app's capabilities to the broader MCP ecosystem rather than consuming external tools.
 
+### MCP capability coverage
+
+Honest expectations — ManifoldKit's MCP surface is **tool-and-resource first**, with full OAuth 2.1. What ships today, verified against `Sources/ManifoldMCP` / `Sources/ManifoldMCPHost`:
+
+| Capability | Client (consume) | Host (expose) | Notes |
+|---|---|---|---|
+| **Tools** (`tools/list`, `tools/call`) | ✅ | ✅ | `MCPToolSource` / `MCPToolExecutor`; bridged into the `ToolRegistry`. |
+| **Resources** (`resources/list`, `resources/read`) | ✅ | ✅ | Client exposes `supportsResources`; host serves list + read. |
+| **Prompts** (`prompts/list`, `prompts/get`) | ⚠️ partial | ❌ | Capability is **detected** (`supportsPrompts`) but not yet consumed — no client call wired. |
+| **OAuth 2.1** | ✅ | — | Authorization-server discovery, token exchange, PKCE, secured token store. |
+| **Sampling** (`sampling/createMessage`) | ❌ | ❌ | Not implemented — the MCP surface is text-passthrough. Tracked in [#1925](https://github.com/roryford/ManifoldKit/issues/1925). |
+| **Elicitation** | ❌ | ❌ | Not implemented. Tracked in [#1926](https://github.com/roryford/ManifoldKit/issues/1926). |
+| **Transports** | stdio, streamable-HTTP (SSE) | stdio, streamable-HTTP | Both client and host support both transports. |
+
 ## Skills, Handoffs, and Hooks
 
 Three session-scoped extension points complement MCP for non-MCP hosts:
@@ -428,6 +442,8 @@ open Advanced.xcodeproj
 AnyLanguageModel is HuggingFace's Swift package — it mirrors Apple's `FoundationModels` API and exposes many providers behind a single protocol. ManifoldKit and AnyLanguageModel occupy adjacent niches: AnyLanguageModel optimises for provider coverage and API familiarity; ManifoldKit optimises for production reliability and drop-in chat UI (`ChatView` + `SessionListView` + `ModelManagementSheet` on day one). Pick the one whose axis matches the problem you're solving.
 
 ManifoldKit also **consumes** AnyLanguageModel as a backend: the `ManifoldAnyLanguageModel` product (the retired `AnyLanguageModel` trait's replacement since v0.48) is the supported path for providers without a native backend — Gemini, xAI, Groq, Mistral, OpenRouter, and any OpenAI/Anthropic-compatible endpoint — so they plug into the same `ChatViewModel` and runtime as a native backend. See [docs/PROVIDER-BRIDGE.md](docs/PROVIDER-BRIDGE.md) for the provider list, URL setup, and capability limits.
+
+Coming from Apple's `LanguageModelSession` / `@Generable` or AnyLanguageModel's provider abstraction? [docs/MIGRATING-FROM-FOUNDATION-MODELS.md](docs/MIGRATING-FROM-FOUNDATION-MODELS.md) maps those idioms onto ManifoldKit's `quickStart()` / `ChatViewModel` / `ToolDefinition` surface.
 
 ## Migrating from BaseChatKit
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Honest expectations — ManifoldKit's MCP surface is **tool-and-resource first**
 | Capability | Client (consume) | Host (expose) | Notes |
 |---|---|---|---|
 | **Tools** (`tools/list`, `tools/call`) | ✅ | ✅ | `MCPToolSource` / `MCPToolExecutor`; bridged into the `ToolRegistry`. |
-| **Resources** (`resources/list`, `resources/read`) | ✅ | ✅ | Client exposes `supportsResources`; host serves list + read. |
+| **Resources** (`resources/list`, `resources/read`) | ⚠️ partial | ✅ | Host serves list + read; client **detects** `supportsResources` but no outbound `resources/*` call is wired yet (only `tools/*` is consumed). |
 | **Prompts** (`prompts/list`, `prompts/get`) | ⚠️ partial | ❌ | Capability is **detected** (`supportsPrompts`) but not yet consumed — no client call wired. |
 | **OAuth 2.1** | ✅ | — | Authorization-server discovery, token exchange, PKCE, secured token store. |
 | **Sampling** (`sampling/createMessage`) | ❌ | ❌ | Not implemented — the MCP surface is text-passthrough. Tracked in [#1925](https://github.com/roryford/ManifoldKit/issues/1925). |

--- a/docs/MIGRATING-FROM-FOUNDATION-MODELS.md
+++ b/docs/MIGRATING-FROM-FOUNDATION-MODELS.md
@@ -1,0 +1,216 @@
+# Migrating from Apple Foundation Models / AnyLanguageModel
+
+If you already think in Apple's `LanguageModelSession` / `@Generable` idioms — or
+in HuggingFace **AnyLanguageModel**'s provider abstraction — this guide maps that
+mental model onto ManifoldKit's surface. The translation is mostly a level-up:
+ManifoldKit operates one altitude *above* a model-access library, so the session,
+tool, and structured-output concepts you know become the turn loop, the tool
+registry, and `GenerationConfig`.
+
+> **TL;DR.** A `LanguageModelSession` becomes a `ChatViewModel` (or a
+> `ConversationRuntime` if you want headless control). `session.respond(to:)`
+> becomes `chatVM.sendMessage(_:)`. Tools map onto `ToolDefinition` +
+> `ToolRegistry`. `@Generable` has **no macro equivalent yet** — use the raw
+> structured-output strategies (`GenerationConfig.structuredOutput`) and track
+> the ergonomic sugar in [#1915](https://github.com/roryford/ManifoldKit/issues/1915).
+
+---
+
+## Why migrate (and why not)
+
+Apple's `FoundationModels` framework is a single on-device system model with a
+clean session API. ManifoldKit **wraps that exact model** as one backend
+(`FoundationBackend`, iOS 26 / macOS 26+) and adds: many other backends behind
+one protocol, a persisted multi-session turn loop, drop-in SwiftUI, tool
+approval, RAG, and cloud providers. You migrate when you outgrow "one model, one
+session" and want a product surface; you stay on raw `FoundationModels` if you
+only ever need the system model and no persistence/UI.
+
+ManifoldKit does not *replace* AnyLanguageModel — it **consumes** it. Providers
+without a native ManifoldKit backend (Gemini, xAI, Groq, Mistral, OpenRouter)
+arrive through the [AnyLanguageModel bridge](PROVIDER-BRIDGE.md), so your
+AnyLanguageModel knowledge transfers directly to configuring those providers.
+
+---
+
+## Concept map
+
+| Apple `FoundationModels` / AnyLanguageModel | ManifoldKit equivalent | Notes |
+|---|---|---|
+| `LanguageModelSession` | `ChatViewModel` (UI) or `ConversationRuntime` (headless) | Persisted, multi-turn, multi-backend |
+| `session.respond(to:)` / `streamResponse(to:)` | `chatVM.sendMessage(_:)` | Streaming is built into the turn loop |
+| `SystemLanguageModel` (the model) | `InferenceBackend` (the protocol) + `FoundationBackend` (that model) | One of many backends |
+| AnyLanguageModel `LanguageModel` (provider abstraction) | `InferenceBackend` + the AnyLanguageModel **bridge** | MK consumes AnyLanguageModel as a backend |
+| `Tool` protocol / tool calling | `ToolDefinition` + `ToolRegistry` + `ToolExecutor` | Local **and** cloud, with approval gating |
+| `@Generable` / guided generation | `GenerationConfig.structuredOutput` (`.gbnf` / `.jsonSchema` / `.guided` / `.jsonPrompting`) | **No `@Generable` macro** — see below |
+| `GenerationOptions` (temperature, etc.) | `GenerationConfig` (temperature, topP, topK, …) | Same knobs, one struct |
+| Transcript / conversation history | `MessageStore` + `SessionStore` (SwiftData) | Persisted by default |
+
+---
+
+## 1. Session → ChatViewModel
+
+In `FoundationModels` you create a session and ask it to respond. In ManifoldKit
+the equivalent is `quickStart()`, which hands you a fully wired `ChatViewModel`
+backed by a persisted turn loop:
+
+```swift,no-build
+import ManifoldKit
+
+// FoundationModels:
+//   let session = LanguageModelSession()
+//   let reply = try await session.respond(to: "Summarise this.")
+
+// ManifoldKit:
+let result = try await ManifoldKit.quickStart()
+let chatVM = result.viewModel
+let reply = try await chatVM.sendMessage("Summarise this.")
+```
+
+`quickStart()` returns a `QuickStartResult` carrying the `viewModel`,
+`bootstrap`, and `sessionManager`. Drop the `viewModel` into your SwiftUI
+environment and present the shipped `ChatView`, or call `sendMessage(_:)`
+yourself for a headless flow. Unlike a `LanguageModelSession`, the conversation
+is **persisted** across launches via SwiftData — no transcript bookkeeping.
+
+For full control without the view model, drive `ConversationRuntime` directly —
+it owns `send`/`regenerate`/`edit`/`branch`/`cancel` through a single
+`processTurn(_:)` entry point taking a `TurnInput`. Most apps don't need this;
+`ChatViewModel` is the ergonomic session equivalent.
+
+---
+
+## 2. Picking the model = picking the backend
+
+`FoundationModels` gives you exactly one model. ManifoldKit's `FoundationBackend`
+wraps that same model, but it's one registrar among several:
+
+```swift,no-build
+import ManifoldKit
+import ManifoldFoundation   // FoundationBackends registrar (iOS 26 / macOS 26+)
+
+// Register only Apple's on-device model — closest to staying on FoundationModels:
+let result = try await ManifoldKit.quickStart(backends: [FoundationBackends.self])
+```
+
+`FoundationBackend` is gated `@available(iOS 26, macOS 26, *)`;
+`FoundationBackends.register(with:)` checks availability at call time and no-ops
+on older OSes, so it's safe to list unconditionally. Add other registrars
+(`OllamaBackends`, `CloudSaaSBackends`, the companion `LlamaBackends` /
+`MLXBackends`) to the array to offer more models behind the same `ChatViewModel`.
+
+To reach a provider AnyLanguageModel supports but ManifoldKit doesn't implement
+natively, add the bridge product and configure by URL scheme — see
+[PROVIDER-BRIDGE.md](PROVIDER-BRIDGE.md):
+
+```swift,no-build
+import ManifoldAnyLanguageModel
+
+// gemini://gemini-2.0-flash?apiKey=KEY  →  one InferenceBackend, same turn loop.
+let backend = AnyLanguageModelBackend()
+```
+
+---
+
+## 3. Tools
+
+Apple's `Tool` protocol and ManifoldKit's `ToolDefinition` express the same idea:
+a named, described, schema'd capability the model can call. ManifoldKit's version
+works across **every** backend (local and cloud) and adds human-in-the-loop
+approval.
+
+```swift,no-build
+import ManifoldKit
+
+let getWeather = ToolDefinition(
+    name: "get_weather",
+    description: "Look up the current weather for a city.",
+    parameters: .object([
+        "city": .string(description: "City name")
+    ])
+)
+```
+
+Register the definition with an executor in the `ToolRegistry`, and the turn loop
+calls it automatically — the same multi-step tool loop you'd hand-roll around
+`session.respond(to:)`. See [QUICKSTART-TOOLS.md](QUICKSTART-TOOLS.md) for the
+end-to-end registry + executor wiring, and [LOCAL-TOOL-CALLING.md](LOCAL-TOOL-CALLING.md)
+for how local GGUF/MLX models emit tool calls.
+
+> If you used Apple's `@Generable` purely to *describe a tool's arguments*,
+> ManifoldKit has the `@ToolSchema` macro (opt-in `Macros` trait) that generates
+> a `ToolDefinition`'s parameter schema from a Swift type. That is the **only**
+> `@Generable`-shaped macro in ManifoldKit today.
+
+---
+
+## 4. Structured output: `@Generable`'s honest mapping
+
+This is the one place where the translation is **not** one-to-one, so be precise.
+
+Apple's `@Generable` + guided generation gives you a *decoded Swift instance*
+straight from the model. **ManifoldKit has no `@Generable` macro and no
+`generate(as: MyType.self)` API.** What ships is the raw strategy layer on
+`GenerationConfig.structuredOutput`:
+
+```swift,no-build
+import ManifoldKit
+
+var config = GenerationConfig()
+
+// Constrain output with a JSON Schema document (capability-routed):
+config.structuredOutput = .jsonSchema(#"""
+{ "type": "object",
+  "properties": { "sentiment": { "enum": ["pos", "neg", "neutral"] } },
+  "required": ["sentiment"] }
+"""#)
+
+// Other strategies:
+//   .gbnf("root ::= ...")       — GBNF grammar (llama.cpp-class backends)
+//   .guided(MyType.self)        — Foundation guided-generation target type
+//   .jsonPrompting              — prompt-level JSON instruction fallback
+```
+
+`StructuredOutputRouter` picks the best mechanism the active backend supports
+(grammar-constrained decoding where available, falling back to `.jsonPrompting`).
+You then **decode the returned string yourself** (`JSONDecoder`) — ManifoldKit
+constrains the *generation*, but does not hand you a typed instance.
+
+> The `@Generable`/Codable → decoded-instance ergonomics are tracked in
+> [#1915](https://github.com/roryford/ManifoldKit/issues/1915). Until that
+> ships, do **not** expect `let x: MyType = try await ...generate(...)` — it
+> does not exist. Map `@Generable` onto the raw strategy above.
+
+---
+
+## 5. Generation options
+
+`GenerationOptions` → `GenerationConfig`. The sampling knobs you know
+(`temperature`, `topP`, `topK`, repetition penalties, `maxThinkingTokens`,
+`tools`, `toolChoice`, `maxToolIterations`) all live on the one
+`GenerationConfig` struct, set per turn.
+
+---
+
+## Migration checklist
+
+1. Replace `LanguageModelSession()` with `try await ManifoldKit.quickStart()`;
+   use `result.viewModel`.
+2. Replace `session.respond(to:)` with `chatVM.sendMessage(_:)`.
+3. To stay on Apple's model only, pass `backends: [FoundationBackends.self]`.
+4. Port `Tool`s to `ToolDefinition` + a `ToolRegistry` executor.
+5. Port `@Generable` to `GenerationConfig.structuredOutput` (raw strategy) +
+   manual `JSONDecoder` — no typed-instance API yet ([#1915]).
+6. For a non-native provider AnyLanguageModel supports, add the
+   [AnyLanguageModel bridge](PROVIDER-BRIDGE.md) and configure by URL scheme.
+
+[#1915]: https://github.com/roryford/ManifoldKit/issues/1915
+
+---
+
+## See also
+
+- [`QUICKSTART.md`](QUICKSTART.md) — the `quickStart()` and bootstrap paths.
+- [`PROVIDER-BRIDGE.md`](PROVIDER-BRIDGE.md) — AnyLanguageModel configuration.
+- [`QUICKSTART-TOOLS.md`](QUICKSTART-TOOLS.md) — tool registry + executor.
+- [`POSITIONING.md`](POSITIONING.md) §9 — ManifoldKit vs. AnyLanguageModel.

--- a/docs/MIGRATING-FROM-FOUNDATION-MODELS.md
+++ b/docs/MIGRATING-FROM-FOUNDATION-MODELS.md
@@ -125,8 +125,17 @@ import ManifoldKit
 let getWeather = ToolDefinition(
     name: "get_weather",
     description: "Look up the current weather for a city.",
+    // parameters is a JSONSchemaValue — a typed enum (.object / .string / …),
+    // not a [String: Any]. Build the JSON-Schema document explicitly:
     parameters: .object([
-        "city": .string(description: "City name")
+        "type": .string("object"),
+        "properties": .object([
+            "city": .object([
+                "type": .string("string"),
+                "description": .string("City name")
+            ])
+        ]),
+        "required": .array([.string("city")])
     ])
 )
 ```

--- a/docs/QUICKSTART-RAG.md
+++ b/docs/QUICKSTART-RAG.md
@@ -243,6 +243,8 @@ with the shipped `CitationsView`, or read the array directly.
 
 ## Where to go next
 
+- [`docs/RAG-TUNING.md`](RAG-TUNING.md) — tune chunk size/overlap, decide whether
+  reranking earns its latency, and read the citation surface once setup works.
 - [`docs/QUICKSTART.md`](QUICKSTART.md) — the full-stack `quickStart()` and
   `ManifoldBootstrap.build(...)` paths this guide extends.
 - [`docs/SWIFTUI-MULTI-SESSION.md`](SWIFTUI-MULTI-SESSION.md) — pair RAG with a

--- a/docs/RAG-TUNING.md
+++ b/docs/RAG-TUNING.md
@@ -1,0 +1,226 @@
+# ManifoldKit RAG Tuning
+
+A reference for the *knobs* on ManifoldKit's on-device RAG pipeline — once you
+have retrieval working end-to-end via [`QUICKSTART-RAG.md`](QUICKSTART-RAG.md),
+this page explains how to trade recall against latency, size your chunks, decide
+whether reranking earns its keep, and read the citation surface.
+
+> **Read the quickstart first.** This guide assumes you already have a
+> `RAGConfiguration` wired through `ManifoldBootstrap` and documents ingesting.
+> It does not re-teach setup — it only adds tuning depth.
+
+> **Honest scope.** ManifoldKit ships **one** sentence-aware chunker and a
+> **dense-with-keyword-fallback** retriever — *not* a selectable "chunking
+> strategy" menu or a configurable hybrid-fusion mode. The tuning surface below
+> is exactly what the source exposes; everything else is editorialised away.
+
+---
+
+## The pipeline, and where each knob lives
+
+```
+ingest(url:)                         retrieve(query:limit:) / retrieveSlots
+   │                                          │
+   ├─ parse  (.txt / .md / .pdf)              ├─ truncate query to maxRAGQueryBytes
+   ├─ chunk  (chunkSize, overlap)             ├─ embed query  ──(fail/no model)──┐
+   └─ embed  (embeddingBackend, at index time)│                                  │
+                                              ├─ vector search (top N candidates) │
+                                              │     N = limit × 3 if reranker ready│
+                                              ├─ rerank (reranker)  ◀─────────────┘
+                                              └─ keep top `limit`, build [Citation]
+                                                                    └─ keyword fallback
+```
+
+Every tunable property is on
+[`RAGConfiguration`](../Sources/ManifoldPersistenceSwiftData/ManifoldBootstrap.swift)
+(passed to `ManifoldBootstrap.build(...)`), except the query cap, which is a
+process-global on `ManifoldConfiguration`.
+
+| Knob | Type / default | Stage | What it trades |
+|------|----------------|-------|----------------|
+| `chunkSize` | `Int = 1800` (characters) | index | Larger = more context per hit, fewer hits, coarser citations |
+| `chunkOverlap` | `Int = 200` (characters) | index | Higher = fewer answers split across a chunk boundary, more index bloat |
+| `topK` | `Int = 5` | retrieve | More passages injected per turn → better recall, more prompt budget burned |
+| `embeddingBackend` | `nil` | index + retrieve | Present → semantic search; absent → keyword fallback |
+| `reranker` | `nil` | retrieve | Present + loaded → widen-then-rescore; absent → byte-for-byte non-reranked |
+| `maxRAGQueryBytes` | `8_000` (bytes, on `ManifoldConfiguration`) | retrieve | Query truncation guard against OOM on a pathological input |
+
+---
+
+## 1. Chunk size and overlap
+
+`DocumentChunker` is sentence-aware: it packs whole sentences up to `chunkSize`
+characters, then starts the next chunk `chunkOverlap` characters back so an
+answer that straddles a boundary still lands intact in at least one chunk.
+
+```swift,no-build
+RAGConfiguration(
+    embeddingBackend: embedder,
+    chunkSize: 1800,    // default — characters, not tokens
+    chunkOverlap: 200   // default — ~11% of chunkSize
+)
+```
+
+**How to choose:**
+
+- **Smaller chunks (800–1200)** sharpen retrieval precision and produce tighter,
+  more quotable citations — the snippet you show the user is closer to the
+  matched passage. The cost is that a fact spread across several sentences can
+  land in different chunks, so you may need a higher `topK` to reassemble it.
+- **Larger chunks (2000–3000)** give the model more surrounding context per hit
+  and tolerate sloppy queries, but dilute the embedding (the vector averages
+  more text, so cosine similarity is noisier) and make citations coarse.
+- **Overlap** earns its cost on prose with cross-sentence reasoning. Keep it
+  around 10–15% of `chunkSize`. Pushing it higher inflates the index (every
+  overlapped span is embedded and stored again) for diminishing recall.
+
+`chunkSize` is in **characters, not tokens** — a rough rule of thumb is
+~4 characters/token, so the default 1800 is roughly a 450-token passage. Budget
+`topK × chunkSize / 4` tokens of prompt headroom for retrieval and confirm it
+fits under your model's context window minus the system prompt and history.
+
+> Chunking happens at **index time**. Changing `chunkSize`/`chunkOverlap` only
+> affects documents ingested *after* the change — re-ingest to re-chunk.
+
+---
+
+## 2. Dense (semantic) vs. keyword fallback
+
+There is no "hybrid mode" switch. Retrieval picks its path automatically:
+
+| Path | When | Behaviour |
+|------|------|-----------|
+| **Semantic (dense)** | An `EmbeddingBackend` is loaded | Cosine similarity over chunk embeddings |
+| **Keyword fallback** | No embedding backend, **or** the embedder throws (e.g. OOM) | Case-insensitive substring match; every hit scored `1.0` |
+
+The fallback is a *degradation*, not a parallel mode you fuse with the dense
+results — when the embedding backend fails on a query, `retrieve` catches it and
+falls through to keyword search rather than returning nothing. This means RAG
+"works" with zero models loaded (handy for tests and first-run), but recall is
+substring-only until you load an embedder and **re-ingest** so chunks get
+embedded.
+
+**Implications for tuning:**
+
+- Documents ingested while no embedder was loaded are keyword-only forever (no
+  stored vector). Re-ingest after loading the embedder.
+- Because keyword hits all score `1.0`, you cannot threshold or rank them by
+  relevance — if you sort citations by `score`, keyword results tie. Treat the
+  fallback as a coarse safety net, not a tuning target.
+
+---
+
+## 3. Reranking: latency vs. recall
+
+A cross-encoder reranker (e.g. a `bge-reranker`-class GGUF behind
+`ManifoldLlama`'s `LlamaReranker`) scores each *(query, candidate)* pair jointly
+instead of comparing pre-computed vectors. It is strictly more accurate than
+cosine similarity — and strictly more expensive, because it runs a forward pass
+per candidate.
+
+ManifoldKit's reranking is a **widen-then-rescore**:
+
+1. When a reranker reports `isReady == true`, the retriever widens its
+   first-stage candidate pool to `limit × 3`
+   (`RAGService.rerankCandidateMultiplier = 3`).
+2. The reranker re-scores those candidates against the query.
+3. The top `limit` survive and become the injected passages + citations.
+
+```swift,no-build
+RAGConfiguration(
+    embeddingBackend: embedder,
+    reranker: reranker   // LlamaReranker, from manifold-llama
+)
+```
+
+**The tradeoff to reason about:**
+
+- **Recall.** The reranker can only re-order what first-stage retrieval surfaced.
+  The `× 3` widening is what gives it room to *rescue* a relevant chunk that
+  cosine similarity ranked just outside `topK`. With `topK = 5`, the reranker
+  sees 15 candidates and promotes the best 5 — so the recall win comes from the
+  widened pool, not the reranker alone.
+- **Latency.** Cost scales with the **widened** pool, not `topK`: roughly
+  `topK × 3` cross-encoder forward passes per turn, on the critical path before
+  the first token. A larger `topK` multiplies this — `topK = 10` reranks 30
+  candidates. If reranking pushes time-to-first-token past your budget, lower
+  `topK` before dropping the reranker entirely.
+- **Graceful degrade.** With no reranker, or one whose model is not loaded
+  (`isReady == false`, e.g. `PassthroughReranker`), retrieval is **byte-for-byte
+  the non-reranked behaviour**, including the keyword fallback. You can ship the
+  reranker config and let it no-op on devices that can't afford the model.
+
+**When reranking is worth it:** large or noisy corpora where the right passage
+is frequently *near* the top but not *at* it. **When to skip it:** small
+hand-curated corpora where dense `topK = 5` already returns the right chunk —
+you pay the latency for no recall gain.
+
+---
+
+## 4. The query-size cap
+
+Before embedding or keyword-matching, the query is truncated to
+`ManifoldConfiguration.shared.maxRAGQueryBytes` (default **8,000 bytes**) of its
+UTF-8 prefix. This is an OOM guard for pathological inputs (a user pasting a
+whole document into the box), not a relevance knob — but if you embed an
+unusually long retrieval query and recall feels off, confirm it isn't being
+silently truncated. Raise the cap only if your embedder handles longer inputs
+without memory pressure.
+
+---
+
+## 5. Reading the citation surface
+
+Every retrieved passage produces a
+[`Citation`](../Sources/ManifoldInference/Models/Citation.swift) attached to the
+assistant `ChatMessage`:
+
+```swift,no-build
+public struct Citation {
+    public let documentID: UUID
+    public let documentTitle: String
+    public let chunkIndex: Int      // which chunk within the document
+    public let snippet: String      // truncated preview, ≤ 240 chars
+    public let score: Float         // cosine similarity (semantic) or 1.0 (keyword)
+}
+```
+
+- **`snippet`** is truncated to `Citation.snippetCharacterLimit` (240
+  characters) at construction — it is a preview, not the full chunk text. Don't
+  rely on it for re-retrieval; use `documentID` + `chunkIndex` to fetch the
+  source.
+- **`score`** lets you sort or filter in a custom UI. Remember that **keyword
+  hits all score `1.0`**, so a score-based threshold only discriminates in
+  semantic mode.
+- The shipped `ChatView` renders these as a collapsible "Sources" disclosure
+  automatically; bring-your-own-UI hosts read `message.citations` and render
+  `CitationsView` (or their own).
+
+Tighter chunks → tighter, more quotable snippets. This is the second-order
+reason to prefer smaller `chunkSize` for user-facing citation quality even when
+recall doesn't demand it.
+
+---
+
+## Tuning checklist
+
+1. **Start at defaults** (`chunkSize 1800`, `overlap 200`, `topK 5`, no
+   reranker) with an embedding model loaded. Re-ingest after loading the
+   embedder.
+2. **If answers miss context that's clearly in the docs:** raise `topK` first
+   (cheap), then `chunkOverlap` if facts straddle boundaries.
+3. **If citations are too coarse / off-topic:** lower `chunkSize` and re-ingest.
+4. **If the right passage is near-but-not-top:** add a reranker — the `× 3`
+   widening is the recall lever.
+5. **If time-to-first-token regresses after adding a reranker:** lower `topK`
+   (you rerank `topK × 3` candidates) before removing the reranker.
+6. **Mind the prompt budget:** `topK × chunkSize / 4 ≈ injected tokens`. Keep it
+   under context − system prompt − history.
+
+---
+
+## See also
+
+- [`QUICKSTART-RAG.md`](QUICKSTART-RAG.md) — end-to-end setup this guide extends.
+- [`FeatureMatrix.md`](FeatureMatrix.md) — backend → capability table (which
+  backends provide embeddings / reranking).


### PR DESCRIPTION
Implements the **writable-now subset** of the #1940 competitive-research docs checklist, scoped strictly to what ships in `Sources/` today (verified by two independent code sweeps + the issue's own investigation pass).

## Done

- [x] **RAG tuning guide** → `docs/RAG-TUNING.md`. Chunk size/overlap selection, the honest **dense-with-keyword-fallback** model (not a configurable "hybrid" mode), reranker **widen-then-rescore** latency↔recall tradeoff (`limit × 3` candidate pool, `rerankCandidateMultiplier = 3`), the `maxRAGQueryBytes` cap, and the `Citation` surface. Grounded in `RAGService` / `DocumentChunker` / `Reranker` / `Citation`. Linked from `QUICKSTART-RAG.md`.
- [x] **Migrating from AnyLanguageModel / FoundationModels** → `docs/MIGRATING-FROM-FOUNDATION-MODELS.md`. Concept map from `LanguageModelSession`/`@Generable`/`Tool` onto `quickStart()` / `ChatViewModel.sendMessage` / `ConversationRuntime` / `ToolDefinition` / `GenerationConfig.structuredOutput`. **Honest:** MK has no `@Generable` macro — maps to the raw structured-output strategies and points at #1915. Linked from README.
- [x] **MCP feature-coverage matrix** → new `### MCP capability coverage` table in `README.md`. Tools ✅, Resources ✅, Prompts ⚠️ (detected, not wired), OAuth 2.1 ✅, Sampling ❌ (#1925), Elicitation ❌ (#1926), transports (stdio + streamable-HTTP). Verified against `Sources/ManifoldMCP` / `Sources/ManifoldMCPHost`.

## Skipped (with reason)

- [ ] **Positioning / comparison page** — the issue's own investigation recommends **not** creating a new page: `docs/POSITIONING.md` already carries the "vs the field" table, and adding Ollamac/LM Studio/AnythingLLM rows is a low-priority judgment call left to the maintainer.
- [ ] **Recipes / cookbook** — skipped to keep the snippet gate green. Each recipe must be a snippet-gate-validated *runnable*, but the high-value recipes (tool loop, RAG, model-pick) are already covered end-to-end by existing quickstarts, and the headline structured-output form is blocked on #1915, fallback-chain on #1935. Net new value didn't justify the gate risk.
- [ ] **Model-management guide** — partial; Manifoldfile bundle section blocked on #1932. Deferred (lower leverage than the three shipped).
- [ ] **Local voice integration guide** — mostly vaporware until #1928 (SpeechAnalyzer/WhisperKit/VAD/barge-in are 0-reference); the shipped half-duplex path is already in `QUICKSTART-VOICE.md`. Deferred.

## Snippet gate

**Not run — not needed.** Every `swift` code block in the new docs is tagged `swift,no-build` (AnyLanguageModel/Foundation/MCP APIs aren't umbrella-reachable, and the structured-output/tool snippets mix concepts that shouldn't link in the scaffold). No buildable snippets were added, so `readme-snippets` has nothing new to compile.

Refs #1940 — multi-item umbrella, do **not** close. Boxes ticked above reflect what this PR completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)