### PR TITLE
fix: guarantee task-registry and background-scheduler cleanup on completion

### DIFF
--- a/Sources/ManifoldRuntime/Services/ConversationTurnTaskRegistry.swift
+++ b/Sources/ManifoldRuntime/Services/ConversationTurnTaskRegistry.swift
@@ -23,9 +23,19 @@ package final class ConversationTurnTaskRegistry: @unchecked Sendable {
         operation: @escaping @Sendable () async -> Void
     ) async -> Task<Void, Never> {
         let gate = ConversationTurnTaskStartGate()
-        let task = Task.detached(priority: priority) { [weak self] in
+        // Capture `self` strongly for the lifetime of the task so the
+        // `unregister` cleanup is guaranteed to run, even if the owning
+        // runtime deallocates while generation is still in flight. A `[weak
+        // self]` capture would silently drop the cleanup on early dealloc,
+        // leaking the handle's entry in `tasks` forever. The strong capture
+        // forms a temporary owner → tasks → task → registry retain cycle that
+        // is self-breaking: the moment the task unregisters its own handle,
+        // `tasks` no longer retains the task and the registry can deallocate
+        // normally. The task always reaches `unregister` — `operation()` is
+        // `() async -> Void` and cannot throw past this scope.
+        let task = Task.detached(priority: priority) {
             await gate.wait()
-            defer { self?.unregister(handle) }
+            defer { self.unregister(handle) }
             await operation()
         }
 

--- a/Sources/ManifoldRuntime/Services/DefaultBackgroundTaskScheduler.swift
+++ b/Sources/ManifoldRuntime/Services/DefaultBackgroundTaskScheduler.swift
@@ -62,14 +62,25 @@ public final class DefaultBackgroundTaskScheduler: BackgroundTaskScheduler, @unc
         work: @Sendable @escaping () async throws -> Void
     ) async {
         let sampler = memorySampler
-        let task = Task.detached { [weak self] in
+        // Capture `self` strongly for the lifetime of the task so the
+        // `clear(identifier:)` cleanup is guaranteed to run, even if the
+        // scheduler deallocates while the work is still in flight. A `[weak
+        // self]` capture would silently drop the cleanup on early dealloc,
+        // leaving an orphaned `inFlight[identifier]` entry that blocks future
+        // scheduling for that id. The strong capture forms a temporary
+        // scheduler → inFlight → task → scheduler retain cycle that is
+        // self-breaking: the moment the task clears its own identifier,
+        // `inFlight` no longer retains the task and the scheduler can
+        // deallocate normally. `runWithBudget` swallows its errors, so the
+        // task always reaches `clear`.
+        let task = Task.detached {
             await Self.runWithBudget(
                 identifier: identifier,
                 budget: budget,
                 memorySampler: sampler,
                 work: work
             )
-            self?.clear(identifier: identifier)
+            self.clear(identifier: identifier)
         }
 
         // `schedule` as a "replace if newer" primitive: swap the new task

--- a/Tests/ManifoldRuntimeTests/BackgroundTaskSchedulerTests.swift
+++ b/Tests/ManifoldRuntimeTests/BackgroundTaskSchedulerTests.swift
@@ -166,6 +166,58 @@ final class BackgroundTaskSchedulerTests: XCTestCase {
         await fulfillment(of: [cancelled], timeout: 1.0)
     }
 
+    // MARK: - DefaultBackgroundTaskScheduler — completion cleanup
+
+    /// The detached task clears its own `inFlight` entry on completion. That
+    /// cleanup must be guaranteed even when the scheduler deallocates while the
+    /// work is still in flight — otherwise the orphaned entry would block
+    /// future scheduling for that identifier. The strong `self` capture that
+    /// provides this guarantee must be transient: once the task completes and
+    /// clears its entry, the scheduler must be free to deallocate (no permanent
+    /// retain cycle). We drop the only strong reference to the scheduler while
+    /// its work runs, then let it finish and confirm the scheduler deallocates.
+    func test_default_schedulerDeallocates_afterWorkCompletes_underEarlyOwnerDrop() async {
+        weak var weakScheduler: DefaultBackgroundTaskScheduler?
+        let started = expectation(description: "work started")
+        let finished = expectation(description: "work finished")
+        // A `Sendable` gate the test holds open without capturing the
+        // non-`Sendable` `XCTestCase` inside the `@Sendable` work closure.
+        let gate = SchedulerTestGate()
+
+        do {
+            let scheduler = DefaultBackgroundTaskScheduler(memorySampler: { 1_000 })
+            weakScheduler = scheduler
+            await scheduler.schedule(
+                identifier: "default.dealloc",
+                budget: MemoryBudget(maxBytes: 10_000_000, sampleInterval: .seconds(60))
+            ) {
+                started.fulfill()
+                await gate.wait()
+                finished.fulfill()
+            }
+            // `scheduler` leaves scope here — only the detached task's transient
+            // strong capture keeps it alive while the work runs.
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+        XCTAssertNotNil(weakScheduler, "scheduler stays alive while its work runs")
+
+        await gate.open()
+        await fulfillment(of: [finished], timeout: 2.0)
+
+        // The task clears its identifier and releases its transient strong
+        // capture. Give the detached task's tail a turn to run, then assert the
+        // scheduler has deallocated — proving the cleanup ran and the cycle
+        // self-broke rather than leaking.
+        for _ in 0..<50 where weakScheduler != nil {
+            await Task.yield()
+        }
+        XCTAssertNil(
+            weakScheduler,
+            "scheduler must deallocate once the completed task releases its transient strong capture"
+        )
+    }
+
     // MARK: - Recommended identifiers
 
     func test_recommendedIdentifiers_areStableStrings() {
@@ -176,5 +228,30 @@ final class BackgroundTaskSchedulerTests: XCTestCase {
                        "com.manifoldkit.background.indexing")
         XCTAssertEqual(ManifoldBackgroundTaskIdentifiers.archive,
                        "com.manifoldkit.background.archive")
+    }
+}
+
+/// A `Sendable` one-shot gate so a test can park a scheduler's `@Sendable`
+/// work closure and release it later without capturing the non-`Sendable`
+/// `XCTestCase`.
+private actor SchedulerTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
     }
 }

--- a/Tests/ManifoldRuntimeTests/ConversationTurnTaskRegistryTests.swift
+++ b/Tests/ManifoldRuntimeTests/ConversationTurnTaskRegistryTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import ManifoldRuntime
+
+/// Unit tests for ``ConversationTurnTaskRegistry`` cleanup guarantees.
+///
+/// The registry launches detached turn tasks that unregister themselves on
+/// completion. Earlier the cleanup ran through a `[weak self]` capture, so a
+/// task whose owning runtime deallocated mid-flight would skip `unregister`
+/// and leave a permanent entry in `tasks`. These tests pin the completion-path
+/// cleanup and prove the self-clearing capture does not leak the registry.
+///
+/// Classification: Unit (no SwiftData, no network — pure in-memory registry).
+final class ConversationTurnTaskRegistryTests: XCTestCase {
+
+    /// A completed task must remove its own handle from the registry so the
+    /// per-runtime bookkeeping does not grow without bound.
+    func test_launch_clearsEntryOnCompletion() async {
+        let registry = ConversationTurnTaskRegistry()
+        let handle = ConversationStreamHandle()
+        let started = expectation(description: "operation started")
+        let gate = TestGate()
+
+        let task = await registry.launch(handle: handle) {
+            started.fulfill()
+            await gate.wait()
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+        XCTAssertEqual(registry.count, 1, "entry should be present while running")
+
+        await gate.open()
+        await task.value
+
+        XCTAssertEqual(registry.count, 0, "completed task must unregister its handle")
+    }
+
+    /// The strong `self` capture that guarantees cleanup must be transient: it
+    /// is held only for the task's lifetime. Once the task completes and clears
+    /// its entry, the registry must be free to deallocate — i.e. no permanent
+    /// retain cycle. We launch a task, drop the only strong reference to the
+    /// registry while the task runs, then let the task finish and confirm the
+    /// registry deallocates.
+    func test_registryDeallocates_afterTaskCompletes_underEarlyOwnerDrop() async {
+        weak var weakRegistry: ConversationTurnTaskRegistry?
+        let started = expectation(description: "operation started")
+        let gate = TestGate()
+
+        // Capture the task so it outlives the strong registry reference,
+        // mirroring an owner that deallocates while generation is in flight.
+        var task: Task<Void, Never>?
+
+        do {
+            let registry = ConversationTurnTaskRegistry()
+            weakRegistry = registry
+            let handle = ConversationStreamHandle()
+            task = await registry.launch(handle: handle) {
+                started.fulfill()
+                await gate.wait()
+            }
+            await fulfillment(of: [started], timeout: 1.0)
+            // `registry` goes out of scope here — only the task's transient
+            // strong capture keeps it alive.
+        }
+
+        XCTAssertNotNil(weakRegistry, "registry stays alive while its task runs")
+
+        await gate.open()
+        await task?.value
+        task = nil
+
+        // Give the detached task's tail (the `defer { unregister }`) a turn.
+        for _ in 0..<50 where weakRegistry != nil {
+            await Task.yield()
+        }
+
+        XCTAssertNil(
+            weakRegistry,
+            "registry must deallocate once the completed task releases its transient strong capture"
+        )
+    }
+
+    /// A one-shot gate the test can hold open from the operation body without
+    /// capturing the non-`Sendable` `XCTestCase` itself. Mirrors the production
+    /// `ConversationTurnTaskStartGate` shape.
+    private actor TestGate {
+        private var isOpen = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            if isOpen { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        func open() {
+            guard !isOpen else { return }
+            isOpen = true
+            let pending = waiters
+            waiters.removeAll()
+            for continuation in pending {
+                continuation.resume()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Two detached-task owners leaked a completion-path cleanup when the owner deallocated mid-flight:

1. **`ConversationTurnTaskRegistry.launch`** — `Task.detached { [weak self] in await gate.wait(); defer { self?.unregister(handle) }; await operation() }`. On early owner dealloc, `self?` is nil and `unregister` is skipped, leaving a permanent entry in `tasks`.
2. **`DefaultBackgroundTaskScheduler.schedule`** — `Task.detached { [weak self] in await ...; self?.clear(identifier:) }`. On early scheduler dealloc, `clear` is skipped, leaving an orphaned `inFlight[identifier]` entry that **blocks future scheduling for that id**.

## Ownership analysis

In both cases the owner strongly retains the task (registry's `tasks[handle] = task`; scheduler's `inFlight[identifier] = task`). The task only references the owner to perform its own cleanup. So a `[weak self]` capture is strictly worse than a strong one here: the only retained reference cycle (owner → table → task → owner) is **self-breaking** — the instant the task removes its own entry, the table stops retaining the task and the owner can deallocate normally. There is no path where a strong capture causes a permanent leak.

## Fix

Capture `self` strongly for the task's lifetime so the cleanup is guaranteed. Same principle as the media-services cleanup fix. All other behavior is identical (the task body is unchanged apart from the capture).

### Tradeoff considered

The alternative — restructure so cleanup runs through a non-retaining channel (e.g. the owner's `deinit` reaps stale entries) — is heavier and unnecessary: the table already retains the task, so the cycle is bounded by the task's own completion. The minimal correct fix is the strong capture. Documented inline in both files for the reviewer.

## Tests

- `ConversationTurnTaskRegistryTests`: asserts the handle is cleared on completion, and that the registry deallocates after the completed task releases its transient strong capture — under early owner drop (proving no permanent cycle).
- `BackgroundTaskSchedulerTests.test_default_schedulerDeallocates_afterWorkCompletes_underEarlyOwnerDrop`: same shape for the scheduler.

Both use a small actor gate to park the task body without capturing the non-`Sendable` `XCTestCase`.

## Status

Held as **draft** for human morning review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
