### PR TITLE
feat: add ChatTemplate value + template-derived stop sequences (#1944)

### DIFF
--- a/Sources/ManifoldInference/Services/ChatTemplate.swift
+++ b/Sources/ManifoldInference/Services/ChatTemplate.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// A typed value owning prompt formatting + the stop sequences a model's chat
+/// format implies.
+///
+/// `ChatTemplate` wraps — it does not replace — the
+/// `(PromptTemplate enum, chatTemplateRaw: String?)` pair that ``PromptRenderer``
+/// has always taken. A template is one of two sources:
+///
+/// - ``Source/embeddedJinja(_:)`` — the model's real `tokenizer.chat_template`
+///   Jinja string (rendered via ``JinjaPromptRenderer``), or
+/// - ``Source/builtIn(_:)`` — the hand-rolled ``PromptTemplate`` enum fallback
+///   for templateless models and for embedded templates `swift-jinja` cannot
+///   evaluate (#1811).
+///
+/// For v1 (#1944) `ChatTemplate` is a thin, behaviour-preserving wrapper around
+/// the existing render path: ``format(_:systemPrompt:tools:)`` delegates to a
+/// ``PromptRenderer`` built from the same pair, then attaches the
+/// template-derived ``stopSequences`` to the result. The public
+/// ``PromptRenderer`` / ``PromptTemplate`` / ``ThinkingMarkers`` surface stays
+/// exactly as it was — `ChatTemplate` is additive.
+///
+/// The eventual goal (deferred to a follow-up) is a public format protocol the
+/// companion backend packages conform to; v1 only introduces the value and the
+/// template-derived stop sequences so #1942's D2 has a home.
+public struct ChatTemplate: Sendable {
+
+    /// Where a template's formatting comes from.
+    enum Source: Sendable {
+        /// The model's embedded GGUF Jinja chat-template string.
+        case embeddedJinja(String)
+        /// The hand-rolled enum fallback.
+        case builtIn(PromptTemplate)
+    }
+
+    let source: Source
+
+    /// Wraps the hand-rolled enum fallback for a templateless model.
+    public init(builtIn: PromptTemplate) {
+        self.source = .builtIn(builtIn)
+    }
+
+    /// Wraps a model's embedded Jinja chat-template string.
+    public init(embeddedJinja: String) {
+        self.source = .embeddedJinja(embeddedJinja)
+    }
+
+    /// The thinking-marker pair this template advertises, or `nil` when the
+    /// model does not emit reasoning blocks.
+    ///
+    /// - For ``Source/builtIn(_:)`` this delegates to
+    ///   ``PromptTemplate/thinkingMarkers``.
+    /// - For ``Source/embeddedJinja(_:)`` it runs
+    ///   ``PromptTemplateDetector/detectThinkingMarkers(from:)`` over the raw
+    ///   template string (the same detection the model-load path uses).
+    public var thinkingMarkers: ThinkingMarkers? {
+        switch source {
+        case .builtIn(let template):
+            return template.thinkingMarkers
+        case .embeddedJinja(let raw):
+            return PromptTemplateDetector.detectThinkingMarkers(from: raw)
+        }
+    }
+
+    /// The turn-terminator stop sequences this template implies.
+    ///
+    /// These are the strings that, when emitted, signal the model has finished
+    /// its turn — so a backend that honours stop strings can cut generation
+    /// before leaking the next role's opening delimiter into the output.
+    ///
+    /// - For ``Source/builtIn(_:)`` this is a *curated* subset of the family's
+    ///   turn-terminators (see ``builtInStopSequences(for:)``) — not the full
+    ///   ``PromptTemplate`` special-token union, which also contains opening
+    ///   delimiters that must NOT stop generation.
+    /// - For ``Source/embeddedJinja(_:)`` this is `[]`: the embedded template
+    ///   carries no machine-readable stop list, and parsing one out of Jinja is
+    ///   deferred. Callers that need stops for an embedded-template model should
+    ///   set ``GenerationConfig/stopSequences`` explicitly.
+    public var stopSequences: [String] {
+        switch source {
+        case .builtIn(let template):
+            return Self.builtInStopSequences(for: template)
+        case .embeddedJinja:
+            // Documented gap: no machine-readable stop list is extractable from
+            // a raw Jinja string in v1.
+            return []
+        }
+    }
+
+    /// Renders `messages` into a ``RenderedPrompt`` — the prompt text plus the
+    /// template-derived ``stopSequences``.
+    ///
+    /// Behaviour-preserving: the `text` is byte-identical to
+    /// ``PromptRenderer/render(messages:systemPrompt:tools:documents:warnOnCapabilityLoss:)``
+    /// for the same inputs. `ChatTemplate` only *adds* the stop-sequence channel.
+    public func format(
+        _ messages: [StructuredMessage],
+        systemPrompt: String?,
+        tools: [ToolDefinition]
+    ) -> RenderedPrompt {
+        let renderer: PromptRenderer
+        switch source {
+        case .builtIn(let template):
+            renderer = PromptRenderer(template: template, chatTemplateRaw: nil)
+        case .embeddedJinja(let raw):
+            // Mirror the model-load detector so the enum fallback (when the
+            // embedded template is unusable) lands on the right family.
+            let fallback = PromptTemplateDetector.detect(fromChatTemplate: raw)
+            renderer = PromptRenderer(template: fallback, chatTemplateRaw: raw)
+        }
+        let text = renderer.render(
+            messages: messages,
+            systemPrompt: systemPrompt,
+            tools: tools
+        )
+        return RenderedPrompt(text: text, stopSequences: stopSequences)
+    }
+
+    /// Curated turn-terminator stop sequences per built-in family.
+    ///
+    /// Only *closing* / end-of-turn delimiters belong here — emitting one means
+    /// "the assistant turn is over". Opening delimiters (`<|im_start|>`,
+    /// `<|start_header_id|>`, role headers) are deliberately excluded: they are
+    /// valid mid-prompt and would abort generation prematurely.
+    static func builtInStopSequences(for template: PromptTemplate) -> [String] {
+        switch template {
+        case .chatML:
+            return ["<|im_end|>"]
+        case .llama3:
+            return ["<|eot_id|>"]
+        case .mistral:
+            return ["</s>"]
+        case .alpaca:
+            // Alpaca has no special end token; the next section header is the
+            // natural turn boundary.
+            return ["### Instruction:", "### Input:"]
+        case .gemma:
+            return ["<end_of_turn>"]
+        case .gemma4:
+            return ["<|end_of_turn>"]
+        case .phi:
+            return ["<|end|>"]
+        }
+    }
+}
+
+/// The product of ``ChatTemplate/format(_:systemPrompt:tools:)`` — the rendered
+/// prompt text plus the stop sequences the template implies.
+public struct RenderedPrompt: Sendable {
+    /// The fully-assembled prompt string ready for the backend.
+    public let text: String
+
+    /// The template-derived turn-terminator stop sequences. A backend may merge
+    /// these with any caller-supplied ``GenerationConfig/stopSequences`` (caller
+    /// overrides win).
+    public let stopSequences: [String]
+
+    public init(text: String, stopSequences: [String]) {
+        self.text = text
+        self.stopSequences = stopSequences
+    }
+}

--- a/Sources/ManifoldInference/Services/GenerationHistoryInstaller.swift
+++ b/Sources/ManifoldInference/Services/GenerationHistoryInstaller.swift
@@ -4,15 +4,64 @@ import Foundation
 /// provides the legacy flattened history shape for text-only consumers.
 enum GenerationHistoryInstaller {
     /// Flattens ``StructuredMessage`` to the legacy `(role, content)` shape
-    /// for backends and helpers that operate on plain strings.
+    /// for the genuine string-only ``ConversationHistoryReceiver`` seam.
     ///
+    /// This projection is **lossy by design**: it carries only `.text` parts.
     /// Thinking parts are dropped because they would either bloat the prompt
     /// with provider-internal reasoning or fail validation on the
-    /// non-Anthropic providers that don't accept replayed thinking.
-    /// ``StructuredHistoryReceiver`` adopters read the unflattened form
-    /// directly to preserve thinking signatures.
+    /// non-Anthropic providers that don't accept replayed thinking; tool-call /
+    /// tool-result / image parts are dropped because the string seam cannot
+    /// represent them. That drop is *intentional redundancy*, not the
+    /// tool-rendering bug fixed in #1944: backends that need the structured
+    /// shape adopt ``StructuredHistoryReceiver`` and receive the unflattened
+    /// form *first* (see ``installHistory(on:structuredMessages:)``), so the
+    /// flattened form is only a fallback for backends that inspect strings.
+    ///
+    /// - Important: This is **not** the projection used to render a prompt for a
+    ///   templateless model. The prompt-render fallback in ``PromptRenderer``
+    ///   uses ``toolAwareProjection(_:)`` so tool parts reach the prompt text.
     static func flatten(_ messages: [StructuredMessage]) -> [(role: String, content: String)] {
         messages.map { (role: $0.role, content: $0.textContent) }
+    }
+
+    /// Projects ``StructuredMessage`` to `(role, content)` for the enum-fallback
+    /// *prompt-render* path, folding tool-call / tool-result parts into the text
+    /// so they are NOT dropped (#1944).
+    ///
+    /// The hand-rolled ``PromptTemplate`` formatters only consume the textual
+    /// `content`, so a templateless (or unrenderable-template) model that drove
+    /// the fallback through ``flatten(_:)`` lost every tool call and tool result
+    /// — exactly the silent tool-drop #1944 fixes. This projection renders those
+    /// parts into a compact textual form the model can read:
+    ///
+    /// - `.toolCall` → `[tool_call] <name>(<arguments JSON>)`
+    /// - `.toolResult` → `[tool_result] <name>: <content>` (errors flagged)
+    ///
+    /// Text parts are preserved verbatim; thinking and image/audio parts are
+    /// still dropped (a text prompt cannot carry them — image gating happens
+    /// upstream in ``GenerationQueue``). When a turn carries both text and tool
+    /// parts they are joined with newlines in original part order.
+    static func toolAwareProjection(
+        _ messages: [StructuredMessage]
+    ) -> [(role: String, content: String)] {
+        messages.map { message in
+            var pieces: [String] = []
+            for part in message.parts {
+                switch part {
+                case .text(let text):
+                    if !text.isEmpty { pieces.append(text) }
+                case .toolCall(let call):
+                    pieces.append("[tool_call] \(call.toolName)(\(call.arguments))")
+                case .toolResult(let result):
+                    let prefix = result.errorKind != nil ? "[tool_error]" : "[tool_result]"
+                    pieces.append("\(prefix) \(result.content)")
+                case .thinking, .image, .audio, .generatedMedia:
+                    // Not representable in a text prompt; dropped (see #1944 doc).
+                    break
+                }
+            }
+            return (role: message.role, content: pieces.joined(separator: "\n"))
+        }
     }
 
     static func containsImages(_ messages: [StructuredMessage]) -> Bool {

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -59,6 +59,33 @@ final class GenerationQueue {
         PromptRenderer(template: selectedPromptTemplate, chatTemplateRaw: selectedChatTemplateRaw)
     }
 
+    /// The typed ``ChatTemplate`` for the active model (#1944). Used to derive
+    /// template-default stop sequences. Mirrors ``promptRenderer``'s
+    /// embedded-vs-enum precedence: an embedded Jinja string wins.
+    var chatTemplate: ChatTemplate {
+        if let raw = selectedChatTemplateRaw,
+           !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return ChatTemplate(embeddedJinja: raw)
+        }
+        return ChatTemplate(builtIn: selectedPromptTemplate)
+    }
+
+    /// Returns `config` with its ``GenerationConfig/stopSequences`` filled from
+    /// the active template's defaults when the caller did not set any (#1944).
+    ///
+    /// Merge policy: a caller-supplied list wins outright (caller overrides);
+    /// an empty list inherits the template-derived turn-terminators. In-core
+    /// backends may ignore stop sequences (like `seed`); companion backends read
+    /// them to cut generation at the turn boundary.
+    func applyingTemplateStopSequences(to config: GenerationConfig) -> GenerationConfig {
+        guard config.stopSequences.isEmpty else { return config }
+        let derived = chatTemplate.stopSequences
+        guard !derived.isEmpty else { return config }
+        var merged = config
+        merged.stopSequences = derived
+        return merged
+    }
+
     /// Bind the backend-state closures in one call. Inverts the previous
     /// `coord.provider = self` assignment; the caller decides retain semantics
     /// via the captures it passes in.
@@ -433,8 +460,16 @@ final class GenerationQueue {
         backend: InferenceBackend,
         messages: [StructuredMessage],
         systemPrompt: String?,
-        config: GenerationConfig
+        config rawConfig: GenerationConfig
     ) throws -> GenerationStream {
+        // Fill the effective stop sequences from the active template's defaults
+        // when the caller set none, for prompt-template backends (#1944). The
+        // merged list rides on the dispatched config so companion backends that
+        // honour stop strings can cut at the turn boundary; in-core backends may
+        // ignore it (documented as ignored, like `seed`).
+        let config = backend.capabilities.requiresPromptTemplate
+            ? applyingTemplateStopSequences(to: rawConfig)
+            : rawConfig
         Self.warnIfJSONModeUnsupported(backend: backend, config: config)
 
         if GenerationHistoryInstaller.containsImages(messages), !backend.capabilities.supportsVision {

--- a/Sources/ManifoldInference/Services/PromptRenderer.swift
+++ b/Sources/ManifoldInference/Services/PromptRenderer.swift
@@ -167,8 +167,13 @@ struct PromptRenderer {
             warnIfCapabilityLost(messages: messages, tools: tools, viaEmbeddedTemplate: false)
         }
 
+        // Use the tool-aware projection (not `flatten`) so `.toolCall` /
+        // `.toolResult` parts reach the prompt text instead of being silently
+        // dropped (#1944). The enum formatters still consume only the textual
+        // `content`, but that content now carries the folded tool turns. `tools`
+        // remains threaded for the `.gemma4` native-declaration branch.
         return template.format(
-            messages: GenerationHistoryInstaller.flatten(messages),
+            messages: GenerationHistoryInstaller.toolAwareProjection(messages),
             systemPrompt: systemPrompt,
             tools: tools
         )

--- a/Tests/ManifoldInferenceTests/ChatTemplateStopAndFlattenTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateStopAndFlattenTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Regression + policy tests for #1944's flatten() tool-drop fix, the stop-
+/// sequence merge policy, and `GenerationConfig.stopSequences` Codable
+/// back-compat.
+final class ChatTemplateStopAndFlattenTests: XCTestCase {
+
+    // MARK: - flatten-residual tool-drop regression (#1944)
+
+    /// A templateless model (`chatTemplateRaw == nil`) carrying a `.toolResult`
+    /// part must render that tool content into the fallback prompt. Before the
+    /// fix the fallback used `flatten()`, which dropped tool parts entirely.
+    func test_enumFallback_rendersToolResultContent() {
+        let toolResult = ToolResult(callId: "call_1", content: "The weather is 21C and sunny.")
+        let messages: [StructuredMessage] = [
+            StructuredMessage(role: "user", content: "What's the weather?"),
+            StructuredMessage(role: "assistant", parts: [
+                .toolCall(ToolCall(id: "call_1", toolName: "get_weather", arguments: "{\"city\":\"Dublin\"}")),
+            ]),
+            StructuredMessage(role: "tool", parts: [.toolResult(toolResult)]),
+        ]
+
+        let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: nil)
+        let prompt = renderer.render(messages: messages, systemPrompt: nil, tools: [])
+
+        // The tool result content must survive into the prompt (regression).
+        XCTAssertTrue(
+            prompt.contains("The weather is 21C and sunny."),
+            "Tool result content must reach the enum-fallback prompt (#1944); got:\n\(prompt)"
+        )
+        // And the tool call name should also be present.
+        XCTAssertTrue(
+            prompt.contains("get_weather"),
+            "Tool call name should reach the prompt; got:\n\(prompt)"
+        )
+    }
+
+    /// Direct unit check of the projection that backs the fix: tool parts fold
+    /// into the textual content rather than disappearing.
+    func test_toolAwareProjection_foldsToolParts() {
+        let messages: [StructuredMessage] = [
+            StructuredMessage(role: "tool", parts: [
+                .toolResult(ToolResult(callId: "c", content: "RESULT-TEXT")),
+            ]),
+        ]
+        let projected = GenerationHistoryInstaller.toolAwareProjection(messages)
+        XCTAssertEqual(projected.count, 1)
+        XCTAssertTrue(projected[0].content.contains("RESULT-TEXT"))
+
+        // Sabotage-counterpart: the legacy flatten() drops it (proves the two
+        // projections genuinely differ on tool parts — the bug was using this).
+        let flattened = GenerationHistoryInstaller.flatten(messages)
+        XCTAssertFalse(
+            flattened[0].content.contains("RESULT-TEXT"),
+            "flatten() is the lossy string-only seam; it must still drop tool parts"
+        )
+    }
+
+    // MARK: - stop-sequence merge policy
+
+    @MainActor
+    func test_mergePolicy_callerOverridesTemplateDefault() {
+        let queue = GenerationQueue()
+        queue.selectedPromptTemplateProvider = { .chatML }
+        // chatML's template default is ["<|im_end|>"].
+        var config = GenerationConfig()
+        config.stopSequences = ["CUSTOM_STOP"]
+        let merged = queue.applyingTemplateStopSequences(to: config)
+        XCTAssertEqual(merged.stopSequences, ["CUSTOM_STOP"], "Caller-supplied stops win outright")
+    }
+
+    @MainActor
+    func test_mergePolicy_emptyInheritsTemplateDefault() {
+        let queue = GenerationQueue()
+        queue.selectedPromptTemplateProvider = { .llama3 }
+        var config = GenerationConfig()
+        config.stopSequences = []
+        let merged = queue.applyingTemplateStopSequences(to: config)
+        XCTAssertEqual(merged.stopSequences, ["<|eot_id|>"], "Empty stops inherit the template default")
+    }
+
+    @MainActor
+    func test_mergePolicy_embeddedJinjaNoDefault_leavesEmpty() {
+        let queue = GenerationQueue()
+        queue.selectedPromptTemplateProvider = { .chatML }
+        queue.selectedChatTemplateRawProvider = { "{% for m in messages %}{{ m }}{% endfor %}" }
+        var config = GenerationConfig()
+        config.stopSequences = []
+        let merged = queue.applyingTemplateStopSequences(to: config)
+        XCTAssertEqual(merged.stopSequences, [], "Embedded-Jinja has no derived default; stays empty")
+    }
+
+    // MARK: - GenerationConfig.stopSequences Codable back-compat
+
+    func test_codable_roundTrip_withStopSequences() throws {
+        var config = GenerationConfig()
+        config.stopSequences = ["<|im_end|>", "STOP"]
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+        XCTAssertEqual(decoded.stopSequences, ["<|im_end|>", "STOP"])
+    }
+
+    func test_codable_roundTrip_emptyStopSequences_omitsKeyButDecodesEmpty() throws {
+        let config = GenerationConfig() // empty stopSequences
+        let data = try JSONEncoder().encode(config)
+        // Empty list is omitted from the payload (preserves prior shape).
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertFalse(json.contains("stopSequences"), "Empty stopSequences must be omitted from the payload")
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: data)
+        XCTAssertEqual(decoded.stopSequences, [])
+    }
+
+    func test_codable_decodeOldJSON_lackingStopSequencesKey() throws {
+        // Simulate an old persisted payload that pre-dates the key: encode a
+        // config (empty stopSequences are already omitted) and strip any
+        // stopSequences key to be certain none is present, then decode.
+        let original = GenerationConfig()
+        let data = try JSONEncoder().encode(original)
+        var dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        dict.removeValue(forKey: "stopSequences")
+        XCTAssertNil(dict["stopSequences"], "Fixture must lack the key")
+        let strippedData = try JSONSerialization.data(withJSONObject: dict)
+
+        let decoded = try JSONDecoder().decode(GenerationConfig.self, from: strippedData)
+        XCTAssertEqual(decoded.stopSequences, [], "Missing key decodes to empty (back-compat)")
+    }
+}

--- a/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit tests for the v1 ``ChatTemplate`` value (#1944): construction from both
+/// sources, `thinkingMarkers` delegation, behaviour-preserving `format` parity
+/// with ``PromptRenderer``, and template-derived stop-sequence derivation +
+/// merge policy. Plus the flatten-residual tool-drop regression the same issue
+/// fixes, and `GenerationConfig.stopSequences` Codable back-compat.
+final class ChatTemplateTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func msg(_ role: String, _ content: String) -> StructuredMessage {
+        StructuredMessage(role: role, content: content)
+    }
+
+    /// A minimal embedded Jinja ChatML template that swift-jinja can render.
+    private let chatMLJinja = """
+    {% for message in messages %}<|im_start|>{{ message['role'] }}
+    {{ message['content'] }}<|im_end|>
+    {% endfor %}{% if add_generation_prompt %}<|im_start|>assistant
+    {% endif %}
+    """
+
+    // MARK: - Construction
+
+    func test_builtInConstruction_carriesEnumSource() {
+        let template = ChatTemplate(builtIn: .llama3)
+        guard case .builtIn(let inner) = template.source else {
+            return XCTFail("Expected .builtIn source")
+        }
+        XCTAssertEqual(inner, .llama3)
+    }
+
+    func test_embeddedJinjaConstruction_carriesRawSource() {
+        let template = ChatTemplate(embeddedJinja: chatMLJinja)
+        guard case .embeddedJinja(let raw) = template.source else {
+            return XCTFail("Expected .embeddedJinja source")
+        }
+        XCTAssertEqual(raw, chatMLJinja)
+    }
+
+    // MARK: - thinkingMarkers delegation
+
+    func test_thinkingMarkers_builtIn_delegatesToEnum() {
+        // .chatML maps to .qwen3 in PromptTemplate.thinkingMarkers.
+        XCTAssertEqual(ChatTemplate(builtIn: .chatML).thinkingMarkers, .qwen3)
+        // A non-thinking family returns nil.
+        XCTAssertNil(ChatTemplate(builtIn: .mistral).thinkingMarkers)
+    }
+
+    func test_thinkingMarkers_embeddedJinja_delegatesToDetector() {
+        let thinking = "{% for m in messages %}<think>{{ m }}</think>{% endfor %}"
+        XCTAssertEqual(ChatTemplate(embeddedJinja: thinking).thinkingMarkers, .qwen3)
+        XCTAssertNil(ChatTemplate(embeddedJinja: chatMLJinja).thinkingMarkers)
+    }
+
+    // MARK: - format parity (behaviour-preserving wrap)
+
+    func test_format_builtIn_textIsByteIdenticalToPromptRenderer() {
+        let messages = [msg("user", "Hello"), msg("assistant", "Hi"), msg("user", "How are you?")]
+        let system = "You are helpful."
+
+        let expected = PromptRenderer(template: .chatML, chatTemplateRaw: nil)
+            .render(messages: messages, systemPrompt: system, tools: [])
+
+        let rendered = ChatTemplate(builtIn: .chatML)
+            .format(messages, systemPrompt: system, tools: [])
+
+        XCTAssertEqual(rendered.text, expected, "ChatTemplate.format must wrap PromptRenderer byte-for-byte")
+    }
+
+    func test_format_embeddedJinja_textIsByteIdenticalToPromptRenderer() {
+        let messages = [msg("user", "Hello")]
+        let expected = PromptRenderer(template: .chatML, chatTemplateRaw: chatMLJinja)
+            .render(messages: messages, systemPrompt: nil, tools: [])
+
+        let rendered = ChatTemplate(embeddedJinja: chatMLJinja)
+            .format(messages, systemPrompt: nil, tools: [])
+
+        XCTAssertEqual(rendered.text, expected)
+    }
+
+    func test_format_attachesTemplateDerivedStopSequences() {
+        let rendered = ChatTemplate(builtIn: .chatML)
+            .format([msg("user", "Hi")], systemPrompt: nil, tools: [])
+        XCTAssertEqual(rendered.stopSequences, ["<|im_end|>"])
+    }
+
+    // MARK: - stopSequences derivation per family
+
+    func test_stopSequences_perFamily() {
+        XCTAssertEqual(ChatTemplate(builtIn: .chatML).stopSequences, ["<|im_end|>"])
+        XCTAssertEqual(ChatTemplate(builtIn: .llama3).stopSequences, ["<|eot_id|>"])
+        XCTAssertEqual(ChatTemplate(builtIn: .mistral).stopSequences, ["</s>"])
+        XCTAssertEqual(ChatTemplate(builtIn: .gemma).stopSequences, ["<end_of_turn>"])
+        XCTAssertEqual(ChatTemplate(builtIn: .gemma4).stopSequences, ["<|end_of_turn>"])
+        XCTAssertEqual(ChatTemplate(builtIn: .phi).stopSequences, ["<|end|>"])
+        XCTAssertEqual(ChatTemplate(builtIn: .alpaca).stopSequences, ["### Instruction:", "### Input:"])
+    }
+
+    func test_stopSequences_excludeOpeningDelimiters() {
+        // Opening delimiters would abort generation prematurely — they must NOT
+        // appear in the derived stop list.
+        let chatML = ChatTemplate(builtIn: .chatML).stopSequences
+        XCTAssertFalse(chatML.contains("<|im_start|>"))
+        let llama3 = ChatTemplate(builtIn: .llama3).stopSequences
+        XCTAssertFalse(llama3.contains("<|start_header_id|>"))
+        XCTAssertFalse(llama3.contains("<|begin_of_text|>"))
+    }
+
+    func test_stopSequences_embeddedJinja_isEmptyGap() {
+        // Documented v1 gap: no machine-readable stop list from raw Jinja.
+        XCTAssertEqual(ChatTemplate(embeddedJinja: chatMLJinja).stopSequences, [])
+    }
+}


### PR DESCRIPTION
## What (v1 scope, #1944)

Three additive changes — nothing removed.

1. **`ChatTemplate` typed value** (`ManifoldInference`) — wraps the existing `(PromptTemplate enum, chatTemplateRaw: String?)` pair `PromptRenderer` already takes. Two sources (`builtIn` / `embeddedJinja`); delegates `thinkingMarkers`, derives `stopSequences`, and `format(_:systemPrompt:tools:)` returns a `RenderedPrompt { text; stopSequences }`. `format` delegates to the existing `PromptRenderer` so the rendered text is byte-identical (behaviour-preserving wrap).
2. **flatten() tool-drop fix** — the enum-fallback render path in `PromptRenderer` formerly called `template.format(messages: flatten(messages), …)`, which dropped `.toolCall` / `.toolResult` parts (silent tool loss for templateless models). It now uses a new `GenerationHistoryInstaller.toolAwareProjection(_:)` that folds tool turns into the prompt text. `flatten()` is kept verbatim for the genuine string-only `ConversationHistoryReceiver` seam, with its doc-comment updated to explain that drop is intentional redundancy.
3. **Template-derived stop sequences** — `GenerationConfig.stopSequences` already existed as `[String]` (default `[]`), so it was NOT re-added as `[String]?` (would be breaking). `ChatTemplate.stopSequences` derives a curated per-family turn-terminator subset (built-in) / `[]` (embedded-Jinja, documented gap). `GenerationQueue` merges them onto the dispatched config — caller-supplied wins; empty inherits the template default. In-core backends may ignore (documented like `seed`); companion backends read it later.

## Deferred (out of scope, follow-ups)
- Public `format` **protocol** companion repos conform to.
- Companion stop-honoring (manifold-mlx / manifold-llama, separate repos).

Unblocks #1942 D2.

## Backend / test checklist
- [x] `ChatTemplate` unit tests (construction, thinkingMarkers delegation, format parity, stop derivation, merge policy)
- [x] flatten-residual regression (templateless + `.toolResult` → prompt contains tool content), sabotage-verified
- [x] `GenerationConfig` Codable round-trip with/without `stopSequences`
- [ ] companion backends honour `stopSequences` (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
