### PR TITLE
feat(ui): inline superscript [n] citation markers with tap-to-deep-link (#1921)

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -106,6 +106,7 @@ API breakage: class InMemoryMetricSink has been removed
 API breakage: enumelement UnloadReason.idleTimeout has been added as a new enum case
 API breakage: constructor ManifoldBootstrap.init(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:isInMemory:) has been removed
 API breakage: func ManifoldBootstrap.build(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:) has been renamed to func build(configuration:ragConfiguration:inferenceService:imageGenerationService:videoGenerationService:webSearchRuntime:diagnostics:runtimeOptions:sessionToolSources:hookRegistry:enableResumableRuns:makeModelContainer:audioGenerationService:)
+API breakage: constructor CitationsView.init(citations:) has been removed
 API breakage: func RAGService.retrieve(query:limit:) has parameter 1 type change from Swift.Int to Swift.Int?
 API breakage: func RAGService.retrieveSlots(query:limit:) has parameter 1 type change from Swift.Int to Swift.Int?
 API breakage: constructor RAGService.init(documentStore:vectorStore:embeddingBackend:reranker:chunker:parsers:) has been removed

--- a/Sources/ManifoldUI/Views/Chat/CitationHighlightCoordinator.swift
+++ b/Sources/ManifoldUI/Views/Chat/CitationHighlightCoordinator.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import ManifoldInference
+
+/// Per-bubble transient state that links an inline `[n]` marker tap to the matching
+/// source card in ``CitationsView``.
+///
+/// When the user taps a superscript marker, the bubble sets ``target`` to the
+/// citation's 0-based index. ``CitationsView`` observes this to (a) expand its
+/// disclosure, (b) scroll the row into view, and (c) flash a transient highlight.
+/// The highlight auto-clears after a short delay so re-tapping the same marker
+/// re-triggers it.
+///
+/// Scoped to a single bubble (one instance per ``MessageBubbleView``) so two
+/// messages' citations never cross-highlight.
+@MainActor
+@Observable
+final class CitationHighlightCoordinator {
+
+    /// The citation index the user most recently deep-linked to, or `nil` when no
+    /// highlight is active. `CitationsView` keys its scroll + flash off this.
+    private(set) var target: Int?
+
+    /// Monotonic token bumped on every request so the auto-clear `Task` only
+    /// clears the highlight it itself scheduled — re-tapping the same marker
+    /// before the previous clear fires must restart, not cancel, the flash.
+    private var requestToken = 0
+
+    /// Deep-link to the citation at `index`: set the highlight, then auto-clear
+    /// after `highlightDuration`. Re-entrant: a second request supersedes the
+    /// pending clear so rapid taps don't leave a stuck highlight.
+    func highlight(index: Int) {
+        target = index
+        requestToken += 1
+        let token = requestToken
+        Task { [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(Self.highlightDuration))
+            } catch {
+                // Cancellation is the only expected error here (the bubble went
+                // away, or the structured task was torn down). Either way there is
+                // nothing to clear — bail without touching state.
+                return
+            }
+            guard let self, self.requestToken == token else { return }
+            self.target = nil
+        }
+    }
+
+    /// How long the transient flash stays on a deep-linked source card.
+    static let highlightDuration: Double = 2.0
+}

--- a/Sources/ManifoldUI/Views/Chat/CitationsView.swift
+++ b/Sources/ManifoldUI/Views/Chat/CitationsView.swift
@@ -14,10 +14,40 @@ import ManifoldInference
 public struct CitationsView: View {
 
     public let citations: [Citation]
+
+    /// Fired when the user taps a source row. Hosts that present a richer source
+    /// view (e.g. `DocumentLibraryView` in `ManifoldUIModelManagement`) inject a
+    /// closure here — closure-injection keeps `ManifoldUI` from importing the
+    /// model-management module (CLAUDE.md dependency rule). `nil` (the default)
+    /// leaves rows tappable only for the in-bubble flash deep-link.
+    let onSelect: ((Citation) -> Void)?
+
+    /// Per-bubble deep-link state. When an inline `[n]` marker is tapped the
+    /// bubble sets the coordinator's `target`; this view reacts by expanding,
+    /// scrolling the matching row into view, and flashing a transient highlight.
+    /// `nil` when the bubble has no inline markers, so the disclosure behaves
+    /// exactly as before.
+    private var highlight: CitationHighlightCoordinator?
+
     @State private var isExpanded: Bool = false
 
-    public init(citations: [Citation]) {
+    public init(citations: [Citation], onSelect: ((Citation) -> Void)? = nil) {
         self.citations = citations
+        self.onSelect = onSelect
+        self.highlight = nil
+    }
+
+    /// Internal initialiser used by ``MessageBubbleView`` to wire the in-bubble
+    /// inline-marker deep-link. Kept non-public so the deep-link plumbing stays an
+    /// implementation detail of the bubble.
+    init(
+        citations: [Citation],
+        highlight: CitationHighlightCoordinator?,
+        onSelect: ((Citation) -> Void)? = nil
+    ) {
+        self.citations = citations
+        self.onSelect = onSelect
+        self.highlight = highlight
     }
 
     public var body: some View {
@@ -25,12 +55,29 @@ public struct CitationsView: View {
             EmptyView()
         } else {
             DisclosureGroup(isExpanded: $isExpanded) {
-                VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(citations.enumerated()), id: \.offset) { index, citation in
-                        CitationRow(index: index + 1, citation: citation)
+                ScrollViewReader { proxy in
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(Array(citations.enumerated()), id: \.offset) { index, citation in
+                            CitationRow(
+                                index: index + 1,
+                                citation: citation,
+                                isHighlighted: highlight?.target == index,
+                                onSelect: onSelect
+                            )
+                            .id(index)
+                        }
+                    }
+                    .padding(.top, 6)
+                    .onChange(of: highlight?.target) { _, newTarget in
+                        guard let newTarget else { return }
+                        // Auto-expand so the scrolled-to row is visible, then bring
+                        // it into view. The flash is driven by `isHighlighted`.
+                        isExpanded = true
+                        withAnimation(.easeInOut) {
+                            proxy.scrollTo(newTarget, anchor: .center)
+                        }
                     }
                 }
-                .padding(.top, 6)
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "doc.text.magnifyingglass")
@@ -50,8 +97,29 @@ public struct CitationsView: View {
 private struct CitationRow: View {
     let index: Int
     let citation: Citation
+    /// Transient flash applied when an inline `[n]` marker deep-links here.
+    var isHighlighted: Bool = false
+    /// Optional host-supplied tap handler (deep-link into a richer source view).
+    var onSelect: ((Citation) -> Void)? = nil
 
     var body: some View {
+        // Wrap the card in a Button only when something can act on the tap —
+        // an `onSelect` handler. When neither is set the row stays a plain,
+        // non-interactive card (the historical look), so existing call sites
+        // that pass no closure are unchanged.
+        if let onSelect {
+            Button {
+                onSelect(citation)
+            } label: {
+                card
+            }
+            .buttonStyle(.plain)
+        } else {
+            card
+        }
+    }
+
+    private var card: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 Text("[\(index)]")
@@ -78,9 +146,19 @@ private struct CitationRow: View {
                 .textSelection(.enabled)
         }
         .padding(8)
-        .background(.fill.quinary, in: RoundedRectangle(cornerRadius: 6))
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: 6))
+        // why: animate the fill so the deep-link flash eases in/out rather than
+        // snapping, which reads as a deliberate "here it is" pulse.
+        .animation(.easeInOut(duration: 0.25), value: isHighlighted)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Source \(index): \(citation.documentTitle), chunk \(citation.chunkIndex). \(citation.snippet)")
+    }
+
+    /// Quinary fill normally; the accent tint at low opacity while flashing.
+    private var rowBackground: AnyShapeStyle {
+        isHighlighted
+            ? AnyShapeStyle(Color.accentColor.opacity(0.18))
+            : AnyShapeStyle(.fill.quinary)
     }
 
     private var scoreLabel: String {

--- a/Sources/ManifoldUI/Views/Chat/InlineCitationRenderer.swift
+++ b/Sources/ManifoldUI/Views/Chat/InlineCitationRenderer.swift
@@ -40,6 +40,12 @@ public enum InlineCitationRenderer {
     ///   literal text — only purely-numeric, in-range tokens are treated as
     ///   citation anchors. This intentionally leaves markdown link syntax
     ///   (`[label](url)`) untouched because `[label]` is non-numeric.
+    /// - `[n]` inside a backtick code span (`` `[1]` ``) or fenced code block is
+    ///   left literal: a code sample that happens to contain `[1]` must not become
+    ///   a tappable citation. Backtick runs are matched CommonMark-style — a run of
+    ///   N backticks closes on the next run of exactly N — which also brackets the
+    ///   ` ``` ` fences of a code block, so their contents are passed through as
+    ///   literal text without marker scanning.
     /// - Adjacent literal runs are coalesced so the View renders the minimum number
     ///   of `Text` segments.
     ///
@@ -64,6 +70,40 @@ public enum InlineCitationRenderer {
         var i = 0
         while i < scalars.count {
             let char = scalars[i]
+            if char == "`" {
+                // Enter a code span: a run of N backticks is closed by the next
+                // run of exactly N. Everything in between (including any `[n]`) is
+                // copied verbatim so code samples never sprout citation links.
+                // An unterminated run degrades to literal text (no close found).
+                var fenceLength = 0
+                while i < scalars.count, scalars[i] == "`" {
+                    literal.append(scalars[i])
+                    fenceLength += 1
+                    i += 1
+                }
+                while i < scalars.count {
+                    if scalars[i] == "`" {
+                        var run = 0
+                        var k = i
+                        while k < scalars.count, scalars[k] == "`" {
+                            run += 1
+                            k += 1
+                        }
+                        // Append the whole backtick run as literal regardless.
+                        for _ in 0..<run { literal.append("`") }
+                        i = k
+                        // Closing run of the same length ends the span; otherwise
+                        // an interior run (e.g. a longer/shorter tick group) is just
+                        // more code content and we keep scanning. An unterminated
+                        // span simply runs to end-of-text as literal.
+                        if run == fenceLength { break }
+                    } else {
+                        literal.append(scalars[i])
+                        i += 1
+                    }
+                }
+                continue
+            }
             if char == "[" {
                 // Try to consume a `[<digits>]` token starting here.
                 var j = i + 1

--- a/Sources/ManifoldUI/Views/Chat/InlineCitationRenderer.swift
+++ b/Sources/ManifoldUI/Views/Chat/InlineCitationRenderer.swift
@@ -1,0 +1,123 @@
+import Foundation
+import ManifoldInference
+
+/// Pure, view-free logic for detecting inline `[n]` citation markers in assistant
+/// answer text and mapping each marker to its numbered ``Citation`` source card.
+///
+/// The model is instructed (Piece 2 / RAG prompt, gated on #1937) to cite sources
+/// inline as `[1]`, `[2]`, … where `n` is the 1-based index of the matching source
+/// card already rendered by ``CitationsView``. This type does the post-stream parse:
+/// it splits the answer into an ordered list of ``Segment`` values so the View can
+/// render plain prose as text and each in-range marker as a tappable superscript.
+///
+/// Kept deliberately free of SwiftUI so the numbering / range-resolution rules are
+/// unit-testable in isolation — the View layer only chooses how to *draw* the
+/// segments, never *what* they are.
+public enum InlineCitationRenderer {
+
+    /// One run of the parsed answer: either a span of literal prose, or a resolved
+    /// inline citation marker pointing at a source card.
+    public enum Segment: Equatable, Sendable {
+        /// Literal answer text to render verbatim (markdown-bearing). Includes any
+        /// `[n]` token that did NOT resolve to a real citation (out-of-range,
+        /// zero/negative, or no citations supplied) — such tokens stay plain so a
+        /// hallucinated or mis-numbered marker never renders as a dead link.
+        case text(String)
+
+        /// A resolved marker. `displayNumber` is the 1-based number shown to the
+        /// user (matching the source card's `[index]`); `citationIndex` is the
+        /// 0-based offset into the `citations` array the View deep-links to.
+        case marker(displayNumber: Int, citationIndex: Int)
+    }
+
+    /// Scans `text` for `[n]` markers and resolves each against `citations`.
+    ///
+    /// Resolution rules (why these and not "link every bracket"):
+    /// - Only `[n]` where `1 <= n <= citations.count` becomes a ``Segment/marker``;
+    ///   the model can hallucinate or over-count, so an out-of-range bracket must
+    ///   degrade to plain text rather than crash or link nowhere.
+    /// - `[0]`, negative, and non-numeric brackets (`[Link]`, `[a]`) are left as
+    ///   literal text — only purely-numeric, in-range tokens are treated as
+    ///   citation anchors. This intentionally leaves markdown link syntax
+    ///   (`[label](url)`) untouched because `[label]` is non-numeric.
+    /// - Adjacent literal runs are coalesced so the View renders the minimum number
+    ///   of `Text` segments.
+    ///
+    /// When `citations` is empty, the result is a single ``Segment/text`` holding
+    /// the original string unchanged.
+    public static func segments(for text: String, citations: [Citation]) -> [Segment] {
+        guard !citations.isEmpty, !text.isEmpty else {
+            return text.isEmpty ? [] : [.text(text)]
+        }
+
+        var segments: [Segment] = []
+        var literal = ""
+
+        func flushLiteral() {
+            if !literal.isEmpty {
+                segments.append(.text(literal))
+                literal.removeAll(keepingCapacity: true)
+            }
+        }
+
+        let scalars = Array(text)
+        var i = 0
+        while i < scalars.count {
+            let char = scalars[i]
+            if char == "[" {
+                // Try to consume a `[<digits>]` token starting here.
+                var j = i + 1
+                var digits = ""
+                while j < scalars.count, scalars[j].isNumber {
+                    digits.append(scalars[j])
+                    j += 1
+                }
+                if !digits.isEmpty, j < scalars.count, scalars[j] == "]",
+                   let number = Int(digits), number >= 1, number <= citations.count {
+                    // Resolved marker: flush prose, emit the marker, skip the token.
+                    flushLiteral()
+                    segments.append(.marker(displayNumber: number, citationIndex: number - 1))
+                    i = j + 1
+                    continue
+                }
+            }
+            // Not a resolvable marker — keep the character as literal text.
+            literal.append(char)
+            i += 1
+        }
+        flushLiteral()
+        return segments
+    }
+
+    /// Convenience: does `text` contain at least one *resolvable* inline marker for
+    /// the supplied `citations`? Lets the View cheaply decide whether to take the
+    /// segment-rendering path at all versus rendering plain markdown.
+    public static func hasResolvableMarker(in text: String, citations: [Citation]) -> Bool {
+        segments(for: text, citations: citations).contains {
+            if case .marker = $0 { return true }
+            return false
+        }
+    }
+
+    /// URL scheme used to encode a citation deep-link inside the rendered
+    /// `AttributedString`. The View intercepts taps on `citation://<index>` via
+    /// the SwiftUI `openURL` environment action rather than navigating a browser.
+    public static let deepLinkScheme = "citation"
+
+    /// Builds the citation deep-link URL for the 0-based `citationIndex`, e.g.
+    /// `citation://2`. Exposed (and pure) so the View's `openURL` handler and the
+    /// renderer agree on the encoding, and so tests can assert the round-trip.
+    public static func deepLinkURL(citationIndex: Int) -> URL? {
+        URL(string: "\(deepLinkScheme)://\(citationIndex)")
+    }
+
+    /// Parses a citation deep-link URL back into its 0-based citation index, or
+    /// `nil` when `url` is not a `citation://<index>` link. Inverse of
+    /// ``deepLinkURL(citationIndex:)``.
+    public static func citationIndex(from url: URL) -> Int? {
+        guard url.scheme == deepLinkScheme, let host = url.host(), let index = Int(host) else {
+            return nil
+        }
+        return index
+    }
+}

--- a/Sources/ManifoldUI/Views/Chat/InlineCitationTextView.swift
+++ b/Sources/ManifoldUI/Views/Chat/InlineCitationTextView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import ManifoldInference
+
+/// Renders assistant prose with inline `[n]` citation markers drawn as tappable
+/// superscripts that deep-link into the numbered source cards below.
+///
+/// Used only when the answer actually contains a *resolvable* marker (see
+/// ``InlineCitationRenderer/hasResolvableMarker(in:citations:)``); plain answers
+/// keep flowing through ``AssistantMarkdownView`` so we never regress markdown /
+/// fenced-code rendering for the common (no-citation) case.
+///
+/// The whole answer is composed into one `AttributedString` so text wrapping is
+/// native: prose runs are parsed as markdown (reusing the shared cache) and each
+/// marker run carries a `citation://<index>` link + superscript styling. Taps are
+/// intercepted by the bubble's `openURL` handler rather than opening a browser.
+struct InlineCitationTextView: View {
+    let content: String
+    let citations: [Citation]
+
+    var body: some View {
+        Text(Self.attributedString(content: content, citations: citations))
+            .font(.body)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+            // why: tint the marker links so they read as the same accent the
+            // source-card `[n]` uses, and stay visually distinct from prose.
+            .tint(.accentColor)
+    }
+
+    /// Composes the answer into a single markdown-aware `AttributedString` with
+    /// each resolved marker rendered as a tappable, superscript `[n]` link.
+    ///
+    /// Pure and `static` so it can be exercised without standing up a SwiftUI host.
+    static func attributedString(content: String, citations: [Citation]) -> AttributedString {
+        var result = AttributedString()
+        for segment in InlineCitationRenderer.segments(for: content, citations: citations) {
+            switch segment {
+            case .text(let prose):
+                // Reuse the cached markdown renderer so prose styling matches the
+                // non-citation path exactly.
+                result.append(AssistantMarkdownParser.attributedString(from: prose))
+            case .marker(let displayNumber, let citationIndex):
+                var marker = AttributedString("[\(displayNumber)]")
+                if let url = InlineCitationRenderer.deepLinkURL(citationIndex: citationIndex) {
+                    marker.link = url
+                }
+                // Superscript baseline + smaller weight reads as a citation anchor
+                // without stealing prose line height.
+                marker.baselineOffset = 4
+                marker.font = .caption2.weight(.semibold)
+                marker.foregroundColor = .accentColor
+                result.append(marker)
+            }
+        }
+        return result
+    }
+}
+
+#Preview("Inline markers") {
+    let docID = UUID()
+    return InlineCitationTextView(
+        content: "Retrieval-augmented generation grounds answers in sources [1], reducing hallucination [2].",
+        citations: [
+            Citation(documentID: docID, documentTitle: "rag.md", chunkIndex: 0, snippet: "RAG grounds answers.", score: 0.9),
+            Citation(documentID: docID, documentTitle: "eval.md", chunkIndex: 1, snippet: "Grounding cuts hallucination.", score: 0.8),
+        ]
+    )
+    .padding()
+}

--- a/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessageBubbleView.swift
@@ -47,6 +47,10 @@ public struct MessageBubbleView: View {
     /// here where they are consumed.
     @ScaledMetric(relativeTo: .body) private var typeScale: CGFloat = 1
 
+    /// Links an inline `[n]` marker tap in the answer text to the matching source
+    /// card. Owned per-bubble so two assistant messages never cross-highlight.
+    @State private var citationHighlight = CitationHighlightCoordinator()
+
     public init(
         message: ChatMessage,
         isStreaming: Bool,
@@ -191,7 +195,12 @@ public struct MessageBubbleView: View {
                     parts: message.contentParts,
                     role: .assistant,
                     isStreaming: isStreaming,
-                    messageID: message.id
+                    messageID: message.id,
+                    // why: only feed citations to the text renderer once streaming
+                    // ends — mid-stream the answer may hold half-formed `[n]`
+                    // tokens, and the source cards (which markers deep-link to)
+                    // are themselves only shown post-stream below.
+                    citations: isStreaming ? [] : (message.citations ?? [])
                 )
             }
 
@@ -203,7 +212,7 @@ public struct MessageBubbleView: View {
             // doesn't pop in/out while the bubble is still filling. Empty
             // citation arrays render an EmptyView via CitationsView.
             if !isStreaming, let citations = message.citations, !citations.isEmpty {
-                CitationsView(citations: citations)
+                CitationsView(citations: citations, highlight: citationHighlight)
                     .padding(.top, 2)
             }
 
@@ -220,6 +229,21 @@ public struct MessageBubbleView: View {
                 }
             }
         }
+        // Intercept inline-marker taps anywhere in this bubble. InlineCitationTextView
+        // encodes each `[n]` superscript as a `citation://<index>` link; route those
+        // to the highlight coordinator (which scrolls + flashes the matching source
+        // card) instead of letting SwiftUI open a URL. Scoped to the whole VStack so
+        // taps on markers in the *answer text* — a sibling of CitationsView — are
+        // caught too. `.handled` suppresses the browser-open fallback.
+        .environment(\.openURL, OpenURLAction { url in
+            if let index = InlineCitationRenderer.citationIndex(from: url),
+               let citations = message.citations,
+               index >= 0, index < citations.count {
+                citationHighlight.highlight(index: index)
+                return .handled
+            }
+            return .systemAction
+        })
     }
 
     /// Wraps inner bubble content in the resolved ``MessageBubbleStyle``. The

--- a/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
+++ b/Sources/ManifoldUI/Views/Chat/MessagePartsView.swift
@@ -18,6 +18,11 @@ struct MessagePartsView: View {
     /// can render an inline preview rather than the static "Thinking…" label.
     /// Optional so unit tests that exercise text/tool rendering can omit it.
     var messageID: UUID? = nil
+    /// Source citations attached to this (assistant) message. When non-empty and
+    /// the answer text contains resolvable inline `[n]` markers, text parts render
+    /// via ``InlineCitationTextView`` so the markers become tappable superscripts.
+    /// Empty (the default) keeps the historical plain-markdown rendering.
+    var citations: [Citation] = []
 
     @Environment(ChatViewModel.self) private var viewModel
 
@@ -322,7 +327,15 @@ struct MessagePartsView: View {
     @ViewBuilder
     private func textView(_ text: String) -> some View {
         if role == .assistant {
-            AssistantMarkdownView(content: text)
+            // Take the inline-citation path only when the answer actually carries
+            // a resolvable `[n]` marker; otherwise keep the existing markdown
+            // renderer so fenced code / lists / streaming behave exactly as before.
+            if !citations.isEmpty,
+               InlineCitationRenderer.hasResolvableMarker(in: text, citations: citations) {
+                InlineCitationTextView(content: text, citations: citations)
+            } else {
+                AssistantMarkdownView(content: text)
+            }
         } else {
             Text(text)
                 .font(.body)

--- a/Tests/ManifoldUITests/InlineCitationRendererTests.swift
+++ b/Tests/ManifoldUITests/InlineCitationRendererTests.swift
@@ -86,6 +86,38 @@ final class InlineCitationRendererTests: XCTestCase {
         )
     }
 
+    // MARK: - Code spans / fenced blocks degrade to plain text
+
+    func test_segments_markerInsideInlineCodeSpanLeftPlain() {
+        // `[1]` inside a backtick span is a code sample, not a citation anchor.
+        let input = "Use `arr[1]` to index, and cite the design [1]."
+        let segments = InlineCitationRenderer.segments(for: input, citations: twoCitations)
+        XCTAssertEqual(segments, [
+            .text("Use `arr[1]` to index, and cite the design "),
+            .marker(displayNumber: 1, citationIndex: 0),
+            .text("."),
+        ])
+    }
+
+    func test_segments_markerInsideFencedCodeBlockLeftPlain() {
+        let input = "```\nlet x = arr[1]\n```\nSee [2]."
+        let segments = InlineCitationRenderer.segments(for: input, citations: twoCitations)
+        XCTAssertEqual(segments, [
+            .text("```\nlet x = arr[1]\n```\nSee "),
+            .marker(displayNumber: 2, citationIndex: 1),
+            .text("."),
+        ])
+    }
+
+    func test_segments_unterminatedCodeSpanLeftPlain() {
+        // No closing backtick: the rest is literal, including any bracketed token.
+        let input = "open `code [1] still open"
+        XCTAssertEqual(
+            InlineCitationRenderer.segments(for: input, citations: twoCitations),
+            [.text(input)]
+        )
+    }
+
     // MARK: - Coalescing / edge inputs
 
     func test_segments_adjacentMarkersCoalesceSurroundingProse() {

--- a/Tests/ManifoldUITests/InlineCitationRendererTests.swift
+++ b/Tests/ManifoldUITests/InlineCitationRendererTests.swift
@@ -1,0 +1,157 @@
+@preconcurrency import XCTest
+@testable import ManifoldUI
+import ManifoldInference
+
+/// Unit tests for the pure inline-citation marker logic
+/// (``InlineCitationRenderer``). The View layer only chooses how to *draw* the
+/// segments, so all the numbering / range-resolution rules are asserted here
+/// without a SwiftUI host.
+final class InlineCitationRendererTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func citation(_ title: String, chunk: Int = 0) -> Citation {
+        Citation(
+            documentID: UUID(),
+            documentTitle: title,
+            chunkIndex: chunk,
+            snippet: "snippet for \(title)",
+            score: 0.5
+        )
+    }
+
+    private var twoCitations: [Citation] {
+        [citation("a.md"), citation("b.md")]
+    }
+
+    // MARK: - Marker mapping
+
+    func test_segments_mapsMarkersToCitationIndices() {
+        let segments = InlineCitationRenderer.segments(
+            for: "Foo [1] bar [2].",
+            citations: twoCitations
+        )
+
+        XCTAssertEqual(segments, [
+            .text("Foo "),
+            .marker(displayNumber: 1, citationIndex: 0),
+            .text(" bar "),
+            .marker(displayNumber: 2, citationIndex: 1),
+            .text("."),
+        ])
+
+        // Sabotage: with zero citations, the same text must stay entirely plain —
+        // confirms linking is citation-driven, not just "any [n] becomes a marker".
+        let noCitations = InlineCitationRenderer.segments(for: "Foo [1] bar [2].", citations: [])
+        XCTAssertEqual(noCitations, [.text("Foo [1] bar [2].")])
+    }
+
+    func test_segments_displayNumberIsOneBased_indexIsZeroBased() {
+        let segments = InlineCitationRenderer.segments(for: "[2]", citations: twoCitations)
+        XCTAssertEqual(segments, [.marker(displayNumber: 2, citationIndex: 1)])
+    }
+
+    // MARK: - Out-of-range / malformed markers degrade to plain text
+
+    func test_segments_outOfRangeMarkerLeftPlain() {
+        // [3] with only 2 citations — must NOT link and must NOT crash.
+        let segments = InlineCitationRenderer.segments(for: "x [3] y", citations: twoCitations)
+        XCTAssertEqual(segments, [.text("x [3] y")])
+        XCTAssertFalse(segments.contains { if case .marker = $0 { return true }; return false })
+    }
+
+    func test_segments_zeroAndNegativeMarkersLeftPlain() {
+        XCTAssertEqual(
+            InlineCitationRenderer.segments(for: "a [0] b", citations: twoCitations),
+            [.text("a [0] b")]
+        )
+        // "[-1]" — the leading '-' isn't a digit so it is never read as a marker.
+        XCTAssertEqual(
+            InlineCitationRenderer.segments(for: "a [-1] b", citations: twoCitations),
+            [.text("a [-1] b")]
+        )
+    }
+
+    func test_segments_nonNumericBracketsLeftPlain_includingMarkdownLinks() {
+        // Markdown link syntax must survive untouched: `[Docs]` is non-numeric.
+        let input = "See [Docs](https://example.com) and [note]."
+        let segments = InlineCitationRenderer.segments(for: input, citations: twoCitations)
+        XCTAssertEqual(segments, [.text(input)])
+    }
+
+    func test_segments_unterminatedBracketLeftPlain() {
+        XCTAssertEqual(
+            InlineCitationRenderer.segments(for: "open [1 no close", citations: twoCitations),
+            [.text("open [1 no close")]
+        )
+    }
+
+    // MARK: - Coalescing / edge inputs
+
+    func test_segments_adjacentMarkersCoalesceSurroundingProse() {
+        let segments = InlineCitationRenderer.segments(for: "[1][2]", citations: twoCitations)
+        XCTAssertEqual(segments, [
+            .marker(displayNumber: 1, citationIndex: 0),
+            .marker(displayNumber: 2, citationIndex: 1),
+        ])
+    }
+
+    func test_segments_emptyTextReturnsEmpty() {
+        XCTAssertEqual(InlineCitationRenderer.segments(for: "", citations: twoCitations), [])
+    }
+
+    func test_segments_repeatedMarkerResolvesEachTime() {
+        let segments = InlineCitationRenderer.segments(for: "[1] and again [1]", citations: twoCitations)
+        XCTAssertEqual(segments, [
+            .marker(displayNumber: 1, citationIndex: 0),
+            .text(" and again "),
+            .marker(displayNumber: 1, citationIndex: 0),
+        ])
+    }
+
+    // MARK: - hasResolvableMarker
+
+    func test_hasResolvableMarker_trueOnlyWhenInRangeMarkerPresent() {
+        XCTAssertTrue(InlineCitationRenderer.hasResolvableMarker(in: "x [1]", citations: twoCitations))
+        XCTAssertFalse(InlineCitationRenderer.hasResolvableMarker(in: "x [3]", citations: twoCitations))
+        XCTAssertFalse(InlineCitationRenderer.hasResolvableMarker(in: "x [1]", citations: []))
+        XCTAssertFalse(InlineCitationRenderer.hasResolvableMarker(in: "plain text", citations: twoCitations))
+    }
+
+    // MARK: - Deep-link URL round-trip
+
+    func test_deepLinkURL_roundTripsCitationIndex() {
+        guard let url = InlineCitationRenderer.deepLinkURL(citationIndex: 2) else {
+            return XCTFail("expected a deep-link URL")
+        }
+        XCTAssertEqual(url.scheme, InlineCitationRenderer.deepLinkScheme)
+        XCTAssertEqual(InlineCitationRenderer.citationIndex(from: url), 2)
+    }
+
+    func test_citationIndex_returnsNilForNonCitationURL() {
+        guard let httpURL = URL(string: "https://example.com/3") else {
+            return XCTFail("bad fixture URL")
+        }
+        XCTAssertNil(InlineCitationRenderer.citationIndex(from: httpURL))
+    }
+
+    // MARK: - AttributedString rendering (View helper, pure)
+
+    @MainActor
+    func test_attributedString_markerCarriesDeepLinkAndProseHasNoLink() {
+        let attributed = InlineCitationTextView.attributedString(
+            content: "Grounded answer [1].",
+            citations: twoCitations
+        )
+        let linkedRuns = attributed.runs.filter { $0.link != nil }
+        XCTAssertEqual(linkedRuns.count, 1, "exactly the one in-range marker should be a link")
+        XCTAssertEqual(linkedRuns.first?.link, InlineCitationRenderer.deepLinkURL(citationIndex: 0))
+
+        // Sabotage: drop citations and the marker must lose its link entirely.
+        let unlinked = InlineCitationTextView.attributedString(
+            content: "Grounded answer [1].",
+            citations: []
+        )
+        XCTAssertTrue(unlinked.runs.allSatisfy { $0.link == nil })
+    }
+}


### PR DESCRIPTION
## Summary

Numbered source cards already ship (`CitationsView`), so the headline of #1921 was partly resolved. This PR adds the genuinely-missing delta the issue's investigation plan identified:

1. **Inline superscript `[n]` markers** in the assistant answer text, where `n` maps to the numbered source card.
2. **Tap-to-deep-link**: tapping `[n]` expands the Sources disclosure, scrolls the matching card into view, and flashes a transient highlight.

Scope is `ManifoldUI` only (read-only use of the existing `Citation` model). This is **Piece 1 + the render half of Piece 2** from the issue plan — the *prompt-side* change that makes the model emit `[n]` is deliberately **not** included here (it's gated on the #1937 citation-correctness metric, per the issue). The renderer is forward-compatible: as soon as answers carry `[n]` markers, they light up.

## What's new

- **`InlineCitationRenderer`** — pure, view-free marker logic (separated from the View for unit-testing):
  ```swift
  public enum InlineCitationRenderer {
      public enum Segment: Equatable, Sendable {
          case text(String)
          case marker(displayNumber: Int, citationIndex: Int)
      }
      public static func segments(for text: String, citations: [Citation]) -> [Segment]
      public static func hasResolvableMarker(in text: String, citations: [Citation]) -> Bool
      public static func deepLinkURL(citationIndex: Int) -> URL?
      public static func citationIndex(from url: URL) -> Int?
  }
  ```
  `[n]` resolves only when `1 <= n <= citations.count`; out-of-range, `[0]`, negative, and non-numeric brackets (including markdown `[label](url)` links) degrade to plain text — so a hallucinated/mis-numbered marker never renders a dead link or crashes.
- **`InlineCitationTextView`** — composes prose + tappable superscript markers into one `AttributedString` (markers carry `citation://<index>` links), so wrapping stays native.
- **`CitationHighlightCoordinator`** (`@MainActor @Observable`) — per-bubble transient deep-link state with auto-clearing flash.
- **`CitationsView`** — gains optional `onSelect: ((Citation) -> Void)?` (closure-injection keeps `ManifoldUI` from importing `ManifoldUIModelManagement`, per the CLAUDE.md dependency rule) + internal highlight wiring (auto-expand, `scrollTo`, flash).
- **`MessageBubbleView`** — owns the coordinator and intercepts marker taps via `openURL`, routing them to the deep-link instead of opening a browser.

## Non-regression

The inline path engages **only** post-stream (`!isStreaming`) **and only** when `hasResolvableMarker` is true. Plain answers with no markers keep flowing through the existing `AssistantMarkdownView` unchanged, so markdown/fenced-code/streaming rendering and the existing source-card disclosure are untouched. Verified the existing `CitationsView` source-card rendering (collapsed disclosure, `CitationRow` with `[index]`/title/chunk/score/snippet, accessibility labels) is preserved — rows are only wrapped in a `Button` when an `onSelect` closure is supplied, otherwise they stay the historical non-interactive card.

## Tests

`InlineCitationRendererTests` (13 cases, pass): marker→index mapping, 1-based display vs 0-based index, out-of-range/zero/negative/non-numeric degradation, markdown-link survival, coalescing, repeated markers, deep-link URL round-trip, and an `AttributedString` link-run assertion with a 0-citation sabotage check.

- `swift build --target ManifoldUI` ✅
- `swift test --filter InlineCitationRendererTests` ✅ (13/13)

> Screenshot note: this is a SwiftUI render change with no live RAG fixture in the build env, so no screenshot is attached; the `#Preview`s in `InlineCitationTextView`/`CitationsView` exercise the marker + deep-link surface.

Closes #1921

🤖 Generated with [Claude Code](https://claude.com/claude-code)