### PR TITLE
feat: add tool-call render-consistency check (#2005 Layer 2)

### DIFF
--- a/Sources/ManifoldInference/Services/RenderConsistencyChecker.swift
+++ b/Sources/ManifoldInference/Services/RenderConsistencyChecker.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// The verdict of a static tool-call render round-trip — Layer 2 of the
+/// tool-call-conformance design (#2005).
+///
+/// Layer 1 (``ChatTemplateToolDescriptor``, #2009) produces an honest *claim*
+/// by parsing the chat template's text. Layer 2 closes the loop on that claim
+/// **without live inference**: it feeds a fixed canonical tool-call
+/// conversation through the very renderer the local backends use at generation
+/// time (``JinjaPromptRenderer``) and checks that the rendered prompt actually
+/// contains what the Layer-1 claim promised — the tool name (the `{% if tools %}`
+/// branch fired and the tool definition reached the model) and, when the claim
+/// declares a call delimiter, that delimiter (the assistant tool-call turn
+/// rendered through the template's `{% for tool_call in … %}` branch).
+///
+/// This catches the regression class behind #1909: a template whose tools
+/// guard parses as positive but whose render path silently drops the tool
+/// grammar (because the renderer was fed a text-only projection, or the
+/// template's branch never fires). A static descriptor cannot see that — only
+/// actually rendering can.
+///
+/// ## Limitation: presence, not a parse verdict
+///
+/// This is a **presence** check, not a family-specific parse-back. It asserts
+/// that the declared delimiter and the tool name appear in the rendered prompt;
+/// it does **not** re-parse the rendered call with a family decoder. Full
+/// round-trip parse-back (`ToolCallMarker.parseBody` and the per-family
+/// `ToolCallMarkers`) lives in the companion backend targets (manifold-llama /
+/// manifold-mlx), which own the actual extraction grammar — core deliberately
+/// asserts only delimiter/tool-name PRESENCE here. A `.consistent` verdict
+/// therefore means "the template renders the declared grammar", not "a model's
+/// emitted call will parse cleanly" (that is Layer 3, a live soak, deferred).
+public struct RenderConsistency: Sendable, Equatable {
+
+    /// The outcome of the round-trip.
+    public enum Status: Sendable, Equatable {
+        /// The render contains every grammar element the Layer-1 claim promised.
+        case consistent
+        /// The render is missing the tool name and/or the declared delimiter —
+        /// the template's tools grammar did not survive rendering (#1909 class).
+        case inconsistent
+        /// There is nothing to round-trip: the template carries no tools guard
+        /// (a trustworthy negative claim) or there is no template at all.
+        case notApplicable
+    }
+
+    /// The outcome.
+    public let status: Status
+
+    /// The Layer-1 claim this round-trip was checked against.
+    public let claim: ChatTemplateToolDescriptor
+
+    /// `true` iff the probe tool's name (`get_weather`) appeared in the render.
+    public let toolDefinitionRendered: Bool
+
+    /// `true`/`false` when the claim declares an open delimiter and we checked
+    /// for it; `nil` when the claim declares no opener (bare-JSON / python-tag
+    /// dialects such as Llama-3.1, which have nothing to assert presence of).
+    public let declaredDelimiterRendered: Bool?
+
+    /// Human-readable description of the discrepancy, naming exactly which check
+    /// failed. Empty string when `status` is `.consistent`.
+    public let detail: String
+}
+
+/// Runs the Layer-2 (#2005) static render round-trip for a chat template.
+///
+/// See ``RenderConsistency`` for what the verdict means and its presence-only
+/// limitation. There is no live inference here — this is a deterministic,
+/// offline check suitable for catalog-time validation and CI.
+public enum RenderConsistencyChecker {
+
+    /// The fixed probe tool every round-trip renders: a single string param so
+    /// the `{% if tools %}` branch has a concrete definition to emit.
+    private static let probeToolName = "get_weather"
+
+    /// Round-trips a chat template against a canonical tool-call conversation.
+    ///
+    /// - Parameter chatTemplateRaw: the model's embedded `tokenizer.chat_template`
+    ///   Jinja string (``ModelInfo/chatTemplateRaw``). `nil` or blank yields
+    ///   ``RenderConsistency/Status/notApplicable``.
+    /// - Returns: the round-trip verdict.
+    public static func check(chatTemplateRaw: String?) -> RenderConsistency {
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: chatTemplateRaw)
+
+        // A negative claim (no tools guard, or no template) is trustworthy — the
+        // descriptor already reports it honestly and there is nothing to render
+        // back. Don't manufacture a probe for a template that cannot express
+        // tools; report notApplicable.
+        guard let raw = chatTemplateRaw,
+              !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              claim.toolsExpressible else {
+            return RenderConsistency(
+                status: .notApplicable,
+                claim: claim,
+                toolDefinitionRendered: false,
+                declaredDelimiterRendered: nil,
+                detail: "template does not express tools (no guard or no template); nothing to round-trip"
+            )
+        }
+
+        let probeTool = ToolDefinition(
+            name: probeToolName,
+            description: "Returns current weather for a location.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "location": .object([
+                        "type": .string("string"),
+                        "description": .string("City name"),
+                    ]),
+                ]),
+                "required": .array([.string("location")]),
+            ])
+        )
+
+        // Canonical tool-call conversation: user question, assistant turn that
+        // CALLS the tool (this exercises the template's
+        // `{% for tool_call in message.tool_calls %}` delimiter branch), then a
+        // tool-result turn. The assistant call turn is what makes the declared
+        // delimiter appear via the template rather than as static text.
+        let probeCall = ToolCall(
+            id: "call_0",
+            toolName: probeToolName,
+            arguments: #"{"location":"Paris"}"#
+        )
+        let probe: [StructuredMessage] = [
+            StructuredMessage(role: "user", content: "What's the weather in Paris?"),
+            StructuredMessage(role: "assistant", parts: [.toolCall(probeCall)]),
+            StructuredMessage(
+                role: "tool",
+                parts: [.toolResult(ToolResult(callId: "call_0", content: "sunny"))]
+            ),
+        ]
+
+        guard let rendered = JinjaPromptRenderer.render(
+            rawTemplate: raw,
+            messages: probe,
+            systemPrompt: nil,
+            tools: [probeTool]
+        ) else {
+            return RenderConsistency(
+                status: .inconsistent,
+                claim: claim,
+                toolDefinitionRendered: false,
+                declaredDelimiterRendered: claim.declaredDialect?.openDelimiter == nil ? nil : false,
+                detail: "template claims tools but failed to render"
+            )
+        }
+
+        let toolDefinitionRendered = rendered.contains(probeToolName)
+
+        // The delimiter check only applies when the claim declares an opener.
+        // Bare-JSON / python-tag dialects (Llama-3.1) declare none — there is no
+        // literal to assert presence of, so leave it nil and don't gate on it.
+        let declaredDelimiter = claim.declaredDialect?.openDelimiter
+        let declaredDelimiterRendered: Bool? = declaredDelimiter.map { rendered.contains($0) }
+
+        var failures: [String] = []
+        if !toolDefinitionRendered {
+            failures.append("tool definition '\(probeToolName)' missing from render (tools branch did not fire / tools dropped)")
+        }
+        if let delimiter = declaredDelimiter, declaredDelimiterRendered == false {
+            failures.append("declared open delimiter '\(delimiter)' missing from render")
+        }
+
+        let consistent = toolDefinitionRendered
+            && (declaredDelimiterRendered == nil || declaredDelimiterRendered == true)
+
+        return RenderConsistency(
+            status: consistent ? .consistent : .inconsistent,
+            claim: claim,
+            toolDefinitionRendered: toolDefinitionRendered,
+            declaredDelimiterRendered: declaredDelimiterRendered,
+            detail: consistent ? "" : failures.joined(separator: "; ")
+        )
+    }
+}

--- a/Tests/ManifoldInferenceTests/RenderConsistencyCheckerTests.swift
+++ b/Tests/ManifoldInferenceTests/RenderConsistencyCheckerTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Layer-2 (#2005) render round-trip checks. These exercise the *real*
+/// ``JinjaPromptRenderer`` so the templates here must be evaluable by
+/// swift-jinja — unlike the Layer-1 ``ChatTemplateToolDescriptorTests``
+/// fixtures, which only need to satisfy the substring parser. Each consistent
+/// fixture both (a) emits the tool name from its `{% if tools %}` branch and
+/// (b) emits the declared call delimiter from its
+/// `{% for tc in message.tool_calls %}` branch, so the assertion proves the
+/// grammar survives rendering rather than appearing as static text.
+///
+/// The renderable shapes mirror the proven `nativeToolTemplate` in
+/// ``JinjaPromptRendererTests`` (per-message `{% if message.tool_calls %}`
+/// nested in the message loop) rather than the Layer-1 substring fixtures,
+/// which are not swift-jinja-evaluable.
+final class RenderConsistencyCheckerTests: XCTestCase {
+
+    // MARK: - Recognised families render consistently
+
+    func testQwenStyleRendersConsistently() {
+        // {% if tools %} guard + <tool_call>…</tool_call> JSON dialect.
+        let template = """
+        {%- if tools %}
+        <tools>
+        {%- for tool in tools %}{{ tool.name }}
+        {%- endfor %}
+        </tools>
+        {%- endif %}
+        {%- for message in messages %}
+        <|{{ message.role }}|>{{ message.content }}
+        {%- if message.tool_calls %}
+            {%- for tc in message.tool_calls %}<tool_call>
+        {"name": "{{ tc.function.name }}"}
+        </tool_call>
+            {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .consistent, result.detail)
+        XCTAssertTrue(result.toolDefinitionRendered)
+        XCTAssertEqual(result.declaredDelimiterRendered, true)
+        XCTAssertEqual(result.claim.declaredDialect?.openDelimiter, "<tool_call>")
+        XCTAssertEqual(result.detail, "")
+    }
+
+    func testGemmaStyleRendersConsistently() {
+        // {% if tools %} guard + <|tool_call> key/value dialect.
+        let template = """
+        {%- if tools %}
+        Tools:
+        {%- for tool in tools %}{{ tool.name }}
+        {%- endfor %}
+        {%- endif %}
+        {%- for message in messages %}
+        {{ message.role }}: {{ message.content }}
+        {%- if message.tool_calls %}
+            {%- for tc in message.tool_calls %}<|tool_call>
+        name: {{ tc.function.name }}
+        <|/tool_call>
+            {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .consistent, result.detail)
+        XCTAssertTrue(result.toolDefinitionRendered)
+        XCTAssertEqual(result.declaredDelimiterRendered, true)
+        XCTAssertEqual(result.claim.declaredDialect?.openDelimiter, "<|tool_call>")
+    }
+
+    func testMistralStyleRendersConsistently() {
+        // tools-is-not-none guard + [TOOL_CALLS] dialect.
+        let template = """
+        {%- if tools is not none %}
+        [AVAILABLE_TOOLS]
+        {%- for tool in tools %}{{ tool.name }}
+        {%- endfor %}
+        [/AVAILABLE_TOOLS]
+        {%- endif %}
+        {%- for message in messages %}
+        {{ message.role }}: {{ message.content }}
+        {%- if message.tool_calls %}
+            {%- for tc in message.tool_calls %}[TOOL_CALLS] {{ tc.function.name }}
+            {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .consistent, result.detail)
+        XCTAssertTrue(result.toolDefinitionRendered)
+        XCTAssertEqual(result.declaredDelimiterRendered, true)
+        XCTAssertEqual(result.claim.declaredDialect?.openDelimiter, "[TOOL_CALLS]")
+    }
+
+    func testHermesStyleRendersConsistently() {
+        // {% for tool in tools %} guard (no `if`) + <tool_call> dialect.
+        let template = """
+        {%- for tool in tools %}{{ tool.name }}
+        {%- endfor %}
+        {%- for message in messages %}
+        {{ message.role }}: {{ message.content }}
+        {%- if message.tool_calls %}
+            {%- for tc in message.tool_calls %}<tool_call>
+        {"name": "{{ tc.function.name }}"}
+        </tool_call>
+            {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .consistent, result.detail)
+        XCTAssertTrue(result.toolDefinitionRendered)
+        XCTAssertEqual(result.declaredDelimiterRendered, true)
+    }
+
+    func testLlamaStyleNoDelimiterRendersConsistently() {
+        // Llama-3.1: Environment: ipython guard, bare-JSON dialect — the claim
+        // declares NO open delimiter, so declaredDelimiterRendered must be nil
+        // and consistency must hinge on the tool name alone.
+        let template = """
+        {%- if tools %}
+        Environment: ipython
+        {%- for tool in tools %}{{ tool.name }}
+        {%- endfor %}
+        {%- endif %}
+        {%- for message in messages %}
+        {{ message.role }}: {{ message.content }}
+        {%- if message.tool_calls %}
+            {%- for tc in message.tool_calls %}{"name": "{{ tc.function.name }}"}
+            {%- endfor %}
+        {%- endif %}
+        {%- endfor %}
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .consistent, result.detail)
+        XCTAssertTrue(result.toolDefinitionRendered)
+        XCTAssertNil(result.declaredDelimiterRendered, "bare-JSON dialect has no opener to assert")
+        XCTAssertNil(result.claim.declaredDialect?.openDelimiter)
+    }
+
+    // MARK: - Not applicable
+
+    func testToollessTemplateIsNotApplicable() {
+        // Phi-style: no tools guard at all → trustworthy negative claim.
+        let template = """
+        {%- for message in messages %}
+        <|im_start|>{{ message.role }}<|im_sep|>{{ message.content }}<|im_end|>
+        {%- endfor %}
+        <|im_start|>assistant<|im_sep|>
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .notApplicable)
+        XCTAssertFalse(result.claim.toolsExpressible)
+        XCTAssertFalse(result.toolDefinitionRendered)
+        XCTAssertNil(result.declaredDelimiterRendered)
+    }
+
+    func testNilTemplateIsNotApplicable() {
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: nil)
+        XCTAssertEqual(result.status, .notApplicable)
+        XCTAssertFalse(result.claim.toolsExpressible)
+    }
+
+    func testBlankTemplateIsNotApplicable() {
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: "   \n\t  ")
+        XCTAssertEqual(result.status, .notApplicable)
+        XCTAssertFalse(result.claim.toolsExpressible)
+    }
+
+    // MARK: - Broken template: claims tools, never emits the tool name
+
+    func testGuardPresentButToolNameNeverEmittedIsInconsistent() {
+        // The `{% if tools %}` guard makes the Layer-1 claim positive, but the
+        // body never iterates `tools` nor emits any tool name — the #1909 class.
+        // The renderer produces a non-nil prompt that simply lacks `get_weather`.
+        let template = """
+        {%- if tools %}
+        (this model supports tools)
+        {%- endif %}
+        {%- for message in messages %}
+        {{ message.role }}: {{ message.content }}
+        {%- endfor %}
+        """
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+
+        XCTAssertEqual(result.status, .inconsistent)
+        XCTAssertFalse(result.toolDefinitionRendered)
+        XCTAssertTrue(
+            result.detail.contains("get_weather"),
+            "detail should name the missing tool definition; was: \(result.detail)"
+        )
+
+        // SABOTAGE (verified 2026-06-22, then removed): asserting the opposite
+        // here — XCTAssertEqual(result.status, .consistent) — fails, proving the
+        // test catches a checker that stops flagging the dropped tool grammar.
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Layer 2** of the tool-call-conformance design (#2005): a static render round-trip that validates the Layer-1 ``ChatTemplateToolDescriptor`` *claim* (#2009) against what the local backends' actual renderer (``JinjaPromptRenderer``) produces — **no live inference**.

New files:
- `Sources/ManifoldInference/Services/RenderConsistencyChecker.swift` — `RenderConsistency` result + `RenderConsistencyChecker.check(chatTemplateRaw:)`.
- `Tests/ManifoldInferenceTests/RenderConsistencyCheckerTests.swift` — 9 XCTest cases.

## What Layer 2 checks

`check(chatTemplateRaw:)`:
1. Builds the Layer-1 claim via `ChatTemplateToolDescriptor(parsingChatTemplate:)`.
2. If the claim is negative (no tools guard) or the template is nil/blank → `.notApplicable` (the negative claim is already trustworthy; nothing to round-trip).
3. Otherwise feeds a fixed canonical probe — a `get_weather(location)` tool, a user question, an **assistant turn carrying a `ToolCall`**, and a tool-result turn — through `JinjaPromptRenderer.render(...)`.
4. Asserts on the rendered string:
   - the probe tool name (`get_weather`) is present (the `{% if tools %}` branch fired / tools weren't dropped — the #1909 regression class);
   - when the claim declares an **open delimiter**, that delimiter is present (rendered via the template's `{% for tc in message.tool_calls %}` branch). Bare-JSON / python-tag dialects (Llama-3.1) declare no opener, so `declaredDelimiterRendered` is `nil` and isn't gated on.
   - `.consistent` only when the tool name is present **and** (no declared delimiter, or it's present); otherwise `.inconsistent` with a `detail` naming exactly which check failed.

## Parse-back limitation

This is a **presence** check, not a family-specific parse-back. Full round-trip parse-back (`ToolCallMarker.parseBody` / per-family `ToolCallMarkers`) lives in the companion backend targets (manifold-llama / manifold-mlx) which own the extraction grammar — core deliberately asserts only delimiter/tool-name PRESENCE. A `.consistent` verdict means "the template renders the declared grammar", not "an emitted call will parse" (that is Layer 3, a live soak, deferred).

## Validation

- `swift build --build-tests` → green.
- `swift test --filter RenderConsistencyCheckerTests` → 9 passed, 0 failures.
- `swift test --filter SilentCatchAuditTest` → passed (no `try?` in production).
- Zero new force-unwraps (`!`/`try!`/`as!`) in the Sources file.
- Sabotage check verified: flipping the broken-template assertion to `.consistent` makes the test fail (then removed; comment left in place).

Closes part of #2005 (Layer 1 shipped in #2009; Layer 3 soak deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)