### PR TITLE
feat(runtime): add ToolCallConformance port + value type + in-memory cache (measured tool-calling spine)

### DIFF
--- a/Sources/ManifoldRuntime/Services/ToolCallConformance.swift
+++ b/Sources/ManifoldRuntime/Services/ToolCallConformance.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Cache key for a measured tool-calling conformance verdict.
+///
+/// Tool-call conformance is a property of the **weights × packaging × backend**,
+/// not of a device — so the key is `(model × quant × backend)`, mirroring the
+/// plan's matrix (`docs/plans/tool-call-conformance.md`). Two artifacts that
+/// differ only in quantization can land on opposite sides of the
+/// supported/unsupported line, and the backend's renderer/parser moves the rate
+/// too, so all three coordinates are load-bearing.
+///
+/// `quant` is optional because some artifacts (e.g. full-precision or
+/// backend-internal formats) carry no meaningful quantization label.
+public struct ToolCallConformanceKey: Hashable, Sendable, Codable {
+
+    /// The model identity (e.g. `"Qwen2.5-7B-Instruct"`). Not the file name —
+    /// quantization is carried separately so the same weights at different
+    /// quants share a model coordinate.
+    public let model: String
+
+    /// The quantization label (e.g. `"Q4_K_M"`), or `nil` when the artifact
+    /// carries no meaningful quant.
+    public let quant: String?
+
+    /// The backend family that rendered and parsed the calls (e.g. `"llama"`,
+    /// `"mlx"`, `"ollama"`). The renderer/parser pair is part of the verdict.
+    public let backend: String
+
+    public init(model: String, quant: String?, backend: String) {
+        self.model = model
+        self.quant = quant
+        self.backend = backend
+    }
+}
+
+/// The tool-calling capability verdict for a cache cell.
+///
+/// `unknown` is the lazy default for any cell that has not been measured — it is
+/// never a cold-start tax, and hosts treat it as "recommend = no; allow with a
+/// warning = host's call" (see the plan's Acceptance section).
+public enum ToolCallCapability: String, Codable, Sendable {
+    /// Measured (or statically proven) able to drive tool calls.
+    case supported
+    /// Proven unable — e.g. a template with no tools block, or a soak that
+    /// produced ~0% parseable calls.
+    case unsupported
+    /// Not yet measured. The default for an unpopulated cell.
+    case unknown
+}
+
+/// Which layer of the conformance pipeline produced a verdict.
+///
+/// Ordered weakest → strongest evidence: a `templateExpressible` positive is
+/// only necessary-not-sufficient, whereas `measured` is the authoritative
+/// verdict source.
+public enum ToolCallConformanceSource: String, Codable, Sendable {
+    /// Derived from the chat template alone (`{% if tools %}` present/absent).
+    /// Authoritative for the negative; necessary-not-sufficient for the positive.
+    case templateExpressible
+    /// The static render-consistency check confirmed MK's renderer emits the
+    /// template-declared dialect (catches the #1909 class without a soak).
+    case renderConsistent
+    /// A live soak through the real render+parse path measured the rate. The
+    /// only authoritative positive verdict.
+    case measured
+}
+
+/// A measured tool-calling conformance verdict for one `(model × quant × backend)` cell.
+///
+/// The analog of `ModelBenchmarkResult`, with one deliberate distinction:
+/// `ModelBenchmarkResult` (tokens/sec) is **device-specific** and decays, so it
+/// carries a 7-day `isStale`. `ToolCallConformance` is a property of the
+/// **weights** — measure it on any machine and it holds on every machine — so it
+/// **does not decay** and intentionally carries no TTL / `isStale` helper.
+/// `measuredAt` is recorded for provenance, not for expiry.
+public struct ToolCallConformance: Sendable, Codable, Equatable {
+
+    /// The verdict for this cell.
+    public var capability: ToolCallCapability
+
+    /// The raw dialect family name observed (e.g. `"hermes"`, `"mistral"`).
+    /// Kept a `String` to stay decoupled from the `ToolCallDialect` type that
+    /// ships in a parallel PR (step 4).
+    public var observedDialect: String?
+
+    /// Which layer produced this verdict.
+    public var source: ToolCallConformanceSource
+
+    /// Precision of parseable tool calls from the soak, if measured.
+    public var precision: Double?
+
+    /// Recall of expected tool calls from the soak, if measured.
+    public var recall: Double?
+
+    /// F1 of the soak, if measured.
+    public var f1: Double?
+
+    /// When the measurement was taken, for provenance. Not used for expiry —
+    /// conformance does not decay.
+    public var measuredAt: Date?
+
+    /// How many scenarios/samples backed the measurement. `0` for purely static
+    /// (template/render) verdicts.
+    public var sampleCount: Int
+
+    public init(
+        capability: ToolCallCapability,
+        observedDialect: String? = nil,
+        source: ToolCallConformanceSource,
+        precision: Double? = nil,
+        recall: Double? = nil,
+        f1: Double? = nil,
+        measuredAt: Date? = nil,
+        sampleCount: Int = 0
+    ) {
+        self.capability = capability
+        self.observedDialect = observedDialect
+        self.source = source
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+        self.measuredAt = measuredAt
+        self.sampleCount = sampleCount
+    }
+
+    /// The lazy default for an unmeasured cell — `unknown`, no dialect, sourced
+    /// from the static template layer with zero samples. Returned by a cache for
+    /// a key it has never seen.
+    public static let unknownDefault = ToolCallConformance(
+        capability: .unknown,
+        source: .templateExpressible
+    )
+}
+
+/// Storage-neutral port for persisting measured tool-call conformance verdicts.
+///
+/// Mirrors ``BenchmarkCache``'s shape: the port trafficks in the
+/// ``ToolCallConformance`` value type only — any backing `@Model` never escapes
+/// the impl. Keyed by ``ToolCallConformanceKey`` (`model × quant × backend`).
+///
+/// A missing key returns ``ToolCallConformance/unknownDefault`` rather than
+/// `nil`: conformance is lazy and `unknown` until measured, never a cold-start
+/// tax. The SwiftData-backed adapter (and its schema migration) is a separate
+/// follow-up — this surface ships with an in-memory adapter only.
+public protocol ToolCallConformanceCache: Sendable {
+
+    /// Returns the conformance verdict for the given cell, or
+    /// ``ToolCallConformance/unknownDefault`` if the cell has never been measured.
+    func get(_ key: ToolCallConformanceKey) async -> ToolCallConformance
+
+    /// Stores a verdict for the given cell, replacing any previous entry.
+    func put(_ key: ToolCallConformanceKey, _ conformance: ToolCallConformance) async
+
+    /// Returns every cached verdict keyed by cell.
+    func fetchAll() async -> [ToolCallConformanceKey: ToolCallConformance]
+}
+
+/// In-memory ``ToolCallConformanceCache`` — the write-path spike.
+///
+/// Proves the `get`/`put` round-trip before anyone wires a SwiftData adapter.
+/// An `actor` (not `@unchecked Sendable`) guards the dictionary.
+public actor InMemoryToolCallConformanceCache: ToolCallConformanceCache {
+
+    private var storage: [ToolCallConformanceKey: ToolCallConformance]
+
+    public init(seed: [ToolCallConformanceKey: ToolCallConformance] = [:]) {
+        self.storage = seed
+    }
+
+    public func get(_ key: ToolCallConformanceKey) async -> ToolCallConformance {
+        storage[key] ?? .unknownDefault
+    }
+
+    public func put(_ key: ToolCallConformanceKey, _ conformance: ToolCallConformance) async {
+        storage[key] = conformance
+    }
+
+    public func fetchAll() async -> [ToolCallConformanceKey: ToolCallConformance] {
+        storage
+    }
+}

--- a/Tests/ManifoldRuntimeTests/ToolCallConformanceCacheTests.swift
+++ b/Tests/ManifoldRuntimeTests/ToolCallConformanceCacheTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import ManifoldRuntime
+
+final class ToolCallConformanceCacheTests: XCTestCase {
+
+    private func sampleConformance() -> ToolCallConformance {
+        ToolCallConformance(
+            capability: .supported,
+            observedDialect: "hermes",
+            source: .measured,
+            precision: 0.97,
+            recall: 0.93,
+            f1: 0.95,
+            measuredAt: Date(timeIntervalSince1970: 1_700_000_000),
+            sampleCount: 40
+        )
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = sampleConformance()
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ToolCallConformance.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testKeyCodableRoundTrip() throws {
+        let key = ToolCallConformanceKey(model: "Qwen2.5-7B-Instruct", quant: "Q4_K_M", backend: "llama")
+        let data = try JSONEncoder().encode(key)
+        let decoded = try JSONDecoder().decode(ToolCallConformanceKey.self, from: data)
+        XCTAssertEqual(decoded, key)
+    }
+
+    func testGetAfterPutReturnsStoredValue() async {
+        let cache = InMemoryToolCallConformanceCache()
+        let key = ToolCallConformanceKey(model: "Qwen2.5-7B-Instruct", quant: "Q4_K_M", backend: "llama")
+        let value = sampleConformance()
+
+        await cache.put(key, value)
+        let fetched = await cache.get(key)
+
+        XCTAssertEqual(fetched, value)
+    }
+
+    func testGetMissingKeyReturnsUnknownDefault() async {
+        let cache = InMemoryToolCallConformanceCache()
+        let key = ToolCallConformanceKey(model: "never-measured", quant: nil, backend: "mlx")
+
+        let fetched = await cache.get(key)
+
+        XCTAssertEqual(fetched.capability, .unknown)
+        XCTAssertEqual(fetched, ToolCallConformance.unknownDefault)
+        XCTAssertEqual(fetched.sampleCount, 0)
+    }
+
+    func testFetchAllReturnsAllPuts() async {
+        let cache = InMemoryToolCallConformanceCache()
+        let k1 = ToolCallConformanceKey(model: "a", quant: "Q4_K_M", backend: "llama")
+        let k2 = ToolCallConformanceKey(model: "b", quant: nil, backend: "ollama")
+
+        await cache.put(k1, sampleConformance())
+        await cache.put(k2, ToolCallConformance(capability: .unsupported, source: .templateExpressible))
+
+        let all = await cache.fetchAll()
+        XCTAssertEqual(all.count, 2)
+        XCTAssertEqual(all[k1]?.capability, .supported)
+        XCTAssertEqual(all[k2]?.capability, .unsupported)
+    }
+}


### PR DESCRIPTION
Step 3 of the measured tool-call conformance plan (`docs/plans/tool-call-conformance.md`, layer 3). Builds the conformance cache surface as a **pure port + value type + in-memory adapter**, mirroring `BenchmarkCache`. **No SwiftData this PR** — the SwiftData adapter + a new schema version is a deliberately separate follow-up (schema migrations are reviewed by a human, not auto-merged).

## What's here (all in `Sources/ManifoldRuntime/Services/ToolCallConformance.swift`)
- `ToolCallConformanceKey: Hashable, Sendable, Codable` = `{ model, quant?, backend }` — the plan's `(model × quant × backend)` matrix key.
- `ToolCallCapability` (`supported | unsupported | unknown`), `ToolCallConformanceSource` (`templateExpressible | renderConsistent | measured`).
- `ToolCallConformance: Sendable, Codable, Equatable` with `capability`, `observedDialect: String?` (raw dialect name — kept a `String` to stay decoupled from step 4's `ToolCallDialect` type shipping in a parallel PR), `source`, `precision/recall/f1`, `measuredAt`, `sampleCount`.
- **No TTL / `isStale`**: `BenchmarkCache`/`ModelBenchmarkResult` decay because tokens/sec is device-specific; conformance is a property of the **weights**, so it does not decay. `measuredAt` is provenance, not expiry. Documented inline.
- `ToolCallConformanceCache` port — async `get`/`put`/`fetchAll` keyed by the cell. A missing key returns `.unknownDefault` (lazy; `unknown` until measured — never a cold-start tax).
- `InMemoryToolCallConformanceCache: actor` — the write-path spike. `actor`, not `@unchecked Sendable`.

## Write-path design (the spike)
The in-memory adapter exists to prove the get/put round-trip before anyone wires SwiftData. End to end, a measured cell reaches core like this:
1. A companion repo (manifold-llama / manifold-mlx) runs the live soak through its real render+parse path and emits a **transcript JSONL** (attributed by backend/model/quant — landed in #2027).
2. `ConformanceScorer` (already in `ManifoldTools`, #2027) consumes that JSONL and produces scored rows (precision/recall/f1, observed dialect, sample count).
3. A host maps each row to a `ToolCallConformanceKey` + `ToolCallConformance` and calls `cache.put(key, conformance)`. Reads are `cache.get(key)` → `.unknownDefault` for any unmeasured cell.

Because the verdict holds on every machine, a populated cache is **shippable as catalog data** / poolable later — it is not re-measured per device.

## Follow-up (held for morning — NOT in this PR)
The **SwiftData-backed adapter + a new schema version** is a separate DRAFT PR. Schema migrations aren't auto-merged; a human reviews them.

## Tests
`Tests/ManifoldRuntimeTests/ToolCallConformanceCacheTests.swift`: Codable round-trip of `ToolCallConformance` and the key; `InMemoryToolCallConformanceCache` get-after-put returns the stored value; missing key returns `.unknownDefault`; `fetchAll` round-trip.

Additive only — no API breakage expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)