### PR TITLE
feat(contract): add closesAtEnd + multi-call body to ToolCallMarker for Mistral [TOOL_CALLS]

### DIFF
--- a/Sources/ManifoldContract/ToolCallTransform.swift
+++ b/Sources/ManifoldContract/ToolCallTransform.swift
@@ -285,23 +285,23 @@ public struct ToolCallTransform: StreamTransform {
     /// stream truncation is observable (#1858).
     public mutating func finalize() -> [GenerationEvent] {
         var events: [GenerationEvent] = []
-        if activeMarker == nil {
-            if !buffer.isEmpty {
-                events.append(.token(buffer))
+        if let active = activeMarker {
+            if markers[active].closesAtEnd {
+                // EOS-keyed close: this is the normal terminus for the block, not
+                // a truncation. Fold any held-back buffer into the body and parse.
+                let body = bodyBuffer + buffer
+                events += emitEvents(for: markers[active], body: body)
+            } else if surfaceTruncatedToolBody {
+                // Inside an unterminated block: the held-back `buffer` is a partial
+                // close suffix that still belongs to the body, so fold it in before
+                // surfacing. Default behavior (flag off) discards silently.
+                let partial = bodyBuffer + buffer
+                if !partial.isEmpty {
+                    events.append(.toolCallTruncated(rawBody: partial))
+                }
             }
-        } else if markers[activeMarker!].closesAtEnd {
-            // EOS-keyed close: this is the normal terminus for the block, not a
-            // truncation. Fold any held-back buffer into the body and parse it.
-            let body = bodyBuffer + buffer
-            events += emitEvents(for: markers[activeMarker!], body: body)
-        } else if surfaceTruncatedToolBody {
-            // Inside an unterminated block: the held-back `buffer` is a partial
-            // close suffix that still belongs to the body, so fold it in before
-            // surfacing. Default behavior (flag off) discards silently.
-            let partial = bodyBuffer + buffer
-            if !partial.isEmpty {
-                events.append(.toolCallTruncated(rawBody: partial))
-            }
+        } else if !buffer.isEmpty {
+            events.append(.token(buffer))
         }
         buffer = ""
         bodyBuffer = ""

--- a/Sources/ManifoldContract/ToolCallTransform.swift
+++ b/Sources/ManifoldContract/ToolCallTransform.swift
@@ -6,15 +6,41 @@
 /// `parseBody` as an injected closure is what lets the dialect-specific JSON /
 /// Gemma-4 brace parsing stay in the family targets while the scanning core
 /// stays in `ManifoldInference`, free of MLX/Llama deps and free of `try?`.
+///
+/// Two additive shapes (#1982) extend the original open/close/single-call form
+/// without breaking it:
+///
+/// - **EOS-keyed close (`closesAtEnd`).** Some dialects — notably Mistral's
+///   `[TOOL_CALLS]` — emit a bare JSON payload right after a literal open token
+///   with NO closing delimiter; the block ends at end-of-generation. Such a
+///   marker buffers its body to the stream end and is parsed in `finalize()`
+///   instead of on a close tag. `close` is irrelevant for these markers (pass
+///   `""`); the scanner never searches for it.
+/// - **Multi-call body (`parseBodyMulti`).** A single block can carry MORE than
+///   one call (Mistral's payload is a JSON *array*). When provided, the
+///   transform prefers it and emits one `.toolCall` per element.
 public struct ToolCallMarker: Sendable {
     /// Delimiter that opens a tool-call block (e.g. `<tool_call>`, `<|tool_call>`).
     public let open: String
     /// Delimiter that closes the block (e.g. `</tool_call>`, `<|end_of_turn>`).
+    /// Irrelevant when ``closesAtEnd`` is `true` (the block closes at EOS).
     public let close: String
     /// Turns the buffered body between `open` and `close` into a `ToolCall`,
     /// or returns `nil` to drop a malformed call.
     public let parseBody: @Sendable (String) -> ToolCall?
+    /// When `true`, the block has no closing delimiter — it ends at
+    /// end-of-generation. The scanner buffers the whole body (subject to the
+    /// runaway byte cap) and parses it in `finalize()`. Defaults to `false`,
+    /// preserving the historical close-tag-keyed behavior (#1982).
+    public let closesAtEnd: Bool
+    /// Optional multi-call parser: turns the buffered body into ZERO or more
+    /// `ToolCall`s (e.g. a JSON array of calls). When non-nil the transform
+    /// prefers it over ``parseBody`` and emits one `.toolCall` per element.
+    /// Defaults to `nil`, leaving single-call dialects unchanged (#1982).
+    public let parseBodyMulti: (@Sendable (String) -> [ToolCall])?
 
+    /// Original single-call, close-tag-keyed dialect. Unchanged: `closesAtEnd`
+    /// is `false` and there is no multi-call parser.
     public init(
         open: String,
         close: String,
@@ -23,6 +49,26 @@ public struct ToolCallMarker: Sendable {
         self.open = open
         self.close = close
         self.parseBody = parseBody
+        self.closesAtEnd = false
+        self.parseBodyMulti = nil
+    }
+
+    /// Multi-call / EOS-keyed dialect (Mistral `[TOOL_CALLS]` shape). The body
+    /// is parsed by `parseBodyMulti` and may yield multiple calls; `close` may
+    /// be omitted when `closesAtEnd` is `true`. `parseBody` is stubbed to return
+    /// `nil` so the stored property stays non-optional — the transform consults
+    /// `parseBodyMulti` first regardless.
+    public init(
+        open: String,
+        close: String = "",
+        closesAtEnd: Bool = false,
+        parseBodyMulti: @escaping @Sendable (String) -> [ToolCall]
+    ) {
+        self.open = open
+        self.close = close
+        self.parseBody = { _ in nil }
+        self.closesAtEnd = closesAtEnd
+        self.parseBodyMulti = parseBodyMulti
     }
 }
 
@@ -39,11 +85,14 @@ public struct ToolCallMarker: Sendable {
 ///   caller that lists Gemma-4 before JSON keeps Llama's historical
 ///   preference), the parser switches into the block.
 /// - Inside a block, body text is buffered and suppressed from `.token`.
-/// - On the matching close, `marker.parseBody(body)` runs; a non-nil result
-///   emits `.toolCall`. A `nil` result no longer vanishes silently — it emits
-///   a non-fatal `.toolCallParseFailed(rawBody:)` diagnostic carrying the
-///   buffered body so hosts can distinguish a broken tool call from no tool
-///   call (#1857).
+/// - On the matching close, the body is parsed (`marker.parseBodyMulti` when
+///   present, else `marker.parseBody`); each resulting call emits a `.toolCall`.
+///   An empty result no longer vanishes silently — it emits a non-fatal
+///   `.toolCallParseFailed(rawBody:)` diagnostic carrying the buffered body so
+///   hosts can distinguish a broken tool call from no tool call (#1857).
+/// - A `closesAtEnd` marker (#1982, Mistral `[TOOL_CALLS]`) has NO close tag:
+///   the scanner drains the whole body to the stream end and `finalize()` parses
+///   it, emitting `.toolCall`s (or `.toolCallParseFailed`) — see `finalize()`.
 /// - On the body-size cap or an unterminated block at `finalize()`, the partial
 ///   body is discarded by default. Constructing the transform with
 ///   `surfaceTruncatedToolBody: true` instead emits a non-fatal
@@ -100,26 +149,50 @@ public struct ToolCallTransform: StreamTransform {
 
     private var openMarkers: [String] { markers.map(\.open) }
 
+    /// Parse a completed body and turn it into emit events. Prefers the marker's
+    /// multi-call parser (#1982 — a single block may carry several calls, e.g. a
+    /// JSON array) and falls back to the single-call `parseBody`. An empty result
+    /// surfaces the `.toolCallParseFailed(rawBody:)` diagnostic, preserving #1857.
+    private func emitEvents(for marker: ToolCallMarker, body: String) -> [GenerationEvent] {
+        let calls = marker.parseBodyMulti?(body) ?? marker.parseBody(body).map { [$0] } ?? []
+        if calls.isEmpty {
+            return [.toolCallParseFailed(rawBody: body)]
+        }
+        return calls.map { .toolCall($0) }
+    }
+
     private mutating func scan(_ chunk: String) -> [GenerationEvent] {
         buffer += chunk
         var events: [GenerationEvent] = []
 
         while true {
             if let active = activeMarker {
+                // A closesAtEnd marker (#1982) has no close tag: drain everything
+                // into the body and wait for more tokens. `finalize()` parses the
+                // buffered body. Never call `range(of: "")` for such a marker —
+                // its `close` is empty/irrelevant.
+                if markers[active].closesAtEnd {
+                    bodyBuffer += buffer
+                    buffer = ""
+                    if bodyBuffer.utf8.count > Self.maxBodyBytes {
+                        Log.inference.warning(
+                            "ToolCallTransform: dropping closesAtEnd tool-call body exceeding \(Self.maxBodyBytes)-byte cap"
+                        )
+                        if surfaceTruncatedToolBody {
+                            events.append(.toolCallTruncated(rawBody: bodyBuffer))
+                        }
+                        bodyBuffer = ""
+                        activeMarker = nil
+                        continue
+                    }
+                    break
+                }
                 // Inside a block: scan for this dialect's close tag.
                 let closeTag = markers[active].close
                 if let range = buffer.range(of: closeTag) {
                     bodyBuffer += String(buffer[..<range.lowerBound])
                     buffer = String(buffer[range.upperBound...])
-                    if let call = markers[active].parseBody(bodyBuffer) {
-                        events.append(.toolCall(call))
-                    } else {
-                        // A well-formed open/close pair surrounded a body the
-                        // dialect parser rejected. Surface it as a non-fatal
-                        // diagnostic instead of dropping the call silently so
-                        // hosts can recover or report (#1857).
-                        events.append(.toolCallParseFailed(rawBody: bodyBuffer))
-                    }
+                    events += emitEvents(for: markers[active], body: bodyBuffer)
                     bodyBuffer = ""
                     activeMarker = nil
                 } else {
@@ -196,10 +269,17 @@ public struct ToolCallTransform: StreamTransform {
 
     /// Flush the held-back buffer at stream end.
     ///
-    /// Remaining visible text outside a block is emitted as `.token`. An
-    /// incomplete (unclosed) tool-call block is discarded by default — partial
-    /// body text cannot produce a valid `ToolCall` — matching both legacy
-    /// parsers. When the transform was constructed with
+    /// Remaining visible text outside a block is emitted as `.token`.
+    ///
+    /// A `closesAtEnd` marker (#1982) is the EXPECTED close path, not a
+    /// truncation: its body has no close tag, so the buffered body is parsed here
+    /// and `.toolCall`s (or `.toolCallParseFailed`) are emitted — independent of
+    /// `surfaceTruncatedToolBody`, which governs only the truncation of genuine
+    /// close-tag dialects.
+    ///
+    /// An incomplete (unclosed) close-tag tool-call block is discarded by
+    /// default — partial body text cannot produce a valid `ToolCall` — matching
+    /// both legacy parsers. When the transform was constructed with
     /// `surfaceTruncatedToolBody: true`, the partial body is instead surfaced as
     /// a non-fatal `.toolCallTruncated(rawBody:)` diagnostic so a mid-tool-call
     /// stream truncation is observable (#1858).
@@ -209,6 +289,11 @@ public struct ToolCallTransform: StreamTransform {
             if !buffer.isEmpty {
                 events.append(.token(buffer))
             }
+        } else if markers[activeMarker!].closesAtEnd {
+            // EOS-keyed close: this is the normal terminus for the block, not a
+            // truncation. Fold any held-back buffer into the body and parse it.
+            let body = bodyBuffer + buffer
+            events += emitEvents(for: markers[activeMarker!], body: body)
         } else if surfaceTruncatedToolBody {
             // Inside an unterminated block: the held-back `buffer` is a partial
             // close suffix that still belongs to the body, so fold it in before

--- a/Tests/ManifoldInferenceTests/OutputParserSessionTests.swift
+++ b/Tests/ManifoldInferenceTests/OutputParserSessionTests.swift
@@ -365,4 +365,88 @@ final class OutputParserSessionTests: XCTestCase {
             "A fully-closed block plus trailing text must not emit a truncation diagnostic")
         XCTAssertEqual(visible(events), "tail")
     }
+
+    // MARK: - #1982: closesAtEnd (EOS-keyed) + multi-call body (Mistral [TOOL_CALLS])
+
+    /// A Mistral `[TOOL_CALLS]` dialect: a bare JSON array of `{"name", "arguments"}`
+    /// objects emitted right after the literal token, with NO closing tag — the
+    /// block ends at end-of-generation and may carry multiple calls.
+    private func mistralMarker() -> ToolCallMarker {
+        ToolCallMarker(open: "[TOOL_CALLS]", closesAtEnd: true) { body in
+            let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let data = trimmed.data(using: .utf8),
+                  let arr = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]]
+            else { return [] }
+            return arr.compactMap { obj in
+                guard let name = obj["name"] as? String, !name.isEmpty else { return nil }
+                let args: String
+                if let argObj = obj["arguments"],
+                   let argData = try? JSONSerialization.data(withJSONObject: argObj),
+                   let argStr = String(data: argData, encoding: .utf8) {
+                    args = argStr
+                } else {
+                    args = "{}"
+                }
+                return ToolCall(id: "mistral-\(name)", toolName: name, arguments: args)
+            }
+        }
+    }
+
+    func test_closesAtEnd_multiCall_parsesArrayAtFinalize_andEmitsTwoCalls() {
+        var transform = ToolCallTransform(markers: [mistralMarker()])
+        var events = transform.process([.token("here you go[TOOL_CALLS]")])
+        events += transform.process([.token("[{\"name\":\"calc\",\"arguments\":{\"x\":1}},")])
+        events += transform.process([.token("{\"name\":\"now\",\"arguments\":{}}]")])
+        events += transform.finalize()
+
+        let calls = toolCalls(events)
+        XCTAssertEqual(calls.map(\.toolName), ["calc", "now"],
+            "A closesAtEnd Mistral block must surface BOTH array elements as separate .toolCall events (#1982)")
+        XCTAssertEqual(calls.first?.arguments, "{\"x\":1}")
+        XCTAssertEqual(visible(events), "here you go",
+            "Text before the [TOOL_CALLS] marker is emitted as a normal token")
+
+        // Sabotage (verified, removed): replacing parseBodyMulti with `{ _ in [] }`
+        // makes calls empty; folding only the first element makes the count 1.
+    }
+
+    func test_closesAtEnd_parsesOnlyAtFinalize_notMidStream() {
+        var transform = ToolCallTransform(markers: [mistralMarker()])
+        var midStream = transform.process([.token("[TOOL_CALLS][{\"name\":\"calc\",\"arguments\":{}}]")])
+
+        XCTAssertTrue(toolCalls(midStream).isEmpty,
+            "A closesAtEnd block must NOT emit any .toolCall before finalize — it has no close tag")
+
+        midStream += transform.finalize()
+        XCTAssertEqual(toolCalls(midStream).map(\.toolName), ["calc"],
+            "The call surfaces only once finalize() runs the EOS-keyed parse")
+
+        // Sabotage (verified, removed): emitting in scan() rather than finalize()
+        // would make the pre-finalize assertion fail.
+    }
+
+    func test_closesAtEnd_emptyArrayBody_emitsParseFailed() {
+        var transform = ToolCallTransform(markers: [mistralMarker()])
+        var events = transform.process([.token("[TOOL_CALLS][]")])
+        events += transform.finalize()
+
+        XCTAssertTrue(toolCalls(events).isEmpty)
+        XCTAssertEqual(parseFailures(events), ["[]"],
+            "A closesAtEnd body that parses to an empty array must surface one .toolCallParseFailed (#1857 preserved)")
+
+        // Sabotage (verified, removed): dropping the isEmpty→parseFailed branch
+        // emits nothing and this assertion fails.
+    }
+
+    func test_closesAtEnd_doesNotAffectSingleCallCloseTagMarker() {
+        // Regression: the original single-call close-tag dialect is untouched.
+        var transform = ToolCallTransform(markers: [jsonMarker()])
+        var events = transform.process([.token("a<tool_call>{\"name\":\"f\"}</tool_call>b")])
+        events += transform.finalize()
+
+        XCTAssertEqual(toolCalls(events).map(\.toolName), ["f"],
+            "A close-tag marker must still emit exactly one .toolCall, unaffected by the #1982 additions")
+        XCTAssertEqual(toolCalls(events).count, 1)
+        XCTAssertEqual(visible(events), "ab")
+    }
 }


### PR DESCRIPTION
## What

Additive, backward-compatible API on `ManifoldContract.ToolCallMarker` / `ToolCallTransform` so a consumer (manifold-llama) can express the **Mistral `[TOOL_CALLS]` dialect**: a bare JSON array emitted right after a literal `[TOOL_CALLS]` token, with **no closing tag** (block ends at end-of-generation), possibly carrying **multiple calls**.

## Two gaps closed

### Gap 1 — EOS-keyed close (`closesAtEnd: Bool`, default `false`)
- `scan()`: for a `closesAtEnd` marker, the active branch drains the whole `buffer` into `bodyBuffer` (no close-suffix holdback) and breaks to wait for more tokens — it never searches for a close tag and never calls `range(of: "")`. The `maxBodyBytes` runaway guard still applies.
- `finalize()`: a `closesAtEnd` block is the **expected terminus**, not a truncation. The buffered body (folding in any held-back `buffer`) is parsed and emits `.toolCall` events (or `.toolCallParseFailed`) — independent of `surfaceTruncatedToolBody`, which stays scoped to truncation of close-tag dialects.

### Gap 2 — Multi-call body (`parseBodyMulti: (@Sendable (String) -> [ToolCall])?`, default `nil`)
- When present the transform prefers it: `marker.parseBodyMulti?(body) ?? marker.parseBody(body).map { [$0] } ?? []`, emitting one `.toolCall` per element. Applied at **both** emit sites (close-tag path and the new `closesAtEnd` finalize path).
- An empty result still surfaces `.toolCallParseFailed(rawBody:)`, preserving #1857.

## Backward compatibility
- The existing `init(open:close:parseBody:)` is **untouched** (sets `closesAtEnd = false`, `parseBodyMulti = nil`).
- New `init(open:close:closesAtEnd:parseBodyMulti:)` covers the Mistral shape; `parseBody` is stubbed to `nil` so the stored property stays non-optional.
- No change to `parseBody` / `close` / `surfaceTruncatedToolBody` types or to `GenerationEvent`.

## Tests
Added to `OutputParserSessionTests` (XCTest, matching the file):
1. `closesAtEnd` + `parseBodyMulti` across multiple chunks → **two** `.toolCall` events with correct names/args; pre-marker text emitted as `.token`.
2. `closesAtEnd` parses **only at finalize** (no `.toolCall` mid-stream).
3. `closesAtEnd` body parsing to an empty array → one `.toolCallParseFailed`.
4. Regression: an existing single-call `<tool_call>`…`</tool_call>` marker still emits exactly one `.toolCall`, unaffected.

Each new positive assertion was verified with a temporary sabotage check (broke the emit path, confirmed the test failed) then restored before committing.

`swift build --build-tests` clean; `swift test --filter OutputParserSessionTests` → 22/22 pass.

Closes #1982. Unblocks downstream manifold-llama #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)