### PR TITLE
fix: guarantee state-restore cleanup in media generation services when consumer drops early

### DIFF
--- a/Sources/ManifoldInference/Services/AudioGenerationService.swift
+++ b/Sources/ManifoldInference/Services/AudioGenerationService.swift
@@ -93,27 +93,38 @@ public final class AudioGenerationService {
             // call from the same actor observes the transition deterministically.
             state = .generating
 
-            let task = Task.detached(priority: .userInitiated) { [weak self] in
+            // Strong-capture `self` for the lifetime of this detached task.
+            // The state-restore (`restoreIdleState`) is must-complete cleanup:
+            // if it were gated on a weak `self?` and the service deallocated
+            // (or the consumer dropped the stream) before the task ran, the
+            // restore would silently drop and the service would stay stuck in
+            // `.generating`. A weak capture is the documented anti-pattern for
+            // must-complete `Task.detached` work ("No [weak self] in
+            // must-complete Task.detached — strong capture or work drops").
+            // The temporary retain cycle (task → service) breaks the moment
+            // the task completes, which it always does: the stream finishes,
+            // throws, or is cancelled via `onTermination`.
+            let task = Task.detached(priority: .userInitiated) {
                 do {
                     for try await event in upstream {
                         if Task.isCancelled {
-                            await self?.restoreIdleState()
+                            await self.restoreIdleState()
                             continuation.finish()
                             return
                         }
                         continuation.yield(event)
                     }
-                    await self?.restoreIdleState()
+                    await self.restoreIdleState()
                     continuation.finish()
                 } catch is CancellationError {
-                    await self?.restoreIdleState()
+                    await self.restoreIdleState()
                     continuation.finish()
                 } catch {
                     if Task.isCancelled {
-                        await self?.restoreIdleState()
+                        await self.restoreIdleState()
                         continuation.finish()
                     } else {
-                        await self?.restoreIdleState()
+                        await self.restoreIdleState()
                         continuation.finish(throwing: error)
                     }
                 }

--- a/Sources/ManifoldInference/Services/ImageGenerationService.swift
+++ b/Sources/ManifoldInference/Services/ImageGenerationService.swift
@@ -228,27 +228,38 @@ public final class ImageGenerationService {
             // into the producer — without the check, a backend that yields
             // events on a timer keeps feeding the wrapper even after the
             // downstream consumer dropped its iterator.
-            let task = Task.detached(priority: .userInitiated) { [weak self] in
+            // Strong-capture `self` for the lifetime of this detached task.
+            // The state-restore (`restoreLoadedState`) is must-complete cleanup:
+            // if it were gated on a weak `self?` and the service deallocated
+            // (or the consumer dropped the stream) before the task ran, the
+            // restore would silently drop and the service would stay stuck in
+            // `.generating`. A weak capture is the documented anti-pattern for
+            // must-complete `Task.detached` work ("No [weak self] in
+            // must-complete Task.detached — strong capture or work drops").
+            // The temporary retain cycle (task → service) breaks the moment
+            // the task completes, which it always does: the stream finishes,
+            // throws, or is cancelled via `onTermination`.
+            let task = Task.detached(priority: .userInitiated) {
                 do {
                     for try await event in upstream {
                         if Task.isCancelled {
-                            await self?.restoreLoadedState(for: info)
+                            await self.restoreLoadedState(for: info)
                             continuation.finish()
                             return
                         }
                         continuation.yield(event)
                     }
-                    await self?.restoreLoadedState(for: info)
+                    await self.restoreLoadedState(for: info)
                     continuation.finish()
                 } catch is CancellationError {
-                    await self?.restoreLoadedState(for: info)
+                    await self.restoreLoadedState(for: info)
                     continuation.finish()
                 } catch {
                     if Task.isCancelled {
-                        await self?.restoreLoadedState(for: info)
+                        await self.restoreLoadedState(for: info)
                         continuation.finish()
                     } else {
-                        await self?.restoreLoadedState(for: info)
+                        await self.restoreLoadedState(for: info)
                         continuation.finish(throwing: error)
                     }
                 }

--- a/Sources/ManifoldInference/Services/VideoGenerationService.swift
+++ b/Sources/ManifoldInference/Services/VideoGenerationService.swift
@@ -91,27 +91,38 @@ public final class VideoGenerationService {
             let upstream = try await backend.generate(prompt: prompt, config: config)
 
             return AsyncThrowingStream { continuation in
-                let task = Task.detached(priority: .userInitiated) { [weak self] in
+                // Strong-capture `self` for the lifetime of this detached task.
+                // The state-restore (`restoreIdleState`) is must-complete cleanup:
+                // if it were gated on a weak `self?` and the service deallocated
+                // (or the consumer dropped the stream) before the task ran, the
+                // restore would silently drop and the service would stay stuck in
+                // `.generating`. A weak capture is the documented anti-pattern for
+                // must-complete `Task.detached` work ("No [weak self] in
+                // must-complete Task.detached — strong capture or work drops").
+                // The temporary retain cycle (task → service) breaks the moment
+                // the task completes, which it always does: the stream finishes,
+                // throws, or is cancelled via `onTermination`.
+                let task = Task.detached(priority: .userInitiated) {
                     do {
                         for try await event in upstream {
                             if Task.isCancelled {
-                                await self?.restoreIdleState()
+                                await self.restoreIdleState()
                                 continuation.finish()
                                 return
                             }
                             continuation.yield(event)
                         }
-                        await self?.restoreIdleState()
+                        await self.restoreIdleState()
                         continuation.finish()
                     } catch is CancellationError {
-                        await self?.restoreIdleState()
+                        await self.restoreIdleState()
                         continuation.finish()
                     } catch {
                         if Task.isCancelled {
-                            await self?.restoreIdleState()
+                            await self.restoreIdleState()
                             continuation.finish()
                         } else {
-                            await self?.restoreIdleState()
+                            await self.restoreIdleState()
                             continuation.finish(throwing: error)
                         }
                     }

--- a/Tests/ManifoldInferenceTests/AudioGenerationServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/AudioGenerationServiceTests.swift
@@ -1,0 +1,178 @@
+import XCTest
+import Foundation
+@testable import ManifoldInference
+
+/// Coverage for ``AudioGenerationService`` — the TTS orchestration layer.
+/// Drives a mock ``AudioGenerationBackend`` through the service and asserts
+/// state transitions, in particular that must-complete state-restore cleanup
+/// still runs when the consumer drops the stream early.
+@MainActor
+final class AudioGenerationServiceTests: XCTestCase {
+
+    // MARK: - Mock backend
+
+    /// Backend whose stream yields events on a real per-event delay so a
+    /// consumer can drop the iterator mid-stream (with events still queued),
+    /// forcing the `onTermination(.cancelled)` cleanup path.
+    private final class SlowMockBackend: AudioGenerationBackend, @unchecked Sendable {
+        let events: [AudioGenerationEvent]
+        let delayPerEventNs: UInt64
+
+        // Synchronously-read flags are only touched on the main actor by the
+        // service (`stopGeneration`) and read in tests after an await, so a
+        // plain stored property is sufficient.
+        var isGenerating: Bool = false
+
+        init(events: [AudioGenerationEvent], delayPerEventNs: UInt64) {
+            self.events = events
+            self.delayPerEventNs = delayPerEventNs
+        }
+
+        func generate(
+            config: SpeechGenerationConfig
+        ) throws -> AsyncThrowingStream<AudioGenerationEvent, Error> {
+            isGenerating = true
+            let events = self.events
+            let delay = self.delayPerEventNs
+            return AsyncThrowingStream { continuation in
+                let task = Task<Void, Never> {
+                    for event in events {
+                        if Task.isCancelled { break }
+                        do {
+                            try await Task.sleep(nanoseconds: delay)
+                        } catch {
+                            break
+                        }
+                        if Task.isCancelled { break }
+                        continuation.yield(event)
+                    }
+                    continuation.finish()
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+
+        func stopGeneration() { isGenerating = false }
+    }
+
+    // MARK: - Tests
+
+    func test_initialState_isIdle() {
+        let service = AudioGenerationService(backend: SlowMockBackend(events: [], delayPerEventNs: 0))
+        XCTAssertEqual(service.state, .idle)
+    }
+
+    func test_generate_happyPath_restoresIdleState() async throws {
+        let mock = SlowMockBackend(
+            events: [.progress(step: 1, total: 2), .completed(URL(fileURLWithPath: "/tmp/a.caf"))],
+            delayPerEventNs: 1_000_000
+        )
+        let service = AudioGenerationService(backend: mock)
+        let stream = service.generate(config: SpeechGenerationConfig(text: "hi"))
+        XCTAssertEqual(service.state, .generating)
+
+        for try await _ in stream {}
+
+        try await pollUntilState(service, equals: .idle, timeoutNs: 2_000_000_000)
+        XCTAssertEqual(service.state, .idle)
+    }
+
+    /// Regression: when the consumer drops the stream after the first event
+    /// (with more events still queued), the service's must-complete
+    /// state-restore must still run and return the service to `.idle`. Before
+    /// the `[weak self]` → strong-`self` fix the restore could be dropped,
+    /// leaving the service stuck in `.generating`.
+    ///
+    /// While the consumer holds the service alive this test passes either way
+    /// — see `test_generate_consumerDropsEarly_taskRetainsServiceUntilCleanup`
+    /// for the sabotage-provable variant that exercises the dealloc race.
+    func test_generate_consumerDropsEarly_restoresIdleState() async throws {
+        let mock = SlowMockBackend(
+            events: [
+                .progress(step: 1, total: 5),
+                .progress(step: 2, total: 5),
+                .progress(step: 3, total: 5),
+                .progress(step: 4, total: 5),
+                .completed(URL(fileURLWithPath: "/tmp/a.caf")),
+            ],
+            delayPerEventNs: 20_000_000  // 20ms
+        )
+        let service = AudioGenerationService(backend: mock)
+        let stream = service.generate(config: SpeechGenerationConfig(text: "hello"))
+        XCTAssertEqual(service.state, .generating)
+
+        // Consume one event then drop the iterator. onTermination(.cancelled)
+        // cancels the forwarding task, whose strong-self cleanup must run.
+        for try await _ in stream {
+            break
+        }
+
+        try await pollUntilState(service, equals: .idle, timeoutNs: 2_000_000_000)
+        XCTAssertEqual(service.state, .idle, "service must return to .idle after the consumer drops the stream early")
+    }
+
+    /// Sabotage-provable regression for the dealloc race. The bug: the
+    /// forwarding `Task.detached` captured `[weak self]`, so when the only
+    /// strong reference to the service is dropped mid-stream the task does NOT
+    /// keep it alive — the service deallocates and `await self?.restoreIdleState()`
+    /// no-ops, dropping the cleanup. The fix strong-captures `self`, so the task
+    /// retains the service until it finishes; the service must therefore still
+    /// be alive while a generation is in flight even after every external strong
+    /// reference is released.
+    ///
+    /// With the `[weak self]` regression `weakService` is nil immediately after
+    /// the local strong ref is dropped (the service is unreachable). With the
+    /// fix it stays non-nil until the in-flight task completes.
+    func test_generate_consumerDropsEarly_taskRetainsServiceUntilCleanup() async throws {
+        // Long per-event delay so the forwarding task is reliably still
+        // in-flight when we drop our strong reference below.
+        let mock = SlowMockBackend(
+            events: [
+                .progress(step: 1, total: 3),
+                .progress(step: 2, total: 3),
+                .completed(URL(fileURLWithPath: "/tmp/a.caf")),
+            ],
+            delayPerEventNs: 500_000_000  // 500ms
+        )
+
+        weak var weakService: AudioGenerationService?
+        // Hold the stream so iteration is in flight; we deliberately do not
+        // iterate it, leaving the forwarding task mid-`Task.sleep`.
+        var stream: AsyncThrowingStream<AudioGenerationEvent, Error>?
+
+        do {
+            let service = AudioGenerationService(backend: mock)
+            weakService = service
+            stream = service.generate(config: SpeechGenerationConfig(text: "hi"))
+            XCTAssertEqual(service.state, .generating)
+            // `service` goes out of scope at the end of this `do` block — the
+            // only remaining potential owner of the service is the forwarding
+            // task (iff it strong-captured self).
+        }
+
+        // The forwarding task is still mid-flight (first event is 500ms out).
+        // With the fix the task retains the service, so it is still alive.
+        XCTAssertNotNil(
+            weakService,
+            "forwarding task must retain the service while a generation is in flight (regressed under [weak self])"
+        )
+
+        // Keep `stream` alive across the assertion above, then release it so the
+        // task can finish and the service can deallocate.
+        withExtendedLifetime(stream) {}
+        stream = nil
+    }
+
+    /// Polls `service.state` until it equals `expected` or the timeout elapses.
+    private func pollUntilState(
+        _ service: AudioGenerationService,
+        equals expected: AudioGenerationService.State,
+        timeoutNs: UInt64
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNs
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if service.state == expected { return }
+            try await Task.sleep(nanoseconds: 5_000_000)  // 5ms
+        }
+    }
+}

--- a/Tests/ManifoldInferenceTests/ImageGenerationServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/ImageGenerationServiceTests.swift
@@ -268,4 +268,143 @@ final class ImageGenerationServiceTests: XCTestCase {
             XCTFail("expected ImageGenerationServiceError.notLoaded, got \(error)")
         }
     }
+
+    // MARK: - 8. Consumer drops the stream early → state restores to .loaded
+
+    /// Backend whose stream yields events on a real per-event delay so a
+    /// consumer can drop the iterator mid-stream (with events still queued),
+    /// forcing the `onTermination(.cancelled)` cleanup path. The default
+    /// `MockBackend` finishes synchronously, leaving no early-drop window.
+    private final class SlowMockBackend: ImageGenerationBackend, @unchecked Sendable {
+        var isLoaded: Bool = false
+        var isGenerating: Bool = false
+        let events: [ImageGenerationEvent]
+        let delayPerEventNs: UInt64
+
+        init(events: [ImageGenerationEvent], delayPerEventNs: UInt64) {
+            self.events = events
+            self.delayPerEventNs = delayPerEventNs
+        }
+
+        func loadModel(from url: URL) async throws { isLoaded = true }
+
+        func generate(
+            prompt: String,
+            config: ImageGenerationConfig
+        ) throws -> AsyncThrowingStream<ImageGenerationEvent, Error> {
+            isGenerating = true
+            let events = self.events
+            let delay = self.delayPerEventNs
+            return AsyncThrowingStream { continuation in
+                let task = Task<Void, Never> {
+                    for event in events {
+                        if Task.isCancelled { break }
+                        do {
+                            try await Task.sleep(nanoseconds: delay)
+                        } catch {
+                            break
+                        }
+                        if Task.isCancelled { break }
+                        continuation.yield(event)
+                    }
+                    continuation.finish()
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+        }
+
+        func stopGeneration() { isGenerating = false }
+        func unloadModel() { isLoaded = false }
+    }
+
+    /// Regression: when the consumer drops the stream after the first event
+    /// (with more events still queued), the service's must-complete
+    /// state-restore must still run and return the service to `.loaded`. Before
+    /// the `[weak self]` → strong-`self` fix the restore could be dropped,
+    /// leaving the service stuck in `.generating`.
+    func test_generate_consumerDropsEarly_restoresLoadedState() async throws {
+        let outURL = URL(fileURLWithPath: "/tmp/out.png")
+        let mock = SlowMockBackend(
+            events: [
+                .progress(step: 1, total: 5),
+                .progress(step: 2, total: 5),
+                .progress(step: 3, total: 5),
+                .progress(step: 4, total: 5),
+                .completed(outURL),
+            ],
+            delayPerEventNs: 20_000_000  // 20ms
+        )
+        let info = makeInfo()
+        let service = ImageGenerationService()
+        service.registerBackendFactory(for: .mlxDiffusion) { _ in mock }
+        try await service.loadModel(info)
+
+        let stream = service.generate(prompt: "x", config: ImageGenerationConfig())
+
+        // Consume one event then drop the iterator. onTermination(.cancelled)
+        // cancels the forwarding task, whose strong-self cleanup must run.
+        for try await _ in stream {
+            break
+        }
+
+        // Cleanup hops back to the main actor asynchronously; poll-settle.
+        try await pollUntilState(service, equals: .loaded(info), timeoutNs: 2_000_000_000)
+        XCTAssertEqual(service.state, .loaded(info), "service must return to .loaded after the consumer drops the stream early")
+        XCTAssertEqual(service.loadedModel, info)
+    }
+
+    /// Sabotage-provable regression for the dealloc race. The bug: the
+    /// forwarding `Task.detached` captured `[weak self]`, so when the only
+    /// strong reference to the service is dropped mid-stream the task does NOT
+    /// keep it alive — the service deallocates and `await self?.restoreLoadedState(...)`
+    /// no-ops, dropping the cleanup. The fix strong-captures `self`, so the task
+    /// retains the service until it finishes; the service must therefore still
+    /// be alive while a generation is in flight even after every external strong
+    /// reference is released.
+    func test_generate_consumerDropsEarly_taskRetainsServiceUntilCleanup() async throws {
+        let mock = SlowMockBackend(
+            events: [
+                .progress(step: 1, total: 3),
+                .progress(step: 2, total: 3),
+                .completed(URL(fileURLWithPath: "/tmp/out.png")),
+            ],
+            delayPerEventNs: 500_000_000  // 500ms — task reliably in-flight at the assert
+        )
+        let info = makeInfo()
+
+        weak var weakService: ImageGenerationService?
+        var stream: AsyncThrowingStream<ImageGenerationEvent, Error>?
+
+        do {
+            let service = ImageGenerationService()
+            service.registerBackendFactory(for: .mlxDiffusion) { _ in mock }
+            try await service.loadModel(info)
+            weakService = service
+            stream = service.generate(prompt: "x", config: ImageGenerationConfig())
+            XCTAssertEqual(service.state, .generating(info))
+            // `service` leaves scope here — the forwarding task is the only
+            // remaining potential owner (iff it strong-captured self).
+        }
+
+        XCTAssertNotNil(
+            weakService,
+            "forwarding task must retain the service while a generation is in flight (regressed under [weak self])"
+        )
+
+        withExtendedLifetime(stream) {}
+        stream = nil
+    }
+
+    /// Polls `service.state` until it equals `expected` or the timeout elapses.
+    private func pollUntilState(
+        _ service: ImageGenerationService,
+        equals expected: ImageGenerationService.State,
+        timeoutNs: UInt64
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNs
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if service.state == expected { return }
+            try await Task.sleep(nanoseconds: 5_000_000)  // 5ms
+        }
+    }
 }

--- a/Tests/ManifoldInferenceTests/VideoGenerationServiceTests.swift
+++ b/Tests/ManifoldInferenceTests/VideoGenerationServiceTests.swift
@@ -176,6 +176,101 @@ final class VideoGenerationServiceTests: XCTestCase {
         XCTAssertEqual(url, videoURL)
     }
 
+    /// Regression: when the consumer drops the stream after the first event
+    /// (while more events are still queued), the service's must-complete
+    /// state-restore must still run and return the service to `.idle`. Before
+    /// the `[weak self]` → strong-`self` fix the restore could be dropped,
+    /// leaving the service stuck in `.generating`.
+    func test_generate_consumerDropsEarly_restoresIdleState() async throws {
+        let backend = MockVideoBackend()
+        // Many events with a real per-event delay so we can break after the
+        // first while the producer still has work queued — that forces the
+        // onTermination(.cancelled) path rather than a natural finish.
+        backend.setPlan(.init(
+            events: [
+                .queued,
+                .generating(fractionComplete: 0.2),
+                .generating(fractionComplete: 0.4),
+                .generating(fractionComplete: 0.6),
+                .generating(fractionComplete: 0.8),
+                .completed(URL(fileURLWithPath: "/tmp/vid.mp4"))
+            ],
+            delayPerEventNs: 20_000_000  // 20ms
+        ))
+
+        let service = VideoGenerationService(backend: backend)
+        let stream = try await service.generate(prompt: "x", config: Self.config)
+        XCTAssertEqual(service.state, .generating)
+
+        // Consume exactly one event, then drop the iterator (break). The
+        // stream's onTermination fires .cancelled, the forwarding task is
+        // cancelled, and its strong-self cleanup must run.
+        for try await _ in stream {
+            break
+        }
+
+        // The cleanup hops back to the main actor asynchronously, so poll-settle
+        // rather than asserting synchronously. Bounded wait keeps the test from
+        // hanging if the fix regresses.
+        try await pollUntilState(service, equals: .idle, timeoutNs: 2_000_000_000)
+        XCTAssertEqual(service.state, .idle, "service must return to .idle after the consumer drops the stream early")
+    }
+
+    /// Sabotage-provable regression for the dealloc race. The bug: the
+    /// forwarding `Task.detached` captured `[weak self]`, so when the only
+    /// strong reference to the service is dropped mid-stream the task does NOT
+    /// keep it alive — the service deallocates and `await self?.restoreIdleState()`
+    /// no-ops, dropping the cleanup. The fix strong-captures `self`, so the task
+    /// retains the service until it finishes; the service must therefore still
+    /// be alive while a generation is in flight even after every external strong
+    /// reference is released.
+    func test_generate_consumerDropsEarly_taskRetainsServiceUntilCleanup() async throws {
+        let backend = MockVideoBackend()
+        backend.setPlan(.init(
+            events: [
+                .queued,
+                .generating(fractionComplete: 0.5),
+                .completed(URL(fileURLWithPath: "/tmp/vid.mp4"))
+            ],
+            delayPerEventNs: 500_000_000  // 500ms — task reliably in-flight at the assert
+        ))
+
+        weak var weakService: VideoGenerationService?
+        var stream: AsyncThrowingStream<VideoGenerationEvent, Error>?
+
+        // `generate` is `async throws`, so the submission handshake must run
+        // while the service is alive; the service is dropped right after.
+        do {
+            let service = VideoGenerationService(backend: backend)
+            weakService = service
+            stream = try await service.generate(prompt: "x", config: Self.config)
+            XCTAssertEqual(service.state, .generating)
+        }
+
+        XCTAssertNotNil(
+            weakService,
+            "forwarding task must retain the service while a generation is in flight (regressed under [weak self])"
+        )
+
+        withExtendedLifetime(stream) {}
+        stream = nil
+    }
+
+    /// Polls `service.state` until it equals `expected` or the timeout elapses.
+    /// Used for transitions that complete on an async actor hop after a stream
+    /// drop, where a synchronous assert would race the cleanup.
+    private func pollUntilState(
+        _ service: VideoGenerationService,
+        equals expected: VideoGenerationService.State,
+        timeoutNs: UInt64
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNs
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if service.state == expected { return }
+            try await Task.sleep(nanoseconds: 5_000_000)  // 5ms
+        }
+    }
+
     func test_generate_trailingStreamError_propagates() async throws {
         struct NetworkError: Error {}
         let backend = MockVideoBackend()


### PR DESCRIPTION
## HOLD — draft for morning human review

## Problem

`ImageGenerationService`, `AudioGenerationService`, and `VideoGenerationService` each wrap the backend's event stream in an `AsyncThrowingStream`. The forwarding `Task.detached` captured `[weak self]` and ran the must-complete state-restore cleanup as `await self?.restoreLoadedState(...)` / `await self?.restoreIdleState(...)`.

If `self` is nil when the task reaches the cleanup, the restore **silently drops** and the service stays stuck in `.generating`, never returning to `.loaded`/`.idle`. Per the repo convention *"No [weak self] in must-complete Task.detached — strong capture or work drops,"* must-complete cleanup must not be gated on a weak self.

## Ownership analysis (for the reviewer)

I verified the retain graph before choosing a fix:

- The service (`@MainActor @Observable final class`) does **not** strongly retain the forwarding `Task`. The `task` is a local `let` captured only by `continuation.onTermination`, which is owned by the consumer's `AsyncThrowingStream`.
- The detached task body captured `[weak self]`, so it did **not** keep the service alive.
- Consequence: once the consumer drops its strong reference to the service (e.g. fire-and-forget a generation, then release the service while the stream is still in flight), `self` can be nil by the time the task runs its cleanup arm → the `.generating → .loaded/.idle` transition is dropped and the service is stuck.

Note: while the *consumer keeps the service alive*, weak-self happens to work — so a naive "drop the iterator and check `service.state`" test passes either way. The bug is specifically the dealloc race, which is what the new tests target (see Tests below).

## Fix chosen: Option A (strong capture)

The forwarding `Task.detached` now strong-captures `self` instead of `[weak self]`. This is the documented retain/detach/release pattern: the temporary retain cycle (task → service) breaks the moment the task completes, and the task **always** completes — the upstream stream finishes, throws, or is cancelled via `onTermination` (which calls `task.cancel()`; the per-iteration `Task.isCancelled` check and the `catch is CancellationError` arm then run the restore and finish the continuation). All three terminal arms (normal finish, cancellation, error) already call the restore, so cleanup runs exactly once.

**Why not Option B (`onTermination` capturing state):** `restoreLoadedState`/`restoreIdleState` are guarded transitions (`if case .generating(active) = state, active == info`) that read live `@MainActor` state to decide whether the transition is still valid against a concurrent `unload()`/`loadModel(other)`. Re-implementing that guard inside `onTermination` (which fires on `.cancelled` *and* `.finished`) would duplicate the guard and risk a double-restore. Keeping the single restore path inside the task and only fixing the capture strength is the minimal correct change — all other behavior is byte-identical.

The `onTermination` closures keep their `[weak self]` for the best-effort `backend.stopGeneration()` / `backend.cancel()` nudge — that is genuinely best-effort (if the service is gone, the backend stop is moot) and should not pin the service alive.

## Files

- `Sources/ManifoldInference/Services/ImageGenerationService.swift`
- `Sources/ManifoldInference/Services/AudioGenerationService.swift`
- `Sources/ManifoldInference/Services/VideoGenerationService.swift`

## Tests

Each service suite gains `test_generate_consumerDropsEarly_taskRetainsServiceUntilCleanup` (and `AudioGenerationServiceTests` is new). The test starts a generation against a slow per-event mock backend, releases **every external strong reference** to the service while the forwarding task is mid-flight, and asserts a `weak var` to the service is still non-nil — i.e. the task is keeping it alive long enough to run cleanup.

**Sabotage-verified:** I reverted each service to the `[weak self]` form and confirmed all three retention tests fail (the service deallocates immediately, weak ref nils out); restored the fix and all pass. Also added consumer-drops-early `state == .idle/.loaded` settle tests and an audio happy-path test.

Local run: 21 tests across the three suites, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)