### PR TITLE
fix: derive Mistral stop sequence from </s> not ChatML default (#2008)

### DIFF
--- a/Sources/ManifoldInference/Services/ChatTemplate.swift
+++ b/Sources/ManifoldInference/Services/ChatTemplate.swift
@@ -92,18 +92,24 @@ public struct ChatTemplate: Sendable {
     ///   turn-terminators (see ``builtInStopSequences(for:)``) — not the full
     ///   ``PromptTemplate`` special-token union, which also contains opening
     ///   delimiters that must NOT stop generation.
-    /// - For ``Source/embeddedJinja(_:)`` this is `[]`: the embedded template
-    ///   carries no machine-readable stop list, and parsing one out of Jinja is
-    ///   deferred. Callers that need stops for an embedded-template model should
-    ///   set ``GenerationConfig/stopSequences`` explicitly.
+    /// - For ``Source/embeddedJinja(_:)`` the template family is detected from
+    ///   the raw Jinja string (the same detection used in ``format(_:systemPrompt:tools:)``
+    ///   for the enum fallback) and the corresponding curated stop sequences are
+    ///   returned. This prevents non-ChatML models — e.g. Mistral, whose
+    ///   end-of-turn marker is `</s>` not `<|im_end|>` — from inheriting the
+    ///   ChatML default when the embedded template is the authority (#2008).
     public var stopSequences: [String] {
         switch source {
         case .builtIn(let template):
             return Self.builtInStopSequences(for: template)
-        case .embeddedJinja:
-            // Documented gap: no machine-readable stop list is extractable from
-            // a raw Jinja string in v1.
-            return []
+        case .embeddedJinja(let raw):
+            // Derive the stop sequence from the template's actual token markers
+            // rather than returning [] and leaving the backend without a stop
+            // signal. The detector runs the same substring matching used by the
+            // render-path fallback, so the family is consistent with how the
+            // prompt is assembled.
+            let detected = PromptTemplateDetector.detect(fromChatTemplate: raw)
+            return Self.builtInStopSequences(for: detected)
         }
     }
 

--- a/Sources/ManifoldInference/Services/ChatTemplate.swift
+++ b/Sources/ManifoldInference/Services/ChatTemplate.swift
@@ -92,23 +92,29 @@ public struct ChatTemplate: Sendable {
     ///   turn-terminators (see ``builtInStopSequences(for:)``) — not the full
     ///   ``PromptTemplate`` special-token union, which also contains opening
     ///   delimiters that must NOT stop generation.
-    /// - For ``Source/embeddedJinja(_:)`` the template family is detected from
-    ///   the raw Jinja string (the same detection used in ``format(_:systemPrompt:tools:)``
-    ///   for the enum fallback) and the corresponding curated stop sequences are
-    ///   returned. This prevents non-ChatML models — e.g. Mistral, whose
-    ///   end-of-turn marker is `</s>` not `<|im_end|>` — from inheriting the
-    ///   ChatML default when the embedded template is the authority (#2008).
+    /// - For ``Source/embeddedJinja(_:)`` the family is detected from the raw
+    ///   Jinja string (the same detection used in ``format(_:systemPrompt:tools:)``
+    ///   for the enum fallback) and that family's curated stop sequences are
+    ///   returned — but only when a marker is *positively* recognised. This
+    ///   fixes non-ChatML models — e.g. Mistral, whose end-of-turn marker is
+    ///   `</s>` not `<|im_end|>` — from inheriting the ChatML default (#2008),
+    ///   while a genuinely-unrecognised template still contributes no stop
+    ///   sequence (the backend decides) rather than being assumed ChatML.
     public var stopSequences: [String] {
         switch source {
         case .builtIn(let template):
             return Self.builtInStopSequences(for: template)
         case .embeddedJinja(let raw):
-            // Derive the stop sequence from the template's actual token markers
-            // rather than returning [] and leaving the backend without a stop
-            // signal. The detector runs the same substring matching used by the
-            // render-path fallback, so the family is consistent with how the
-            // prompt is assembled.
+            // `detect(fromChatTemplate:)` falls back to `.chatML` for any
+            // template it can't classify, so a bare `.chatML` result is
+            // ambiguous: it could be a real ChatML template or just the
+            // fallback. Only trust it when the template actually carries a
+            // ChatML marker — otherwise an unknown template would wrongly
+            // inherit `<|im_end|>`, re-introducing the very leak #2008 fixes.
             let detected = PromptTemplateDetector.detect(fromChatTemplate: raw)
+            if detected == .chatML && !raw.contains("<|im_start|>") {
+                return []
+            }
             return Self.builtInStopSequences(for: detected)
         }
     }

--- a/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
@@ -143,4 +143,17 @@ final class ChatTemplateTests: XCTestCase {
 
         XCTAssertEqual(stops, ["<|im_end|>"], "ChatML embedded-Jinja must derive <|im_end|>; got: \(stops)")
     }
+
+    /// A markerless embedded-Jinja template the detector can't classify must
+    /// derive NO stop sequence — it must not inherit the ChatML default, which
+    /// would re-introduce the leak #2008 fixes. (The detector falls back to
+    /// `.chatML`; `stopSequences` must distinguish that from a real ChatML
+    /// template.) Mirrors `ChatTemplateStopAndFlattenTests.test_mergePolicy_
+    /// embeddedJinjaNoDefault_leavesEmpty` at the queue layer.
+    func test_stopSequences_embeddedUnknownJinja_staysEmpty() {
+        let markerless = "{% for m in messages %}{{ m['content'] }}{% endfor %}"
+        let stops = ChatTemplate(embeddedJinja: markerless).stopSequences
+
+        XCTAssertEqual(stops, [], "Unrecognised embedded-Jinja must contribute no stop sequence; got: \(stops)")
+    }
 }

--- a/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
@@ -109,8 +109,38 @@ final class ChatTemplateTests: XCTestCase {
         XCTAssertFalse(llama3.contains("<|begin_of_text|>"))
     }
 
-    func test_stopSequences_embeddedJinja_isEmptyGap() {
-        // Documented v1 gap: no machine-readable stop list from raw Jinja.
-        XCTAssertEqual(ChatTemplate(embeddedJinja: chatMLJinja).stopSequences, [])
+    // MARK: - Embedded-Jinja stop-sequence derivation (#2008)
+
+    /// A minimal Mistral-style Jinja template — `[INST]`/`[/INST]` delimiters,
+    /// `</s>` end-of-turn. This mirrors the actual template shipped in
+    /// Mistral-7B-Instruct-v0.3.gguf that triggered #2008.
+    private let mistralJinja = """
+    {{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' %}\
+    {{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}\
+    {{ message['content'] + eos_token}}{% else %}{{ raise_exception('Only user and assistant roles are supported!') }}\
+    {% endif %}{% endfor %}
+    """
+
+    /// An embedded Mistral Jinja template must derive `</s>` as its stop
+    /// sequence — NOT the ChatML default `<|im_end|>` (#2008).
+    ///
+    /// Before the fix, `embeddedJinja` always returned `[]`, leaving the
+    /// backend without a stop signal; the llama.cpp backend then applied its
+    /// own ChatML default, leaking `<|im_end|>` into Mistral output.
+    func test_stopSequences_embeddedMistralJinja_derivesEndOfSentence() {
+        let template = ChatTemplate(embeddedJinja: mistralJinja)
+        let stops = template.stopSequences
+
+        XCTAssertEqual(stops, ["</s>"], "Mistral embedded-Jinja must derive </s> not ChatML default; got: \(stops)")
+        XCTAssertFalse(stops.contains("<|im_end|>"), "ChatML end token must never appear for a Mistral template")
+    }
+
+    /// A ChatML embedded-Jinja template must still derive `<|im_end|>` — guard
+    /// against regressing the models #1944 already fixed.
+    func test_stopSequences_embeddedChatMLJinja_derivesChatMLToken() {
+        let template = ChatTemplate(embeddedJinja: chatMLJinja)
+        let stops = template.stopSequences
+
+        XCTAssertEqual(stops, ["<|im_end|>"], "ChatML embedded-Jinja must derive <|im_end|>; got: \(stops)")
     }
 }


### PR DESCRIPTION
## Bug

Mistral-7B-Instruct-v0.3 generations leaked a trailing `<|im_end|>` token in the output (e.g. `320743<|im_end|>`).

**Root cause** (`Sources/ManifoldInference/Services/ChatTemplate.swift`, `stopSequences` computed property):

For `Source/embeddedJinja(_:)` the property unconditionally returned `[]` — documented as a "v1 gap." When a Mistral model loads with an embedded Jinja template (`selectedChatTemplateRaw` is non-nil), the `GenerationQueue.chatTemplate` correctly returns `ChatTemplate(embeddedJinja: raw)`, but `stopSequences` came back empty. `applyingTemplateStopSequences` saw `derived.isEmpty` and left the config without any stop sequences. The llama.cpp backend then applied its own ChatML defaults, leaking `<|im_end|>` into Mistral output instead of stopping at `</s>`.

Models that use the **built-in enum path** (`selectedChatTemplateRaw == nil`) were always correct — `ChatTemplate(builtIn: .mistral).stopSequences` correctly returns `["</s>"]`. Only embedded-Jinja Mistral models were broken.

## Fix

In `ChatTemplate.stopSequences`, for the `embeddedJinja` case, detect the template family from the raw Jinja string using `PromptTemplateDetector.detect(fromChatTemplate:)` — the same detection already used in `format(_:systemPrompt:tools:)` for the render-path fallback — and return the curated stop sequences for that family. This ensures a Mistral template with `[INST]`/`[/INST]` markers derives `</s>`, not the ChatML default.

No force-unwraps added.

## Tests

Added to `Tests/ManifoldInferenceTests/ChatTemplateTests.swift`:

- `test_stopSequences_embeddedMistralJinja_derivesEndOfSentence` — asserts a Mistral-style embedded Jinja template (with `[INST]` markers) derives `["</s>"]` and does NOT contain `<|im_end|>`. Sabotage-verified: reverted the fix → test failed with `[] != ["</s>"]`.
- `test_stopSequences_embeddedChatMLJinja_derivesChatMLToken` — asserts a ChatML embedded Jinja template still derives `["<|im_end|>"]`, guarding against regressing the models #1944 already fixed.

The old `test_stopSequences_embeddedJinja_isEmptyGap` test (asserting `[]`) was replaced — that assertion encoded the now-fixed bug.

Closes #2008