### PR TITLE
feat: add respond(to:) convenience entry point (#1942)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ struct MyChatApp: App {
 }
 ```
 
+#### One-shot response
+
+Already have a `QuickStartResult` and just want one reply as a `String`? `respond(to:)` sends the message, drives the turn, and returns the assistant's text — no `inputText`/observation plumbing:
+
+```swift
+import ManifoldKit
+// + `import ManifoldLlama` for the GGUF seed below (see the note above)
+
+func oneShot() async throws -> String {
+    let kit = try await ManifoldKit.quickStart(
+        // backends: [LlamaBackends.self], ← uncomment with the manifold-llama package
+        seed: .recommendedSmallModel()
+    )
+    return try await kit.respond(to: "Explain monads in one sentence.")
+}
+```
+
 > **About `seed:`** — `.recommendedSmallModel()` downloads Qwen3-0.6B (~400 MB) in the background before returning, so the composer is generating the moment the view appears. The download is skipped when a model is already available (Foundation on iOS/macOS 26+, or a local model on disk), and it accepts a `{ progress in … }` closure for a progress indicator.
 >
 > **Don't want the starter download?** Drop `seed:` — the chat is then inert until you select a model. `quickStart` registers the backends but loads none, so on first run the composer reads "No model loaded" and the empty-state **Select Model** button only flips `showModelManagement` — nothing is presented until you attach a sheet to that binding. Fastest route: present `ModelManagementSheet` (from the opt-in `ManifoldUIModelManagement` module) with `.sheet(isPresented: $showModelManagement)`, or keep `seed:`. Step-by-step: [First-launch backend selection](docs/QUICKSTART.md#first-launch-backend-selection).

--- a/Sources/ManifoldKit/QuickStart.swift
+++ b/Sources/ManifoldKit/QuickStart.swift
@@ -606,6 +606,16 @@ public struct QuickStartResult: Sendable {
         self.viewModel = viewModel
         self.sessionManager = sessionManager
     }
+
+    /// Sends `text` and returns the assistant's reply as a `String`.
+    ///
+    /// One-hop convenience over ``ChatViewModel/respond(to:)`` so consumers can
+    /// write `try await kit.respond(to: "…")` without the `.viewModel`
+    /// indirection. Throws the same ``SendMessageError`` cases.
+    @discardableResult
+    public func respond(to text: String) async throws -> String {
+        try await viewModel.respond(to: text)
+    }
 }
 
 // MARK: - ManifoldConfiguration.default

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+Respond.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+Respond.swift
@@ -12,6 +12,13 @@ extension ChatViewModel {
     /// agent identity). The heavy lifting — stream drain, persistence, the
     /// single-turn drive — is inherited unchanged from ``sendMessage(_:)``.
     ///
+    /// - Note: The return is `ChatMessage.content` — the concatenated *visible
+    ///   text* parts. A turn that produces only tool calls or only `.thinking`
+    ///   parts (no visible text) therefore returns the empty string even though
+    ///   the turn ran and an assistant record was persisted. Callers that need
+    ///   to distinguish "ran but no visible text" from "produced text" should
+    ///   use ``sendMessage(_:)`` and inspect the full ``ChatMessage`` instead.
+    ///
     /// - Throws: ``SendMessageError`` — `.noActiveSession` / `.noModelLoaded`
     ///   for precondition failures, `.empty` when the turn produces no
     ///   assistant record, or `.runtime(error)` when the underlying runtime

--- a/Sources/ManifoldUI/ViewModels/ChatViewModel+Respond.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatViewModel+Respond.swift
@@ -1,0 +1,23 @@
+import Foundation
+import ManifoldInference
+
+// MARK: - ChatViewModel + Respond
+
+extension ChatViewModel {
+
+    /// Sends `text` and returns the assistant's reply as a `String`.
+    ///
+    /// Convenience over ``sendMessage(_:)`` for callers that only want the
+    /// reply text and don't need the full ``ChatMessage`` (citations, parts,
+    /// agent identity). The heavy lifting — stream drain, persistence, the
+    /// single-turn drive — is inherited unchanged from ``sendMessage(_:)``.
+    ///
+    /// - Throws: ``SendMessageError`` — `.noActiveSession` / `.noModelLoaded`
+    ///   for precondition failures, `.empty` when the turn produces no
+    ///   assistant record, or `.runtime(error)` when the underlying runtime
+    ///   surfaces an error. Cancellation propagates from ``sendMessage(_:)``.
+    @discardableResult
+    public func respond(to text: String) async throws -> String {
+        try await sendMessage(text).content
+    }
+}

--- a/Tests/ManifoldUITests/ChatViewModelRespondTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelRespondTests.swift
@@ -1,0 +1,111 @@
+@preconcurrency import XCTest
+import SwiftData
+@testable import ManifoldUI
+import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+@testable import ManifoldInference
+import ManifoldTestSupport
+
+/// Tests for the `respond(to:)` String-typed convenience over `sendMessage(_:)`.
+///
+/// `respond(to:)` is a thin wrapper that returns `sendMessage(text).content`, so
+/// these tests verify it (1) returns the assistant's reply text on the happy
+/// path and (2) propagates the same `SendMessageError` rim as `sendMessage`.
+@MainActor
+final class ChatViewModelRespondTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var vm: ChatViewModel!
+    private var sessionManager: SessionManagerViewModel!
+    private var mock: MockInferenceBackend!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        container = try makeInMemoryContainer()
+        context = container.mainContext
+
+        mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["Hello", " world"]
+
+        let service = InferenceService(backend: mock, name: "MockRespond")
+        vm = ChatViewModel(inferenceService: service)
+        vm.configure(persistence: SwiftDataPersistenceProvider(modelContext: context))
+
+        sessionManager = SessionManagerViewModel()
+        sessionManager.configure(persistence: SwiftDataPersistenceProvider(modelContext: context), autoLoad: false)
+    }
+
+    override func tearDown() async throws {
+        vm = nil
+        sessionManager = nil
+        mock = nil
+        context = nil
+        container = nil
+        try await super.tearDown()
+    }
+
+    @discardableResult
+    private func createAndActivateSession(title: String = "Respond Chat") async -> ManifoldInference.ChatSession {
+        let session = try! await sessionManager.createSession(title: title)
+        sessionManager.activeSession = session
+        await vm.switchToSession(session)
+        return session
+    }
+
+    // MARK: - Happy path
+
+    func testRespondReturnsAssistantReplyText() async throws {
+        await createAndActivateSession()
+
+        let reply = try await vm.respond(to: "Hi there")
+
+        XCTAssertEqual(reply, "Hello world", "respond(to:) should return the concatenated assistant token text")
+    }
+
+    // MARK: - Precondition errors
+
+    func testRespondThrowsNoModelLoadedWhenModelMissing() async throws {
+        await createAndActivateSession()
+        mock.isModelLoaded = false
+
+        do {
+            _ = try await vm.respond(to: "Hi there")
+            XCTFail("Expected respond(to:) to throw when no model is loaded")
+        } catch let error as SendMessageError {
+            guard case .noModelLoaded = error else {
+                return XCTFail("Expected .noModelLoaded, got \(error)")
+            }
+        }
+    }
+
+    func testRespondThrowsNoActiveSessionWhenNoSession() async throws {
+        // No session activated.
+        do {
+            _ = try await vm.respond(to: "Hi there")
+            XCTFail("Expected respond(to:) to throw when no session is active")
+        } catch let error as SendMessageError {
+            guard case .noActiveSession = error else {
+                return XCTFail("Expected .noActiveSession, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Runtime error
+
+    func testRespondThrowsRuntimeWhenBackendErrors() async throws {
+        await createAndActivateSession()
+        mock.shouldThrowOnGenerate = InferenceError.inferenceFailure("boom")
+
+        do {
+            _ = try await vm.respond(to: "Hi there")
+            XCTFail("Expected respond(to:) to throw when the backend errors")
+        } catch let error as SendMessageError {
+            guard case .runtime = error else {
+                return XCTFail("Expected .runtime, got \(error)")
+            }
+        }
+    }
+}

--- a/Tests/ManifoldUITests/ChatViewModelRespondTests.swift
+++ b/Tests/ManifoldUITests/ChatViewModelRespondTests.swift
@@ -69,7 +69,10 @@ final class ChatViewModelRespondTests: XCTestCase {
 
     func testRespondThrowsNoModelLoadedWhenModelMissing() async throws {
         await createAndActivateSession()
-        mock.isModelLoaded = false
+        // The test-injection InferenceService init marks the lifecycle loaded;
+        // unload so `vm.isModelLoaded` (which proxies the service) is false and
+        // the precondition fires before the runtime is invoked.
+        vm.inferenceService.unloadModel()
 
         do {
             _ = try await vm.respond(to: "Hi there")


### PR DESCRIPTION
## Deliverable 1 of #1942 — `respond(to:)` convenience entry point

A thin **String-typed** convenience over the existing typed `ChatViewModel.sendMessage(_:) -> ChatMessage`. The heavy lifting (stream drain, persistence, single-turn drive) is inherited unchanged from `sendMessage` via `ConversationRuntime` — no `GenerationStream`/`collectTokens`/`inferenceService` touched.

### What's in this PR (the shippable-now slice)
- **1a** `ChatViewModel.respond(to:) async throws -> String` (new `Sources/ManifoldUI/ViewModels/ChatViewModel+Respond.swift`) — returns `sendMessage(text).content`. Reuses the existing `SendMessageError` rim; no new error type; no `try?`.
- **1b** `QuickStartResult.respond(to:)` forwarder so consumers can write `try await kit.respond(to: "…")` without the `.viewModel` hop.
- Tests: `Tests/ManifoldUITests/ChatViewModelRespondTests.swift` — happy path + `.noModelLoaded` / `.noActiveSession` / `.runtime` error paths via `MockInferenceBackend`.
- README: new "One-shot response" subsection.

### Deferred
**Deliverable 2** (the `LLM(from:template:)` constructor) is **out of scope** here — blocked on #1944, handled by a separate worker.

Additive public API (safe under the api-break gate).

Refs #1942

🤖 Generated with [Claude Code](https://claude.com/claude-code)