### PR TITLE
fix(tools): route ScenarioRunner through InferenceService so the prompt renderer injects tools

### DIFF
--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -845,18 +845,23 @@ public final class InferenceService {
         generation.preToolUseHook = hook
     }
 
-    #if DEBUG
-    /// Debug-only init that pre-loads a backend, optionally alongside a
-    /// ``ToolRegistry`` and ``ToolApprovalGate``. Used by tests to drive a
-    /// mock backend, and by ``--uitesting`` launches in the example app so
-    /// the approval sheet can be exercised deterministically against a
-    /// ``ScriptedBackend``.
+    /// Init that pre-loads a backend, optionally alongside a ``ToolRegistry``
+    /// and ``ToolApprovalGate``. Used by tests to drive a mock backend, by
+    /// ``--uitesting`` launches in the example app so the approval sheet can
+    /// be exercised deterministically against a ``ScriptedBackend``, and by
+    /// the `ManifoldTools` scenario harness so its mock/offline path drives
+    /// the same orchestrator (and therefore the same prompt-renderer +
+    /// tool-injection seam) that production uses (#1983).
     ///
     /// When `toolRegistry` is `nil` (the default) the generation coordinator
     /// is constructed without tool-calling wired in — matching the behaviour
     /// every existing test suite relies on. Pass a non-nil registry to
     /// enable tool dispatch; `toolApprovalGate` then gates each call and
     /// defaults to ``AutoApproveGate`` so legacy callers see no change.
+    ///
+    /// Always available (previously `#if DEBUG`-gated): the harness is a
+    /// legitimate release consumer that must inject a scripted backend with a
+    /// registry so the offline path mirrors the live orchestration path.
     public init(
         backend: any InferenceBackend,
         name: String = "Mock",
@@ -872,7 +877,6 @@ public final class InferenceService {
         wireGenerationContext()
         Self.scheduleToolSpillReap()
     }
-    #endif
 
     /// Fire-and-forget detached sweep of stale tool-spill files, scheduled
     /// from every public `init`. Detached so it never blocks instantiation

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -130,9 +130,12 @@ final class ModelLifecycleCoordinator {
 
     nonisolated init() {}
 
-    #if DEBUG
-    /// Test-only seam for preloading a backend without driving the real load
-    /// pipeline.
+    /// Seam for preloading a backend without driving the real load pipeline.
+    ///
+    /// Always available (previously `#if DEBUG`-gated): the offline tool-calling
+    /// harness (`ManifoldTools.ScenarioRunner`) is a legitimate release consumer
+    /// that injects a pre-built backend so its scenario runs mirror the live
+    /// orchestration path. The body only sets stored fields — no test-only types.
     ///
     /// - Parameters:
     ///   - backend: the pre-configured backend to install as current.
@@ -161,7 +164,6 @@ final class ModelLifecycleCoordinator {
             startedAtUptime: ProcessInfo.processInfo.systemUptime
         )
     }
-    #endif
 
     // MARK: - Backend Registration
 

--- a/Sources/ManifoldTools/ScenarioRunner.swift
+++ b/Sources/ManifoldTools/ScenarioRunner.swift
@@ -77,6 +77,11 @@ public final class ScenarioRunner {
         var accumulatedText = ""
         var toolCallsExecuted: [String] = []
         var toolResults: [ToolResultRecord] = []
+        // `.toolResult` carries only the call id (not the tool name), so map
+        // each result back to its originating `.toolCall` by id. This is robust
+        // to any short-circuit path (cancellation/byte-budget) that emits a
+        // result whose position doesn't line up with the call ordinal.
+        var toolNameByCallID: [String: String] = [:]
 
         // Single enqueue through the production orchestrator. The dispatch
         // loop runs every tool iteration internally and surfaces each turn's
@@ -96,25 +101,28 @@ public final class ScenarioRunner {
 
             case .toolCall(let call):
                 toolCallsExecuted.append(call.toolName)
+                toolNameByCallID[call.id] = call.toolName
                 logger?.append(.toolCall(scenarioId: scenario.id, name: call.toolName, arguments: call.arguments))
 
             case .toolResult(let result):
+                let name = toolNameByCallID[result.callId] ?? ""
                 toolResults.append(ToolResultRecord(
-                    toolName: toolName(for: result, executed: toolCallsExecuted, recorded: toolResults),
+                    toolName: name,
                     content: result.content,
                     errorKind: result.errorKind?.rawValue
                 ))
                 logger?.append(.toolResult(
                     scenarioId: scenario.id,
-                    name: toolResults.last?.toolName ?? "",
+                    name: name,
                     content: result.content,
                     errorKind: result.errorKind?.rawValue
                 ))
 
             case .generationCompleted:
                 // Terminal marker — the orchestrator finished the whole turn
-                // (all tool iterations included). Stop consuming.
-                break
+                // (all tool iterations included); the stream finishes right
+                // after, so the `for await` loop ends on its own.
+                continue
 
             case .prefillProgress, .promptRendered, .usage, .thinkingToken,
                  .thinkingCompleted, .thinkingSignature, .kvCacheReuse,
@@ -152,22 +160,6 @@ public final class ScenarioRunner {
             toolResults: toolResults,
             assertions: assertionOutcomes
         )
-    }
-
-    /// Resolves the tool name for a `.toolResult` event. ``ToolResult`` only
-    /// carries the call id, not the tool name, so we recover the name by
-    /// matching the result against the pending `.toolCall` events in dispatch
-    /// order: the Nth recorded result corresponds to the Nth executed call.
-    private func toolName(
-        for result: ToolResult,
-        executed: [String],
-        recorded: [ToolResultRecord]
-    ) -> String {
-        let index = recorded.count
-        if index < executed.count {
-            return executed[index]
-        }
-        return executed.last ?? ""
     }
 
     private func makeConfig(for scenario: Scenario, tools: [ToolDefinition]) -> GenerationConfig {

--- a/Sources/ManifoldTools/ScenarioRunner.swift
+++ b/Sources/ManifoldTools/ScenarioRunner.swift
@@ -1,24 +1,30 @@
 import Foundation
 import ManifoldInference
 
-/// Runs a single ``Scenario`` against a supplied backend and registry.
+/// Runs a single ``Scenario`` against a supplied ``InferenceService``.
 ///
-/// The runner is the glue between the declarative scenario JSON, the generic
-/// ``ToolRegistry`` dispatch seam, and the chosen ``InferenceBackend``. It
-/// loops up to ``maxIterations`` times:
+/// The runner is the glue between the declarative scenario JSON and the
+/// production inference path. It performs **one** ``InferenceService/enqueue``
+/// per scenario turn and consumes the resulting ``GenerationStream`` end to
+/// end. The orchestrator (`GenerationQueue` → `GenerationToolDispatchLoop`)
+/// owns the tool loop entirely:
 ///
-/// 1. Request generation from the backend with the current conversation state.
-/// 2. Consume every ``GenerationEvent`` — accumulating token text and any
-///    ``ToolCall`` the model emits.
-/// 3. If the model requested tool calls, dispatch each through the registry,
-///    record the results on the conversation, and go round again.
-/// 4. If no tool calls were emitted (or the budget is exhausted), the
-///    accumulated text is the final answer and assertions run against it.
+/// 1. It renders the prompt through `PromptRenderer` / `JinjaPromptRenderer`,
+///    which is the only path that applies the chat template and injects the
+///    tool definitions (`[AVAILABLE_TOOLS]` / native tool blocks). Local
+///    backends never see that the tools exist otherwise (#1983).
+/// 2. It dispatches each `.toolCall` the model emits through the
+///    ``ToolRegistry`` carried by the service, re-generating to continue the
+///    turn up to `config.maxToolIterations`.
+/// 3. It emits `.toolCall` / `.toolResult` events back into the stream and a
+///    terminal `.generationCompleted` event.
 ///
-/// Conversation history is plumbed into backends that conform to
-/// ``ConversationHistoryReceiver`` (same pattern as ``GenerationQueue``);
-/// backends that do not conform get a plain-text prompt with appended tool
-/// results.
+/// The runner therefore just observes the stream: it accumulates token text
+/// for the final answer and reconstructs ``Outcome/toolCallsExecuted`` /
+/// ``Outcome/toolResults`` from the `.toolCall` / `.toolResult` events. This
+/// is deliberately the **real** orchestration path, not a parallel
+/// hand-rolled tool loop — the whole point of the harness is to validate what
+/// production does.
 @MainActor
 public final class ScenarioRunner {
 
@@ -31,19 +37,23 @@ public final class ScenarioRunner {
         public var passed: Bool { assertions.allSatisfy(\.passed) }
     }
 
-    public let backend: any InferenceBackend
-    public let registry: ToolRegistry
+    /// The production inference service driving generation. It carries the
+    /// ``ToolRegistry`` the orchestrator dispatches through, so the runner
+    /// never dispatches tools itself.
+    public let service: InferenceService
     public let logger: TranscriptLogger?
     public let maxIterations: Int
 
+    /// The registry the service dispatches through. Used to derive the tool
+    /// definitions advertised to the model for a given scenario.
+    private var registry: ToolRegistry? { service.toolRegistry }
+
     public init(
-        backend: any InferenceBackend,
-        registry: ToolRegistry,
+        service: InferenceService,
         logger: TranscriptLogger? = nil,
         maxIterations: Int = 6
     ) {
-        self.backend = backend
-        self.registry = registry
+        self.service = service
         self.logger = logger
         self.maxIterations = maxIterations
     }
@@ -53,117 +63,71 @@ public final class ScenarioRunner {
     public func run(_ scenario: Scenario) async throws -> Outcome {
         logger?.append(.prompt(scenarioId: scenario.id, system: scenario.systemPrompt, user: scenario.userPrompt))
 
-        var history: [(role: String, content: String)] = [
-            (role: "system", content: scenario.systemPrompt),
-            (role: "user", content: scenario.userPrompt)
+        let messages: [StructuredMessage] = [
+            StructuredMessage(role: "user", content: scenario.userPrompt)
         ]
+
+        let allDefinitions = registry?.definitions ?? []
+        let definitions = allDefinitions.filter {
+            scenario.requiredTools.isEmpty || scenario.requiredTools.contains($0.name)
+        }
+
+        let config = makeConfig(for: scenario, tools: definitions)
+
         var accumulatedText = ""
         var toolCallsExecuted: [String] = []
         var toolResults: [ToolResultRecord] = []
 
-        let definitions = registry.definitions.filter { scenario.requiredTools.isEmpty || scenario.requiredTools.contains($0.name) }
+        // Single enqueue through the production orchestrator. The dispatch
+        // loop runs every tool iteration internally and surfaces each turn's
+        // `.toolCall` / `.toolResult` events on this one stream — the runner
+        // does not loop or dispatch.
+        let (_, stream) = try service.enqueue(
+            structuredMessages: messages,
+            systemPrompt: scenario.systemPrompt,
+            config: config
+        )
 
-        let config = makeConfig(for: scenario, tools: definitions)
+        for try await event in stream.events {
+            switch event {
+            case .token(let text):
+                accumulatedText += text
+                logger?.append(.tokenDelta(scenarioId: scenario.id, text: text))
 
-        for _ in 0..<maxIterations {
-            if let receiver = backend as? ConversationHistoryReceiver {
-                receiver.setConversationHistory(history)
-            }
-
-            let prompt = history.last { $0.role == "user" || $0.role == "tool" }?.content ?? scenario.userPrompt
-            let system = scenario.systemPrompt
-
-            let stream = try backend.generate(prompt: prompt, systemPrompt: system, config: config)
-
-            var turnText = ""
-            var turnToolCalls: [ToolCall] = []
-
-            for try await event in stream.events {
-                switch event {
-                case .token(let t):
-                    turnText += t
-                    logger?.append(.tokenDelta(scenarioId: scenario.id, text: t))
-                case .toolCall(let call):
-                    turnToolCalls.append(call)
-                    logger?.append(.toolCall(scenarioId: scenario.id, name: call.toolName, arguments: call.arguments))
-                case .prefillProgress, .promptRendered, .usage, .thinkingToken, .thinkingCompleted, .thinkingSignature:
-                    continue
-                case .toolResult, .toolIterationLimitExceeded, .runTokenBudgetExceeded:
-                    // ScenarioRunner calls backend.generate() directly and owns
-                    // dispatch below, so it never receives GenerationQueue's
-                    // orchestrator events on this path. Stay exhaustive for growth.
-                    continue
-                case .kvCacheReuse:
-                    continue
-                case .throttleDiagnostic:
-                    // Advisory pause signal from the orchestrator; scenarios
-                    // are deterministic replays so we just keep accumulating.
-                    continue
-                case .toolCallStart, .toolCallArgumentsDelta:
-                    // Streaming tool-call deltas are observational; the
-                    // authoritative call lands on `.toolCall(_:)`.
-                    continue
-                case .toolProgress, .toolDispatchStarted, .toolDispatchCompleted, .toolCallApproved:
-                    // Dispatch lifecycle markers are observational; tool
-                    // accounting flows through `.toolCall` / `.toolResult`.
-                    continue
-                case .toolCallParseFailed, .toolCallTruncated:
-                    // Non-fatal tool-call diagnostics (#1857 / #1858); the
-                    // authoritative call still lands on `.toolCall(_:)` when it
-                    // parses. Observational here.
-                    continue
-                case .handoffRequested:
-                    // Multi-agent handoffs are runtime-driven; deterministic
-                    // single-agent replays never observe them.
-                    continue
-                case .generationCompleted:
-                    // Terminal "response finished" marker. ScenarioRunner
-                    // accumulates text directly and detects stable state via
-                    // empty tool-calls below; the completion event is purely
-                    // observational here.
-                    continue
-                }
-            }
-
-            accumulatedText += turnText
-            if !turnText.isEmpty {
-                history.append((role: "assistant", content: turnText))
-            }
-
-            if turnToolCalls.isEmpty {
-                // Stable state — the model produced a final text answer.
-                break
-            }
-
-            for call in turnToolCalls {
-                let result = await registry.dispatch(call)
+            case .toolCall(let call):
                 toolCallsExecuted.append(call.toolName)
+                logger?.append(.toolCall(scenarioId: scenario.id, name: call.toolName, arguments: call.arguments))
+
+            case .toolResult(let result):
                 toolResults.append(ToolResultRecord(
-                    toolName: call.toolName,
+                    toolName: toolName(for: result, executed: toolCallsExecuted, recorded: toolResults),
                     content: result.content,
                     errorKind: result.errorKind?.rawValue
                 ))
                 logger?.append(.toolResult(
                     scenarioId: scenario.id,
-                    name: call.toolName,
+                    name: toolResults.last?.toolName ?? "",
                     content: result.content,
                     errorKind: result.errorKind?.rawValue
                 ))
-                // Append as a "tool" role message so ConversationHistoryReceiver
-                // backends can feed it back. Plain-text backends get it concatenated
-                // to the next user prompt as a fallback below.
-                history.append((role: "tool", content: result.content))
-            }
 
-            // Non-history-aware backends need the tool result spliced into the
-            // next prompt — otherwise they regenerate from the same input and
-            // loop forever. This branch is only exercised by backends that do
-            // not conform to ConversationHistoryReceiver.
-            if !(backend is ConversationHistoryReceiver) {
-                let toolTrace = turnToolCalls.enumerated().map { idx, call in
-                    "[tool \(call.toolName)] → \(history[history.count - turnToolCalls.count + idx].content)"
-                }.joined(separator: "\n")
-                history.append((role: "user", content: "Tool results:\n\(toolTrace)\nContinue your answer using these results."))
+            case .generationCompleted:
+                // Terminal marker — the orchestrator finished the whole turn
+                // (all tool iterations included). Stop consuming.
+                break
+
+            case .prefillProgress, .promptRendered, .usage, .thinkingToken,
+                 .thinkingCompleted, .thinkingSignature, .kvCacheReuse,
+                 .throttleDiagnostic, .toolCallStart, .toolCallArgumentsDelta,
+                 .toolProgress, .toolDispatchStarted, .toolDispatchCompleted,
+                 .toolCallApproved, .toolCallParseFailed, .toolCallTruncated,
+                 .handoffRequested, .toolIterationLimitExceeded,
+                 .runTokenBudgetExceeded:
+                // Observational / lifecycle markers. Tool accounting flows
+                // through `.toolCall` / `.toolResult`; the runner reconstructs
+                // its Outcome from those alone. Stay exhaustive so a new
+                // GenerationEvent case forces a compile error here.
+                continue
             }
         }
 
@@ -188,6 +152,22 @@ public final class ScenarioRunner {
             toolResults: toolResults,
             assertions: assertionOutcomes
         )
+    }
+
+    /// Resolves the tool name for a `.toolResult` event. ``ToolResult`` only
+    /// carries the call id, not the tool name, so we recover the name by
+    /// matching the result against the pending `.toolCall` events in dispatch
+    /// order: the Nth recorded result corresponds to the Nth executed call.
+    private func toolName(
+        for result: ToolResult,
+        executed: [String],
+        recorded: [ToolResultRecord]
+    ) -> String {
+        let index = recorded.count
+        if index < executed.count {
+            return executed[index]
+        }
+        return executed.last ?? ""
     }
 
     private func makeConfig(for scenario: Scenario, tools: [ToolDefinition]) -> GenerationConfig {

--- a/Sources/manifold-tools/main.swift
+++ b/Sources/manifold-tools/main.swift
@@ -340,8 +340,8 @@ func runCLI() async -> Int32 {
         for model in models {
             print("\n── \(scenario.id) via \(cli.backend.rawValue)/\(model) ──")
             do {
-                let backend = try await makeBackend(cli: cli, scenario: scenario, model: model)
-                let runner = ScenarioRunner(backend: backend, registry: registry, logger: logger)
+                let service = try await makeService(cli: cli, scenario: scenario, model: model, registry: registry)
+                let runner = ScenarioRunner(service: service, logger: logger)
                 let outcome = try await runner.run(scenario)
                 for assertion in outcome.assertions {
                     let marker = assertion.passed ? "  PASS" : "  FAIL"
@@ -368,16 +368,31 @@ func runCLI() async -> Int32 {
 }
 
 @MainActor
-func makeBackend(cli: CLI, scenario: Scenario, model: String) async throws -> any InferenceBackend {
+func makeService(
+    cli: CLI,
+    scenario: Scenario,
+    model: String,
+    registry: ToolRegistry
+) async throws -> InferenceService {
+    let backend: any InferenceBackend
+    let name: String
     switch cli.backend {
     case .mock:
-        return MockFactory.make(for: scenario)
+        backend = MockFactory.make(for: scenario)
+        name = "mock"
     case .ollama:
-        let backend = OllamaBackend(_registrar: ())
-        backend.configure(baseURL: cli.ollamaBaseURL, modelName: model)
-        try await backend.loadModel(from: cli.ollamaBaseURL, plan: .cloud())
-        return backend
+        let ollama = OllamaBackend(_registrar: ())
+        ollama.configure(baseURL: cli.ollamaBaseURL, modelName: model)
+        try await ollama.loadModel(from: cli.ollamaBaseURL, plan: .cloud())
+        backend = ollama
+        name = "ollama"
     }
+    // Inject the pre-loaded backend together with the tool registry so the
+    // scenario runs through the production GenerationQueue → dispatch-loop
+    // path. That path is the only one that renders the prompt template and
+    // injects tool definitions, so the model is actually told the tools exist
+    // (#1983). Driving the raw backend directly would dispatch zero tools.
+    return InferenceService(backend: backend, name: name, modelName: model, toolRegistry: registry)
 }
 
 enum MockFactory {

--- a/Tests/ManifoldToolsTests/ScenarioRunnerTests.swift
+++ b/Tests/ManifoldToolsTests/ScenarioRunnerTests.swift
@@ -5,6 +5,20 @@ import ManifoldInference
 @MainActor
 final class ScenarioRunnerTests: XCTestCase {
 
+    /// Builds a `ScenarioRunner` driving the production `InferenceService`
+    /// orchestration path: the scripted backend is injected together with the
+    /// tool registry so `GenerationQueue` → `GenerationToolDispatchLoop` runs
+    /// the tool loop, renders the prompt template, and injects tool
+    /// definitions — exactly what production does (#1983).
+    private func makeRunner(
+        backend: ScriptedBackend,
+        registry: ToolRegistry,
+        maxIterations: Int = 6
+    ) -> ScenarioRunner {
+        let service = InferenceService(backend: backend, name: "scripted", toolRegistry: registry)
+        return ScenarioRunner(service: service, maxIterations: maxIterations)
+    }
+
     // MARK: - Assertion evaluator
 
     func test_containsLiteralAssertion_passesWhenValuePresent() {
@@ -142,7 +156,7 @@ final class ScenarioRunnerTests: XCTestCase {
             ],
             backend: Scenario.BackendSpec(kind: "mock", model: "scripted", fallbackModel: nil, temperature: 0, seed: nil, topK: nil)
         )
-        let runner = ScenarioRunner(backend: backend, registry: registry)
+        let runner = makeRunner(backend: backend, registry: registry)
         let outcome = try await runner.run(scenario)
         XCTAssertTrue(outcome.passed, "outcome should pass; answer=\(outcome.finalAnswer)")
         XCTAssertEqual(outcome.toolCallsExecuted, ["now"])
@@ -165,7 +179,7 @@ final class ScenarioRunnerTests: XCTestCase {
             ],
             backend: Scenario.BackendSpec(kind: "mock", model: "scripted", fallbackModel: nil, temperature: 0, seed: nil, topK: nil)
         )
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
         XCTAssertTrue(outcome.passed)
     }
 
@@ -181,7 +195,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["Aurora shipped the deterministic tool harness; Beacon is blocked on MCP credentials."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         XCTAssertEqual(outcome.toolCallsExecuted, ["list_dir", "read_file"])
@@ -203,7 +217,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["apples and rice cost 19.75; skip saffron."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         XCTAssertEqual(outcome.toolCallsExecuted, ["read_file", "calc"])
@@ -221,7 +235,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["DEMO-README-NONCE appears in both; Backend A uses streaming tools and Backend B uses batch tools."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         XCTAssertEqual(outcome.toolCallsExecuted, ["read_file", "read_file"])
@@ -254,7 +268,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["The tool output exceeds maxBytes; request a narrower slice."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "assertions=\(outcome.assertions)")
         XCTAssertEqual(outcome.toolResults.first?.errorKind, "invalidArguments")
@@ -269,7 +283,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["The read_file output exceeds maxBytes; ask for a narrower slice."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "default output policy should reject the oversize fixture")
         XCTAssertEqual(outcome.toolResults.first?.errorKind, "invalidArguments")
@@ -284,10 +298,14 @@ final class ScenarioRunnerTests: XCTestCase {
             systemPrompt: "sys",
             userPrompt: "search slowly",
             requiredTools: ["sample_repo_search"],
+            // A `.cancelled` tool result unwinds the production dispatch loop
+            // immediately (the orchestrator does not let the model narrate over
+            // a cancelled tool), so the contract is verified through the
+            // recorded tool result, not a follow-up text turn.
             assertions: [
                 Scenario.Assertion(kind: "toolInvoked", value: "sample_repo_search", values: nil, message: nil),
                 Scenario.Assertion(kind: "toolResultErrorKind", value: "sample_repo_search", values: ["cancelled"], message: nil),
-                Scenario.Assertion(kind: "containsLiteral", value: "cancelled", values: nil, message: nil)
+                Scenario.Assertion(kind: "toolResultContains", value: "sample_repo_search", values: ["cancelled"], message: nil)
             ],
             backend: Scenario.BackendSpec(kind: "mock", model: "scripted", fallbackModel: nil, temperature: 0, seed: nil, topK: nil)
         )
@@ -301,7 +319,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["Search was cancelled by the user; no stale results were used."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         XCTAssertFalse(outcome.finalAnswer.contains("FAKE_STALE_RESULT"))
@@ -329,13 +347,17 @@ final class ScenarioRunnerTests: XCTestCase {
             ]
         )
         let registry = ToolRegistry(tools: [crashingTool])
+        // The retry varies its query. The production dispatch loop
+        // short-circuits two *identical* consecutive tool calls (a safety
+        // valve against loops), so a faithful recovery turn — like a real
+        // model — issues a distinct query on the second attempt.
         let backend = ScriptedBackend(turns: [
             .toolCall(name: "sample_repo_search", arguments: #"{"query":"crash"}"#),
-            .toolCall(name: "sample_repo_search", arguments: #"{"query":"crash"}"#),
+            .toolCall(name: "sample_repo_search", arguments: #"{"query":"crash recovery"}"#),
             .tokens(["The search recovered and found CRASH-RECOVERY-754."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         XCTAssertEqual(outcome.toolCallsExecuted, ["sample_repo_search", "sample_repo_search"])
@@ -368,7 +390,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens(["Created reminder REMINDER-754."])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         let recordedReminders = await recorder.values()
@@ -382,7 +404,7 @@ final class ScenarioRunnerTests: XCTestCase {
             .tokens([#"{"invoice_id":"INV-754-CORE","total":123.45,"currency":"USD"}"#])
         ])
 
-        let outcome = try await ScenarioRunner(backend: backend, registry: registry).run(scenario)
+        let outcome = try await makeRunner(backend: backend, registry: registry).run(scenario)
 
         XCTAssertTrue(outcome.passed, "answer=\(outcome.finalAnswer)")
         XCTAssertTrue(outcome.toolCallsExecuted.isEmpty)
@@ -410,7 +432,7 @@ final class ScenarioRunnerTests: XCTestCase {
             ],
             backend: Scenario.BackendSpec(kind: "mock", model: "scripted", fallbackModel: nil, temperature: 0, seed: nil, topK: nil)
         )
-        let runner = ScenarioRunner(backend: backend, registry: registry, maxIterations: 2)
+        let runner = makeRunner(backend: backend, registry: registry, maxIterations: 2)
         let outcome = try await runner.run(scenario)
         XCTAssertFalse(outcome.passed, "scenario should not pass once the runner aborts on iteration cap")
         XCTAssertEqual(outcome.toolCallsExecuted.count, 2, "should dispatch exactly maxIterations tool calls")


### PR DESCRIPTION
## The bug (#1983)

`ScenarioRunner` called `backend.generate(prompt:systemPrompt:config:)` **directly**, bypassing the production `InferenceService → GenerationQueue → GenerationToolDispatchLoop` path. That orchestrator path is the *only* one that runs `PromptRenderer` / `JinjaPromptRenderer` to apply the chat template and inject tool definitions (`[AVAILABLE_TOOLS]` / native tool blocks). So every local backend was never told the tools existed and dispatched **zero tools** — the harness validated a parallel, non-production code path. It also hand-rolled its own tool-dispatch loop and special-cased `backend as? ConversationHistoryReceiver`, which misses `StructuredHistoryReceiver`-only backends like `LlamaBackend`.

## The fix — route through the real orchestrator

- `ScenarioRunner` now takes a pre-loaded `InferenceService` (carrying the `ToolRegistry`) instead of a raw backend. It does **one** `enqueue(structuredMessages:systemPrompt:config:)` per scenario turn with `config.tools = registry.definitions` and `config.maxToolIterations`, then consumes the whole stream — all tool iterations included.
- The orchestrator owns the tool loop, so the hand-rolled `for _ in 0..<maxIterations` loop, the `ConversationHistoryReceiver` special-casing, the manual `registry.dispatch(call)` calls, and the non-history-aware result splicing are all **deleted**. The runner just reconstructs `Outcome.toolCallsExecuted` / `toolResults` from `.toolCall` / `.toolResult` events and the final answer from `.token` events.
- **Additive `InferenceService` init**: the `init(backend:name:modelName:toolRegistry:toolApprovalGate:)` init was un-gated from `#if DEBUG` so the harness's mock/offline path can inject a scripted backend together with the registry in release too. The signature and all defaults are unchanged.
- `manifold-tools` CLI: `makeBackend` → `makeService`, building the service via that init for both the mock and Ollama paths.
- Reworked the 12 `ScenarioRunnerTests` call sites to build the service via the same init. Two scripted scenarios were adjusted to match real orchestrator behavior:
  - the transient-crash retry issues a **distinct** query (the loop short-circuits two identical consecutive calls — a real loop-safety valve);
  - the cancellation contract is verified through the recorded `.cancelled` tool result (the loop unwinds on cancellation rather than letting the model narrate over it).

## Breaking change

`ScenarioRunner.init(backend:registry:...)` → `ScenarioRunner.init(service:...)`. The companion repos (**manifold-llama#69**) update in lockstep and are out of scope for this PR.

## Validation

- `bash scripts/lint-no-new-force-unwraps.sh Sources` → clean
- `swift build --build-tests` → clean
- `swift test --filter ScenarioRunnerTests` → 22/22 green
- `swift test --filter MessageEnqueueTests` → 6/6 green
- Plus `InferenceServiceTests` / `InferenceServiceNonisolatedTests` / `ManifoldToolsTests` → 109/109 green

Closes #1983

🤖 Generated with [Claude Code](https://claude.com/claude-code)