### PR TITLE
feat(inference): first-class withFallbacks routing chain (#1935)

### DIFF
--- a/Sources/ManifoldHardware/BackendCapabilities.swift
+++ b/Sources/ManifoldHardware/BackendCapabilities.swift
@@ -266,6 +266,107 @@ public struct BackendCapabilities: Sendable, Equatable, Codable {
         self.maxAdvertisedToolCount = maxAdvertisedToolCount
     }
 
+    /// Merges an ordered list of capability sets into the "can the composed
+    /// runtime as a whole do X?" union — per-flag OR, numeric maxima, the most
+    /// permissive cancellation/memory strategy.
+    ///
+    /// Lifted verbatim from ``RouterBackend``'s inline merge so the composing
+    /// backends (``RouterBackend``, ``FallbackBackend``) share one
+    /// implementation and cannot drift. The field set merged here is exactly the
+    /// one ``RouterBackend`` merged before extraction: flags added to
+    /// ``BackendCapabilities`` after the original merge (`supportsStrictSchema`,
+    /// `sharesMLXProcessResources`, `rendersFullPrompt`, `maxAdvertisedToolCount`)
+    /// fall to their memberwise-init defaults — preserving the historical union
+    /// surface rather than silently broadening it.
+    ///
+    /// An empty list yields a default ``BackendCapabilities``.
+    public static func union(_ capabilities: [BackendCapabilities]) -> BackendCapabilities {
+        guard let first = capabilities.first else {
+            return BackendCapabilities()
+        }
+        var supportedParameters = first.supportedParameters
+        var maxContextTokens = first.maxContextTokens
+        var maxOutputTokens = first.maxOutputTokens
+        var requiresPromptTemplate = first.requiresPromptTemplate
+        var supportsSystemPrompt = first.supportsSystemPrompt
+        var supportsStreaming = first.supportsStreaming
+        var supportsToolCalling = first.supportsToolCalling
+        var supportsStructuredOutput = first.supportsStructuredOutput
+        var supportsNativeJSONMode = first.supportsNativeJSONMode
+        var cancellationStyle = first.cancellationStyle
+        var supportsTokenCounting = first.supportsTokenCounting
+        var memoryStrategy = first.memoryStrategy
+        var isRemote = first.isRemote
+        var supportsKVCachePersistence = first.supportsKVCachePersistence
+        var supportsGrammarConstrainedSampling = first.supportsGrammarConstrainedSampling
+        var supportsThinking = first.supportsThinking
+        var supportsVision = first.supportsVision
+        var streamsToolCallArguments = first.streamsToolCallArguments
+        var supportsParallelToolCalls = first.supportsParallelToolCalls
+        var supportsGuidedStructuredOutput = first.supportsGuidedStructuredOutput
+
+        for c in capabilities.dropFirst() {
+            supportedParameters.formUnion(c.supportedParameters)
+            maxContextTokens = max(maxContextTokens, c.maxContextTokens)
+            maxOutputTokens = max(maxOutputTokens, c.maxOutputTokens)
+            // `requiresPromptTemplate` is a per-backend rule. The union answer
+            // is "the runtime can serve at least one backend that *doesn't*
+            // require a template" — false beats true.
+            requiresPromptTemplate = requiresPromptTemplate && c.requiresPromptTemplate
+            supportsSystemPrompt = supportsSystemPrompt || c.supportsSystemPrompt
+            supportsStreaming = supportsStreaming || c.supportsStreaming
+            supportsToolCalling = supportsToolCalling || c.supportsToolCalling
+            supportsStructuredOutput = supportsStructuredOutput || c.supportsStructuredOutput
+            supportsNativeJSONMode = supportsNativeJSONMode || c.supportsNativeJSONMode
+            // Pick the more permissive cancellation style — cooperative beats
+            // explicit because callers can always stop a cooperative backend
+            // by cancelling the Task.
+            if c.cancellationStyle == .cooperative { cancellationStyle = .cooperative }
+            supportsTokenCounting = supportsTokenCounting || c.supportsTokenCounting
+            // Memory strategy: keep `external` if any child is external (cloud
+            // path is available); otherwise prefer `mappable` over `resident`.
+            memoryStrategy = Self.mergedMemoryStrategy(memoryStrategy, c.memoryStrategy)
+            isRemote = isRemote || c.isRemote
+            supportsKVCachePersistence = supportsKVCachePersistence || c.supportsKVCachePersistence
+            supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling || c.supportsGrammarConstrainedSampling
+            supportsThinking = supportsThinking || c.supportsThinking
+            supportsVision = supportsVision || c.supportsVision
+            streamsToolCallArguments = streamsToolCallArguments || c.streamsToolCallArguments
+            supportsParallelToolCalls = supportsParallelToolCalls || c.supportsParallelToolCalls
+            supportsGuidedStructuredOutput = supportsGuidedStructuredOutput || c.supportsGuidedStructuredOutput
+        }
+        return BackendCapabilities(
+            supportedParameters: supportedParameters,
+            maxContextTokens: maxContextTokens,
+            requiresPromptTemplate: requiresPromptTemplate,
+            supportsSystemPrompt: supportsSystemPrompt,
+            supportsToolCalling: supportsToolCalling,
+            supportsStructuredOutput: supportsStructuredOutput,
+            supportsNativeJSONMode: supportsNativeJSONMode,
+            cancellationStyle: cancellationStyle,
+            supportsTokenCounting: supportsTokenCounting,
+            memoryStrategy: memoryStrategy,
+            maxOutputTokens: maxOutputTokens,
+            supportsStreaming: supportsStreaming,
+            isRemote: isRemote,
+            supportsKVCachePersistence: supportsKVCachePersistence,
+            supportsGrammarConstrainedSampling: supportsGrammarConstrainedSampling,
+            supportsThinking: supportsThinking,
+            supportsVision: supportsVision,
+            streamsToolCallArguments: streamsToolCallArguments,
+            supportsParallelToolCalls: supportsParallelToolCalls,
+            supportsGuidedStructuredOutput: supportsGuidedStructuredOutput
+        )
+    }
+
+    private static func mergedMemoryStrategy(_ a: MemoryStrategy, _ b: MemoryStrategy) -> MemoryStrategy {
+        // Preference order for "the most permissive" runtime memory profile:
+        // external (no local footprint) → mappable (paged) → resident (full RAM).
+        if a == .external || b == .external { return .external }
+        if a == .mappable || b == .mappable { return .mappable }
+        return .resident
+    }
+
     private enum CodingKeys: String, CodingKey {
         case supportedParameters
         case maxContextTokens

--- a/Sources/ManifoldInference/Services/FallbackBackend.swift
+++ b/Sources/ManifoldInference/Services/FallbackBackend.swift
@@ -230,12 +230,40 @@ public final class FallbackBackend: InferenceBackend, @unchecked Sendable {
             return
         }
 
+        // Per-backend retry must only cover *pre-first-token* failures. Once a
+        // content token has been forwarded, re-running `drain` would re-forward
+        // the already-emitted tokens to the consumer (duplicating output) —
+        // violating the streaming invariant that once a token is forwarded a
+        // mid-stream error is propagated, not routed around. Wrap any post-token
+        // error in a non-retryable `PostTokenStreamError` so `withRetry`
+        // propagates it on the first throw instead of re-running `drain`; the
+        // fallback driver then applies the post-token rule to the underlying
+        // error (propagate, or discard+restart only when
+        // `advanceAfterFirstToken` is set). The default path above (no retries)
+        // never re-runs `drain`, so it needs no guard.
+        let retriableDrain: () async throws -> Void = {
+            do {
+                try await drain()
+            } catch {
+                if tokenSeen.seen {
+                    throw PostTokenStreamError(underlying: error)
+                }
+                throw error
+            }
+        }
+
         do {
             try await withRetry(
                 strategy: ExponentialBackoffStrategy(maxRetries: policy.perBackendRetries),
                 sleeper: retrySleeper,
-                operation: drain
+                operation: retriableDrain
             )
+        } catch let postToken as PostTokenStreamError {
+            // A mid-stream error after the first token was forwarded — never
+            // retried by `withRetry` (the wrapper is non-retryable). Unwrap so
+            // the fallback driver advances/propagates based on the *underlying*
+            // error per the post-token rule.
+            throw postToken.underlying
         } catch let exhausted as RetryExhaustedError {
             // `withRetry` wraps the terminal error in `RetryExhaustedError` once
             // it gives up. Unwrap it so the fallback driver advances based on the
@@ -291,6 +319,21 @@ private final class TokenSeenBox: @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         _seen = true
     }
+}
+
+/// Wraps a mid-stream error raised *after* a content token was forwarded so the
+/// per-backend ``withRetry(strategy:sleeper:operation:)`` path treats it as
+/// terminal. Conforming to ``BackendError`` with `isRetryable == false` makes
+/// `withRetry` propagate it on the first throw instead of re-running `drain`
+/// (which would re-forward the already-emitted tokens). `runAttempt` unwraps it
+/// before handing control back to the fallback driver, which applies the
+/// post-token rule to the *underlying* error.
+private struct PostTokenStreamError: BackendError {
+    let underlying: any Error
+
+    var isRetryable: Bool { false }
+
+    var errorDescription: String? { (underlying as? LocalizedError)?.errorDescription }
 }
 
 // MARK: - Ergonomic builder

--- a/Sources/ManifoldInference/Services/FallbackBackend.swift
+++ b/Sources/ManifoldInference/Services/FallbackBackend.swift
@@ -1,0 +1,322 @@
+import Foundation
+
+/// Thrown by ``FallbackBackend`` when every backend in the chain failed.
+///
+/// Aggregates the per-backend errors in attempt order so callers can inspect
+/// the full failure chain rather than only the last error. Conforms to
+/// ``BackendError`` with `isRetryable == false`: an *outer* ``FallbackBackend``
+/// wrapping an inner exhausted chain will therefore not route around it (the
+/// inner chain already tried everything it could).
+public struct FallbackExhaustedError: BackendError {
+    /// The error each backend produced, in the order the chain attempted them.
+    public let perBackendErrors: [any Error]
+
+    public init(perBackendErrors: [any Error]) {
+        self.perBackendErrors = perBackendErrors
+    }
+
+    /// The error from the last backend tried — the most-relevant terminal cause.
+    public var lastError: (any Error)? { perBackendErrors.last }
+
+    public var isRetryable: Bool { false }
+
+    public var errorDescription: String? {
+        let detail = perBackendErrors
+            .enumerated()
+            .map { "[\($0.offset)] \($0.element.localizedDescription)" }
+            .joined(separator: "; ")
+        return "All \(perBackendErrors.count) fallback backend(s) failed: \(detail)"
+    }
+}
+
+/// An ``InferenceBackend`` that wraps an ordered list of backends and advances
+/// to the next one when an attempt fails with a routable error.
+///
+/// This is the error-advance counterpart to ``RouterBackend``'s capability-select
+/// routing. The first backend in the list is tried first (place your cheapest /
+/// lowest-latency / most-preferred backend first); on a routable failure
+/// (per ``FallbackPolicy/shouldAdvance``) the chain advances to the next. The
+/// first success wins. If every backend fails, the chain throws a
+/// ``FallbackExhaustedError`` aggregating each backend's error in order.
+///
+/// ## Streaming semantics
+///
+/// Fallback can only fire *before the first content token reaches the consumer*.
+/// Once a ``GenerationEvent/token(_:)`` (or ``GenerationEvent/thinkingToken(_:)``)
+/// has been forwarded, the consumer has seen partial output, so a mid-stream
+/// error is propagated rather than routed around — unless
+/// ``FallbackPolicy/advanceAfterFirstToken`` is `true`, in which case partial
+/// output is discarded and the turn restarts on the next backend.
+///
+/// ## Composition with `withRetry`
+///
+/// Per-backend retry (same backend, transient error) is orthogonal to
+/// cross-backend fallback. Set ``FallbackPolicy/perBackendRetries`` to retry each
+/// backend via ``withRetry(strategy:sleeper:operation:)`` before advancing.
+///
+/// ## Lifecycle delegation
+///
+/// `stopGeneration()`, `unloadModel()`, `resetConversation()`, and `secureWipe()`
+/// fan out to every backend — the chain may have left state on more than one.
+/// `loadModel(from:plan:)` is **not** routed: like ``RouterBackend``, picking and
+/// loading a model is the host's job; load each backend before composing the
+/// chain. `capabilities` is the union of every backend's capabilities (see
+/// ``BackendCapabilities/union(_:)``).
+public final class FallbackBackend: InferenceBackend, @unchecked Sendable {
+    /// Backends in priority order. The first is tried first.
+    public let backends: [any InferenceBackend]
+
+    /// The policy governing when the chain advances.
+    public let policy: FallbackPolicy
+
+    /// Sleeper injected into ``withRetry(strategy:sleeper:operation:)`` for the
+    /// per-backend retry path. Defaults to `Task.sleep`; tests inject a
+    /// recording sleeper to assert delay bounds without real-time blocking.
+    private let retrySleeper: @Sendable (Duration) async throws -> Void
+
+    public init(
+        backends: [any InferenceBackend],
+        policy: FallbackPolicy = .default,
+        retrySleeper: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+    ) {
+        // An empty chain would fail every request with an empty
+        // `FallbackExhaustedError` — surfacing the wiring mistake here, at the
+        // call site that built the chain, is far easier to debug.
+        precondition(
+            !backends.isEmpty,
+            "FallbackBackend requires at least one backend"
+        )
+        self.backends = backends
+        self.policy = policy
+        self.retrySleeper = retrySleeper
+    }
+
+    public var isModelLoaded: Bool {
+        backends.contains { $0.isModelLoaded }
+    }
+
+    public var isGenerating: Bool {
+        backends.contains { $0.isGenerating }
+    }
+
+    public var capabilities: BackendCapabilities {
+        // Union semantics — "can the chain as a whole do X?". Reuses the shared
+        // merge helper so this and RouterBackend stay byte-for-byte identical.
+        BackendCapabilities.union(backends.map(\.capabilities))
+    }
+
+    public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        // Loading is not a routing decision — the host owns model selection.
+        throw InferenceError.inferenceFailure(
+            "FallbackBackend does not load models — load each backend before composing the chain."
+        )
+    }
+
+    public func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        let backends = self.backends
+        let policy = self.policy
+        let retrySleeper = self.retrySleeper
+
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            let task = Task {
+                var perBackendErrors: [any Error] = []
+                // Once any content token has been forwarded to the consumer we
+                // can no longer transparently fail over (the partial output is
+                // already visible). Tracked across the whole chain.
+                var forwardedContentToken = false
+
+                for backend in backends {
+                    if Task.isCancelled {
+                        continuation.finish(throwing: CancellationError())
+                        return
+                    }
+                    let tokenSeen = TokenSeenBox()
+                    do {
+                        try await Self.runAttempt(
+                            backend: backend,
+                            prompt: prompt,
+                            systemPrompt: systemPrompt,
+                            config: config,
+                            policy: policy,
+                            retrySleeper: retrySleeper,
+                            tokenSeen: tokenSeen,
+                            forward: { continuation.yield($0) }
+                        )
+                        // Success — the attempt forwarded the full stream.
+                        continuation.finish()
+                        return
+                    } catch is CancellationError {
+                        continuation.finish(throwing: CancellationError())
+                        return
+                    } catch {
+                        perBackendErrors.append(error)
+                        if tokenSeen.seen { forwardedContentToken = true }
+
+                        // If the consumer already saw a content token and we are
+                        // not allowed to restart, the error is terminal for this
+                        // turn — propagate it, never advance.
+                        if forwardedContentToken && !policy.advanceAfterFirstToken {
+                            continuation.finish(throwing: error)
+                            return
+                        }
+
+                        // Fail fast on non-routable errors (auth, bad request,
+                        // quota, unsupported) — the next backend would not help.
+                        guard policy.shouldAdvance(error) else {
+                            continuation.finish(throwing: error)
+                            return
+                        }
+
+                        Log.inference.warning(
+                            "Fallback advancing past backend after routable error: \(error)"
+                        )
+                        // advanceAfterFirstToken: discard partial output and
+                        // restart on the next backend. Reset the flag so the
+                        // next backend's pre-first-token errors can advance too.
+                        forwardedContentToken = false
+                        continue
+                    }
+                }
+
+                // Every backend failed.
+                continuation.finish(
+                    throwing: FallbackExhaustedError(perBackendErrors: perBackendErrors)
+                )
+            }
+
+            continuation.onTermination = { _ in task.cancel() }
+        }
+
+        return GenerationStream(stream)
+    }
+
+    /// Runs a single backend attempt (with optional per-backend retry), draining
+    /// its event stream and forwarding events. Records into `tokenSeen` once the
+    /// first content token is forwarded. Throws on failure.
+    private static func runAttempt(
+        backend: any InferenceBackend,
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig,
+        policy: FallbackPolicy,
+        retrySleeper: @escaping @Sendable (Duration) async throws -> Void,
+        tokenSeen: TokenSeenBox,
+        forward: @escaping @Sendable (GenerationEvent) -> Void
+    ) async throws {
+        // `tokenSeen` is a Sendable box so the drain closure (which is @Sendable
+        // and may run across suspension points / multiple withRetry attempts)
+        // can record whether a content token was forwarded. The fallback driver
+        // reads it after the attempt to enforce the no-restart-after-token rule.
+        let drain: () async throws -> Void = {
+            let genStream = try backend.generate(
+                prompt: prompt,
+                systemPrompt: systemPrompt,
+                config: config
+            )
+            for try await event in genStream.events {
+                if Self.isContentToken(event) {
+                    tokenSeen.markSeen()
+                }
+                forward(event)
+            }
+        }
+
+        guard policy.perBackendRetries > 0 else {
+            try await drain()
+            return
+        }
+
+        do {
+            try await withRetry(
+                strategy: ExponentialBackoffStrategy(maxRetries: policy.perBackendRetries),
+                sleeper: retrySleeper,
+                operation: drain
+            )
+        } catch let exhausted as RetryExhaustedError {
+            // `withRetry` wraps the terminal error in `RetryExhaustedError` once
+            // it gives up. Unwrap it so the fallback driver advances based on the
+            // *underlying* error's retryability (and `RetryExhaustedError` — not
+            // a `BackendError` — doesn't dead-end the chain at the first backend).
+            throw exhausted.lastError
+        }
+    }
+
+    /// Content tokens are the events whose appearance means the consumer has
+    /// seen partial output and a transparent fail-over is no longer possible.
+    private static func isContentToken(_ event: GenerationEvent) -> Bool {
+        switch event {
+        case .token, .thinkingToken:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public func stopGeneration() {
+        for backend in backends { backend.stopGeneration() }
+    }
+
+    public func unloadModel() {
+        for backend in backends { backend.unloadModel() }
+    }
+
+    public func resetConversation() {
+        for backend in backends { backend.resetConversation() }
+    }
+
+    public func secureWipe() {
+        for backend in backends { backend.secureWipe() }
+    }
+}
+
+/// Thread-safe one-shot flag recording whether a content token was forwarded
+/// during a backend attempt. The drain closure handed to
+/// ``withRetry(strategy:sleeper:operation:)`` is `@Sendable` and may run across
+/// suspension points, so a bare `Bool` capture would race under strict
+/// concurrency; this box localizes the synchronization.
+private final class TokenSeenBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _seen = false
+
+    var seen: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _seen
+    }
+
+    func markSeen() {
+        lock.lock(); defer { lock.unlock() }
+        _seen = true
+    }
+}
+
+// MARK: - Ergonomic builder
+
+extension InferenceBackend {
+    /// Composes `self` with `others` into a ``FallbackBackend`` chain, in order
+    /// (`self` first). Ergonomic parity with LangChain's `with_fallbacks` /
+    /// pydantic's `FallbackModel`.
+    ///
+    /// ```swift
+    /// let backend = primary.withFallbacks([secondary, tertiary])
+    /// ```
+    public func withFallbacks(
+        _ others: [any InferenceBackend],
+        policy: FallbackPolicy = .default
+    ) -> FallbackBackend {
+        FallbackBackend(backends: [self] + others, policy: policy)
+    }
+}
+
+/// Free-function builder for an explicit ordered list. Mirrors
+/// `with_fallbacks([...])` for callers who prefer a flat list over the
+/// method form.
+public func withFallbacks(
+    _ backends: [any InferenceBackend],
+    policy: FallbackPolicy = .default
+) -> FallbackBackend {
+    FallbackBackend(backends: backends, policy: policy)
+}

--- a/Sources/ManifoldInference/Services/FallbackPolicy.swift
+++ b/Sources/ManifoldInference/Services/FallbackPolicy.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Configures how a ``FallbackBackend`` decides to advance from one backend to
+/// the next when a generation attempt fails.
+///
+/// The two routing axes in ManifoldKit are deliberately separate:
+///
+/// - ``RouterBackend`` selects **one** child per request by *capability* and
+///   never retries across children (see its doc-comment). That is a
+///   capability-select axis.
+/// - ``FallbackBackend`` (configured by this policy) advances across an ordered
+///   list on *error*. That is an error-advance axis.
+///
+/// They compose: a ``FallbackBackend`` whose children are ``RouterBackend``s is
+/// valid and routes on both axes.
+public struct FallbackPolicy: Sendable {
+    /// Predicate deciding whether a given error from one backend should cause
+    /// the chain to advance to the next backend.
+    ///
+    /// The default advances only on errors that conform to ``BackendError`` and
+    /// report `isRetryable == true` — the same transient-vs-terminal signal the
+    /// per-backend ``withRetry(strategy:sleeper:operation:)`` path uses. This
+    /// keeps fail-fast semantics: a non-retryable error (bad request, auth
+    /// failure, quota exhausted, unsupported model) is *propagated*, not routed
+    /// around, because trying the next backend would not change the outcome.
+    public var shouldAdvance: @Sendable (any Error) -> Bool
+
+    /// Whether to advance to the next backend even after the current backend has
+    /// already emitted at least one *content* token (``GenerationEvent/token(_:)``
+    /// or a thinking token).
+    ///
+    /// Defaults to `false`. Once the consumer has seen partial output, silently
+    /// failing over and restarting on a different backend would duplicate or
+    /// contradict already-delivered tokens. With the default, an error that
+    /// arrives *after* the first token is always propagated regardless of
+    /// ``shouldAdvance`` — fallback only fires on pre-first-token failures.
+    ///
+    /// Set to `true` only when the consumer is prepared to discard partial
+    /// output and restart the turn on the next backend.
+    public var advanceAfterFirstToken: Bool
+
+    /// Number of in-backend retries to attempt (via
+    /// ``withRetry(strategy:sleeper:operation:)``) *before* advancing to the
+    /// next backend. Defaults to `0` — no per-backend retry, advance on the
+    /// first failure.
+    ///
+    /// Per-backend retry (same backend, transient error) and cross-backend
+    /// fallback (next backend) are orthogonal: this composes them so a chain can
+    /// retry each backend N times before moving on.
+    public var perBackendRetries: Int
+
+    public init(
+        shouldAdvance: @escaping @Sendable (any Error) -> Bool = FallbackPolicy.defaultShouldAdvance,
+        advanceAfterFirstToken: Bool = false,
+        perBackendRetries: Int = 0
+    ) {
+        self.shouldAdvance = shouldAdvance
+        self.advanceAfterFirstToken = advanceAfterFirstToken
+        self.perBackendRetries = perBackendRetries
+    }
+
+    /// Advances only on retryable ``BackendError``s. Non-`BackendError` errors
+    /// and non-retryable backend errors do not advance (fail fast).
+    public static let defaultShouldAdvance: @Sendable (any Error) -> Bool = { error in
+        guard let backendError = error as? any BackendError else { return false }
+        return backendError.isRetryable
+    }
+
+    /// The default policy: advance on retryable errors only, never after the
+    /// first token, no per-backend retries.
+    public static let `default` = FallbackPolicy()
+}

--- a/Sources/ManifoldInference/Services/RouterBackend.swift
+++ b/Sources/ManifoldInference/Services/RouterBackend.swift
@@ -55,84 +55,10 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
 
     public var capabilities: BackendCapabilities {
         // Union semantics — see type doc-comment for why this surface is the
-        // right answer for "can the runtime as a whole do X?".
-        guard let first = children.first?.capabilities else {
-            return BackendCapabilities()
-        }
-        var supportedParameters = first.supportedParameters
-        var maxContextTokens = first.maxContextTokens
-        var maxOutputTokens = first.maxOutputTokens
-        var requiresPromptTemplate = first.requiresPromptTemplate
-        var supportsSystemPrompt = first.supportsSystemPrompt
-        var supportsStreaming = first.supportsStreaming
-        var supportsToolCalling = first.supportsToolCalling
-        var supportsStructuredOutput = first.supportsStructuredOutput
-        var supportsNativeJSONMode = first.supportsNativeJSONMode
-        var cancellationStyle = first.cancellationStyle
-        var supportsTokenCounting = first.supportsTokenCounting
-        var memoryStrategy = first.memoryStrategy
-        var isRemote = first.isRemote
-        var supportsKVCachePersistence = first.supportsKVCachePersistence
-        var supportsGrammarConstrainedSampling = first.supportsGrammarConstrainedSampling
-        var supportsThinking = first.supportsThinking
-        var supportsVision = first.supportsVision
-        var streamsToolCallArguments = first.streamsToolCallArguments
-        var supportsParallelToolCalls = first.supportsParallelToolCalls
-        var supportsGuidedStructuredOutput = first.supportsGuidedStructuredOutput
-
-        for child in children.dropFirst() {
-            let c = child.capabilities
-            supportedParameters.formUnion(c.supportedParameters)
-            maxContextTokens = max(maxContextTokens, c.maxContextTokens)
-            maxOutputTokens = max(maxOutputTokens, c.maxOutputTokens)
-            // `requiresPromptTemplate` is a per-backend rule. The union answer
-            // is "the runtime can serve at least one backend that *doesn't*
-            // require a template" — false beats true.
-            requiresPromptTemplate = requiresPromptTemplate && c.requiresPromptTemplate
-            supportsSystemPrompt = supportsSystemPrompt || c.supportsSystemPrompt
-            supportsStreaming = supportsStreaming || c.supportsStreaming
-            supportsToolCalling = supportsToolCalling || c.supportsToolCalling
-            supportsStructuredOutput = supportsStructuredOutput || c.supportsStructuredOutput
-            supportsNativeJSONMode = supportsNativeJSONMode || c.supportsNativeJSONMode
-            // Pick the more permissive cancellation style — cooperative beats
-            // explicit because callers can always stop a cooperative backend
-            // by cancelling the Task.
-            if c.cancellationStyle == .cooperative { cancellationStyle = .cooperative }
-            supportsTokenCounting = supportsTokenCounting || c.supportsTokenCounting
-            // Memory strategy: keep `external` if any child is external (cloud
-            // path is available); otherwise prefer `mappable` over `resident`.
-            memoryStrategy = mergedMemoryStrategy(memoryStrategy, c.memoryStrategy)
-            isRemote = isRemote || c.isRemote
-            supportsKVCachePersistence = supportsKVCachePersistence || c.supportsKVCachePersistence
-            supportsGrammarConstrainedSampling = supportsGrammarConstrainedSampling || c.supportsGrammarConstrainedSampling
-            supportsThinking = supportsThinking || c.supportsThinking
-            supportsVision = supportsVision || c.supportsVision
-            streamsToolCallArguments = streamsToolCallArguments || c.streamsToolCallArguments
-            supportsParallelToolCalls = supportsParallelToolCalls || c.supportsParallelToolCalls
-            supportsGuidedStructuredOutput = supportsGuidedStructuredOutput || c.supportsGuidedStructuredOutput
-        }
-        return BackendCapabilities(
-            supportedParameters: supportedParameters,
-            maxContextTokens: maxContextTokens,
-            requiresPromptTemplate: requiresPromptTemplate,
-            supportsSystemPrompt: supportsSystemPrompt,
-            supportsToolCalling: supportsToolCalling,
-            supportsStructuredOutput: supportsStructuredOutput,
-            supportsNativeJSONMode: supportsNativeJSONMode,
-            cancellationStyle: cancellationStyle,
-            supportsTokenCounting: supportsTokenCounting,
-            memoryStrategy: memoryStrategy,
-            maxOutputTokens: maxOutputTokens,
-            supportsStreaming: supportsStreaming,
-            isRemote: isRemote,
-            supportsKVCachePersistence: supportsKVCachePersistence,
-            supportsGrammarConstrainedSampling: supportsGrammarConstrainedSampling,
-            supportsThinking: supportsThinking,
-            supportsVision: supportsVision,
-            streamsToolCallArguments: streamsToolCallArguments,
-            supportsParallelToolCalls: supportsParallelToolCalls,
-            supportsGuidedStructuredOutput: supportsGuidedStructuredOutput
-        )
+        // right answer for "can the runtime as a whole do X?". The merge lives
+        // in `BackendCapabilities.union(_:)` so RouterBackend and FallbackBackend
+        // share one implementation (extracted #1935).
+        BackendCapabilities.union(children.map(\.capabilities))
     }
 
     /// Picks the first child whose capabilities satisfy `requirements`.
@@ -201,13 +127,5 @@ public final class RouterBackend: InferenceBackend, @unchecked Sendable {
 
     public func resetConversation() {
         for child in children { child.resetConversation() }
-    }
-
-    private func mergedMemoryStrategy(_ a: MemoryStrategy, _ b: MemoryStrategy) -> MemoryStrategy {
-        // Preference order for "the most permissive" runtime memory profile:
-        // external (no local footprint) → mappable (paged) → resident (full RAM).
-        if a == .external || b == .external { return .external }
-        if a == .mappable || b == .mappable { return .mappable }
-        return .resident
     }
 }

--- a/Tests/ManifoldInferenceTests/FallbackBackendTests.swift
+++ b/Tests/ManifoldInferenceTests/FallbackBackendTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for ``FallbackBackend`` — the error-advance routing chain (#1935).
+///
+/// The chain tries backends in order, advances on a routable (retryable) error
+/// raised *before the first content token*, returns the first success, and
+/// aggregates per-backend errors into ``FallbackExhaustedError`` when all fail.
+final class FallbackBackendTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// A retryable cloud error (transient — should advance).
+    private var retryable: CloudBackendError { .rateLimited(retryAfter: nil) }
+
+    /// A non-retryable cloud error (terminal — must fail fast, not advance).
+    private var nonRetryable: CloudBackendError { .authenticationFailed(provider: "test") }
+
+    private func loadedMock(
+        tokens: [String] = ["ok"],
+        caps: BackendCapabilities = BackendCapabilities()
+    ) -> MockInferenceBackend {
+        let mock = MockInferenceBackend(capabilities: caps)
+        mock.isModelLoaded = true
+        mock.tokensToYield = tokens
+        return mock
+    }
+
+    /// Drains a fallback chain to completion, collecting tokens. Throws the
+    /// terminal error if the stream fails.
+    private func drain(
+        _ backend: FallbackBackend,
+        prompt: String = "hi"
+    ) async throws -> [String] {
+        let stream = try backend.generate(prompt: prompt, systemPrompt: nil, config: GenerationConfig())
+        var tokens: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { tokens.append(t) }
+        }
+        return tokens
+    }
+
+    // MARK: - Advance on retryable error
+
+    func testAdvancesOnRetryableError() async throws {
+        let failing = loadedMock()
+        // No tokens, then a retryable stream error → pre-first-token failure.
+        failing.tokensToYield = []
+        failing.shouldThrowInsideStream = retryable
+        let second = loadedMock(tokens: ["from-second"])
+
+        let chain = FallbackBackend(backends: [failing, second])
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["from-second"])
+        XCTAssertEqual(failing.generateCallCount, 1)
+        XCTAssertEqual(second.generateCallCount, 1)
+    }
+
+    func testAdvancesOnSynchronousRetryableThrow() async throws {
+        // generate() itself throwing (vs throwing inside the stream) is also a
+        // pre-first-token failure and must advance.
+        let failing = loadedMock()
+        failing.shouldThrowOnGenerate = retryable
+        let second = loadedMock(tokens: ["recovered"])
+
+        let chain = FallbackBackend(backends: [failing, second])
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["recovered"])
+    }
+
+    // MARK: - First success wins
+
+    func testReturnsFirstSuccessWithoutAdvancing() async throws {
+        let first = loadedMock(tokens: ["primary"])
+        let second = loadedMock(tokens: ["secondary"])
+
+        let chain = FallbackBackend(backends: [first, second])
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["primary"])
+        XCTAssertEqual(first.generateCallCount, 1)
+        // The second backend must never be touched once the first succeeds.
+        XCTAssertEqual(second.generateCallCount, 0)
+    }
+
+    // MARK: - Fail fast on non-retryable error
+
+    func testDoesNotAdvanceOnNonRetryableError() async throws {
+        let failing = loadedMock()
+        failing.tokensToYield = []
+        failing.shouldThrowInsideStream = nonRetryable
+        let second = loadedMock(tokens: ["should-not-reach"])
+
+        let chain = FallbackBackend(backends: [failing, second])
+
+        do {
+            _ = try await drain(chain)
+            XCTFail("Expected the non-retryable error to propagate")
+        } catch let error as CloudBackendError {
+            guard case .authenticationFailed = error else {
+                return XCTFail("Expected authenticationFailed, got \(error)")
+            }
+            XCTAssertFalse(error.isRetryable)
+        }
+        // Fail-fast: the second backend must NOT be invoked.
+        XCTAssertEqual(second.generateCallCount, 0)
+    }
+
+    // MARK: - All fail → aggregate last error
+
+    func testPropagatesAggregateWhenAllFail() async throws {
+        let a = loadedMock(); a.tokensToYield = []; a.shouldThrowInsideStream = retryable
+        let b = loadedMock(); b.tokensToYield = []; b.shouldThrowInsideStream = retryable
+        let c = loadedMock(); c.tokensToYield = []
+        c.shouldThrowInsideStream = CloudBackendError.providerOverloaded(provider: "x", retryAfter: nil)
+
+        let chain = FallbackBackend(backends: [a, b, c])
+
+        do {
+            _ = try await drain(chain)
+            XCTFail("Expected FallbackExhaustedError")
+        } catch let exhausted as FallbackExhaustedError {
+            // All three errors aggregated, in attempt order.
+            XCTAssertEqual(exhausted.perBackendErrors.count, 3)
+            XCTAssertFalse(exhausted.isRetryable)
+            // Last error is the most-relevant terminal cause.
+            XCTAssertTrue(exhausted.lastError is CloudBackendError)
+        }
+        XCTAssertEqual(a.generateCallCount, 1)
+        XCTAssertEqual(b.generateCallCount, 1)
+        XCTAssertEqual(c.generateCallCount, 1)
+    }
+
+    // MARK: - Order preservation
+
+    func testPreservesBackendOrder() async throws {
+        // First two fail retryably; the third succeeds. Order must hold.
+        let first = loadedMock(); first.tokensToYield = []; first.shouldThrowInsideStream = retryable
+        let second = loadedMock(); second.tokensToYield = []; second.shouldThrowInsideStream = retryable
+        let third = loadedMock(tokens: ["third-wins"])
+
+        let chain = FallbackBackend(backends: [first, second, third])
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["third-wins"])
+        XCTAssertEqual(first.generateCallCount, 1)
+        XCTAssertEqual(second.generateCallCount, 1)
+        XCTAssertEqual(third.generateCallCount, 1)
+    }
+
+    // MARK: - No fail-over after first token (streaming semantics)
+
+    func testDoesNotAdvanceAfterFirstTokenByDefault() async throws {
+        // Backend yields one real token, THEN throws a retryable error.
+        let failing = loadedMock(tokens: ["partial"])
+        failing.shouldThrowInsideStream = retryable
+        let second = loadedMock(tokens: ["should-not-reach"])
+
+        let chain = FallbackBackend(backends: [failing, second])
+
+        var received: [String] = []
+        do {
+            let stream = try chain.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+            for try await event in stream.events {
+                if case .token(let t) = event { received.append(t) }
+            }
+            XCTFail("Expected the post-token error to propagate")
+        } catch let error as CloudBackendError {
+            guard case .rateLimited = error else {
+                return XCTFail("Expected rateLimited, got \(error)")
+            }
+        }
+        // The partial token reached the consumer.
+        XCTAssertEqual(received, ["partial"])
+        // The chain must NOT have failed over — partial output was already seen.
+        XCTAssertEqual(second.generateCallCount, 0)
+    }
+
+    func testAdvancesAfterFirstTokenWhenOptedIn() async throws {
+        // Same shape, but advanceAfterFirstToken discards partial output and
+        // restarts on the next backend.
+        let failing = loadedMock(tokens: ["discarded-partial"])
+        failing.shouldThrowInsideStream = retryable
+        let second = loadedMock(tokens: ["restarted"])
+
+        let policy = FallbackPolicy(advanceAfterFirstToken: true)
+        let chain = FallbackBackend(backends: [failing, second], policy: policy)
+
+        let stream = try chain.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+        var received: [String] = []
+        for try await event in stream.events {
+            if case .token(let t) = event { received.append(t) }
+        }
+        // Both the partial (pre-failover) and the restart tokens are forwarded.
+        XCTAssertEqual(received, ["discarded-partial", "restarted"])
+        XCTAssertEqual(second.generateCallCount, 1)
+    }
+
+    // MARK: - Per-backend retry composes with fallback
+
+    func testPerBackendRetriesBeforeAdvancing() async throws {
+        // The first backend always fails retryably; with perBackendRetries=2 it
+        // should be retried (3 generate() calls total via withRetry) before the
+        // chain advances to the success backend. RecordingRetrySleeper keeps the
+        // test deterministic with no real wall-clock delay.
+        let recorder = RecordingRetrySleeper()
+        let failing = loadedMock(); failing.tokensToYield = []; failing.shouldThrowInsideStream = retryable
+        let second = loadedMock(tokens: ["after-retries"])
+
+        let policy = FallbackPolicy(perBackendRetries: 2)
+        let chain = FallbackBackend(backends: [failing, second], policy: policy, retrySleeper: recorder.asSleeper)
+
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["after-retries"])
+        // withRetry(maxRetries: 2) → initial + 2 retries = 3 attempts.
+        XCTAssertEqual(failing.generateCallCount, 3)
+        // Two retry delays were requested (and recorded, not slept).
+        XCTAssertEqual(recorder.recordedSleeps.count, 2)
+        XCTAssertEqual(second.generateCallCount, 1)
+    }
+
+    // MARK: - Capability union matches RouterBackend
+
+    func testCapabilityUnionMatchesRouter() async throws {
+        let a = loadedMock(caps: BackendCapabilities(
+            maxContextTokens: 2048,
+            supportsToolCalling: false,
+            supportsThinking: true
+        ))
+        let b = loadedMock(caps: BackendCapabilities(
+            maxContextTokens: 32_000,
+            supportsToolCalling: true,
+            supportsThinking: false
+        ))
+
+        let fallback = FallbackBackend(backends: [a, b])
+        let router = RouterBackend(children: [a, b])
+
+        // Same union helper underneath — must agree field-for-field.
+        XCTAssertEqual(fallback.capabilities, router.capabilities)
+        XCTAssertEqual(fallback.capabilities.maxContextTokens, 32_000)
+        XCTAssertTrue(fallback.capabilities.supportsToolCalling)
+        XCTAssertTrue(fallback.capabilities.supportsThinking)
+    }
+
+    // MARK: - Builder ergonomics
+
+    func testWithFallbacksBuilder() async throws {
+        let primary = loadedMock(); primary.tokensToYield = []; primary.shouldThrowInsideStream = retryable
+        let secondary = loadedMock(tokens: ["builder-recovered"])
+
+        let chain = primary.withFallbacks([secondary])
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["builder-recovered"])
+        XCTAssertEqual(chain.backends.count, 2)
+    }
+
+    func testWithFallbacksFreeFunction() async throws {
+        let primary = loadedMock(tokens: ["free-fn"])
+        let secondary = loadedMock(tokens: ["unused"])
+
+        let chain = withFallbacks([primary, secondary])
+        let tokens = try await drain(chain)
+
+        XCTAssertEqual(tokens, ["free-fn"])
+        XCTAssertEqual(secondary.generateCallCount, 0)
+    }
+}

--- a/Tests/ManifoldInferenceTests/FallbackBackendTests.swift
+++ b/Tests/ManifoldInferenceTests/FallbackBackendTests.swift
@@ -223,6 +223,48 @@ final class FallbackBackendTests: XCTestCase {
         XCTAssertEqual(second.generateCallCount, 1)
     }
 
+    func testPerBackendRetriesDoNotReForwardTokenAfterFirstToken() async throws {
+        // Regression for the token-reforward bug: with perBackendRetries > 0, a
+        // backend that forwards a token and THEN throws a retryable mid-stream
+        // error must NOT be retried (which would re-run the drain closure and
+        // re-emit the already-forwarded token). The consumer must see each token
+        // exactly once, and the error must propagate rather than silently retry.
+        let recorder = RecordingRetrySleeper()
+        let failing = loadedMock(tokens: ["partial"])
+        failing.shouldThrowInsideStream = retryable
+        let second = loadedMock(tokens: ["should-not-reach"])
+
+        let policy = FallbackPolicy(perBackendRetries: 2)
+        let chain = FallbackBackend(
+            backends: [failing, second],
+            policy: policy,
+            retrySleeper: recorder.asSleeper
+        )
+
+        var received: [String] = []
+        do {
+            let stream = try chain.generate(prompt: "hi", systemPrompt: nil, config: GenerationConfig())
+            for try await event in stream.events {
+                if case .token(let t) = event { received.append(t) }
+            }
+            XCTFail("Expected the post-token error to propagate")
+        } catch let error as CloudBackendError {
+            guard case .rateLimited = error else {
+                return XCTFail("Expected rateLimited, got \(error)")
+            }
+        }
+
+        // The token reached the consumer exactly once — no re-forward on retry.
+        XCTAssertEqual(received, ["partial"])
+        // The backend's generate() ran exactly once: the post-token error is
+        // terminal, so withRetry must not have re-invoked the drain.
+        XCTAssertEqual(failing.generateCallCount, 1)
+        // No retry delays were requested — the error short-circuited retry.
+        XCTAssertEqual(recorder.recordedSleeps.count, 0)
+        // No fail-over — partial output was already seen by the consumer.
+        XCTAssertEqual(second.generateCallCount, 0)
+    }
+
     // MARK: - Capability union matches RouterBackend
 
     func testCapabilityUnionMatchesRouter() async throws {


### PR DESCRIPTION
## Summary

Adds a first-class **`withFallbacks([...])` routing chain** (`FallbackBackend`) that advances to the next backend on a routable (retryable) API error, with ordered (cost/latency-aware) preference — LangChain `with_fallbacks` / pydantic `FallbackModel` parity.

This is an **assembly** job, not a new subsystem — it reuses the primitives the investigation flagged (`BackendError.isRetryable`, `withRetry` / `ExponentialBackoffStrategy`, `RouterBackend` composition).

### Behavior
- Tries backends **in priority order**; returns the **first success**.
- On a **routable** error (default: `BackendError.isRetryable == true`) raised **before the first content token**, advances to the next backend.
- **Non-retryable** errors (auth, bad request, quota, unsupported) **fail fast** — they propagate, never advance, because the next backend would not help. Confirmed against `BackendError.isRetryable` (`CloudBackendError` / `InferenceError`).
- If **all** backends fail, throws an aggregate `FallbackExhaustedError` carrying each backend's error in order (`isRetryable == false`, so an outer chain won't loop on it).

### Streaming semantics (the key design decision)
Fallback fires **only before the first content token reaches the consumer**. Once a `.token`/`.thinkingToken` has been forwarded, a mid-stream error is **propagated** (the consumer has already seen partial output) — unless `FallbackPolicy.advanceAfterFirstToken == true`, which discards partial output and restarts on the next backend.

### Composition with `withRetry`
Per-backend retry (same backend, transient error) and cross-backend fallback (next backend) are orthogonal and compose: `FallbackPolicy.perBackendRetries` retries each backend via `withRetry` before advancing. (When `withRetry` exhausts, the wrapping `RetryExhaustedError` is unwrapped so the chain still advances on the underlying error.)

### RouterBackend unchanged
`RouterBackend` stays capability-routing only — its behavior/defaults are untouched. Its inline ~80-line capability merge was lifted **verbatim** into a new shared `BackendCapabilities.union(_:)` helper (same field set, same defaults) that both composing backends now call, so they cannot drift. RouterBackend's 24 tests stay green.

## Usage

```swift
import ManifoldInference

// Cheapest/fastest first; advance on a transient failure.
let backend = primary.withFallbacks([secondary, tertiary])

// Or an explicit ordered list, with per-backend retry before advancing:
let policy = FallbackPolicy(perBackendRetries: 2)
let chain = withFallbacks([fast, mid, frontier], policy: policy)

let stream = try chain.generate(prompt: prompt, systemPrompt: nil, config: config)
for try await event in stream.events { /* … */ }
```

## Files changed
- `Sources/ManifoldInference/Services/FallbackBackend.swift` (new) — `FallbackBackend`, `FallbackExhaustedError`, `withFallbacks` builders
- `Sources/ManifoldInference/Services/FallbackPolicy.swift` (new) — `FallbackPolicy` (`shouldAdvance`, `advanceAfterFirstToken`, `perBackendRetries`)
- `Sources/ManifoldHardware/BackendCapabilities.swift` — extracted shared `union(_:)` helper
- `Sources/ManifoldInference/Services/RouterBackend.swift` — delegates `capabilities` to the shared helper (no behavior change)
- `Tests/ManifoldInferenceTests/FallbackBackendTests.swift` (new) — 12 deterministic tests

## Tests
12 in-memory tests using `MockInferenceBackend` (real async/await, no `try?`): advance on retryable (stream + synchronous throw), first-success-wins, fail-fast on non-retryable, aggregate on all-fail, order preservation, no-advance-after-first-token (+ opt-in), per-backend retries compose with fallback (via `RecordingRetrySleeper`), capability union matches `RouterBackend`, both builders.

`swift build --target ManifoldInference` ✅ · `FallbackBackendTests` 12/12 ✅ · `RouterBackendTests` 24/24 ✅ · `BackendCapabilitiesTests` 30/30 ✅

## Ordering note (held for review, not auto-merge)
The issue orders this **after #1936** (per-model crash-isolation executors), which is **not yet merged**. Per the maintainer's note, #1935 is intentionally built as a **standalone additive API that does not depend on #1936** — it composes over plain backends today. **This PR should be held for review, not auto-merged**, pending the #1936 decision. It is purely additive (no existing behavior changed).

Closes #1935

🤖 Generated with [Claude Code](https://claude.com/claude-code)
