### PR TITLE
feat: preemptive memory-pressure eviction + Ollama keep_alive bridge (#1931)

### DIFF
--- a/.github/api-breakage-allowlist.txt
+++ b/.github/api-breakage-allowlist.txt
@@ -126,3 +126,4 @@ API breakage: func InferenceService.enqueueAsync(structuredMessages:systemPrompt
 API breakage: constructor RAGService.RetrievalResult.init(slots:citations:) has been removed
 API breakage: constructor RAGConfiguration.init(embeddingBackend:reranker:chunkSize:chunkOverlap:topK:similarityThreshold:fullContextMode:fullContextBudgetTokens:vectorStoreURL:) has been removed
 API breakage: constructor RAGService.init(documentStore:vectorStore:embeddingBackend:reranker:chunker:parsers:defaultLimit:similarityThreshold:fullContextMode:fullContextBudgetTokens:) has been removed
+API breakage: constructor KeepAlivePolicy.init(idleTimeout:) has been removed

--- a/Sources/ManifoldContract/BackendOptInProtocols.swift
+++ b/Sources/ManifoldContract/BackendOptInProtocols.swift
@@ -153,6 +153,30 @@ public protocol EndpointBackendKeychainConfigurable: AnyObject {
     func configure(baseURL: URL, keychainAccount: String, modelName: String)
 }
 
+/// Adopted by backends whose *residency* is advisory — owned by a remote server
+/// the engine cannot directly evict (e.g. Ollama keeps a model resident in VRAM
+/// server-side and unloads it on its own `keep_alive` timer).
+///
+/// ## Owned vs advisory residency
+///
+/// ``InferenceService``'s ``KeepAlivePolicy`` governs **owned** (in-process)
+/// residency: when its idle timer fires the engine actually frees the model.
+/// For a server-side backend the engine cannot do that — it can only *advise*
+/// the server how long to keep the model loaded after the last request. This
+/// protocol is the bridge: the coordinator translates the owned policy's
+/// `idleTimeout` into the backend's server-side hint so the two horizons agree
+/// instead of diverging (an in-process 5-minute policy paired with Ollama's
+/// independent 30-minute default would otherwise hold VRAM long after MK
+/// considers the model idle).
+public protocol AdvisoryResidencyConfigurable: AnyObject {
+    /// Advises the backend's server-side keep-alive horizon.
+    ///
+    /// - Parameter idleTimeout: The owned policy's idle timeout in seconds, or
+    ///   `nil` for ``KeepAlivePolicy/never`` (the backend should apply its own
+    ///   default residency in that case — no advice is given).
+    func applyAdvisoryKeepAlive(idleTimeout: TimeInterval?)
+}
+
 /// Adopted by backends that can report granular model-load progress.
 ///
 /// `InferenceService` installs a handler before each load and clears it

--- a/Sources/ManifoldInference/KeepAlivePolicy.swift
+++ b/Sources/ManifoldInference/KeepAlivePolicy.swift
@@ -27,14 +27,49 @@ public struct KeepAlivePolicy: Sendable, Equatable {
     /// (≥ 1 second) in practice.
     public var idleTimeout: TimeInterval?
 
+    /// Whether the resident model may be *preemptively* evicted when the OS
+    /// raises an elevated — but not yet critical — memory-pressure warning.
+    ///
+    /// Opt-in (default `false`). The default reactive behaviour only evicts on a
+    /// **critical** pressure level. Setting this to `true` lets the engine free
+    /// the model one step earlier, at `.warning`, so the app is less likely to
+    /// be pushed to `.critical` (or terminated) in the first place — at the cost
+    /// of an extra reload if the warning was transient.
+    ///
+    /// A `.warning` eviction is *advisory and conservative*: it fires only when
+    /// the model is **idle past ``memoryWarningGrace``** and is **not** busy
+    /// generating. A `.warning` raised mid-turn never interrupts generation.
+    public var evictOnMemoryWarning: Bool
+
+    /// How long the model must have been idle before a `.warning`-level pressure
+    /// event is allowed to preemptively evict it.
+    ///
+    /// This short grace window prevents a `.warning` that lands moments after a
+    /// turn completes from tearing down a model the user is actively using.
+    /// Only consulted when ``evictOnMemoryWarning`` is `true`. Defaults to 10s.
+    public var memoryWarningGrace: TimeInterval
+
     /// The default policy: no automatic unloading.
     public static let never = KeepAlivePolicy(idleTimeout: nil)
 
     /// Creates a policy with the given idle timeout.
     ///
-    /// - Parameter idleTimeout: Seconds of idle time after which the model
-    ///   is automatically unloaded. Pass `nil` to disable auto-unload.
-    public init(idleTimeout: TimeInterval?) {
+    /// - Parameters:
+    ///   - idleTimeout: Seconds of idle time after which the model is
+    ///     automatically unloaded. Pass `nil` to disable auto-unload.
+    ///   - evictOnMemoryWarning: When `true`, an idle model may also be evicted
+    ///     on a `.warning`-level memory-pressure event (not just `.critical`).
+    ///     Defaults to `false`.
+    ///   - memoryWarningGrace: Minimum idle duration before a `.warning` may
+    ///     preemptively evict. Defaults to 10 seconds. Ignored unless
+    ///     `evictOnMemoryWarning` is `true`.
+    public init(
+        idleTimeout: TimeInterval?,
+        evictOnMemoryWarning: Bool = false,
+        memoryWarningGrace: TimeInterval = 10
+    ) {
         self.idleTimeout = idleTimeout
+        self.evictOnMemoryWarning = evictOnMemoryWarning
+        self.memoryWarningGrace = memoryWarningGrace
     }
 }

--- a/Sources/ManifoldInference/Services/InferenceService.swift
+++ b/Sources/ManifoldInference/Services/InferenceService.swift
@@ -1110,6 +1110,41 @@ extension InferenceService {
     /// rather than calling this directly.
     package func notifyPressureLevel(_ level: MemoryPressureLevel) {
         pressureBroadcaster.send(.levelChanged(level))
+        maybeEvictOnMemoryWarning(level)
+    }
+
+    /// Preemptively evicts an idle resident model on an elevated (`.warning`)
+    /// memory-pressure level — one step *before* the reactive `.critical` unload
+    /// that ``ChatViewModel/handleMemoryPressure()`` performs.
+    ///
+    /// This is opt-in via ``KeepAlivePolicy/evictOnMemoryWarning`` and deliberately
+    /// conservative: it fires only when the model has been **idle past**
+    /// ``KeepAlivePolicy/memoryWarningGrace`` and is **not** currently generating.
+    /// A `.warning` raised while a turn is in flight must never tear the model
+    /// down mid-generation — the busy guard below enforces that.
+    ///
+    /// Critical-level eviction is handled separately (by the host's reactive
+    /// `.critical` path with ``UnloadReason/criticalMemoryPressure``); this method
+    /// is concerned only with the preemptive `.warning` step and emits
+    /// ``UnloadReason/backgroundEviction``.
+    private func maybeEvictOnMemoryWarning(_ level: MemoryPressureLevel) {
+        guard level == .warning else { return }
+        let policy = lifecycle.keepAlivePolicy
+        guard policy.evictOnMemoryWarning else { return }
+        guard lifecycle.isModelLoaded else { return }
+
+        // Never evict a model mid-turn: a transient warning must not interrupt
+        // an active generation.
+        guard !generation.isGenerating else { return }
+
+        // Only evict once the model has been idle past the short grace window,
+        // so a warning landing right after a turn completes doesn't tear down a
+        // model the user is actively using.
+        let idle = generation.idleDuration
+        guard idle >= policy.memoryWarningGrace else { return }
+
+        Log.inference.info("KeepAlivePolicy: memory .warning + idle \(idle, privacy: .public)s >= grace \(policy.memoryWarningGrace, privacy: .public)s — preemptive eviction")
+        unloadModel(reason: .backgroundEviction)
     }
 }
 

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -413,6 +413,18 @@ final class ModelLifecycleCoordinator {
             urlModelConfigurable.configure(baseURL: url, modelName: endpoint.modelName)
         }
 
+        // Bridge MK's owned keep-alive policy into the backend's *advisory*
+        // (server-side) residency horizon when the backend opts in. MK cannot
+        // actually evict a server-resident model (e.g. Ollama holds it in VRAM);
+        // it can only advise the server how long to keep it. Translating the
+        // idle timeout here keeps the owned (in-process) and advisory
+        // (server-side) timers in agreement instead of diverging. A `.never`
+        // policy (`idleTimeout == nil`) gives no advice — the backend keeps its
+        // own default.
+        if let advisory = newBackend as? AdvisoryResidencyConfigurable {
+            advisory.applyAdvisoryKeepAlive(idleTimeout: keepAlivePolicy.idleTimeout)
+        }
+
         let cloudBackendName = backendDisplayName(for: endpoint.provider)
         let backendURL = url
         let cloudPlan = ModelLoadPlan.cloud()

--- a/Sources/ManifoldOllama/OllamaBackend.swift
+++ b/Sources/ManifoldOllama/OllamaBackend.swift
@@ -20,7 +20,7 @@ import ManifoldCloudCore
 /// let stream = try backend.generate(prompt: "Hello", systemPrompt: nil, config: .init())
 /// for try await event in stream.events { if case .token(let t) = event { print(t, terminator: "") } }
 /// ```
-public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfigurable, ToolCallingHistoryReceiver, StructuredHistoryReceiver, @unchecked Sendable {
+public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfigurable, AdvisoryResidencyConfigurable, ToolCallingHistoryReceiver, StructuredHistoryReceiver, @unchecked Sendable {
 
     // MARK: - Adapter composition (Phase 3/Ollama)
     //
@@ -43,7 +43,33 @@ public final class OllamaBackend: SSECloudBackend, EndpointBackendURLModelConfig
 
     /// How long Ollama should keep the model loaded in VRAM after a request.
     /// Default is "30m" (30 minutes). Ollama's own default is "5m".
+    ///
+    /// This is **advisory residency**: it is sent as the request body's
+    /// `keep_alive` field and the *Ollama server* decides when to actually free
+    /// VRAM. MK cannot evict a server-side model itself. When an Ollama endpoint
+    /// is loaded under a non-`.never` ``KeepAlivePolicy``, the lifecycle
+    /// coordinator overwrites this via ``applyAdvisoryKeepAlive(idleTimeout:)``
+    /// so the server's keep-alive horizon agrees with MK's owned idle policy
+    /// instead of diverging from it.
     public var keepAlive: String = "30m"
+
+    /// Bridges MK's owned ``KeepAlivePolicy`` idle horizon into Ollama's
+    /// server-side `keep_alive` advice.
+    ///
+    /// Owned vs advisory residency: MK's policy unloads the *in-process* model
+    /// when its idle timer fires; this method translates the same horizon into
+    /// the `keep_alive` string Ollama uses to decide when *it* frees VRAM, so
+    /// the two timers agree instead of diverging (see
+    /// ``AdvisoryResidencyConfigurable``). A `nil` timeout (`.never`) leaves the
+    /// existing default in place — no advice is given. Emits seconds (`"<n>s"`)
+    /// so the wire value matches the configured timeout exactly; a fractional
+    /// timeout is rounded up to whole seconds (Ollama parses integer seconds),
+    /// and any non-positive value clamps to `"0s"` (Ollama unloads immediately).
+    public func applyAdvisoryKeepAlive(idleTimeout: TimeInterval?) {
+        guard let idleTimeout else { return }
+        let seconds = max(0, Int(idleTimeout.rounded(.up)))
+        keepAlive = "\(seconds)s"
+    }
 
     /// Whether the currently-loaded Ollama model advertises thinking/reasoning
     /// capability. Detected once at `loadModel` time by probing `/api/show`

--- a/Tests/ManifoldBackendsTests/OllamaKeepAliveBridgeTests.swift
+++ b/Tests/ManifoldBackendsTests/OllamaKeepAliveBridgeTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import ManifoldOllama
+@testable import ManifoldInference
+
+/// Tests for the owned-policy → advisory-residency bridge (#1931).
+///
+/// `OllamaBackend` keeps a model resident **server-side** (in VRAM) on its own
+/// `keep_alive` timer — MK cannot evict it directly, only advise. This suite
+/// verifies the translation from MK's owned ``KeepAlivePolicy/idleTimeout`` into
+/// the wire `keep_alive` string Ollama receives, so the two residency horizons
+/// agree instead of diverging.
+@MainActor
+final class OllamaKeepAliveBridgeTests: XCTestCase {
+
+    func test_applyAdvisoryKeepAlive_translatesSecondsExactly() {
+        let backend = OllamaBackend()
+        backend.applyAdvisoryKeepAlive(idleTimeout: 300)
+        XCTAssertEqual(
+            backend.keepAlive,
+            "300s",
+            "A 300s owned idle timeout must be advised to Ollama as \"300s\""
+        )
+
+        // Sabotage check: confirm the value is actually derived from the input,
+        // not a constant. A different timeout must produce a different string.
+        backend.applyAdvisoryKeepAlive(idleTimeout: 600)
+        XCTAssertEqual(backend.keepAlive, "600s")
+        XCTAssertNotEqual(backend.keepAlive, "300s")
+    }
+
+    func test_applyAdvisoryKeepAlive_roundsFractionalUp() {
+        let backend = OllamaBackend()
+        backend.applyAdvisoryKeepAlive(idleTimeout: 0.5)
+        // Ollama parses integer seconds; a sub-second timeout rounds up so the
+        // server doesn't truncate it to "0s" and unload immediately.
+        XCTAssertEqual(backend.keepAlive, "1s")
+    }
+
+    func test_applyAdvisoryKeepAlive_clampsNonPositiveToZero() {
+        let backend = OllamaBackend()
+        backend.applyAdvisoryKeepAlive(idleTimeout: -10)
+        XCTAssertEqual(backend.keepAlive, "0s", "A non-positive timeout clamps to \"0s\" (Ollama unloads immediately)")
+    }
+
+    func test_applyAdvisoryKeepAlive_nilLeavesDefault() {
+        let backend = OllamaBackend()
+        let original = backend.keepAlive
+        XCTAssertEqual(original, "30m", "Precondition: the default keep_alive is 30m")
+
+        // .never (idleTimeout == nil) gives no advice — the backend keeps its own
+        // default residency.
+        backend.applyAdvisoryKeepAlive(idleTimeout: nil)
+        XCTAssertEqual(backend.keepAlive, original, "A nil (.never) timeout must not overwrite the default keep_alive")
+    }
+
+    func test_ollamaBackend_conformsToAdvisoryResidencyConfigurable() {
+        // The coordinator only bridges when the backend opts in via the protocol;
+        // guard the conformance so a future refactor can't silently drop it.
+        XCTAssertTrue(OllamaBackend() is AdvisoryResidencyConfigurable)
+    }
+}

--- a/Tests/ManifoldInferenceTests/KeepAlivePolicyTests.swift
+++ b/Tests/ManifoldInferenceTests/KeepAlivePolicyTests.swift
@@ -198,6 +198,106 @@ final class KeepAlivePolicyTests: XCTestCase {
 
     // MARK: - Explicit unload cancels the watch task (no double-unload)
 
+    // MARK: - Preemptive eviction on .warning (#1931)
+
+    /// Collects every `didUnload` reason emitted by the service so a test can
+    /// assert *which* reason drove an eviction (or that none did).
+    @MainActor
+    private func collectUnloadReasons(
+        from service: InferenceService
+    ) -> (reasons: () -> [UnloadReason], task: Task<Void, Never>) {
+        let box = UnloadReasonBox()
+        let stream = service.memoryPressureEvents()
+        let task = Task { @MainActor in
+            for await event in stream {
+                if case .didUnload(_, let reason) = event {
+                    box.append(reason)
+                }
+            }
+        }
+        return ({ box.snapshot() }, task)
+    }
+
+    func test_warning_idleModel_preemptivelyEvicts() async throws {
+        let service = makeService()
+        XCTAssertTrue(service.isModelLoaded)
+
+        // Opt in with a zero grace window: a freshly-loaded model that has never
+        // generated reports idleDuration == .infinity, so it is immediately past
+        // any grace window — the warning should evict it straight away.
+        service.keepAlivePolicy = KeepAlivePolicy(idleTimeout: nil, evictOnMemoryWarning: true, memoryWarningGrace: 0)
+
+        let (reasons, eventTask) = collectUnloadReasons(from: service)
+        defer { eventTask.cancel() }
+
+        service.notifyPressureLevel(.warning)
+
+        let didUnload = try await poll(timeout: 1.0) { !service.isModelLoaded }
+        XCTAssertTrue(didUnload, "An idle model should be preemptively evicted on .warning when evictOnMemoryWarning is true")
+
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertTrue(
+            reasons().contains(.backgroundEviction),
+            "Preemptive .warning eviction must carry UnloadReason.backgroundEviction; got \(reasons())"
+        )
+    }
+
+    func test_warning_busyModel_doesNotEvict() async throws {
+        let backend = MockInferenceBackend()
+        backend.isModelLoaded = true
+        backend.tokensToYield = ["one", "two"]
+        // Gate the token emission so the generation is held in-flight: the mock
+        // awaits the gate BEFORE yielding each token, so once a turn starts the
+        // service reports isGenerating == true until we advance the gate.
+        let gate = TokenEmissionGate()
+        backend.tokenEmissionGate = gate
+        let service = InferenceService(backend: backend)
+
+        // Zero grace window so the ONLY thing standing between a .warning and an
+        // eviction is the busy guard — this is what the sabotage check flips.
+        service.keepAlivePolicy = KeepAlivePolicy(idleTimeout: nil, evictOnMemoryWarning: true, memoryWarningGrace: 0)
+
+        let (token, stream) = try service.enqueue(messages: [.user("hi")], config: GenerationConfig())
+        let drain = Task { @MainActor in
+            for try await _ in stream.events {}
+        }
+        defer {
+            drain.cancel()
+            service.cancel(token)
+        }
+
+        // Wait until the turn is actually in flight (the mock is parked on the
+        // gate before its first token).
+        let becameBusy = try await poll(timeout: 1.0) { service.isGenerating }
+        XCTAssertTrue(becameBusy, "Generation should be in flight before we send the warning")
+
+        service.notifyPressureLevel(.warning)
+
+        // Give the (non-)eviction path a moment to run; the model must stay loaded.
+        let stayedLoaded = try await poll(timeout: 0.4) { !service.isModelLoaded }
+        XCTAssertFalse(stayedLoaded, "A .warning must NOT evict a BUSY model — generation in flight")
+        XCTAssertTrue(service.isModelLoaded)
+        XCTAssertTrue(service.isGenerating)
+
+        // Let the generation finish cleanly so the gate doesn't leak.
+        await gate.advance()
+        await gate.advance()
+    }
+
+    func test_warning_defaultPolicy_isNoOp() async throws {
+        let service = makeService()
+        XCTAssertTrue(service.isModelLoaded)
+
+        // Default policy: evictOnMemoryWarning == false. A .warning must do nothing.
+        XCTAssertFalse(service.keepAlivePolicy.evictOnMemoryWarning)
+
+        service.notifyPressureLevel(.warning)
+
+        let evicted = try await poll(timeout: 0.4) { !service.isModelLoaded }
+        XCTAssertFalse(evicted, "With the default policy a .warning must be a no-op — only .critical evicts")
+        XCTAssertTrue(service.isModelLoaded)
+    }
+
     func test_explicitUnload_doesNotTriggerSecondUnload() async throws {
         let service = makeService()
         XCTAssertTrue(service.isModelLoaded)
@@ -225,4 +325,13 @@ final class KeepAlivePolicyTests: XCTestCase {
 
         XCTAssertEqual(didUnloadCount, 1, "Only one unload event should fire — the explicit one")
     }
+}
+
+/// MainActor-confined collector for unload reasons observed on the event stream.
+/// The collecting `Task` is `@MainActor`, so plain mutation is race-free.
+@MainActor
+private final class UnloadReasonBox {
+    private var reasons: [UnloadReason] = []
+    func append(_ reason: UnloadReason) { reasons.append(reason) }
+    func snapshot() -> [UnloadReason] { reasons }
 }

--- a/Tests/ManifoldInferenceTests/ModelLifecycleCoordinatorTests.swift
+++ b/Tests/ManifoldInferenceTests/ModelLifecycleCoordinatorTests.swift
@@ -516,6 +516,101 @@ private final class GatedLoadBackend: InferenceBackend, @unchecked Sendable {
     }
 }
 
+// MARK: - Advisory keep-alive bridge wiring (#1931)
+
+extension ModelLifecycleCoordinatorTests {
+
+    private func makeOllamaEndpoint() -> APIEndpointRecord {
+        APIEndpointRecord(
+            name: "Local Ollama",
+            provider: .ollama,
+            baseURL: "http://localhost:11434",
+            modelName: "llama3.2"
+        )
+    }
+
+    /// A non-`.never` policy must be bridged into the endpoint backend's
+    /// advisory residency horizon at load time.
+    ///
+    /// Sabotage: deleting the `applyAdvisoryKeepAlive` call in
+    /// `loadEndpointBackend` leaves `receivedAdvisoryTimeout == nil` and the
+    /// assertion fails.
+    func test_loadEndpointBackend_bridgesKeepAlivePolicyIntoAdvisoryResidency() async throws {
+        let coordinator = ModelLifecycleCoordinator()
+        let spy = AdvisoryEndpointSpyBackend()
+        coordinator.registerEndpointBackendFactory { provider in
+            provider == .ollama ? spy : nil
+        }
+        coordinator.keepAlivePolicy = KeepAlivePolicy(idleTimeout: 120)
+
+        try await coordinator.loadEndpointBackend(from: makeOllamaEndpoint())
+
+        XCTAssertTrue(coordinator.isModelLoaded)
+        XCTAssertEqual(
+            spy.receivedAdvisoryTimeout,
+            120,
+            "loadEndpointBackend must bridge the owned idleTimeout into the backend's advisory residency"
+        )
+    }
+
+    /// A `.never` policy (idleTimeout == nil) must still call the bridge but
+    /// advise `nil` so the backend keeps its own default residency.
+    func test_loadEndpointBackend_neverPolicy_advisesNilTimeout() async throws {
+        let coordinator = ModelLifecycleCoordinator()
+        let spy = AdvisoryEndpointSpyBackend()
+        coordinator.registerEndpointBackendFactory { provider in
+            provider == .ollama ? spy : nil
+        }
+        // .never is the default; assert explicitly for clarity.
+        coordinator.keepAlivePolicy = .never
+
+        try await coordinator.loadEndpointBackend(from: makeOllamaEndpoint())
+
+        XCTAssertTrue(spy.didReceiveAdvisoryCall, "The bridge should still be invoked under .never")
+        XCTAssertNil(spy.receivedAdvisoryTimeout, "A .never policy advises a nil timeout — no advice given")
+    }
+}
+
+/// Endpoint backend spy that records the advisory keep-alive timeout it is given.
+private final class AdvisoryEndpointSpyBackend:
+    InferenceBackend,
+    EndpointBackendURLModelConfigurable,
+    AdvisoryResidencyConfigurable,
+    @unchecked Sendable {
+
+    private(set) var didReceiveAdvisoryCall = false
+    private(set) var receivedAdvisoryTimeout: TimeInterval?
+
+    private let stateLock = OSAllocatedUnfairLock(initialState: false)
+    var isModelLoaded: Bool { stateLock.withLock { $0 } }
+    var isGenerating: Bool { false }
+
+    let capabilities = BackendCapabilities(
+        supportedParameters: [.temperature],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    func configure(baseURL: URL, modelName: String) {}
+
+    func applyAdvisoryKeepAlive(idleTimeout: TimeInterval?) {
+        didReceiveAdvisoryCall = true
+        receivedAdvisoryTimeout = idleTimeout
+    }
+
+    func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        stateLock.withLock { $0 = true }
+    }
+
+    func generate(prompt: String, systemPrompt: String?, config: GenerationConfig) throws -> GenerationStream {
+        GenerationStream(AsyncThrowingStream<GenerationEvent, Error> { $0.finish() })
+    }
+
+    func stopGeneration() {}
+    func unloadModel() { stateLock.withLock { $0 = false } }
+}
+
 // MARK: - LoadGate Actor
 
 /// An actor-based gate that blocks `loadModel` until the test releases it.


### PR DESCRIPTION
Implements the **descoped** #1931 — two genuinely-new pieces atop the already-shipped TTL / idle-unload / evict-before-load / pressure-react primitives. **Multi-model LRU residency (`[ModelID: InferenceBackend]`) is explicitly out of scope / a non-goal** — MK is single-resident by design.

## What shipped

### 1. Preemptive eviction on `.warning`
Today only `.critical` evicts. New opt-in `KeepAlivePolicy.evictOnMemoryWarning: Bool` (default `false`) plus a short `memoryWarningGrace` window (default 10s). On a `.warning`-level pressure event with an **idle** model past the grace window, `InferenceService.notifyPressureLevel()` frees the model with the already-existing `UnloadReason.backgroundEviction` — one step before the existing reactive `.critical` unload, giving the app a chance to avoid `.critical` / termination.

- A `.warning` while the model is **BUSY generating never evicts** (busy guard).
- `evictOnMemoryWarning == false` (default) makes `.warning` a no-op (regression guard).

### 2. Bridge `KeepAlivePolicy.idleTimeout` -> `OllamaBackend.keepAlive`
New `AdvisoryResidencyConfigurable` protocol. When an Ollama endpoint is loaded under a non-`.never` policy, the lifecycle coordinator translates the owned idle timeout into Ollama's server-side `keep_alive` string (`"<n>s"`) so the two horizons agree instead of diverging (MK's in-process 5-min policy vs Ollama's independent 30-min default). The **owned residency (in-process, evictable) vs advisory residency (Ollama server-side, MK can only advise)** distinction is documented on the protocol and method — MK cannot itself evict a server-resident model.

## Tests (sabotage-verified)
- `.warning` + idle model -> fires `unloadModel(.backgroundEviction)`. **Sabotage check ran**: flipping the busy guard so busy also evicts made the busy-case test fail, confirming the guard is load-bearing; sabotage removed before commit.
- `.warning` + BUSY model -> does NOT evict (held in-flight via `TokenEmissionGate`).
- `evictOnMemoryWarning == false` (default) -> `.warning` is a no-op.
- Ollama bridge: emitted `keep_alive` string matches the configured `idleTimeout`; `.never` leaves the default in place; fractional rounds up; non-positive clamps to `0s`.

## Gate
- `swift build --build-tests` clean (no switched-enum changes — `.backgroundEviction` already existed, so the `--traits Server,Macros` sweep was not required).
- Affected `ManifoldInferenceTests` (KeepAlive/lifecycle) + Ollama suites run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)