### PR TITLE
test: tighten vacuous error assertions in LLM constructor and JSONL import tests

### DIFF
--- a/Tests/ManifoldKitTests/LLMConstructorTests.swift
+++ b/Tests/ManifoldKitTests/LLMConstructorTests.swift
@@ -85,7 +85,12 @@ final class LLMConstructorTests: XCTestCase {
             _ = try await llm.respond(to: "hi")
             XCTFail("LLM.respond(to:) must throw when the backend fails the turn, not return empty text.")
         } catch let error as SendMessageError {
-            XCTAssertNotNil(error, "Expected a typed SendMessageError to propagate.")
+            // A backend generate-time failure surfaces as .runtime — the ConversationRuntime
+            // wraps the underlying error rather than re-typing it. Asserting the specific
+            // case (not just the type) catches regressions where the wrong case propagates.
+            guard case .runtime = error else {
+                return XCTFail("Expected SendMessageError.runtime, got \(error)")
+            }
         }
     }
 

--- a/Tests/ManifoldRuntimeTests/JSONLImportFormatTests.swift
+++ b/Tests/ManifoldRuntimeTests/JSONLImportFormatTests.swift
@@ -190,10 +190,14 @@ final class JSONLImportFormatTests: XCTestCase {
         let missingRole = #"{"content":"hi","timestamp":"2026-01-01T00:00:00Z"}"# + "\n"
         let data = missingRole.data(using: .utf8)!
         XCTAssertThrowsError(try format.decode(data)) { error in
-            // Missing role decodes into a Swift error from JSONDecoder (keyNotFound),
-            // which surfaces as malformedJSON since MessageLine requires role.
-            XCTAssertNotNil(error as? JSONLImportError,
-                            "Missing role must produce a JSONLImportError, not a generic error")
+            // Missing role triggers a JSONDecoder keyNotFound error on the non-optional
+            // MessageLine.role field, which the importer re-throws as .malformedJSON.
+            // Asserting the specific case (not just the type) ensures a raw DecodingError
+            // leaking past the importer's catch also fails this test.
+            guard case .malformedJSON = error as? JSONLImportError else {
+                XCTFail("Expected JSONLImportError.malformedJSON, got \(error)")
+                return
+            }
         }
     }
 
@@ -202,8 +206,14 @@ final class JSONLImportFormatTests: XCTestCase {
         let missingContent = #"{"role":"user","timestamp":"2026-01-01T00:00:00Z"}"# + "\n"
         let data = missingContent.data(using: .utf8)!
         XCTAssertThrowsError(try format.decode(data)) { error in
-            XCTAssertNotNil(error as? JSONLImportError,
-                            "Missing content must produce a JSONLImportError")
+            // Missing content triggers a JSONDecoder keyNotFound error on the non-optional
+            // MessageLine.content field, which the importer re-throws as .malformedJSON.
+            // Asserting the specific case (not just the type) ensures a raw DecodingError
+            // leaking past the importer's catch also fails this test.
+            guard case .malformedJSON = error as? JSONLImportError else {
+                XCTFail("Expected JSONLImportError.malformedJSON, got \(error)")
+                return
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Hardens two test catch blocks that were vacuously true, giving them real regression-catching value:

- **`LLMConstructorTests.test_respond_propagatesSendMessageError`**: The catch block used `XCTAssertNotNil(error)` where `error` is a bound, non-optional `SendMessageError` — always passes regardless of which case propagated. Now asserts `guard case .runtime = error` to confirm that a backend generate-time failure maps to the correct case.

- **`JSONLImportFormatTests.test_error_missingRoleFieldThrows`** and **`test_error_missingContentFieldThrows`**: Both used `XCTAssertNotNil(error as? JSONLImportError)` — asserts the type but not the case. Verified from `JSONLImportFormat.swift` that missing required fields on `MessageLine` produce `.malformedJSON` (JSONDecoder throws `keyNotFound`, the importer catches and re-throws as `.malformedJSON`). Now uses `guard case .malformedJSON = error as? JSONLImportError` so a raw `DecodingError` leaking past the importer's catch would also fail these tests.

## Verification

- Confirmed `SendMessageError.runtime` case by reading `Sources/ManifoldUI/ViewModels/ChatViewModel+Messages.swift` and cross-referencing `Tests/ManifoldUITests/ChatViewModelRespondTests.swift` (existing passing test uses same pattern at line 109).
- Confirmed `.malformedJSON` case by tracing `JSONLImportFormat.decode()` in `Sources/ManifoldRuntime/Services/JSONLImportFormat.swift` — the `do { try decoder.decode(MessageLine.self) } catch { throw JSONLImportError.malformedJSON(...) }` path is the only route for missing required fields.
- `swift build --build-tests`: exit 0 ✓

## Test plan

- [ ] `scripts/test.sh --filter ManifoldKitTests/LLMConstructorTests --skip-update`
- [ ] `scripts/test.sh --filter ManifoldRuntimeTests/JSONLImportFormatTests --skip-update`
- [ ] Full gate: `scripts/test.sh --profile local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)