### PR TITLE
feat(catalog): add template-derived tool-call claim to ModelInfo

### DIFF
--- a/Sources/ManifoldModelCatalog/ChatTemplateToolDescriptor.swift
+++ b/Sources/ManifoldModelCatalog/ChatTemplateToolDescriptor.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// A static, template-derived **claim** about whether (and how) a model's chat
+/// template expresses tool calls.
+///
+/// This is Layer 1 of the tool-call-conformance design (#2005): an honest
+/// *claim*, not a measured *verdict*. It is produced by a pure substring/regex
+/// parse of the Jinja chat template ManifoldKit already stores
+/// (``ModelInfo/chatTemplateRaw``) — no engine, no trial-render, no live soak.
+///
+/// **How to read the claim:**
+/// - **Negative is trustworthy.** When a template carries no tools guard at all
+///   (e.g. Phi-4), tools are genuinely *not expressible* through that template —
+///   ``toolsExpressible`` is `false` and a host should not attempt tool calling.
+/// - **Positive is necessary-but-NOT-sufficient.** When a template *does* carry
+///   a tools guard, this value claims the model "expresses tools in dialect X".
+///   That is a precondition, not a guarantee: a base (non-instruct) checkpoint
+///   often carries the instruct template verbatim yet cannot follow it. The host
+///   verifies this claim itself by actually running the model — ManifoldKit
+///   deliberately does **not** measure here (measurement is consumer-owned and
+///   explicitly out of scope for Layer 1).
+///
+/// The parser is intentionally heuristic. It recognises the guard and call
+/// dialect of the common open-weight families; an unrecognised-but-present guard
+/// still reports ``toolsExpressible`` `true` with a `nil` ``declaredDialect``.
+public struct ChatTemplateToolDescriptor: Sendable, Equatable {
+
+    /// The serialisation a model uses to encode tool-call *arguments*.
+    public enum ArgEncoding: Sendable, Equatable {
+        /// JSON object, e.g. `{"location": "Paris"}` (Qwen, Hermes, Mistral).
+        case json
+        /// Newline-delimited `key: value` pairs (Gemma's `<|tool_call>` form).
+        case keyValue
+        /// `key=value` pairs (some Llama python-tag style calls).
+        case keyEqualsValue
+    }
+
+    /// How cleanly a host can extract a tool call from the model's output.
+    public enum Extractability: Sendable, Equatable {
+        /// A distinct open/close delimiter brackets the call — trivial to scan.
+        case clean
+        /// The call is bare JSON or a `python_tag` blob with no reliable
+        /// delimiter (Llama-3.1) — extractable, but requires heuristics and is
+        /// easy to confuse with ordinary assistant prose.
+        case buried
+        /// The template cannot express tools at all.
+        case toolless
+    }
+
+    /// The tool-call dialect a template *declares* it will emit, when one is
+    /// recognised. `nil` when tools are not expressible or the dialect is
+    /// present-but-unrecognised.
+    public struct ToolCallDialect: Sendable, Equatable {
+        /// Opening delimiter the model wraps a tool call in, e.g. `<tool_call>`.
+        /// `nil` for bare-JSON / python-tag dialects with no opener.
+        public let openDelimiter: String?
+        /// Closing delimiter, e.g. `</tool_call>`. `nil` when there is no opener.
+        public let closeDelimiter: String?
+        /// How the call's arguments are serialised.
+        public let argEncoding: ArgEncoding
+
+        public init(openDelimiter: String?, closeDelimiter: String?, argEncoding: ArgEncoding) {
+            self.openDelimiter = openDelimiter
+            self.closeDelimiter = closeDelimiter
+            self.argEncoding = argEncoding
+        }
+    }
+
+    /// `true` iff the chat template carries a tools guard — a necessary
+    /// precondition for tool calling. See the type doc for why a `true` here is
+    /// a *claim*, not a guarantee.
+    public let toolsExpressible: Bool
+
+    /// The recognised call dialect, or `nil` (not expressible / unrecognised).
+    public let declaredDialect: ToolCallDialect?
+
+    /// How cleanly tool calls can be extracted from model output.
+    public let extractability: Extractability
+
+    /// Parses a chat-template string into a tool-call claim.
+    ///
+    /// A `nil` or whitespace-only template yields a trustworthy negative:
+    /// ``toolsExpressible`` `false`, ``extractability`` ``Extractability/toolless``.
+    public init(parsingChatTemplate raw: String?) {
+        guard let raw, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            self.toolsExpressible = false
+            self.declaredDialect = nil
+            self.extractability = .toolless
+            return
+        }
+
+        // --- 1. Guard detection -------------------------------------------------
+        // Recognise the tools-block guard shapes from the evidence table. Jinja
+        // whitespace-control variants (`{%-`/`-%}`) and extra inner spacing are
+        // normalised by collapsing runs of whitespace before substring matching.
+        let normalized = raw
+            // Drop Jinja whitespace-control hyphens so `{%-`/`-%}` match the
+            // plain `{%`/`%}` guard shapes below.
+            .replacingOccurrences(of: #"\{%-?"#, with: "{%", options: .regularExpression)
+            .replacingOccurrences(of: #"-?%\}"#, with: "%}", options: .regularExpression)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+
+        let guardShapes = [
+            "{% if tools %}",            // gemma, Qwen ({%- if tools %} normalises to this)
+            "{% if tools is not none",   // Mistral
+            "{% for tool",               // Hermes (iterates tools directly)
+            "Environment: ipython",      // Llama-3.1 system preamble
+            "[TOOL_CALLS]",              // Mistral call token (also a guard signal)
+        ]
+        let hasGuard = guardShapes.contains { normalized.contains($0) }
+
+        guard hasGuard else {
+            self.toolsExpressible = false
+            self.declaredDialect = nil
+            self.extractability = .toolless
+            return
+        }
+        self.toolsExpressible = true
+
+        // --- 2. Dialect mapping -------------------------------------------------
+        // Order matters: probe for the most specific call markers first. The
+        // checks read the (un-normalised) raw template so delimiter literals are
+        // matched verbatim.
+        if raw.contains("[TOOL_CALLS]") {
+            // Mistral: [TOOL_CALLS] then a JSON array of calls.
+            self.declaredDialect = ToolCallDialect(
+                openDelimiter: "[TOOL_CALLS]", closeDelimiter: nil, argEncoding: .json
+            )
+            self.extractability = .clean
+        } else if raw.contains("<|tool_call>") {
+            // Gemma: <|tool_call> with newline-delimited key: value args.
+            self.declaredDialect = ToolCallDialect(
+                openDelimiter: "<|tool_call>", closeDelimiter: "<|/tool_call>", argEncoding: .keyValue
+            )
+            self.extractability = .clean
+        } else if raw.contains("<tool_call>") {
+            // Qwen / Hermes: <tool_call>…</tool_call> wrapping a JSON object.
+            self.declaredDialect = ToolCallDialect(
+                openDelimiter: "<tool_call>", closeDelimiter: "</tool_call>", argEncoding: .json
+            )
+            self.extractability = .clean
+        } else if raw.contains("Environment: ipython") || raw.contains("python_tag") || raw.contains("<|python_tag|>") {
+            // Llama-3.1: bare JSON or a python_tag blob, no reliable delimiter.
+            self.declaredDialect = ToolCallDialect(
+                openDelimiter: nil, closeDelimiter: nil, argEncoding: .json
+            )
+            self.extractability = .buried
+        } else {
+            // Guard present but call dialect unrecognised — still a claim that
+            // tools are expressible, just with no decoded dialect.
+            self.declaredDialect = nil
+            self.extractability = .clean
+        }
+    }
+}

--- a/Sources/ManifoldModelCatalog/ChatTemplateToolDescriptor.swift
+++ b/Sources/ManifoldModelCatalog/ChatTemplateToolDescriptor.swift
@@ -94,16 +94,18 @@ public struct ChatTemplateToolDescriptor: Sendable, Equatable {
         // whitespace-control variants (`{%-`/`-%}`) and extra inner spacing are
         // normalised by collapsing runs of whitespace before substring matching.
         let normalized = raw
-            // Drop Jinja whitespace-control hyphens so `{%-`/`-%}` match the
-            // plain `{%`/`%}` guard shapes below.
-            .replacingOccurrences(of: #"\{%-?"#, with: "{%", options: .regularExpression)
-            .replacingOccurrences(of: #"-?%\}"#, with: "%}", options: .regularExpression)
+            // Drop Jinja whitespace-control markers (`{%-`/`{%+`/`-%}`/`+%}`) so
+            // the trimmed/non-trimmed tag spellings all match the plain `{%`/`%}`
+            // guard shapes below, then collapse runs of whitespace (including
+            // newlines inside a multi-line tag) to single spaces.
+            .replacingOccurrences(of: #"\{%[-+]?"#, with: "{%", options: .regularExpression)
+            .replacingOccurrences(of: #"[-+]?%\}"#, with: "%}", options: .regularExpression)
             .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
 
         let guardShapes = [
             "{% if tools %}",            // gemma, Qwen ({%- if tools %} normalises to this)
             "{% if tools is not none",   // Mistral
-            "{% for tool",               // Hermes (iterates tools directly)
+            "{% for tool in tools",      // Hermes (iterates the tools list directly)
             "Environment: ipython",      // Llama-3.1 system preamble
             "[TOOL_CALLS]",              // Mistral call token (also a guard signal)
         ]

--- a/Sources/ManifoldModelCatalog/ChatTemplateToolDescriptor.swift
+++ b/Sources/ManifoldModelCatalog/ChatTemplateToolDescriptor.swift
@@ -23,10 +23,13 @@ import Foundation
 /// The parser is intentionally heuristic. It recognises the guard and call
 /// dialect of the common open-weight families; an unrecognised-but-present guard
 /// still reports ``toolsExpressible`` `true` with a `nil` ``declaredDialect``.
-public struct ChatTemplateToolDescriptor: Sendable, Equatable {
+public struct ChatTemplateToolDescriptor: Sendable, Equatable, Hashable, Codable {
 
     /// The serialisation a model uses to encode tool-call *arguments*.
-    public enum ArgEncoding: Sendable, Equatable {
+    ///
+    /// Raw values are stable wire identifiers — never renumber or rename them; a
+    /// persisted catalog claim decodes against these strings.
+    public enum ArgEncoding: String, Sendable, Equatable, Hashable, Codable {
         /// JSON object, e.g. `{"location": "Paris"}` (Qwen, Hermes, Mistral).
         case json
         /// Newline-delimited `key: value` pairs (Gemma's `<|tool_call>` form).
@@ -36,12 +39,17 @@ public struct ChatTemplateToolDescriptor: Sendable, Equatable {
     }
 
     /// How cleanly a host can extract a tool call from the model's output.
-    public enum Extractability: Sendable, Equatable {
+    ///
+    /// Raw values are stable wire identifiers — never renumber or rename them.
+    public enum Extractability: String, Sendable, Equatable, Hashable, Codable {
         /// A distinct open/close delimiter brackets the call — trivial to scan.
         case clean
         /// The call is bare JSON or a `python_tag` blob with no reliable
         /// delimiter (Llama-3.1) — extractable, but requires heuristics and is
-        /// easy to confuse with ordinary assistant prose.
+        /// easy to confuse with ordinary assistant prose. A host should still
+        /// attempt extraction (the claim is positive), but must scan with the
+        /// family heuristic rather than a delimiter, and treat a miss as
+        /// "model emitted prose" rather than "malformed call".
         case buried
         /// The template cannot express tools at all.
         case toolless
@@ -50,7 +58,7 @@ public struct ChatTemplateToolDescriptor: Sendable, Equatable {
     /// The tool-call dialect a template *declares* it will emit, when one is
     /// recognised. `nil` when tools are not expressible or the dialect is
     /// present-but-unrecognised.
-    public struct ToolCallDialect: Sendable, Equatable {
+    public struct ToolCallDialect: Sendable, Equatable, Hashable, Codable {
         /// Opening delimiter the model wraps a tool call in, e.g. `<tool_call>`.
         /// `nil` for bare-JSON / python-tag dialects with no opener.
         public let openDelimiter: String?
@@ -89,11 +97,21 @@ public struct ChatTemplateToolDescriptor: Sendable, Equatable {
             return
         }
 
+        // --- 0. Strip Jinja comments -------------------------------------------
+        // `{# ... #}` comment blocks are inert text the renderer never emits, yet
+        // they freely contain guard/delimiter literals (a commented-out
+        // `{# {% if tools %} #}` or a "{# emits [TOOL_CALLS] #}" note). Remove
+        // them before BOTH guard and dialect probing so a comment can never trip
+        // a claim. Non-greedy, dot-matches-newline so multi-line comments go too.
+        let commentless = raw.replacingOccurrences(
+            of: #"(?s)\{#.*?#\}"#, with: "", options: .regularExpression
+        )
+
         // --- 1. Guard detection -------------------------------------------------
         // Recognise the tools-block guard shapes from the evidence table. Jinja
         // whitespace-control variants (`{%-`/`-%}`) and extra inner spacing are
         // normalised by collapsing runs of whitespace before substring matching.
-        let normalized = raw
+        let normalized = commentless
             // Drop Jinja whitespace-control markers (`{%-`/`{%+`/`-%}`/`+%}`) so
             // the trimmed/non-trimmed tag spellings all match the plain `{%`/`%}`
             // guard shapes below, then collapse runs of whitespace (including
@@ -121,27 +139,31 @@ public struct ChatTemplateToolDescriptor: Sendable, Equatable {
 
         // --- 2. Dialect mapping -------------------------------------------------
         // Order matters: probe for the most specific call markers first. The
-        // checks read the (un-normalised) raw template so delimiter literals are
-        // matched verbatim.
-        if raw.contains("[TOOL_CALLS]") {
+        // checks read the comment-stripped template so delimiter literals are
+        // matched verbatim but a commented-out literal cannot win. Ordering note:
+        // `<|tool_call>` must be probed before the broader `<tool_call>` (the
+        // latter is NOT a substring of the former — different leading char — so
+        // there is no shadowing, but keeping Gemma ahead of Qwen documents intent
+        // and guards against a future loosening of either literal).
+        if commentless.contains("[TOOL_CALLS]") {
             // Mistral: [TOOL_CALLS] then a JSON array of calls.
             self.declaredDialect = ToolCallDialect(
                 openDelimiter: "[TOOL_CALLS]", closeDelimiter: nil, argEncoding: .json
             )
             self.extractability = .clean
-        } else if raw.contains("<|tool_call>") {
+        } else if commentless.contains("<|tool_call>") {
             // Gemma: <|tool_call> with newline-delimited key: value args.
             self.declaredDialect = ToolCallDialect(
                 openDelimiter: "<|tool_call>", closeDelimiter: "<|/tool_call>", argEncoding: .keyValue
             )
             self.extractability = .clean
-        } else if raw.contains("<tool_call>") {
+        } else if commentless.contains("<tool_call>") {
             // Qwen / Hermes: <tool_call>…</tool_call> wrapping a JSON object.
             self.declaredDialect = ToolCallDialect(
                 openDelimiter: "<tool_call>", closeDelimiter: "</tool_call>", argEncoding: .json
             )
             self.extractability = .clean
-        } else if raw.contains("Environment: ipython") || raw.contains("python_tag") || raw.contains("<|python_tag|>") {
+        } else if commentless.contains("Environment: ipython") || commentless.contains("python_tag") || commentless.contains("<|python_tag|>") {
             // Llama-3.1: bare JSON or a python_tag blob, no reliable delimiter.
             self.declaredDialect = ToolCallDialect(
                 openDelimiter: nil, closeDelimiter: nil, argEncoding: .json

--- a/Sources/ManifoldModelCatalog/ModelInfo.swift
+++ b/Sources/ManifoldModelCatalog/ModelInfo.swift
@@ -121,6 +121,19 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
         curatedSupportsReasoning ?? detectedSupportsReasoning ?? false
     }
 
+    /// A static, template-derived **claim** about tool calling, parsed from
+    /// ``chatTemplateRaw`` (#2005, Layer 1).
+    ///
+    /// Read it as a claim, not a verdict: a negative (no tools guard in the
+    /// template) is trustworthy, while a positive ("expresses tools in dialect
+    /// X") is necessary-but-not-sufficient — a base checkpoint can carry an
+    /// instruct template it cannot actually follow. The host verifies a positive
+    /// itself by running the model; ManifoldKit does not measure here. Computed
+    /// on access (no stored field, no schema change).
+    public var toolCallClaim: ChatTemplateToolDescriptor {
+        ChatTemplateToolDescriptor(parsingChatTemplate: chatTemplateRaw)
+    }
+
     /// Applies a curation override, copying the three capability flags from a
     /// ``CuratedModelCapabilities`` value. Only non-nil fields override; `nil`
     /// leaves the existing detected/curated layer untouched. This is the

--- a/Tests/ManifoldModelCatalogTests/ChatTemplateToolDescriptorTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ChatTemplateToolDescriptorTests.swift
@@ -143,6 +143,56 @@ final class ChatTemplateToolDescriptorTests: XCTestCase {
         XCTAssertEqual(claim.extractability, .toolless)
     }
 
+    // MARK: - False positives — a tools-shaped substring must NOT trip the guard
+
+    /// Prose that merely mentions the word "tools" (a system-prompt string, a
+    /// comment) carries no Jinja guard construct and must stay toolless — the
+    /// guard is anchored to the `{% if tools %}` / `[TOOL_CALLS]` shapes, not to
+    /// the bare word.
+    func testProseMentioningToolsIsNotExpressible() {
+        let template = """
+        {% for message in messages %}
+        <|im_start|>{{ message.role }}
+        You are a helpful assistant. You may use tools when the user asks.
+        {{ message.content }}<|im_end|>
+        {% endfor %}
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertFalse(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect)
+        XCTAssertEqual(claim.extractability, .toolless)
+    }
+
+    /// A `{% for tool_message in ... %}` loop iterates an unrelated variable that
+    /// merely starts with "tool" — it is not the Hermes `for tool in tools`
+    /// guard and must not be mistaken for one.
+    func testForLoopOverToolPrefixedVariableIsNotExpressible() {
+        let template = """
+        {% for tool_message in history %}
+        {{ tool_message.content }}
+        {% endfor %}
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertFalse(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect)
+        XCTAssertEqual(claim.extractability, .toolless)
+    }
+
+    // MARK: - Whitespace-control variants of the guard tag all normalise
+
+    /// The `{%+` trim-plus marker and newlines inside the tag must normalise to
+    /// the plain `{% if tools %}` guard just like `{%-` does.
+    func testWhitespaceControlVariantsNormaliseToGuard() {
+        for tag in ["{%+ if tools %}", "{%-\n if tools +%}", "{%   if tools   %}"] {
+            let template = tag + "\n<tool_call>\n{\"name\": \"x\"}\n</tool_call>"
+            let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+            XCTAssertTrue(claim.toolsExpressible, "guard tag \(tag) should be recognised")
+            XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<tool_call>", "tag \(tag)")
+        }
+    }
+
     // MARK: - ModelInfo accessor wiring
 
     func testModelInfoExposesClaimFromChatTemplate() {

--- a/Tests/ManifoldModelCatalogTests/ChatTemplateToolDescriptorTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ChatTemplateToolDescriptorTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import ManifoldModelCatalog
+
+/// Verifies the static, template-derived tool-call **claim** parser
+/// (``ChatTemplateToolDescriptor``, #2005 Layer 1) across the six common
+/// open-weight families plus the empty/nil trustworthy-negative case.
+///
+/// The snippets are intentionally minimal — only the tools guard and the
+/// call-dialect markers the parser keys on, not full templates. The parser is a
+/// heuristic substring/regex match (the leaf catalog cannot trial-render), so
+/// these assert the recognised shapes, not template completeness.
+final class ChatTemplateToolDescriptorTests: XCTestCase {
+
+    // MARK: - Gemma 4 — {% if tools %} guard, <|tool_call> / key:value
+
+    func testGemmaExpressesToolsWithKeyValueDialect() {
+        let template = """
+        {{ bos_token }}
+        {%- if tools %}
+        You may call the following tools:
+        {%- for tool in tools %}{{ tool.name }}{%- endfor %}
+        {%- endif %}
+        <|tool_call>
+        name: get_weather
+        location: Paris
+        <|/tool_call>
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<|tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .keyValue)
+        XCTAssertEqual(claim.extractability, .clean)
+    }
+
+    // MARK: - Qwen2.5-Instruct — {% if tools %} guard, <tool_call> / json
+
+    func testQwenExpressesToolsWithJSONDialect() {
+        let template = """
+        {%- if tools %}
+        <tools>
+        {%- for tool in tools %}{{ tool | tojson }}{%- endfor %}
+        </tools>
+        {%- endif %}
+        <tool_call>
+        {"name": "get_weather", "arguments": {"location": "Paris"}}
+        </tool_call>
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.closeDelimiter, "</tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .json)
+        XCTAssertEqual(claim.extractability, .clean)
+    }
+
+    // MARK: - Hermes-2-Pro — {% for tool %} guard, <tool_call> / json
+
+    func testHermesExpressesToolsWithJSONDialect() {
+        let template = """
+        {% for tool in tools %}
+        {{ tool.function | tojson }}
+        {% endfor %}
+        <tool_call>
+        {"name": "search", "arguments": {"q": "weather"}}
+        </tool_call>
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .json)
+        XCTAssertEqual(claim.extractability, .clean)
+    }
+
+    // MARK: - Llama-3.1-Instruct — Environment: ipython guard, bare/python_tag
+
+    func testLlamaExpressesToolsButBuried() {
+        let template = """
+        <|start_header_id|>system<|end_header_id|>
+        Environment: ipython
+        You have access to the following functions.
+        <|python_tag|>{"name": "get_weather", "parameters": {"location": "Paris"}}
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect?.openDelimiter)
+        XCTAssertNil(claim.declaredDialect?.closeDelimiter)
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .json)
+        XCTAssertEqual(claim.extractability, .buried)
+    }
+
+    // MARK: - Mistral-v0.3 — tools is not none guard, [TOOL_CALLS] / json
+
+    func testMistralExpressesToolsWithJSONDialect() {
+        let template = """
+        {%- if tools is not none %}
+        [AVAILABLE_TOOLS] {{ tools | tojson }} [/AVAILABLE_TOOLS]
+        {%- endif %}
+        [TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "Paris"}}]
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertEqual(claim.declaredDialect?.openDelimiter, "[TOOL_CALLS]")
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .json)
+        XCTAssertEqual(claim.extractability, .clean)
+    }
+
+    // MARK: - Phi-4 — no tools guard, toolless (trustworthy negative)
+
+    func testPhi4IsToolless() {
+        let template = """
+        {% for message in messages %}
+        <|im_start|>{{ message.role }}<|im_sep|>{{ message.content }}<|im_end|>
+        {% endfor %}
+        <|im_start|>assistant<|im_sep|>
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertFalse(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect)
+        XCTAssertEqual(claim.extractability, .toolless)
+    }
+
+    // MARK: - Empty / nil templates — trustworthy negative
+
+    func testNilTemplateIsToolless() {
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: nil)
+
+        XCTAssertFalse(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect)
+        XCTAssertEqual(claim.extractability, .toolless)
+    }
+
+    func testEmptyTemplateIsToolless() {
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: "   \n  ")
+
+        XCTAssertFalse(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect)
+        XCTAssertEqual(claim.extractability, .toolless)
+    }
+
+    // MARK: - ModelInfo accessor wiring
+
+    func testModelInfoExposesClaimFromChatTemplate() {
+        let model = ModelInfo(
+            name: "Qwen",
+            fileName: "qwen.gguf",
+            url: URL(fileURLWithPath: "/tmp/qwen.gguf"),
+            fileSize: 1024,
+            modelType: .gguf,
+            chatTemplateRaw: "{%- if tools %}{% endif %}<tool_call></tool_call>"
+        )
+
+        XCTAssertTrue(model.toolCallClaim.toolsExpressible)
+        XCTAssertEqual(model.toolCallClaim.declaredDialect?.openDelimiter, "<tool_call>")
+    }
+}

--- a/Tests/ManifoldModelCatalogTests/ChatTemplateToolDescriptorTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ChatTemplateToolDescriptorTests.swift
@@ -180,6 +180,69 @@ final class ChatTemplateToolDescriptorTests: XCTestCase {
         XCTAssertEqual(claim.extractability, .toolless)
     }
 
+    /// A guard literal that lives ONLY inside a Jinja `{# ... #}` comment is
+    /// inert text the renderer never emits, so it must not trip the claim — even
+    /// though the raw substring `{% if tools %}` is present in the source.
+    func testGuardInsideJinjaCommentIsNotExpressible() {
+        let template = """
+        {# Historical note: {% if tools %} used to live here, and the model
+           would emit [TOOL_CALLS] / <tool_call>, but tool support was dropped. #}
+        {% for message in messages %}
+        <|im_start|>{{ message.role }}{{ message.content }}<|im_end|>
+        {% endfor %}
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertFalse(claim.toolsExpressible)
+        XCTAssertNil(claim.declaredDialect)
+        XCTAssertEqual(claim.extractability, .toolless)
+    }
+
+    /// A real guard outside a comment still wins even when a comment elsewhere in
+    /// the template mentions a *different* dialect literal — comment stripping
+    /// must not swallow the live guard, and the live dialect (Qwen `<tool_call>`)
+    /// must be the one reported, not the commented `[TOOL_CALLS]`.
+    func testLiveGuardSurvivesUnrelatedCommentMentioningAnotherDialect() {
+        let template = """
+        {# this model does NOT use [TOOL_CALLS]; see Mistral for that #}
+        {%- if tools %}
+        {%- endif %}
+        <tool_call>
+        {"name": "x"}
+        </tool_call>
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .json)
+    }
+
+    // MARK: - Codable round-trip (claim is shippable as catalog data)
+
+    /// The claim is documented as catalog data a host may persist/transmit, so it
+    /// must survive a JSON encode/decode round-trip with stable enum raw values.
+    func testClaimCodableRoundTrips() throws {
+        let original = ChatTemplateToolDescriptor(
+            parsingChatTemplate: "{%- if tools %}{% endif %}<tool_call></tool_call>"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ChatTemplateToolDescriptor.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.declaredDialect?.argEncoding, .json)
+    }
+
+    /// Enum raw values are wire identifiers — pin them so a rename can't silently
+    /// break a persisted catalog claim.
+    func testEnumRawValuesAreStable() {
+        XCTAssertEqual(ChatTemplateToolDescriptor.ArgEncoding.json.rawValue, "json")
+        XCTAssertEqual(ChatTemplateToolDescriptor.ArgEncoding.keyValue.rawValue, "keyValue")
+        XCTAssertEqual(ChatTemplateToolDescriptor.ArgEncoding.keyEqualsValue.rawValue, "keyEqualsValue")
+        XCTAssertEqual(ChatTemplateToolDescriptor.Extractability.clean.rawValue, "clean")
+        XCTAssertEqual(ChatTemplateToolDescriptor.Extractability.buried.rawValue, "buried")
+        XCTAssertEqual(ChatTemplateToolDescriptor.Extractability.toolless.rawValue, "toolless")
+    }
+
     // MARK: - Whitespace-control variants of the guard tag all normalise
 
     /// The `{%+` trim-plus marker and newlines inside the tag must normalise to
@@ -191,6 +254,44 @@ final class ChatTemplateToolDescriptorTests: XCTestCase {
             XCTAssertTrue(claim.toolsExpressible, "guard tag \(tag) should be recognised")
             XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<tool_call>", "tag \(tag)")
         }
+    }
+
+    // MARK: - Real-world full template (snippet-vs-reality drift guard)
+
+    /// A faithful excerpt of the *shipped* Qwen2.5-Instruct chat template — the
+    /// real guard wording, the `<tools>` block, the System message scaffolding,
+    /// and the `<tool_call>` emission — not the minimal snippet the other tests
+    /// use. Catches drift between the parser's assumptions and a template that
+    /// actually moves in the wild.
+    func testRealWorldQwenTemplateExpressesToolsWithJSONDialect() {
+        let template = """
+        {%- if tools %}
+            {{- '<|im_start|>system\\n' }}
+            {%- if messages[0].role == 'system' %}
+                {{- messages[0].content + '\\n\\n' }}
+            {%- endif %}
+            {{- "# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>" }}
+            {%- for tool in tools %}
+                {{- "\\n" }}
+                {{- tool | tojson }}
+            {%- endfor %}
+            {{- "\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\"name\\": <function-name>, \\"arguments\\": <args-json-object>}\\n</tool_call><|im_end|>\\n" }}
+        {%- else %}
+            {%- if messages[0].role == 'system' %}
+                {{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}
+            {%- endif %}
+        {%- endif %}
+        {%- for message in messages %}
+            {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}
+        {%- endfor %}
+        """
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: template)
+
+        XCTAssertTrue(claim.toolsExpressible)
+        XCTAssertEqual(claim.declaredDialect?.openDelimiter, "<tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.closeDelimiter, "</tool_call>")
+        XCTAssertEqual(claim.declaredDialect?.argEncoding, .json)
+        XCTAssertEqual(claim.extractability, .clean)
     }
 
     // MARK: - ModelInfo accessor wiring


### PR DESCRIPTION
Reduced **Layer 1** of #2005 — a static, template-derived **claim** about tool calling, parsed from the Jinja chat template `ManifoldModelCatalog` already stores (`ModelInfo.chatTemplateRaw`). Supersedes the static-flag approach explored in #2001 (no `supportsToolCalling` Bool — the accessor name reads as a *claim*, not a verdict).

## What it does

New `ChatTemplateToolDescriptor` (a `Sendable, Equatable` value in the leaf catalog) produced by a pure substring/regex parse of the template — **no engine, no trial-render** (the leaf imports only `ManifoldHardware`):

- `toolsExpressible: Bool` — true iff the template carries a tools guard (`{% if tools %}`, `{% for tool %}`, `tools is not none`, `Environment: ipython`, `[TOOL_CALLS]`; Jinja `{%-`/`-%}` whitespace-control variants normalised).
- `declaredDialect: ToolCallDialect?` — open/close delimiter + `ArgEncoding` (`json` / `keyValue` / `keyEqualsValue`), mapped for the six common families.
- `extractability: clean | buried | toolless` — `buried` for Llama-3.1's bare-JSON/python_tag shape.

Surfaced as a computed `ModelInfo.toolCallClaim` accessor (no stored field, no schema/Codable change).

## How to read the claim

- **Negative is trustworthy.** No tools guard (e.g. Phi-4) ⇒ tools genuinely not expressible.
- **Positive is necessary-but-NOT-sufficient.** A base checkpoint can carry an instruct template it cannot follow. The host verifies a positive itself by running the model — **ManifoldKit does not measure**.

## Scope note

Layer 1 only. The MK-run soak, measured conformance table, `ToolCallConformance` port, SwiftData adapter, and render-consistency check are **explicitly out of scope** (consumer-owned).

## Tests

`ChatTemplateToolDescriptorTests` covers all six families (gemma-4, Qwen2.5-Instruct, Hermes-2-Pro, Llama-3.1-Instruct, Mistral-v0.3, Phi-4) plus nil/empty ⇒ toolless, and the `ModelInfo` accessor wiring. `swift build` clean; 9/9 pass.