### PR TITLE
feat: add LLM(from:template:) value-typed entry point (#1942)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ func oneShot() async throws -> String {
 >
 > **Don't want the starter download?** Drop `seed:` — the chat is then inert until you select a model. `quickStart` registers the backends but loads none, so on first run the composer reads "No model loaded" and the empty-state **Select Model** button only flips `showModelManagement` — nothing is presented until you attach a sheet to that binding. Fastest route: present `ModelManagementSheet` (from the opt-in `ManifoldUIModelManagement` module) with `.sheet(isPresented: $showModelManagement)`, or keep `seed:`. Step-by-step: [First-launch backend selection](docs/QUICKSTART.md#first-launch-backend-selection).
 
+#### Value-typed front door: `LLM`
+
+Want the LLM.swift feel — construct a value, call `.respond(to:)`? `LLM(from:template:)` wraps the same `quickStart` plumbing in a value type. `backends:` defaults to the compiled-in cloud + Foundation families, so a cloud/Foundation `LLM` is genuinely two lines:
+
+```swift
+import ManifoldKit
+// + `import ManifoldLlama` for the local GGUF seed below (see the note above)
+
+func twoLine() async throws -> String {
+    let llm = try await LLM(
+        from: .recommendedSmallModel(),
+        // backends: [LlamaBackends.self], ← required (+ import) for a LOCAL model
+    )
+    return try await llm.respond(to: "Explain monads in one sentence.")
+}
+```
+
+> **Local models need a companion registrar.** The default `backends:` covers cloud (Ollama / OpenAI / Anthropic) and Apple Foundation Models. For an on-device model, add the `manifold-llama` (GGUF) or `manifold-mlx` package and pass its registrar — `backends: [LlamaBackends.self]` — plus the matching `import`. Pass an optional `template: ChatTemplate` to override formatting for built-in (enum) templates.
+
 See [docs/QUICKSTART.md](docs/QUICKSTART.md) for backend selection and configuration.
 Building a multi-session SwiftUI app with a sidebar, persisted chats, and relaunch restore? See [docs/SWIFTUI-MULTI-SESSION.md](docs/SWIFTUI-MULTI-SESSION.md) — the canonical end-to-end guide.
 Building a CLI, server, or non-SwiftUI consumer? See [docs/QUICKSTART-CLI.md](docs/QUICKSTART-CLI.md) — compile-tested Foundation Models, local GGUF, and Ollama / OpenAI examples.

--- a/Sources/ManifoldInference/Services/ChatTemplate.swift
+++ b/Sources/ManifoldInference/Services/ChatTemplate.swift
@@ -45,6 +45,26 @@ public struct ChatTemplate: Sendable {
         self.source = .embeddedJinja(embeddedJinja)
     }
 
+    /// The hand-rolled ``PromptTemplate`` enum case this template wraps, or
+    /// `nil` when it is backed by an embedded Jinja string.
+    ///
+    /// This is the only template channel reachable through the public
+    /// ``InferenceService/selectedPromptTemplate`` /
+    /// `ChatViewModel.selectedPromptTemplate` setters today, so a caller-supplied
+    /// ``ChatTemplate`` can be applied to the live render path **only** for the
+    /// ``Source/builtIn(_:)`` case. The ``Source/embeddedJinja(_:)`` case has no
+    /// public injection seam — `selectedChatTemplateRaw` is set only at model
+    /// load (`private(set)` on `ModelLifecycleCoordinator`). See
+    /// `LLM(from:template:)` (#1942 D2) for the consumer that relies on this.
+    public var builtInPromptTemplate: PromptTemplate? {
+        switch source {
+        case .builtIn(let template):
+            return template
+        case .embeddedJinja:
+            return nil
+        }
+    }
+
     /// The thinking-marker pair this template advertises, or `nil` when the
     /// model does not emit reasoning blocks.
     ///

--- a/Sources/ManifoldKit/LLM.swift
+++ b/Sources/ManifoldKit/LLM.swift
@@ -1,0 +1,143 @@
+// LLM — value-typed convenience front door (#1942 D2).
+//
+// A two-line entry point in the spirit of LLM.swift: construct an `LLM`, call
+// `.respond(to:)`. It wraps the existing `quickStart` plumbing — there is no
+// new bootstrap path here. `LLM.init` drives `ManifoldKit.quickStart(...)`,
+// retains the resulting `QuickStartResult` (which owns the bootstrap lifetime),
+// and exposes a String-typed `respond(to:)` over the wrapped `ChatViewModel`.
+//
+// Registrar default (#1942 D2, decided): `backends:` defaults to
+// `ManifoldKit.defaultBackendRegistrars` (the compiled-in cloud + Foundation
+// families). A cloud/Foundation `LLM` is therefore genuinely two lines; a LOCAL
+// model requires the caller to pass `backends: [LlamaBackends.self]` (and import
+// the manifold-llama companion package). See the doc-comment on `init`.
+
+import Foundation
+import ManifoldInference
+import ManifoldUI
+
+/// A value-typed convenience front door to a working chat runtime.
+///
+/// `LLM` collapses bootstrap + model selection + a single-turn reply into two
+/// lines, in the spirit of LLM.swift:
+///
+/// ```swift
+/// let llm = try await LLM(from: .recommendedSmallModel())
+/// let answer = try await llm.respond(to: "Explain monads in one sentence.")
+/// ```
+///
+/// It is a thin wrapper over ``ManifoldKit/quickStart(backends:configuration:seed:)``:
+/// the initializer drives that plumbing and retains the resulting
+/// ``QuickStartResult`` (which owns the bootstrap and therefore the underlying
+/// services). Releasing the `LLM` releases the runtime.
+///
+/// ### Backends
+///
+/// `backends:` defaults to ``ManifoldKit/defaultBackendRegistrars`` — the
+/// compiled-in cloud (Ollama + SaaS) and Apple Foundation families. So a
+/// cloud/Foundation `LLM` is genuinely two lines. A **local** model needs a
+/// companion-package registrar:
+///
+/// ```swift
+/// import ManifoldKit
+/// import ManifoldLlama   // manifold-llama companion package
+///
+/// let llm = try await LLM(
+///     from: .recommendedSmallModel(),
+///     backends: [LlamaBackends.self]
+/// )
+/// ```
+///
+/// ### Templates
+///
+/// `template:` accepts a ``ChatTemplate`` to override the model's formatting.
+/// For a ``ChatTemplate`` built from the hand-rolled enum fallback
+/// (`ChatTemplate(builtIn:)`) the override is applied to the live render path.
+/// An embedded-Jinja template (`ChatTemplate(embeddedJinja:)`) is **not** yet
+/// wired — the raw-template channel has no public injection seam (it is set only
+/// at model load). Passing one is harmless: construction succeeds and the
+/// model's own embedded template is used.
+@MainActor
+public struct LLM {
+
+    /// The retained bootstrap + view model + session manager from `quickStart`.
+    /// `LLM` owns this for its lifetime; releasing the `LLM` tears down the
+    /// underlying services.
+    private let result: QuickStartResult
+
+    /// The wrapped chat view model, exposed for callers that need to drop down
+    /// to the full ``ChatViewModel`` surface (model selection, session
+    /// management, the full ``ChatMessage`` from a turn). The String-typed
+    /// ``respond(to:)`` covers the common case.
+    public var viewModel: ChatViewModel { result.viewModel }
+
+    /// Constructs a working chat runtime seeded for `model`.
+    ///
+    /// Drives ``ManifoldKit/quickStart(backends:configuration:seed:)`` to a live
+    /// runtime: the seed downloads the curated model on first launch when no
+    /// model is already selectable (Foundation available, or a model on disk),
+    /// then the selection policy picks it. Errors are surfaced through the same
+    /// unified ``ManifoldKitError`` rim as `quickStart`.
+    ///
+    /// - Parameters:
+    ///   - model: The model seed. Use ``QuickStartSeed/recommendedSmallModel(onProgress:)``
+    ///     for the curated 0.6B floor, or ``QuickStartSeed/recommended(useCase:device:foundationAvailable:onProgress:)``
+    ///     for a device-aware pick. The seed is a no-op when a model is already
+    ///     selectable or no registered backend can load its type.
+    ///   - template: Optional formatting override. A ``ChatTemplate(builtIn:)``
+    ///     is applied to the render path; a ``ChatTemplate(embeddedJinja:)`` is
+    ///     accepted but not yet wired (see the type doc-comment). `nil` (the
+    ///     default) uses the model's embedded/default template.
+    ///   - backends: Backend registrars. Defaults to
+    ///     ``ManifoldKit/defaultBackendRegistrars`` (cloud + Foundation). Pass a
+    ///     companion-package registrar (e.g. `[LlamaBackends.self]`) for local
+    ///     models.
+    ///   - configuration: Framework configuration. Defaults to
+    ///     `ManifoldConfiguration.default`.
+    public init(
+        from model: QuickStartSeed,
+        template: ChatTemplate? = nil,
+        backends: [any BackendRegistrar.Type] = ManifoldKit.defaultBackendRegistrars,
+        configuration: ManifoldConfiguration = .default
+    ) async throws {
+        let result = try await ManifoldKit.quickStart(
+            backends: backends,
+            configuration: configuration,
+            seed: model
+        )
+        Self.apply(template: template, to: result.viewModel)
+        self.result = result
+    }
+
+    /// Test/host seam: wraps a pre-assembled ``QuickStartResult`` (e.g. one
+    /// built over an in-memory bootstrap with a mock backend) without standing
+    /// up a real model download. Production callers use ``init(from:template:backends:configuration:)``.
+    package init(result: QuickStartResult, template: ChatTemplate? = nil) {
+        Self.apply(template: template, to: result.viewModel)
+        self.result = result
+    }
+
+    /// Applies a caller-supplied template to the live render path where a public
+    /// seam exists.
+    ///
+    /// Only the ``ChatTemplate/builtInPromptTemplate`` (enum-fallback) channel is
+    /// reachable today via ``ChatViewModel/selectedPromptTemplate``. The embedded
+    /// raw-Jinja channel (`selectedChatTemplateRaw`) is `private(set)` and set
+    /// only at model load, so a full override there needs render-seam work.
+    // TODO(#1942 D2): full template override pending render-seam work — wire the
+    // embedded-Jinja channel once `selectedChatTemplateRaw` has a public setter.
+    private static func apply(template: ChatTemplate?, to viewModel: ChatViewModel) {
+        guard let promptTemplate = template?.builtInPromptTemplate else { return }
+        viewModel.selectedPromptTemplate = promptTemplate
+    }
+
+    /// Sends `text` and returns the assistant's reply as a `String`.
+    ///
+    /// Delegates to ``ChatViewModel/respond(to:)`` (#1942 D1) — the stream
+    /// drain, persistence, and single-turn drive are inherited unchanged.
+    /// Throws the same ``SendMessageError`` cases.
+    @discardableResult
+    public func respond(to text: String) async throws -> String {
+        try await result.respond(to: text)
+    }
+}

--- a/Sources/ManifoldKit/LLM.swift
+++ b/Sources/ManifoldKit/LLM.swift
@@ -57,6 +57,14 @@ import ManifoldUI
 /// wired — the raw-template channel has no public injection seam (it is set only
 /// at model load). Passing one is harmless: construction succeeds and the
 /// model's own embedded template is used.
+///
+/// A built-in override is **re-asserted immediately before each turn** in
+/// ``respond(to:)``. This matters because `quickStart` dispatches the model load
+/// *asynchronously* and returns before it finishes; a local-GGUF load's
+/// metadata auto-detect fires `onSetSelectedPromptTemplate` and would otherwise
+/// silently clobber the caller's override after `init` set it. Re-asserting on
+/// the turn path (after the load has settled — `respond` requires a loaded
+/// model) guarantees the caller's choice is the one the renderer actually sees.
 @MainActor
 public struct LLM {
 
@@ -64,6 +72,13 @@ public struct LLM {
     /// `LLM` owns this for its lifetime; releasing the `LLM` tears down the
     /// underlying services.
     private let result: QuickStartResult
+
+    /// The caller-supplied template override, retained so ``respond(to:)`` can
+    /// re-assert it on the turn path. The async model load `quickStart`
+    /// dispatches can fire `onSetSelectedPromptTemplate` *after* `init` applied
+    /// the override, clobbering it; re-asserting per turn (post-load) is the
+    /// race-free guarantee point. `nil` means "use the model's own template".
+    private let template: ChatTemplate?
 
     /// The wrapped chat view model, exposed for callers that need to drop down
     /// to the full ``ChatViewModel`` surface (model selection, session
@@ -107,6 +122,7 @@ public struct LLM {
         )
         Self.apply(template: template, to: result.viewModel)
         self.result = result
+        self.template = template
     }
 
     /// Test/host seam: wraps a pre-assembled ``QuickStartResult`` (e.g. one
@@ -115,6 +131,7 @@ public struct LLM {
     package init(result: QuickStartResult, template: ChatTemplate? = nil) {
         Self.apply(template: template, to: result.viewModel)
         self.result = result
+        self.template = template
     }
 
     /// Applies a caller-supplied template to the live render path where a public
@@ -138,6 +155,12 @@ public struct LLM {
     /// Throws the same ``SendMessageError`` cases.
     @discardableResult
     public func respond(to text: String) async throws -> String {
-        try await result.respond(to: text)
+        // Re-assert the built-in override on the turn path. `quickStart`'s async
+        // model load can fire `onSetSelectedPromptTemplate` after `init` set it,
+        // so init-time application is best-effort; the turn path (post-load) is
+        // the race-free guarantee point. No-op when no built-in override was
+        // supplied.
+        Self.apply(template: template, to: result.viewModel)
+        return try await result.respond(to: text)
     }
 }

--- a/Tests/ManifoldKitTests/LLMConstructorTests.swift
+++ b/Tests/ManifoldKitTests/LLMConstructorTests.swift
@@ -108,6 +108,39 @@ final class LLMConstructorTests: XCTestCase {
         )
     }
 
+    /// Template override survives the async model-load clobber. `quickStart`
+    /// dispatches the model load *after* it returns; a local-GGUF load's
+    /// metadata auto-detect fires `onSetSelectedPromptTemplate` and overwrites
+    /// the override `init` applied. Simulate that post-construction clobber, then
+    /// assert `respond(to:)` re-asserts the caller's built-in template before the
+    /// turn so the renderer sees the override — not the model-detected default.
+    func test_builtInTemplate_survivesPostLoadClobber() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["ok"]
+
+        let result = try await makeResult(mock: mock)
+        let llm = LLM(result: result, template: ChatTemplate(builtIn: .llama3))
+        XCTAssertEqual(llm.viewModel.selectedPromptTemplate, .llama3)
+
+        // Simulate the async model load completing and clobbering the override
+        // via the coordinator's `onSetSelectedPromptTemplate` seam.
+        result.viewModel.selectedPromptTemplate = .gemma
+        XCTAssertEqual(
+            llm.viewModel.selectedPromptTemplate,
+            .gemma,
+            "Precondition: the simulated load clobbered the override."
+        )
+
+        _ = try await llm.respond(to: "hi")
+
+        XCTAssertEqual(
+            llm.viewModel.selectedPromptTemplate,
+            .llama3,
+            "respond(to:) must re-assert the caller's built-in template on the turn path so the async-load clobber does not win."
+        )
+    }
+
     /// Template wiring (embedded-Jinja path, deferred): passing an embedded
     /// template does not break construction and leaves the prompt template
     /// untouched (the raw channel has no public injection seam yet).

--- a/Tests/ManifoldKitTests/LLMConstructorTests.swift
+++ b/Tests/ManifoldKitTests/LLMConstructorTests.swift
@@ -1,0 +1,132 @@
+// LLMConstructorTests.swift
+//
+// Exercises the value-typed `LLM(from:template:)` front door (#1942 D2) — the
+// two-line entry point that wraps `quickStart` plumbing and exposes a
+// String-typed `respond(to:)`. Uses the `package` test seam (a pre-assembled
+// `QuickStartResult` over an in-memory bootstrap + `MockInferenceBackend`) so no
+// real model download is required, mirroring `QuickStartRespondTests`.
+
+import XCTest
+import SwiftData
+import ManifoldInference
+import ManifoldRuntime
+import ManifoldPersistenceSwiftData
+import ManifoldUI
+import ManifoldTestSupport
+@testable import ManifoldKit
+
+@MainActor
+final class LLMConstructorTests: XCTestCase {
+
+    /// Builds a `QuickStartResult` over an in-memory bootstrap whose inference
+    /// service is backed by `mock`, with one active session — exactly what
+    /// `_quickStart` assembles, minus the model download.
+    private func makeResult(mock: MockInferenceBackend) async throws -> QuickStartResult {
+        let service = InferenceService(backend: mock, name: "MockLLM")
+        let bootstrap = try ManifoldBootstrap.makeInMemory(
+            configuration: .default,
+            inferenceService: service
+        )
+
+        let viewModel = ChatViewModel(
+            inferenceService: bootstrap.inferenceService,
+            conversationRuntime: bootstrap.conversationRuntime
+        )
+        viewModel.configure(persistence: bootstrap.persistence)
+
+        let sessionManager = SessionManagerViewModel()
+        await sessionManager.configureAndLoad(bootstrap: bootstrap)
+
+        let session = ManifoldInference.ChatSession(title: "LLM Test")
+        try await bootstrap.persistence.insertSession(session)
+        sessionManager.activeSession = session
+        await viewModel.switchToSession(session)
+
+        return QuickStartResult(
+            bootstrap: bootstrap,
+            viewModel: viewModel,
+            sessionManager: sessionManager
+        )
+    }
+
+    /// Happy path: an `LLM` constructs over the test seam and `respond(to:)`
+    /// returns the mock's full accumulated reply.
+    func test_respond_returnsMockReply() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.tokensToYield = ["Mon", "ads", " are ", "monoids"]
+
+        let result = try await makeResult(mock: mock)
+        let llm = LLM(result: result)
+
+        let answer = try await llm.respond(to: "Explain monads")
+
+        XCTAssertEqual(
+            answer,
+            "Monads are monoids",
+            "LLM.respond(to:) must return the full concatenation of every streamed token from the wrapped ChatViewModel."
+        )
+    }
+
+    /// Error propagation: when the backend fails the turn, the same typed
+    /// `SendMessageError` D1 surfaces propagates out of the value-typed front
+    /// door rather than being swallowed.
+    func test_respond_propagatesSendMessageError() async throws {
+        struct ForcedGenerationFailure: Error {}
+
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+        mock.shouldThrowOnGenerate = ForcedGenerationFailure()
+
+        let result = try await makeResult(mock: mock)
+        let llm = LLM(result: result)
+
+        do {
+            _ = try await llm.respond(to: "hi")
+            XCTFail("LLM.respond(to:) must throw when the backend fails the turn, not return empty text.")
+        } catch let error as SendMessageError {
+            XCTAssertNotNil(error, "Expected a typed SendMessageError to propagate.")
+        }
+    }
+
+    /// Template wiring (built-in path): a supplied `ChatTemplate(builtIn:)` is
+    /// applied to the live render path via `selectedPromptTemplate`.
+    func test_builtInTemplate_appliesToRenderPath() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+
+        let result = try await makeResult(mock: mock)
+        // Default is .chatML; pick a distinct family so a no-op wiring fails.
+        XCTAssertNotEqual(result.viewModel.selectedPromptTemplate, .llama3)
+
+        let llm = LLM(result: result, template: ChatTemplate(builtIn: .llama3))
+
+        XCTAssertEqual(
+            llm.viewModel.selectedPromptTemplate,
+            .llama3,
+            "A ChatTemplate(builtIn:) must be applied to the wrapped ChatViewModel's selectedPromptTemplate."
+        )
+    }
+
+    /// Template wiring (embedded-Jinja path, deferred): passing an embedded
+    /// template does not break construction and leaves the prompt template
+    /// untouched (the raw channel has no public injection seam yet).
+    func test_embeddedJinjaTemplate_doesNotBreakConstruction() async throws {
+        let mock = MockInferenceBackend()
+        mock.isModelLoaded = true
+
+        let result = try await makeResult(mock: mock)
+        let original = result.viewModel.selectedPromptTemplate
+
+        let llm = LLM(
+            result: result,
+            template: ChatTemplate(embeddedJinja: "{{ messages }}")
+        )
+
+        XCTAssertEqual(
+            llm.viewModel.selectedPromptTemplate,
+            original,
+            "An embedded-Jinja ChatTemplate has no public injection seam yet (TODO #1942 D2); it must not alter selectedPromptTemplate."
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Completes #1942 **Deliverable 2** (D1 was the `respond(to:)` convenience in #1998): a value-typed `@MainActor public struct LLM` front door in the `ManifoldKit` umbrella, in the spirit of LLM.swift.

```swift
let llm = try await LLM(from: .recommendedSmallModel())          // cloud/Foundation: 2 lines
let answer = try await llm.respond(to: "Explain monads in one sentence.")
```

`LLM` wraps the existing `quickStart` plumbing — no new bootstrap path. `init` drives `ManifoldKit.quickStart(backends:configuration:seed:)`, retains the resulting `QuickStartResult` (which owns bootstrap lifetime), and delegates `respond(to:)` to the wrapped `ChatViewModel.respond(to:)` (D1). `respond` stays String-typed at the public boundary (sidesteps the `ChatMessage`/`ChatSession` umbrella ambiguity).

## Decisions

- **Registrar default (option 1):** `backends:` defaults to `ManifoldKit.defaultBackendRegistrars` (cloud + Foundation), so a cloud/Foundation `LLM` is genuinely two lines. A **local** model requires `backends: [LlamaBackends.self]` plus the manifold-llama companion import. Documented in the doc-comment and README.
- **Template wiring — partial (cheap path wired, embedded-Jinja deferred):** A small additive `ChatTemplate.builtInPromptTemplate: PromptTemplate?` accessor (ManifoldInference) lets `LLM.init` apply a `ChatTemplate(builtIn:)` to the live render path via the existing public `ChatViewModel.selectedPromptTemplate` setter. The `ChatTemplate(embeddedJinja:)` raw channel (`selectedChatTemplateRaw`) is `private(set)` and set only at model load — wiring it needs render-seam plumbing, so it is **accepted but deferred** (`// TODO(#1942 D2)`), passing one is harmless. This keeps the PR additive and small while delivering real, tested override for the common enum-template case.

## Tests

`Tests/ManifoldKitTests/LLMConstructorTests.swift` (4 tests, all green) using the in-memory bootstrap + `MockInferenceBackend` harness (mirrors `QuickStartRespondTests`) via a `package` test seam that wraps a prebuilt `QuickStartResult` (no real download): happy-path exact-String reply, `SendMessageError` propagation, built-in template applied to render path (sabotage-verified), embedded-Jinja template doesn't break construction.

## Gate results (in worktree)

- `swift build --build-tests` — ✅
- `swift test --filter LLMConstructor` — ✅ 4/4
- `swift test --filter AuditTest` — ✅ 62/62
- `scripts/extract-snippets-test.sh` — ✅ 19/19 (new `readme-003`)
- `swift package diagnose-api-breaking-changes origin/main --targets ManifoldKit --targets ManifoldInference` — ✅ No breaking changes detected (additive)

Refs #1942

🤖 Generated with [Claude Code](https://claude.com/claude-code)