### PR TITLE
feat: public JSON-Schema → GBNF grammar + validate/parse surface (#1992)

### DIFF
--- a/Sources/ManifoldInference/Services/ChatTemplate.swift
+++ b/Sources/ManifoldInference/Services/ChatTemplate.swift
@@ -140,7 +140,13 @@ public struct ChatTemplate: Sendable {
             let fallback = PromptTemplateDetector.detect(fromChatTemplate: raw)
             renderer = PromptRenderer(template: fallback, chatTemplateRaw: raw)
         }
-        let text = renderer.render(
+        // `format` is a non-throwing rendering primitive, so it uses the
+        // tool-drop-permitting path rather than the generation path's fail-fast
+        // render (#1957 Tier 3). Production generation goes through the throwing
+        // `PromptRenderer.render` (via `GenerationQueue`), which refuses to drop
+        // tools silently; this lower-level surface preserves its historical,
+        // source-stable behaviour.
+        let text = renderer.renderAllowingToolDrop(
             messages: messages,
             systemPrompt: systemPrompt,
             tools: tools

--- a/Sources/ManifoldInference/Services/GenerationPreflightTrimmer.swift
+++ b/Sources/ManifoldInference/Services/GenerationPreflightTrimmer.swift
@@ -77,7 +77,7 @@ struct GenerationPreflightTrimmer {
             // shape, not of any one trim attempt — emitting them per iteration
             // would spam the log. The returned prompt is re-rendered once below
             // with warnings enabled so the loss is reported exactly once.
-            let prompt = renderer.render(
+            let prompt = try renderer.render(
                 messages: workingMessages,
                 systemPrompt: systemPrompt,
                 tools: config.tools,
@@ -91,7 +91,7 @@ struct GenerationPreflightTrimmer {
                 // (runs only on the success iteration) and uses the renderer's
                 // own path detection, so a present-but-unusable embedded template
                 // still correctly reports the tool-drop fallback.
-                _ = renderer.render(
+                _ = try renderer.render(
                     messages: workingMessages,
                     systemPrompt: systemPrompt,
                     tools: config.tools,

--- a/Sources/ManifoldInference/Services/GenerationQueue.swift
+++ b/Sources/ManifoldInference/Services/GenerationQueue.swift
@@ -537,14 +537,14 @@ final class GenerationQueue {
                     backend: backend,
                     config: config
                 )
-                assembledPrompt = renderer.render(
+                assembledPrompt = try renderer.render(
                     messages: messages,
                     systemPrompt: augmentedSystemPrompt,
                     tools: config.tools,
                     documents: config.documents
                 )
             } else {
-                assembledPrompt = renderer.render(
+                assembledPrompt = try renderer.render(
                     messages: messages,
                     systemPrompt: systemPrompt,
                     documents: config.documents

--- a/Sources/ManifoldInference/Services/PromptRenderer.swift
+++ b/Sources/ManifoldInference/Services/PromptRenderer.swift
@@ -148,7 +148,18 @@ struct PromptRenderer {
         tools: [ToolDefinition] = [],
         documents: [RetrievedDocument] = [],
         warnOnCapabilityLoss: Bool = true
-    ) -> String {
+    ) throws -> String {
+        // FAIL-FAST (#1957 Tier 3 / #1909): an embedded chat template that is
+        // present but unusable would otherwise silently degrade to the text-only
+        // enum fallback, which renders tool definitions only for `.gemma4` and
+        // drops them for every other family — driving tool-calling success to
+        // ~0% on malformed-template models with no error surfaced anywhere. When
+        // the caller is actually trying to use tools, that silent capability
+        // loss is a correctness failure, not a graceful degradation: throw so
+        // the host sees it and can pick a different model or backend rather than
+        // shipping a tool-less prompt and reporting a mystery parse failure.
+        //
+        // Attempt the embedded Jinja render once. If it succeeds, return it.
         if let chatTemplateRaw,
            let rendered = JinjaPromptRenderer.render(
                rawTemplate: chatTemplateRaw,
@@ -163,6 +174,75 @@ struct PromptRenderer {
             return rendered
         }
 
+        // The embedded render failed (or there is none). The fail-fast applies
+        // only when (a) an embedded template exists, (b) tools were requested,
+        // and (c) the text-only enum fallback would not render them — i.e. the
+        // exact ~0%-tool-calling condition. Plain chat (no tools) and `.gemma4`
+        // (which renders tools natively in the enum) fall through to the safe
+        // text-only fallback.
+        if chatTemplateRaw != nil, !tools.isEmpty, !template.rendersToolsNatively {
+            throw InferenceError.inferenceFailure(
+                "PromptRenderer: the model's embedded chat template could not be "
+                    + "rendered, and the \(String(describing: template)) text-only "
+                    + "fallback cannot carry the \(tools.count) requested tool "
+                    + "definition(s). Refusing to send a tool-less prompt that would "
+                    + "silently disable tool calling. Use a model whose chat template "
+                    + "renders correctly, or send this request without tools."
+            )
+        }
+
+        return renderTextOnlyFallback(
+            messages: messages,
+            systemPrompt: systemPrompt,
+            tools: tools,
+            warnOnCapabilityLoss: warnOnCapabilityLoss
+        )
+    }
+
+    /// The lower-level rendering primitive used by
+    /// ``ChatTemplate/format(_:systemPrompt:tools:)``, a non-throwing surface.
+    /// Unlike the throwing ``render(messages:systemPrompt:tools:documents:warnOnCapabilityLoss:)``
+    /// (the generation path), this *permits* a text-only fallback even when that
+    /// drops tool definitions — it predates the fail-fast and keeps
+    /// `ChatTemplate.format`'s historical, source-stable behaviour. Production
+    /// generation does not call this; it goes through the throwing path.
+    func renderAllowingToolDrop(
+        messages: [StructuredMessage],
+        systemPrompt: String?,
+        tools: [ToolDefinition] = [],
+        documents: [RetrievedDocument] = [],
+        warnOnCapabilityLoss: Bool = true
+    ) -> String {
+        if let chatTemplateRaw,
+           let rendered = JinjaPromptRenderer.render(
+               rawTemplate: chatTemplateRaw,
+               messages: messages,
+               systemPrompt: systemPrompt,
+               tools: tools,
+               documents: documents
+           ) {
+            if warnOnCapabilityLoss {
+                warnIfCapabilityLost(messages: messages, tools: tools, viaEmbeddedTemplate: true)
+            }
+            return rendered
+        }
+        return renderTextOnlyFallback(
+            messages: messages,
+            systemPrompt: systemPrompt,
+            tools: tools,
+            warnOnCapabilityLoss: warnOnCapabilityLoss
+        )
+    }
+
+    /// The text-only enum projection used when no embedded template applies (or
+    /// when the caller permits tool-dropping). Shared by both render entry
+    /// points so the fallback shape stays identical.
+    private func renderTextOnlyFallback(
+        messages: [StructuredMessage],
+        systemPrompt: String?,
+        tools: [ToolDefinition],
+        warnOnCapabilityLoss: Bool
+    ) -> String {
         if warnOnCapabilityLoss {
             warnIfCapabilityLost(messages: messages, tools: tools, viaEmbeddedTemplate: false)
         }

--- a/Sources/ManifoldInference/Services/StructuredOutputSchema.swift
+++ b/Sources/ManifoldInference/Services/StructuredOutputSchema.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// A public, self-contained facade over MK's JSON-Schema → constrained-output
+/// machinery, intended to replace the hand-rolled schema layers that downstream
+/// apps built when MK's tool-calling path was unreliable (Idlewick's
+/// `DeclarativeTool`, Fireside's `ExtractionSchema` — see #1992).
+///
+/// One schema in, three capabilities out:
+///
+/// 1. **Lower to a grammar** (``gbnfGrammar()``): turn the schema into a GBNF
+///    grammar string a grammar-capable local backend can use to *constrain*
+///    decoding, so the model can only emit JSON matching the schema. Pass the
+///    result through ``GenerationConfig/grammar``.
+/// 2. **Validate a value** (``validate(_:)`` / ``validate(json:)``): check a
+///    model's output against the schema, getting back a model-readable failure
+///    message you can feed straight back into the conversation for self-repair.
+/// 3. **Parse + validate** (``parse(_:)``): decode a raw JSON string *and*
+///    validate it in one step, returning the typed ``JSONSchemaValue`` tree on
+///    success or a ``SchemaViolation`` on failure.
+///
+/// ## Why a facade
+///
+/// The underlying pieces — ``ToolGrammarBuilder`` (lowering) and
+/// ``JSONSchemaValidator`` (validation) — already existed but were discovered
+/// piecemeal and documented for the internal tool-call path. This type is the
+/// single, documented public entry point so a consumer can write:
+///
+/// ```swift
+/// let schema = StructuredOutputSchema(
+///     .object([
+///         "type": .string("object"),
+///         "properties": .object([
+///             "city": .object(["type": .string("string")]),
+///             "units": .object([
+///                 "type": .string("string"),
+///                 "enum": .array([.string("metric"), .string("imperial")]),
+///             ]),
+///         ]),
+///         "required": .array([.string("city")]),
+///     ])
+/// )
+///
+/// // 1. Constrain decoding.
+/// var config = GenerationConfig()
+/// config.grammar = schema.gbnfGrammar()   // nil → schema carries no constraint
+///
+/// // 2 + 3. Validate / parse the model's reply.
+/// switch schema.parse(modelOutput) {
+/// case .success(let value):  use(value)
+/// case .failure(let violation): retry(with: violation.modelReadableMessage)
+/// }
+/// ```
+///
+/// ## Supported subset
+///
+/// Grammar lowering and validation each cover a deliberate JSON-Schema subset
+/// tuned for LLM structured output — see ``ToolGrammarBuilder`` and
+/// ``JSONSchemaValidator`` for the exact keyword coverage. The two surfaces
+/// differ slightly: lowering *degrades gracefully* (an unmodeled node lowers to
+/// a generic JSON value, never failing the build), while validation *fails
+/// closed* on unsupported keywords (it refuses to claim validity it cannot
+/// enforce) — a ``SchemaViolation`` naming the unsupported keyword is returned
+/// from ``validate(_:)`` / ``parse(_:)`` in that case.
+public struct StructuredOutputSchema: Sendable, Equatable, Hashable {
+
+    /// The JSON-Schema document this facade wraps.
+    public let schema: JSONSchemaValue
+
+    /// Wraps a JSON-Schema document for constrained output.
+    ///
+    /// - Parameter schema: the schema, typically an object schema with
+    ///   `properties`/`required`. A bare scalar schema carries no structure to
+    ///   constrain — ``gbnfGrammar()`` returns `nil` for it.
+    public init(_ schema: JSONSchemaValue) {
+        self.schema = schema
+    }
+
+    // MARK: - Grammar lowering
+
+    /// Lowers the schema to a GBNF grammar string suitable for
+    /// ``GenerationConfig/grammar``, constraining a grammar-capable backend to
+    /// emit only JSON matching the schema.
+    ///
+    /// Returns `nil` when the schema carries no structural information to
+    /// constrain (a bare scalar, or a node the lowerer models only as the
+    /// generic JSON value). A `nil` result means "do not set a grammar" — a
+    /// vacuous grammar that accepts anything is worse than none, so callers
+    /// should fall back to unconstrained sampling.
+    ///
+    /// Object schemas always produce a grammar: unmodeled sub-nodes degrade to
+    /// the generic JSON value rule rather than failing the build, so the
+    /// envelope and known keys stay constrained even when one field cannot be.
+    ///
+    /// - Returns: a GBNF grammar string, or `nil` if the schema constrains
+    ///   nothing.
+    public func gbnfGrammar() -> String? {
+        // Prefer the object-payload lowering: it accepts type-omitted object
+        // schemas (common in extraction payloads) and always returns a grammar
+        // for object-shaped input. For non-object schemas it returns nil, in
+        // which case the generic schema lowerer is the right path (it constrains
+        // arrays / typed scalars and returns nil only for the truly vacuous).
+        if let objectGrammar = ToolGrammarBuilder().buildObjectGrammar(for: schema) {
+            return objectGrammar
+        }
+        return ToolGrammarBuilder().buildSchemaGrammar(for: schema)
+    }
+
+    // MARK: - Validation
+
+    /// A structured-output validation failure, carrying both a model-readable
+    /// message (feed it back to the model for self-repair) and the structural
+    /// path to the offending node (for logging / tests).
+    ///
+    /// This re-exports ``JSONSchemaValidator/ValidationFailure`` under the
+    /// facade's vocabulary so consumers need not reach into the validator type.
+    public typealias SchemaViolation = JSONSchemaValidator.ValidationFailure
+
+    /// Validates an already-parsed JSON value against the schema.
+    ///
+    /// - Parameter value: the value to check, as a ``JSONSchemaValue`` tree.
+    /// - Returns: `nil` when the value satisfies the schema; otherwise the first
+    ///   ``SchemaViolation`` encountered.
+    public func validate(_ value: JSONSchemaValue) -> SchemaViolation? {
+        JSONSchemaValidator().validate(value, against: schema)
+    }
+
+    /// Parses a raw JSON string and validates it against the schema *without*
+    /// returning the parsed value — use when you only need a pass/fail verdict.
+    ///
+    /// - Parameter json: the raw JSON text emitted by the model.
+    /// - Returns: `nil` when the text parses and satisfies the schema; otherwise
+    ///   a ``SchemaViolation`` describing the parse error or first violation.
+    public func validate(json: String) -> SchemaViolation? {
+        JSONSchemaValidator().validate(arguments: json, against: schema)
+    }
+
+    /// Parses a raw JSON string *and* validates it against the schema in one
+    /// step, returning the typed value on success.
+    ///
+    /// This is the primary entry point for the "constrain → parse → use" loop:
+    /// the model's output is decoded into a typed ``JSONSchemaValue`` tree only
+    /// when it both parses as JSON and satisfies the schema. On failure the
+    /// ``SchemaViolation`` carries a model-readable message you can append to the
+    /// conversation to drive a self-correction turn.
+    ///
+    /// - Parameter json: the raw JSON text emitted by the model.
+    /// - Returns: `.success(value)` with the validated tree, or
+    ///   `.failure(violation)` describing the parse error or first violation.
+    public func parse(_ json: String) -> Result<JSONSchemaValue, SchemaViolation> {
+        guard let data = json.data(using: .utf8) else {
+            return .failure(SchemaViolation(
+                modelReadableMessage: "output was not valid UTF-8 JSON.",
+                path: []
+            ))
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(
+                with: data,
+                options: [.fragmentsAllowed]
+            )
+        } catch {
+            return .failure(SchemaViolation(
+                modelReadableMessage: "output was not valid JSON.",
+                path: []
+            ))
+        }
+        let value = JSONSchemaValidator.lift(parsed)
+        if let violation = validate(value) {
+            return .failure(violation)
+        }
+        return .success(value)
+    }
+}

--- a/Tests/ManifoldInferenceTests/ChatTemplateStopAndFlattenTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateStopAndFlattenTests.swift
@@ -11,7 +11,7 @@ final class ChatTemplateStopAndFlattenTests: XCTestCase {
     /// A templateless model (`chatTemplateRaw == nil`) carrying a `.toolResult`
     /// part must render that tool content into the fallback prompt. Before the
     /// fix the fallback used `flatten()`, which dropped tool parts entirely.
-    func test_enumFallback_rendersToolResultContent() {
+    func test_enumFallback_rendersToolResultContent() throws {
         let toolResult = ToolResult(callId: "call_1", content: "The weather is 21C and sunny.")
         let messages: [StructuredMessage] = [
             StructuredMessage(role: "user", content: "What's the weather?"),
@@ -22,7 +22,7 @@ final class ChatTemplateStopAndFlattenTests: XCTestCase {
         ]
 
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: nil)
-        let prompt = renderer.render(messages: messages, systemPrompt: nil, tools: [])
+        let prompt = try renderer.render(messages: messages, systemPrompt: nil, tools: [])
 
         // The tool result content must survive into the prompt (regression).
         XCTAssertTrue(

--- a/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateTests.swift
@@ -57,11 +57,11 @@ final class ChatTemplateTests: XCTestCase {
 
     // MARK: - format parity (behaviour-preserving wrap)
 
-    func test_format_builtIn_textIsByteIdenticalToPromptRenderer() {
+    func test_format_builtIn_textIsByteIdenticalToPromptRenderer() throws {
         let messages = [msg("user", "Hello"), msg("assistant", "Hi"), msg("user", "How are you?")]
         let system = "You are helpful."
 
-        let expected = PromptRenderer(template: .chatML, chatTemplateRaw: nil)
+        let expected = try PromptRenderer(template: .chatML, chatTemplateRaw: nil)
             .render(messages: messages, systemPrompt: system, tools: [])
 
         let rendered = ChatTemplate(builtIn: .chatML)
@@ -70,9 +70,9 @@ final class ChatTemplateTests: XCTestCase {
         XCTAssertEqual(rendered.text, expected, "ChatTemplate.format must wrap PromptRenderer byte-for-byte")
     }
 
-    func test_format_embeddedJinja_textIsByteIdenticalToPromptRenderer() {
+    func test_format_embeddedJinja_textIsByteIdenticalToPromptRenderer() throws {
         let messages = [msg("user", "Hello")]
-        let expected = PromptRenderer(template: .chatML, chatTemplateRaw: chatMLJinja)
+        let expected = try PromptRenderer(template: .chatML, chatTemplateRaw: chatMLJinja)
             .render(messages: messages, systemPrompt: nil, tools: [])
 
         let rendered = ChatTemplate(embeddedJinja: chatMLJinja)

--- a/Tests/ManifoldInferenceTests/GenerationQueueToolSystemPromptTests.swift
+++ b/Tests/ManifoldInferenceTests/GenerationQueueToolSystemPromptTests.swift
@@ -25,13 +25,15 @@ final class GenerationQueueToolSystemPromptTests: XCTestCase {
 
     private func makeBackend(
         template: PromptTemplate,
-        supportsToolCalling: Bool
+        supportsToolCalling: Bool,
+        chatTemplateRaw: String? = nil
     ) -> (backend: ToolPromptCountingBackend, provider: ToolPromptFakeProvider, queue: GenerationQueue) {
         let backend = ToolPromptCountingBackend(supportsToolCalling: supportsToolCalling)
         // Always-fits: one count under budget so generate runs without trimming.
         backend.countTokensResponses = [10]
         let provider = ToolPromptFakeProvider(backend: backend)
         provider.promptTemplate = template
+        provider.chatTemplateRaw = chatTemplateRaw
         let queue = GenerationQueue()
         provider.bind(to: queue)
         return (backend, provider, queue)
@@ -116,6 +118,52 @@ final class GenerationQueueToolSystemPromptTests: XCTestCase {
                      "rejected request must never reach the backend, so nothing is injected")
         withExtendedLifetime(provider) {}
     }
+
+    // (d) THE PRODUCTION FAIL-FAST (#1957 Tier 3 / #1909): an unrenderable
+    // embedded chat template + tools requested must surface an *error through the
+    // real generation path* — not silently drop the tools and ship a tool-less
+    // prompt. This exercises the exact `GenerationQueue` → `PromptRenderer.render`
+    // (throwing) route a local GGUF model takes, proving the fix is wired into
+    // production and not merely present on the unit-level `render` API. The
+    // `PromptRendererToolFidelityTests` cover the unit; this guards the seam.
+    func test_productionPath_failsFast_onUnusableTemplateWithTools() async throws {
+        // A template swift-jinja cannot parse → the embedded render always misses,
+        // forcing the fail-fast since `.chatML` does not render tools natively.
+        let (backend, provider, queue) = makeBackend(
+            template: .chatML,
+            supportsToolCalling: true,
+            chatTemplateRaw: "{%- if broken"
+        )
+
+        let (_, stream) = try queue.enqueue(
+            messages: [("user", "what time is it?")],
+            systemPrompt: "You are a helpful assistant.",
+            tools: [tool("get_time")]
+        )
+
+        var thrown: Error?
+        do {
+            for try await _ in stream.events {}
+        } catch {
+            thrown = error
+        }
+
+        let error = try XCTUnwrap(
+            thrown,
+            "the production generation path must surface an error when the embedded "
+                + "template is unusable and tools were requested — not silently drop tools"
+        )
+        XCTAssertTrue(
+            String(describing: error).contains("tool"),
+            "the surfaced error must name the tool-fidelity failure; got: \(error)"
+        )
+        // The tool-less prompt must NOT have reached the backend.
+        XCTAssertNil(
+            backend.lastPrompt,
+            "a fail-fast turn must abort before dispatching a tool-less prompt to the backend"
+        )
+        withExtendedLifetime(provider) {}
+    }
 }
 
 // MARK: - Local mocks
@@ -176,6 +224,7 @@ private final class ToolPromptCountingBackend: InferenceBackend, TokenCountingBa
 private final class ToolPromptFakeProvider {
     let backend: ToolPromptCountingBackend
     var promptTemplate: PromptTemplate = .chatML
+    var chatTemplateRaw: String?
 
     init(backend: ToolPromptCountingBackend) {
         self.backend = backend
@@ -186,7 +235,8 @@ private final class ToolPromptFakeProvider {
         queue.bindContext(
             currentBackend: { [weak self] in self?.backend },
             isBackendLoaded: { [weak self] in self?.backend.isModelLoaded ?? false },
-            selectedPromptTemplate: { [weak self] in self?.promptTemplate ?? .chatML }
+            selectedPromptTemplate: { [weak self] in self?.promptTemplate ?? .chatML },
+            selectedChatTemplateRaw: { [weak self] in self?.chatTemplateRaw }
         )
     }
 }

--- a/Tests/ManifoldInferenceTests/JinjaPromptRendererTests.swift
+++ b/Tests/ManifoldInferenceTests/JinjaPromptRendererTests.swift
@@ -210,9 +210,9 @@ final class JinjaPromptRendererTests: XCTestCase {
         XCTAssertFalse(noTools.contains("<|tools|>"), "no tools → declaration block must not render")
     }
 
-    func test_promptRenderer_threadsToolsThroughJinjaPath() {
+    func test_promptRenderer_threadsToolsThroughJinjaPath() throws {
         let renderer = PromptRenderer(template: .gemma4, chatTemplateRaw: Self.nativeToolTemplate)
-        let out = renderer.render(
+        let out = try renderer.render(
             messages: [StructuredMessage(role: "user", content: "weather?")],
             systemPrompt: nil,
             tools: [Self.weatherTool()]
@@ -299,24 +299,26 @@ final class JinjaPromptRendererTests: XCTestCase {
 
     // MARK: - PromptRenderer prefers Jinja, falls back to the enum
 
-    func test_promptRenderer_prefersJinjaWhenTemplatePresent() {
+    func test_promptRenderer_prefersJinjaWhenTemplatePresent() throws {
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: Self.qwen25Template)
-        let out = renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
+        let out = try renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
         XCTAssertTrue(out.contains("You are Qwen"), "Renderer must prefer the real embedded Jinja")
     }
 
-    func test_promptRenderer_fallsBackToEnum_whenNoTemplate() {
+    func test_promptRenderer_fallsBackToEnum_whenNoTemplate() throws {
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: nil)
-        let out = renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
+        let out = try renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
         let enumOut = PromptTemplate.chatML.format(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
         XCTAssertEqual(out, enumOut, "No embedded template → enum output verbatim")
     }
 
-    func test_promptRenderer_fallsBackToEnum_whenTemplateMalformed() {
-        // A template swift-jinja cannot parse must not block generation — the
-        // renderer falls back to the enum (a recoverable boundary condition).
+    func test_promptRenderer_fallsBackToEnum_whenTemplateMalformed() throws {
+        // A template swift-jinja cannot parse must not block generation *when no
+        // tools are requested* — the renderer falls back to the enum (a
+        // recoverable boundary condition). The tools-present case fails fast
+        // instead (see PromptRendererToolFidelityTests, #1957 Tier 3).
         let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: "{%- if broken")
-        let out = renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
+        let out = try renderer.render(messages: [msg("user", "Hi")], systemPrompt: nil)
         let enumOut = PromptTemplate.chatML.format(messages: [(role: "user", content: "Hi")], systemPrompt: nil)
         XCTAssertEqual(out, enumOut, "Malformed embedded template → enum fallback, no crash")
     }

--- a/Tests/ManifoldInferenceTests/PromptRendererToolFidelityTests.swift
+++ b/Tests/ManifoldInferenceTests/PromptRendererToolFidelityTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Proves the #1957 Tier 3 / #1909 fail-fast: when a model's embedded chat
+/// template is present but unrenderable and the caller requested tools, the
+/// renderer must **throw** rather than silently degrade to the text-only enum
+/// fallback (which renders tools only for `.gemma4` and drops them otherwise,
+/// driving tool-calling success to ~0% with no visible error).
+final class PromptRendererToolFidelityTests: XCTestCase {
+
+    // A template swift-jinja cannot parse → the embedded render always misses.
+    private let brokenTemplate = "{%- if broken"
+
+    private func weatherTool() -> ToolDefinition {
+        ToolDefinition(
+            name: "get_weather",
+            description: "Look up the weather.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object(["city": .object(["type": .string("string")])]),
+                "required": .array([.string("city")]),
+            ])
+        )
+    }
+
+    private func userMessage() -> [StructuredMessage] {
+        [StructuredMessage(role: "user", content: "weather in Paris?")]
+    }
+
+    /// THE REGRESSION: unrenderable embedded template + tools + non-gemma enum
+    /// must throw, not silently drop the tools.
+    func test_failsFast_whenEmbeddedTemplateUnusableAndToolsRequested() {
+        let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: brokenTemplate)
+        XCTAssertThrowsError(
+            try renderer.render(
+                messages: userMessage(),
+                systemPrompt: nil,
+                tools: [weatherTool()]
+            ),
+            "An unusable embedded template with tools requested must throw, not drop tools silently."
+        ) { error in
+            // The error message should name the tool-drop cause so the host can act.
+            let message = String(describing: error)
+            XCTAssertTrue(
+                message.contains("tool"),
+                "Thrown error must explain the tool-fidelity failure; got: \(message)"
+            )
+        }
+    }
+
+    /// Plain chat (no tools) over the same unusable template must still fall back
+    /// to the enum — there is nothing to drop, so degradation is safe.
+    func test_fallsBack_whenNoToolsRequested() throws {
+        let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: brokenTemplate)
+        let out = try renderer.render(messages: userMessage(), systemPrompt: nil, tools: [])
+        let enumOut = PromptTemplate.chatML.format(
+            messages: [(role: "user", content: "weather in Paris?")],
+            systemPrompt: nil
+        )
+        XCTAssertEqual(out, enumOut, "No tools → safe enum fallback, no throw.")
+    }
+
+    /// `.gemma4` renders tools natively in the enum fallback, so an unusable
+    /// embedded template does NOT drop them — it must not throw.
+    func test_doesNotThrow_whenEnumFallbackRendersToolsNatively() throws {
+        let renderer = PromptRenderer(template: .gemma4, chatTemplateRaw: brokenTemplate)
+        let out = try renderer.render(
+            messages: userMessage(),
+            systemPrompt: nil,
+            tools: [weatherTool()]
+        )
+        XCTAssertFalse(out.isEmpty, "gemma4 enum fallback renders tools; must not throw.")
+    }
+
+    /// A usable embedded template that renders tools must succeed (no false
+    /// positive on the fail-fast).
+    func test_doesNotThrow_whenEmbeddedTemplateRenders() throws {
+        // A minimal renderable ChatML-ish template (no tool block needed; it
+        // renders successfully, so the fail-fast never fires).
+        let usable = "{%- for m in messages %}{{ m.role }}: {{ m.content }}\n{%- endfor %}"
+        let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: usable)
+        let out = try renderer.render(
+            messages: userMessage(),
+            systemPrompt: nil,
+            tools: [weatherTool()]
+        )
+        XCTAssertTrue(out.contains("weather in Paris?"), "Usable template must render and not throw.")
+    }
+
+    /// `renderAllowingToolDrop` is the lower-level primitive (used by
+    /// `ChatTemplate.format`) that preserves the historical tool-dropping
+    /// fallback — it must NOT throw even in the regression scenario.
+    func test_renderAllowingToolDrop_doesNotThrow() {
+        let renderer = PromptRenderer(template: .chatML, chatTemplateRaw: brokenTemplate)
+        let out = renderer.renderAllowingToolDrop(
+            messages: userMessage(),
+            systemPrompt: nil,
+            tools: [weatherTool()]
+        )
+        XCTAssertFalse(out.isEmpty, "The tool-drop-permitting primitive falls back rather than throwing.")
+    }
+}

--- a/Tests/ManifoldInferenceTests/StructuredOutputSchemaTests.swift
+++ b/Tests/ManifoldInferenceTests/StructuredOutputSchemaTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Unit tests for the public ``StructuredOutputSchema`` facade (#1992): schema →
+/// GBNF grammar, and validate / parse against the same schema.
+final class StructuredOutputSchemaTests: XCTestCase {
+
+    // A weather-extraction-style object schema reused across tests.
+    private func weatherSchema() -> JSONSchemaValue {
+        .object([
+            "type": .string("object"),
+            "properties": .object([
+                "city": .object(["type": .string("string")]),
+                "units": .object([
+                    "type": .string("string"),
+                    "enum": .array([.string("metric"), .string("imperial")]),
+                ]),
+            ]),
+            "required": .array([.string("city")]),
+        ])
+    }
+
+    // MARK: - Grammar lowering
+
+    func testObjectSchemaLowersToGrammar() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        let grammar = schema.gbnfGrammar()
+        XCTAssertNotNil(grammar, "An object schema must lower to a non-nil grammar.")
+        let g = grammar ?? ""
+        // The grammar must constrain the declared keys and the enum values.
+        XCTAssertTrue(g.contains("root ::="), "Grammar must declare a root rule.")
+        XCTAssertTrue(g.contains("city"), "Grammar must constrain the 'city' key.")
+        XCTAssertTrue(g.contains("metric") && g.contains("imperial"),
+                      "Grammar must encode the units enum literals.")
+    }
+
+    func testTypeOmittedObjectSchemaStillLowers() {
+        // Extraction payloads commonly omit `type` when `properties` is declared.
+        let schema = StructuredOutputSchema(.object([
+            "properties": .object([
+                "name": .object(["type": .string("string")]),
+            ]),
+        ]))
+        XCTAssertNotNil(schema.gbnfGrammar(),
+                        "A properties-only object schema must still lower to a grammar.")
+    }
+
+    func testBareScalarSchemaLowersToNil() {
+        // A schema that constrains nothing must return nil so the caller can fall
+        // back to unconstrained sampling rather than ship a vacuous grammar.
+        let schema = StructuredOutputSchema(.object([:]))
+        XCTAssertNil(schema.gbnfGrammar(),
+                     "An empty object schema carries no constraint and must lower to nil.")
+    }
+
+    // MARK: - Validation
+
+    func testValidValueValidatesClean() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        let value: JSONSchemaValue = .object([
+            "city": .string("Paris"),
+            "units": .string("metric"),
+        ])
+        XCTAssertNil(schema.validate(value),
+                     "A conforming value must produce no violation.")
+    }
+
+    func testMissingRequiredFieldFailsWithModelReadableMessage() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        let value: JSONSchemaValue = .object(["units": .string("metric")])
+        let violation = schema.validate(value)
+        XCTAssertNotNil(violation, "A missing required field must produce a violation.")
+        XCTAssertTrue(violation?.modelReadableMessage.contains("city") ?? false,
+                      "The message must name the missing field.")
+    }
+
+    func testEnumViolationReported() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        let value: JSONSchemaValue = .object([
+            "city": .string("Paris"),
+            "units": .string("kelvin"),
+        ])
+        let violation = schema.validate(value)
+        XCTAssertNotNil(violation, "An out-of-enum value must fail validation.")
+    }
+
+    // MARK: - validate(json:)
+
+    func testValidateJSONString() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        XCTAssertNil(schema.validate(json: #"{"city":"Paris"}"#),
+                     "Valid JSON satisfying the schema must validate clean.")
+        XCTAssertNotNil(schema.validate(json: #"{"units":"metric"}"#),
+                        "Valid JSON missing a required field must fail.")
+    }
+
+    func testMalformedJSONStringFails() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        let violation = schema.validate(json: "{not json")
+        XCTAssertNotNil(violation, "Malformed JSON must produce a violation, not a pass.")
+    }
+
+    // MARK: - parse
+
+    func testParseReturnsTypedValueOnSuccess() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        switch schema.parse(#"{"city":"Berlin","units":"imperial"}"#) {
+        case .success(let value):
+            guard case let .object(dict) = value else {
+                return XCTFail("Parsed value must be an object.")
+            }
+            XCTAssertEqual(dict["city"], .string("Berlin"))
+        case .failure(let violation):
+            XCTFail("Expected success, got: \(violation.modelReadableMessage)")
+        }
+    }
+
+    func testParseFailsOnSchemaViolation() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        switch schema.parse(#"{"units":"metric"}"#) {
+        case .success:
+            XCTFail("Parse must fail when a required field is missing.")
+        case .failure(let violation):
+            XCTAssertTrue(violation.modelReadableMessage.contains("city"),
+                          "Failure must name the missing field for model self-repair.")
+        }
+    }
+
+    func testParseFailsOnMalformedJSON() {
+        let schema = StructuredOutputSchema(weatherSchema())
+        switch schema.parse("not json at all") {
+        case .success:
+            XCTFail("Parse must fail on non-JSON input.")
+        case .failure:
+            break // expected
+        }
+    }
+
+    func testGrammarConstrainsOutputAcceptedByValidator() {
+        // End-to-end intent: a value the grammar would permit should also pass
+        // validation (the two surfaces agree on the happy path).
+        let schema = StructuredOutputSchema(weatherSchema())
+        XCTAssertNotNil(schema.gbnfGrammar())
+        XCTAssertNil(schema.validate(json: #"{"city":"Tokyo","units":"metric"}"#))
+    }
+}


### PR DESCRIPTION
## Summary

Two deliverables for #1992 in one PR.

### 1. Public `StructuredOutputSchema` facade (ManifoldInference)

Consolidates MK's existing internal pieces — `ToolGrammarBuilder` (GBNF lowering) and `JSONSchemaValidator` (validation) — into a single documented public entry point so downstream apps can drop their hand-rolled schema layers (Idlewick `DeclarativeTool`, Fireside `ExtractionSchema`). One schema in, three capabilities out:

```swift
let schema = StructuredOutputSchema(.object([
    "type": .string("object"),
    "properties": .object([
        "city":  .object(["type": .string("string")]),
        "units": .object(["type": .string("string"),
                          "enum": .array([.string("metric"), .string("imperial")])]),
    ]),
    "required": .array([.string("city")]),
]))

var config = GenerationConfig()
config.grammar = schema.gbnfGrammar()          // constrain decoding (nil = no constraint)

switch schema.parse(modelOutput) {              // decode + validate in one step
case .success(let value):    use(value)
case .failure(let violation): retry(with: violation.modelReadableMessage)
}
```

Public API:
- `init(_ schema: JSONSchemaValue)`
- `gbnfGrammar() -> String?` — lowers to GBNF; `nil` when the schema constrains nothing (caller should sample unconstrained rather than ship a vacuous grammar)
- `validate(_ value:) -> SchemaViolation?`
- `validate(json:) -> SchemaViolation?`
- `parse(_:) -> Result<JSONSchemaValue, SchemaViolation>`
- `typealias SchemaViolation = JSONSchemaValidator.ValidationFailure`

Module placement: `ManifoldInference` (where `ToolGrammarBuilder`/`JSONSchemaValidator` already live; both depend on the engine's tool subsystem). Re-exported via the `ManifoldKit` umbrella. Additive — no existing symbols changed.

### 2. Fail-fast on the tools-dropping Jinja fallback (#1957 Tier 3 / #1909)

`PromptRenderer.render(...)` previously fell back to a text-only enum projection when a model's embedded chat template failed to render. That fallback renders tool definitions only for `.gemma4` and silently drops them for every other family → ~0% tool calling on malformed-template models, with no error anywhere.

`render` is now `throws` and **fails fast** (`InferenceError.inferenceFailure`) when: an embedded template is present, it fails to render, tools were requested, and the enum fallback would not render them. Plain chat (no tools) and `.gemma4` still fall back safely. The lower-level non-throwing primitive used by `ChatTemplate.format` is preserved as `renderAllowingToolDrop` so that public surface stays source-stable (no API break).

Throwing propagates through `GenerationQueue` and `GenerationPreflightTrimmer` (both already `throws`).

## Tests
- `StructuredOutputSchemaTests` — grammar lowering, validation, parse success/failure, malformed JSON.
- `PromptRendererToolFidelityTests` — proves the regression: unusable template + tools throws; no-tools and `.gemma4` fall back; usable template succeeds; `renderAllowingToolDrop` never throws.
- Updated existing `render` call sites in `JinjaPromptRendererTests` / `ChatTemplateTests` / `ChatTemplateStopAndFlattenTests` for the throwing signature.

Refs #1992, #1957, #1909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)