### PR TITLE
feat: add ConfusionCounts + macro-averaging metric to ManifoldInference (#1993)

### DIFF
--- a/Sources/ManifoldInference/Metrics/ConfusionCounts.swift
+++ b/Sources/ManifoldInference/Metrics/ConfusionCounts.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Immutable TP/FP/FN triple with derived precision / recall / F1.
+///
+/// Empty-input semantics: precision, recall, and f1 all return `0.0` when the
+/// corresponding denominator is zero (e.g. an empty `ConfusionCounts`), *not*
+/// `1.0`. This is the conservative choice for set-comparison metrics — an empty
+/// prediction set is not "trivially perfect". Callers who want "trivially perfect
+/// on empty" semantics should wrap this type and override the zero-denominator case.
+public struct ConfusionCounts: Sendable, Equatable {
+    /// Present in both actual and expected (true positives).
+    public let tp: Int
+    /// In actual but not expected (false positives).
+    public let fp: Int
+    /// Expected but missing from actual (false negatives).
+    public let fn: Int
+
+    public init(tp: Int, fp: Int, fn: Int) {
+        self.tp = tp
+        self.fp = fp
+        self.fn = fn
+    }
+
+    /// Total predicted positives (tp + fp).
+    public var predicted: Int { tp + fp }
+
+    /// Total relevant items (tp + fn).
+    public var relevant: Int { tp + fn }
+
+    /// Precision = tp / predicted, or `0.0` when nothing was predicted.
+    public var precision: Double {
+        predicted == 0 ? 0.0 : Double(tp) / Double(predicted)
+    }
+
+    /// Recall = tp / relevant, or `0.0` when nothing was relevant.
+    public var recall: Double {
+        relevant == 0 ? 0.0 : Double(tp) / Double(relevant)
+    }
+
+    /// F1 = harmonic mean of precision and recall, or `0.0` when both are zero.
+    public var f1: Double {
+        let p = precision
+        let r = recall
+        return (p + r) == 0 ? 0.0 : 2 * p * r / (p + r)
+    }
+
+    /// The zero triple (0/0/0).
+    public static let empty = ConfusionCounts(tp: 0, fp: 0, fn: 0)
+
+    /// Computes counts by comparing an actual set against an expected set.
+    ///
+    /// - tp = actual ∩ expected
+    /// - fp = actual − expected
+    /// - fn = expected − actual
+    public static func compute(actual: Set<String>, expected: Set<String>) -> ConfusionCounts {
+        let tp = actual.intersection(expected).count
+        let fp = actual.subtracting(expected).count
+        let fn = expected.subtracting(actual).count
+        return ConfusionCounts(tp: tp, fp: fp, fn: fn)
+    }
+}
+
+/// Macro-averaged precision/recall/F1 — the unweighted mean of the per-class
+/// metrics (each class counts equally regardless of support). Empty input → all 0.0.
+///
+/// This is a macro average: the mean of each class's `precision`/`recall`/`f1`
+/// getters, *not* a pooled (micro) average over summed tp/fp/fn.
+public struct MacroAveragedMetrics: Sendable, Equatable {
+    public let precision: Double
+    public let recall: Double
+    public let f1: Double
+
+    public init(precision: Double, recall: Double, f1: Double) {
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+    }
+
+    public init(perClass: [ConfusionCounts]) {
+        guard !perClass.isEmpty else {
+            self.init(precision: 0.0, recall: 0.0, f1: 0.0)
+            return
+        }
+        let n = Double(perClass.count)
+        let p = perClass.reduce(0.0) { $0 + $1.precision } / n
+        let r = perClass.reduce(0.0) { $0 + $1.recall } / n
+        let f = perClass.reduce(0.0) { $0 + $1.f1 } / n
+        self.init(precision: p, recall: r, f1: f)
+    }
+}

--- a/Tests/ManifoldInferenceTests/ConfusionCountsTests.swift
+++ b/Tests/ManifoldInferenceTests/ConfusionCountsTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import ManifoldInference
+
+final class ConfusionCountsTests: XCTestCase {
+
+    private let accuracy = 1e-9
+
+    func testNormalCasePrecisionRecallF1() {
+        let counts = ConfusionCounts(tp: 3, fp: 1, fn: 2)
+        XCTAssertEqual(counts.predicted, 4)
+        XCTAssertEqual(counts.relevant, 5)
+        XCTAssertEqual(counts.precision, 0.75, accuracy: accuracy)
+        XCTAssertEqual(counts.recall, 0.6, accuracy: accuracy)
+        // 2 * 0.75 * 0.6 / (0.75 + 0.6) = 0.9 / 1.35 = 0.66666...
+        XCTAssertEqual(counts.f1, 2.0 / 3.0, accuracy: accuracy)
+    }
+
+    func testEmptyIsAllZero() {
+        let counts = ConfusionCounts.empty
+        XCTAssertEqual(counts.precision, 0.0, accuracy: accuracy)
+        XCTAssertEqual(counts.recall, 0.0, accuracy: accuracy)
+        XCTAssertEqual(counts.f1, 0.0, accuracy: accuracy)
+    }
+
+    func testPredictedZeroButFnPositive() {
+        let counts = ConfusionCounts(tp: 0, fp: 0, fn: 4)
+        XCTAssertEqual(counts.precision, 0.0, accuracy: accuracy)
+        XCTAssertEqual(counts.recall, 0.0, accuracy: accuracy)
+        XCTAssertEqual(counts.f1, 0.0, accuracy: accuracy)
+    }
+
+    func testRelevantZeroButFpPositive() {
+        let counts = ConfusionCounts(tp: 0, fp: 4, fn: 0)
+        XCTAssertEqual(counts.recall, 0.0, accuracy: accuracy)
+        XCTAssertEqual(counts.precision, 0.0, accuracy: accuracy)
+        XCTAssertEqual(counts.f1, 0.0, accuracy: accuracy)
+    }
+
+    func testComputeOverlappingSets() {
+        let actual: Set<String> = ["a", "b", "c", "d"]
+        let expected: Set<String> = ["b", "c", "e"]
+        let counts = ConfusionCounts.compute(actual: actual, expected: expected)
+        XCTAssertEqual(counts.tp, 2) // b, c
+        XCTAssertEqual(counts.fp, 2) // a, d
+        XCTAssertEqual(counts.fn, 1) // e
+    }
+
+    func testComputeDisjointSets() {
+        let counts = ConfusionCounts.compute(actual: ["x", "y"], expected: ["z"])
+        XCTAssertEqual(counts.tp, 0)
+        XCTAssertEqual(counts.fp, 2)
+        XCTAssertEqual(counts.fn, 1)
+    }
+
+    func testComputeEmptySets() {
+        let counts = ConfusionCounts.compute(actual: [], expected: [])
+        XCTAssertEqual(counts, ConfusionCounts.empty)
+    }
+
+    // MARK: - MacroAveragedMetrics
+
+    func testMacroAverageMeanAcrossClasses() {
+        // Class 1: tp=1, fp=1, fn=1 -> precision 0.5, recall 0.5, f1 0.5
+        let class1 = ConfusionCounts(tp: 1, fp: 1, fn: 1)
+        // Class 2: tp=2, fp=0, fn=0 -> precision 1.0, recall 1.0, f1 1.0
+        let class2 = ConfusionCounts(tp: 2, fp: 0, fn: 0)
+        let macro = MacroAveragedMetrics(perClass: [class1, class2])
+        XCTAssertEqual(macro.precision, 0.75, accuracy: accuracy)
+        XCTAssertEqual(macro.recall, 0.75, accuracy: accuracy)
+        XCTAssertEqual(macro.f1, 0.75, accuracy: accuracy)
+    }
+
+    func testMacroAverageEmptyInputIsAllZero() {
+        let macro = MacroAveragedMetrics(perClass: [])
+        XCTAssertEqual(macro.precision, 0.0, accuracy: accuracy)
+        XCTAssertEqual(macro.recall, 0.0, accuracy: accuracy)
+        XCTAssertEqual(macro.f1, 0.0, accuracy: accuracy)
+    }
+
+    func testMacroAverageExplicitInit() {
+        let macro = MacroAveragedMetrics(precision: 0.1, recall: 0.2, f1: 0.3)
+        XCTAssertEqual(macro.precision, 0.1, accuracy: accuracy)
+        XCTAssertEqual(macro.recall, 0.2, accuracy: accuracy)
+        XCTAssertEqual(macro.f1, 0.3, accuracy: accuracy)
+    }
+}

--- a/Tests/ManifoldInferenceTests/ConfusionCountsTests.swift
+++ b/Tests/ManifoldInferenceTests/ConfusionCountsTests.swift
@@ -70,6 +70,36 @@ final class ConfusionCountsTests: XCTestCase {
         XCTAssertEqual(macro.f1, 0.75, accuracy: accuracy)
     }
 
+    /// Discriminates a *true* macro-average from a (wrong) micro/pooled average
+    /// and from the common mistake of recomputing macro-F1 from the mean
+    /// precision and mean recall.
+    ///
+    /// Classes chosen so the three results are all distinct:
+    ///   - Class A: tp=1, fp=0, fn=0  → P=1.0,    R=1.0, f1=1.0
+    ///   - Class B: tp=1, fp=9, fn=0  → P=0.1,    R=1.0, f1≈0.1818
+    ///
+    /// True macro:                 P=0.55,   R=1.0, f1≈0.5909
+    /// Micro (pooled tp/fp/fn):    P≈0.1818, R=1.0, f1≈0.3077   ← must NOT match
+    /// macroF1 from mean(P),mean(R): ≈0.7097                    ← must NOT match
+    func testMacroAverageIsTrueMacroNotMicroNorRecomputedF1() {
+        let classA = ConfusionCounts(tp: 1, fp: 0, fn: 0)
+        let classB = ConfusionCounts(tp: 1, fp: 9, fn: 0)
+        let macro = MacroAveragedMetrics(perClass: [classA, classB])
+
+        XCTAssertEqual(macro.precision, 0.55, accuracy: accuracy)
+        XCTAssertEqual(macro.recall, 1.0, accuracy: accuracy)
+
+        // Mean of per-class f1 getters: (1.0 + 2/11) / 2.
+        let expectedMacroF1 = (1.0 + (2.0 / 11.0)) / 2.0
+        XCTAssertEqual(macro.f1, expectedMacroF1, accuracy: accuracy)
+
+        // Guard against the two regressions this test exists to catch.
+        let microF1 = 2.0 * (2.0 / 11.0) / (2.0 / 11.0 + 1.0) // 0.3077
+        XCTAssertNotEqual(macro.f1, microF1, accuracy: accuracy)
+        let recomputedFromMeans = 2 * 0.55 * 1.0 / (0.55 + 1.0) // 0.7097
+        XCTAssertNotEqual(macro.f1, recomputedFromMeans, accuracy: accuracy)
+    }
+
     func testMacroAverageEmptyInputIsAllZero() {
         let macro = MacroAveragedMetrics(perClass: [])
         XCTAssertEqual(macro.precision, 0.0, accuracy: accuracy)


### PR DESCRIPTION
## What

Ships a pure, public `ConfusionCounts` value type (TP/FP/FN with derived precision/recall/F1) plus a `MacroAveragedMetrics` aggregate into `ManifoldInference` (`Sources/ManifoldInference/Metrics/ConfusionCounts.swift`). Both flow through the `ManifoldKit` umbrella re-export.

This is the one extractable primitive from the #1993 review — the broader ManifoldEval dedup play was rejected. Refs #1993.

## Why

Fireside (which imports the `ManifoldKit` umbrella) currently carries its own copy of `ConfusionCounts`. The public API here mirrors Fireside's copy **exactly**, so Fireside can delete its version and import MK's as a drop-in replacement.

## Semantics

- **On-empty = 0.0**: precision/recall/f1 all return `0.0` when their denominator is zero (e.g. `ConfusionCounts.empty`), *not* `1.0`. Documented in the doc-comment. Callers wanting "trivially perfect on empty" wrap and override.
- `MacroAveragedMetrics(perClass:)` is a true macro average — the unweighted mean of each class's precision/recall/f1 getters, not a pooled (micro) average over summed counts. Empty input → all 0.0.

## Tests

`Tests/ManifoldInferenceTests/ConfusionCountsTests.swift` (XCTest) covers normal case, empty, predicted==0/relevant==0, `compute(actual:expected:)` set math (overlapping/disjoint/empty), and macro-average mean + empty-array.

Additive public API — expected to show as additive/clean under the api-break gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)