### PR TITLE
fix(ci): guard empty BUILD_PATH_FLAG for Bash 3.2 cold-start gate

### DIFF
--- a/scripts/cold-start-human.sh
+++ b/scripts/cold-start-human.sh
@@ -223,7 +223,10 @@ if [[ -n "${MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR:-}" ]]; then
 fi
 
 echo "==> swift build (Hello World snippet from README)"
-if ! env "${SWIFT_ENV[@]}" swift build --package-path "${WORK}" "${BUILD_PATH_FLAG[@]}" 2>&1 | tail -60; then
+# Bash 3.2 (the CI runner shell) errors under `set -u` when expanding an empty
+# array as "${arr[@]}". BUILD_PATH_FLAG is empty unless a build cache is set, so
+# guard the expansion with the ${arr[@]+...} portable idiom.
+if ! env "${SWIFT_ENV[@]}" swift build --package-path "${WORK}" ${BUILD_PATH_FLAG[@]+"${BUILD_PATH_FLAG[@]}"} 2>&1 | tail -60; then
     echo "::error file=README.md,line=${first_h2_line}::The Hello World snippet does not compile against the current ManifoldKit public API."
     echo "    Either the snippet drifted (e.g. deleted symbol, renamed type) or"
     echo "    a public symbol it relies on was removed without updating the README."


### PR DESCRIPTION
## Problem

The **tier-4 cold-start human-path gate** (`scripts/cold-start-human.sh`) has failed on **every nightly run for 5+ consecutive nights** (e.g. runs 27598331589, 27669781798, 27740389388, 27809141208, 27862231731). The failure was masked by an unrelated CoreData-checksum log spew and a misleading error message.

Root cause: the CI runners ship **Bash 3.2**, which errors under `set -u` when expanding an empty array as `"${arr[@]}"`. `BUILD_PATH_FLAG` (line 218) is empty unless `MANIFOLDKIT_COLD_START_BUILD_CACHE_DIR` is set, so the `swift build` invocation aborted with:

```
scripts/cold-start-human.sh: line 226: BUILD_PATH_FLAG[@]: unbound variable
::error::swift build exited 0 but did not produce HelloWorld.swift.o — check target wiring.
```

The gate never ran a build; it just tripped the array expansion and then misreported it as a missing object file. (Matches the known "CI runners use Bash 3.2 — test scripts under /bin/bash" gotcha.)

## Fix

Guard the expansion with the portable `${arr[@]+"${arr[@]}"}` idiom, which expands to nothing when the array is empty and to the full flag list when populated.

## Verification

- Reproduced the exact `unbound variable` error under `/bin/bash` (GNU bash 3.2.57, the runner shell) and confirmed the new form passes both empty and populated.
- Ran the **full gate end-to-end** under Bash 3.2 → `==> Cold-start conformance (tier 4 — human path): OK`, exit 0.

The other half of #1956's nightly (an API-source-compat break on `RAGConfiguration`/`RAGService`) was a transient pre-#1955 snapshot — those fields exist in both the `v0.56.0` baseline and current `main`, so the digester is clean on `main`.

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)