### PR TITLE
fix: emit parseable JSON tool-call format for templateless local models

### DIFF
--- a/Sources/ManifoldInference/Services/ToolSystemPromptBuilder.swift
+++ b/Sources/ManifoldInference/Services/ToolSystemPromptBuilder.swift
@@ -88,8 +88,7 @@ public struct ToolSystemPromptBuilder: Sendable {
 
                 When a tool can answer a question, you MUST call the tool. \
                 Never guess values (timestamps, math, files, external data) \
-                that a tool can provide. Call tools by emitting the \
-                appropriate tool_call in your response.
+                that a tool can provide. \(toolCallFormatInstruction)
 
                 """
 
@@ -101,8 +100,7 @@ public struct ToolSystemPromptBuilder: Sendable {
 
                 When a tool can answer a question, you MUST call the tool. \
                 Never guess values (timestamps, math, files, external data) \
-                that a tool can provide. Call tools by emitting the \
-                appropriate tool_call in your response.
+                that a tool can provide. \(toolCallFormatInstruction)
 
                 If no tool matches the user's request, say "I don't have a \
                 tool for that" rather than guessing.
@@ -111,19 +109,80 @@ public struct ToolSystemPromptBuilder: Sendable {
         }
     }
 
+    // MARK: - Tool-call format
+
+    /// Concrete tool-call emission format folded into the imperative presets.
+    ///
+    /// ## Why a literal JSON envelope
+    ///
+    /// Templates that don't render tools natively (Phi-3.5, Mistral-7B-Instruct
+    /// GGUFs, and every non-`gemma4` enum template) reach the model through this
+    /// preamble alone — the model is told tools exist but, with only a vague
+    /// "emit a tool_call" nudge, improvises an unparseable shape such as the
+    /// Pythonic `tool_call(calc, "7823 * 41")` (positional, opaque) that no local
+    /// parser can dispatch (#2002). Spelling out the exact `{"name": …,
+    /// "arguments": {…}}` envelope — the shape the local `<tool_call>` /
+    /// bare-`{"name"` dialects already consume — plus the named-argument
+    /// requirement and an explicit "not a Python-style call" prohibition closes
+    /// that gap. Native-tool templates never see this string: `GenerationQueue`'s
+    /// fold decision skips the preamble entirely when the renderer emits tools
+    /// natively (keyed on ``PromptRenderer/rendersToolsNatively``).
+    private static let toolCallFormatInstruction = """
+        To call a tool, respond with a single JSON object of exactly this \
+        form and nothing else:
+
+        {"name": "<one of the tool names above>", "arguments": {"<argument name>": <value>}}
+
+        Use the argument names listed for the chosen tool. Do not write the \
+        call as prose or as a Python-style function call such as `tool(value)`.
+        """
+
     // MARK: - Rendering
 
     /// Renders a single tool definition as one line of the preamble tool list.
     ///
-    /// Shape: `- <name>: <description> (requires: a, b)` or `- <name>:
-    /// <description>` when the tool has no declared required arguments.
-    /// Tool names are emitted verbatim — consumers with exotic characters
-    /// in names are responsible for the consequences.
+    /// Shape: `- <name>: <description> (arguments: a, b) (requires: a)`. Either
+    /// parenthesised clause is dropped when empty, so a tool with no declared
+    /// parameters renders as the bare `- <name>: <description>`. The `arguments`
+    /// clause names every parameter the tool accepts — the JSON keys the model
+    /// must use inside the `"arguments"` object (#2002) — while `requires` marks
+    /// the mandatory subset. Tool names are emitted verbatim; consumers with
+    /// exotic characters in names are responsible for the consequences.
     private static func renderTool(_ tool: ToolDefinition) -> String {
+        let arguments = extractArgumentNames(from: tool.parameters)
         let required = extractRequiredArgumentNames(from: tool.parameters)
-        let base = "- \(tool.name): \(tool.description)"
-        guard !required.isEmpty else { return base }
-        return "\(base) (requires: \(required.joined(separator: ", ")))"
+        var line = "- \(tool.name): \(tool.description)"
+        if !arguments.isEmpty {
+            line += " (arguments: \(arguments.joined(separator: ", ")))"
+        }
+        if !required.isEmpty {
+            line += " (requires: \(required.joined(separator: ", ")))"
+        }
+        return line
+    }
+
+    /// Names every parameter the tool accepts, in a deterministic order.
+    ///
+    /// `properties` is an unordered JSON-Schema object (a Swift dictionary), so a
+    /// raw key walk would emit a non-stable order across runs. To keep the
+    /// preamble byte-stable, required arguments lead in schema-declared order
+    /// (the array preserves it) and any remaining optional properties follow
+    /// alphabetically. Returns `[]` when the schema declares no `properties`
+    /// block — falling back to `required` alone is intentional, since some
+    /// hand-built schemas list `required` without a matching `properties` map.
+    private static func extractArgumentNames(
+        from parameters: JSONSchemaValue
+    ) -> [String] {
+        let required = extractRequiredArgumentNames(from: parameters)
+        guard case .object(let fields) = parameters,
+              case .object(let properties) = fields["properties"] else {
+            return required
+        }
+        let requiredSet = Set(required)
+        let optional = properties.keys
+            .filter { !requiredSet.contains($0) }
+            .sorted()
+        return required + optional
     }
 
     /// Pulls the `required` array out of a JSON-Schema object value.

--- a/Tests/ManifoldInferenceTests/ToolSystemPromptBuilderTests.swift
+++ b/Tests/ManifoldInferenceTests/ToolSystemPromptBuilderTests.swift
@@ -71,6 +71,73 @@ final class ToolSystemPromptBuilderTests: XCTestCase {
         XCTAssertFalse(prompt.contains("I don't have a tool"), "minimal preset must not include refusal clause")
     }
 
+    // MARK: - Templateless JSON tool-call format (#2002)
+
+    /// The imperative presets must spell out the concrete JSON envelope local
+    /// parsers consume — templateless models (Phi-3.5, Mistral GGUF) reach the
+    /// model through this preamble alone and otherwise improvise an unparseable
+    /// Pythonic `tool_call(...)` shape.
+    func test_standardStyle_specifiesJSONToolCallFormat() {
+        let prompt = ToolSystemPromptBuilder.preferTools(for: fixtureTools(), style: .standard)
+
+        // SABOTAGE TARGET: `toolCallFormatInstruction`. Reverting it to the old
+        // vague "emit the appropriate tool_call" phrasing fails these asserts.
+        XCTAssertTrue(prompt.contains("{\"name\":"), "must show the JSON envelope key \"name\"")
+        XCTAssertTrue(prompt.contains("\"arguments\":"), "must show the JSON envelope key \"arguments\"")
+        XCTAssertTrue(
+            prompt.contains("Python-style function call"),
+            "must explicitly prohibit the Pythonic positional-call shape (#2002)"
+        )
+    }
+
+    func test_strictStyle_specifiesJSONToolCallFormat() {
+        let prompt = ToolSystemPromptBuilder.preferTools(for: fixtureTools(), style: .strict)
+
+        XCTAssertTrue(prompt.contains("{\"name\":"))
+        XCTAssertTrue(prompt.contains("\"arguments\":"))
+        XCTAssertTrue(prompt.contains("Python-style function call"))
+        // Strict still carries its differentiating refusal clause alongside the format.
+        XCTAssertTrue(prompt.contains("I don't have a tool for that"))
+    }
+
+    /// The JSON-format instruction is an imperative — `.minimal` (app drives the
+    /// format) must not carry it.
+    func test_minimalStyle_omitsJSONFormatInstruction() {
+        let prompt = ToolSystemPromptBuilder.preferTools(for: fixtureTools(), style: .minimal)
+
+        XCTAssertFalse(prompt.contains("{\"name\":"), "minimal must not dictate a tool-call format")
+        XCTAssertFalse(prompt.contains("Python-style function call"))
+    }
+
+    /// The listing names every parameter (the JSON keys the model must use),
+    /// not just the required subset.
+    func test_listing_namesAllArguments() {
+        let prompt = ToolSystemPromptBuilder.preferTools(for: fixtureTools(), style: .standard)
+        // weather declares one property `city`, which is also required.
+        XCTAssertTrue(prompt.contains("(arguments: city)"), "must enumerate the tool's argument names")
+    }
+
+    /// Argument ordering is deterministic: required args lead in schema order,
+    /// optional properties follow alphabetically (properties is an unordered
+    /// dictionary, so a raw key walk would be byte-unstable).
+    func test_argumentNames_requiredLeadThenOptionalSorted() {
+        let schema: JSONSchemaValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")]),
+                "zebra": .object(["type": .string("string")]),
+                "apple": .object(["type": .string("string")])
+            ]),
+            "required": .array([.string("city")])
+        ])
+        let def = ToolDefinition(name: "weather", description: "x", parameters: schema)
+        let prompt = ToolSystemPromptBuilder.preferTools(for: [def], style: .minimal)
+        XCTAssertTrue(
+            prompt.contains("(arguments: city, apple, zebra)"),
+            "required `city` leads; optional `apple`/`zebra` follow alphabetically; got:\n\(prompt)"
+        )
+    }
+
     func test_stylesProduceDistinctOutput() {
         let standard = ToolSystemPromptBuilder.preferTools(for: fixtureTools(), style: .standard)
         let strict = ToolSystemPromptBuilder.preferTools(for: fixtureTools(), style: .strict)

--- a/docs/LOCAL-TOOL-CALLING.md
+++ b/docs/LOCAL-TOOL-CALLING.md
@@ -117,11 +117,16 @@ let systemPrompt = preamble + "\n\n" + appSpecificSystemPrompt
 
 `preferTools` returns an empty string when `tools` is empty, so it is safe to
 concatenate unconditionally. It renders each tool as
-`- <name>: <description> (requires: a, b)` and (for `.standard`/`.strict`) adds
-the imperative "When a tool can answer a question, you MUST call the tool… Call
-tools by emitting the appropriate tool_call in your response." In ManifoldKit's
-own product testing this lifted `llama3.1:8b` tool-recall from ~50% (no preamble)
-to 70–85%.
+`- <name>: <description> (arguments: a, b) (requires: a)` and (for
+`.standard`/`.strict`) adds the imperative "When a tool can answer a question,
+you MUST call the tool…", followed by the concrete emission format — a single
+JSON object `{"name": …, "arguments": {…}}` using the listed argument names,
+with an explicit prohibition on Python-style positional calls. That format
+clause exists because templateless models (Phi-3.5, Mistral GGUF) reach the
+model through this preamble alone and otherwise improvise an unparseable
+`tool_call(value)` shape ([#2002](https://github.com/roryford/ManifoldKit/issues/2002)).
+In ManifoldKit's own product testing the imperative preamble lifted
+`llama3.1:8b` tool-recall from ~50% (no preamble) to 70–85%.
 
 > **Is this auto-injected?** **Yes, as of [#1856](https://github.com/roryford/ManifoldKit/issues/1856).**
 > The queue calls `ToolSystemPromptBuilder.preferTools(for:)` (`.standard` style)


### PR DESCRIPTION
Closes #2002.

## Problem
Templateless GGUF models (Phi-3.5-mini, Mistral-7B-Instruct-v0.3) have no tool support in their embedded chat template, so they reach the model through the `ToolSystemPromptBuilder` preamble alone. The old preamble said "Call tools by emitting the appropriate tool_call in your response" — no concrete format — so the model improvised an unparseable Pythonic `tool_call(calc, "7823 * 41")` (positional, opaque) that no local parser can dispatch.

Surfaced from `manifold-llama` tool-calling diagnosis. The general fix belongs here in `ToolSystemPromptBuilder` (manifold-llama's harness-level instruction injection was only a stopgap).

## Fix
- **Concrete JSON envelope.** `.standard`/`.strict` now instruct a single JSON object `{"name": ..., "arguments": {...}}` — the shape the local `<tool_call>` / bare-`{"name"` dialects already consume — using named arguments, with an explicit prohibition on Python-style positional calls.
- **Argument enumeration.** The per-tool listing now names every parameter (the JSON keys the model needs), deterministically ordered: required args first in schema-declared order, then optional properties alphabetically (since `properties` is an unordered dictionary). The pinned `(requires: ...)` clause is byte-unchanged.
- **No wiring change needed.** The fold decision already gates on `!renderer.rendersToolsNatively`, so native-tool templates (Foundation / OpenAI / Anthropic / `gemma4`) never see this string. `.minimal` (app drives format) does not carry the format instruction.

## Tests
- 5 new tests covering the JSON envelope, the anti-Python-call clause, `.minimal` omitting the format instruction, full-argument enumeration, and deterministic argument ordering.
- All pre-existing `ToolSystemPromptBuilderTests` / `GenerationQueueToolSystemPromptTests` assertions still pass (preamble marker, `requires:` tokens, style distinctness).
- Full `scripts/test.sh --profile local` gate: **PASSED**.

## Docs
`docs/LOCAL-TOOL-CALLING.md` updated to describe the new render shape and JSON format clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)