### PR TITLE
fix(eval): recover expected tools when transcript omits requiredTools (#2005)

### DIFF
--- a/Sources/ManifoldTools/ConformanceScorer.swift
+++ b/Sources/ManifoldTools/ConformanceScorer.swift
@@ -152,6 +152,15 @@ public enum ConformanceScorer {
             var errored = false
             var toolCallCount = 0
             var expectedTools: [String] = []
+            /// Whether a `prompt` record actually carried a `requiredTools` field.
+            /// Distinguishes "no-tool scenario" (`requiredTools: []`) from "this
+            /// transcript shape never emits the field" — only the latter triggers
+            /// the assertion-derived expected-set recovery below.
+            var requiredToolsPresent = false
+            /// Expected tools recovered from the harness's dispatch-requirement
+            /// assertions (`Scenario requires `X` … — dispatched/never dispatched`).
+            /// Used only as a fallback when `requiredToolsPresent == false`.
+            var recoveredExpectedTools: Set<String> = []
             var calledTools: Set<String> = []
         }
 
@@ -189,15 +198,32 @@ public enum ConformanceScorer {
             switch kind {
             case "prompt":
                 // The prompt record carries the scenario's expected tool set.
-                // Tolerate its absence (older transcripts) — expected stays empty.
+                // Tolerate its absence (older / companion transcript shapes) — the
+                // assertion-derived recovery below fills the gap so a correctly
+                // dispatched tool isn't mis-scored as a false positive.
                 if let required = object["requiredTools"] as? [String] {
                     groups[key]?.expectedTools = required
+                    groups[key]?.requiredToolsPresent = true
                 }
             case "assertion":
                 if (object["passed"] as? Bool) == true {
                     groups[key]?.assertionsPassed += 1
                 } else {
                     groups[key]?.assertionsFailed += 1
+                }
+                // Recover the scenario's required tool(s) from the harness's
+                // dispatch-requirement assertions when the prompt record didn't
+                // carry `requiredTools`. The manifold-llama soak emitter predates
+                // that field, so without this every correct llama tool call lands
+                // in FP against an empty expected set (#2005). We extract ONLY the
+                // backtick-quoted tool token from the structural
+                // `Scenario requires `X` … — dispatched/never dispatched` template —
+                // never free prose — so recovery cannot invent a tool the scenario
+                // didn't require, and a wrong tool still scores FP.
+                if let message = object["message"] as? String {
+                    for tool in expectedToolsFromAssertion(message) {
+                        groups[key]?.recoveredExpectedTools.insert(tool)
+                    }
                 }
             case "tool_call":
                 groups[key]?.toolCallCount += 1
@@ -215,11 +241,19 @@ public enum ConformanceScorer {
 
         return order.compactMap { key -> ResultRow? in
             guard let acc = groups[key] else { return nil }
+            // Expected set: the prompt's `requiredTools` when present, otherwise the
+            // set recovered from dispatch-requirement assertions (older / companion
+            // transcript shapes that omit the field — #2005). When `requiredTools`
+            // *is* present we never consult the recovered set, so the Ollama path is
+            // untouched and an authoritative `requiredTools: []` stays a no-tool row.
+            let expectedTools: [String] = acc.requiredToolsPresent
+                ? acc.expectedTools
+                : acc.recoveredExpectedTools.sorted()
             // Tool-selection confusion: tools called vs tools required. Reuses the
             // shared core metric so the row is comparable with the MLX/llama soak.
             let confusion = ConfusionCounts.compute(
                 actual: acc.calledTools,
-                expected: Set(acc.expectedTools)
+                expected: Set(expectedTools)
             )
             return ResultRow(
                 backend: acc.backend,
@@ -235,13 +269,43 @@ public enum ConformanceScorer {
                     failed: acc.assertionsFailed,
                     errored: acc.errored
                 ),
-                expectedTools: acc.expectedTools,
+                expectedTools: expectedTools,
                 calledTools: acc.calledTools.sorted(),
                 toolTP: confusion.tp,
                 toolFP: confusion.fp,
                 toolFN: confusion.fn
             )
         }
+    }
+
+    /// Recovers the required tool name(s) named in a dispatch-requirement
+    /// assertion message, used only when a transcript omits the `requiredTools`
+    /// prompt field (#2005 — the manifold-llama soak emitter predates it).
+    ///
+    /// Deliberately conservative: it matches ONLY the backtick-quoted tool token
+    /// in the structural `Scenario requires `X` …` template the harness emits.
+    /// Free-prose requirement assertions (e.g. "Scenario requires the shopping
+    /// list to be read from the fixture") yield nothing rather than risk crediting
+    /// a phantom expected tool — under-counting the expected set is safe (it never
+    /// manufactures a false positive *or* a false true-positive), whereas prose
+    /// matching could. A genuinely wrong tool therefore still scores as FP.
+    static func expectedToolsFromAssertion(_ message: String) -> [String] {
+        guard message.hasPrefix("Scenario requires") else { return [] }
+        var tools: [String] = []
+        var rest = Substring(message)
+        while let open = rest.firstIndex(of: "`") {
+            let afterOpen = rest.index(after: open)
+            guard let close = rest[afterOpen...].firstIndex(of: "`") else { break }
+            let token = String(rest[afterOpen..<close])
+            // A tool identifier — reject anything that isn't a bare snake/alnum id
+            // so an incidentally back-ticked prose fragment can't slip through.
+            if !token.isEmpty,
+               token.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) {
+                tools.append(token)
+            }
+            rest = rest[rest.index(after: close)...]
+        }
+        return tools
     }
 
     /// Derives the verdict from the assertion tallies and error flag.

--- a/Tests/ManifoldToolsTests/ScenarioRunnerTests.swift
+++ b/Tests/ManifoldToolsTests/ScenarioRunnerTests.swift
@@ -643,6 +643,97 @@ final class ScenarioRunnerTests: XCTestCase {
         XCTAssertEqual(macro.precision, 0.25, accuracy: 0.0001)
         XCTAssertEqual(macro.recall, 0.5, accuracy: 0.0001)
     }
+
+    // MARK: - #2005: expected-tool recovery for transcripts without `requiredTools`
+
+    /// Regression for #2005. The manifold-llama soak emitter predates the
+    /// `requiredTools` prompt field, so its `prompt` records carry no expected
+    /// tool set. Before the fix, every correctly dispatched llama tool call was
+    /// scored against an empty expected set → `toolTP=0, toolFP=1, f1=0` even
+    /// though the right tool was called and the scenario verdict was `.pass`.
+    ///
+    /// This fixture reproduces the exact llama `tool_call`/`assertion` record
+    /// shape (no `backend`/`model`/`quant`, no `requiredTools`; the required tool
+    /// is named only in the back-ticked dispatch-requirement assertion). The
+    /// scorer must recover `now` as the expected tool and credit it as a TP.
+    func test_conformanceScorer_recoversExpectedToolFromAssertion_whenRequiredToolsAbsent() {
+        let lines = [
+            #"{"kind":"prompt","scenario":"01-now","system":"You have tools.","user":"What time is it?"}"#,
+            #"{"kind":"tool_call","scenario":"01-now","name":"now","arguments":"{}"}"#,
+            #"{"kind":"tool_result","scenario":"01-now","name":"now","content":"{}","errorKind":null}"#,
+            #"{"kind":"assertion","scenario":"01-now","passed":true,"message":"Scenario requires `now` to actually be dispatched — dispatched"}"#,
+            #"{"kind":"assertion","scenario":"01-now","passed":true,"message":"Final answer should quote the OOD timestamp from `now` — found"}"#
+        ].joined(separator: "\n")
+
+        let row = ConformanceScorer.score(jsonl: lines).first { $0.scenario == "01-now" }
+
+        XCTAssertEqual(row?.expectedTools, ["now"], "required `now` recovered from the dispatch assertion")
+        XCTAssertEqual(row?.calledTools, ["now"])
+        XCTAssertEqual(row?.toolTP, 1, "a correctly dispatched expected tool is a true positive, not an FP (#2005)")
+        XCTAssertEqual(row?.toolFP, 0)
+        XCTAssertEqual(row?.toolFN, 0)
+        XCTAssertEqual(row?.confusion.precision ?? 0, 1.0, accuracy: 0.0001, "precision must be > 0 for the recovered cell")
+        XCTAssertEqual(row?.confusion.f1 ?? 0, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(row?.verdict, .pass)
+        XCTAssertTrue(row?.isToolBearing ?? false, "the recovered expected set makes the row tool-bearing")
+    }
+
+    /// Guard: recovery must not loosen matching into false positives. A scenario
+    /// that requires `calc` but where the model called the wrong tool (`read_file`)
+    /// must still score `calc` as a false negative and `read_file` as a false
+    /// positive — never a spurious true positive. (Mirrors `shopping-list-budget`
+    /// from the captured llama transcript.)
+    func test_conformanceScorer_recoveredExpectedTool_stillScoresWrongToolAsFalsePositive() {
+        let lines = [
+            #"{"kind":"prompt","scenario":"shopping-list-budget","system":"You have tools.","user":"Total the cheapest items."}"#,
+            #"{"kind":"tool_call","scenario":"shopping-list-budget","name":"read_file","arguments":"{}"}"#,
+            #"{"kind":"assertion","scenario":"shopping-list-budget","passed":false,"message":"Scenario requires `calc` for the selected total — never dispatched — final answer may be hallucinated"}"#
+        ].joined(separator: "\n")
+
+        let row = ConformanceScorer.score(jsonl: lines).first { $0.scenario == "shopping-list-budget" }
+
+        XCTAssertEqual(row?.expectedTools, ["calc"], "expected `calc` recovered even though it was never dispatched")
+        XCTAssertEqual(row?.calledTools, ["read_file"])
+        XCTAssertEqual(row?.toolTP, 0, "the wrong tool must NOT count as a true positive")
+        XCTAssertEqual(row?.toolFP, 1, "the wrong tool (`read_file`) is a false positive")
+        XCTAssertEqual(row?.toolFN, 1, "the required `calc` is a false negative")
+    }
+
+    /// Recovery is a fallback only. When the prompt record carries an explicit
+    /// `requiredTools` (the Ollama / current-logger shape), the scorer must use it
+    /// verbatim and never consult the assertion text — so an authoritative empty
+    /// set stays a no-tool row even if an assertion happens to name a tool.
+    func test_conformanceScorer_explicitRequiredToolsTakesPrecedenceOverAssertionRecovery() {
+        let lines = [
+            #"{"kind":"prompt","scenario":"s","backend":"ollama","model":"A","requiredTools":[]}"#,
+            #"{"kind":"final","scenario":"s","backend":"ollama","model":"A","text":"hello"}"#,
+            #"{"kind":"assertion","scenario":"s","backend":"ollama","model":"A","passed":true,"message":"Scenario requires `now` to actually be dispatched — dispatched"}"#
+        ].joined(separator: "\n")
+
+        let row = ConformanceScorer.score(jsonl: lines).first { $0.scenario == "s" }
+
+        XCTAssertEqual(row?.expectedTools, [], "explicit empty requiredTools wins over assertion recovery")
+        XCTAssertFalse(row?.isToolBearing ?? true, "an authoritative no-tool scenario stays non-tool-bearing")
+    }
+
+    /// The extractor must ignore free-prose requirement assertions (no back-ticked
+    /// tool token) rather than crediting a phantom expected tool.
+    func test_expectedToolsFromAssertion_ignoresProseAndExtractsBacktickedTools() {
+        XCTAssertEqual(
+            ConformanceScorer.expectedToolsFromAssertion("Scenario requires `read_file` to inspect standup.md — never dispatched — final answer may be hallucinated"),
+            ["read_file"]
+        )
+        XCTAssertEqual(
+            ConformanceScorer.expectedToolsFromAssertion("Scenario requires the shopping list to be read from the fixture — dispatched"),
+            [],
+            "free prose with no back-ticked tool token yields nothing"
+        )
+        XCTAssertEqual(
+            ConformanceScorer.expectedToolsFromAssertion("Final answer should quote the calc result 320743 — found"),
+            [],
+            "only `Scenario requires …` requirement assertions are mined"
+        )
+    }
 }
 
 private struct FixedToolExecutor: ToolExecutor {


### PR DESCRIPTION
## Problem

`ConformanceScorer` counted **correct** llama.cpp tool calls as false positives — `toolTP=0, toolFP=1, precision=0, recall=0, f1=0` — even when the right tool was dispatched and the scenario `verdict=pass`. The aggregate F1 for the recovered llama.cpp-Mistral cell was therefore falsely 0.

## Root cause

The two transcript shapes differ in their `prompt` record:

**Ollama** (scores correctly):
```json
{"advertisedTools":["now"],"backend":"ollama","kind":"prompt","model":"mistral-7b-tools","requiredTools":["now"],"scenario":"01-now", ...}
```

**llama.cpp** (manifold-llama soak emitter — predates the field):
```json
{"kind":"prompt","scenario":"01-now","system":"You have tools. ...","user":"What time is it? ..."}
```

The llama `prompt` record has **no `requiredTools`** (and no `backend`/`model`/`quant`). The scorer treated "field absent" identically to an authoritative empty expected set, so each correctly-named call (`{"kind":"tool_call","name":"now",...}` — the name field *is* correct) was scored as `called − expected = {now} − {} = FP`.

## Fix

When — and only when — a `prompt` record omits `requiredTools` entirely, recover the expected tool set from the harness's structural dispatch-requirement assertions (``Scenario requires `X` … — dispatched``), extracting **only** the back-ticked tool token, never free prose. Conservative by design: it under-counts rather than inventing a phantom expected tool, so a genuinely wrong tool still scores FP and a correct one scores TP. When `requiredTools` is present (Ollama / current logger), the recovered set is never consulted — that path and an authoritative `requiredTools: []` no-tool row are unchanged.

## Tests

`Tests/ManifoldToolsTests/ScenarioRunnerTests.swift`:
- `…recoversExpectedToolFromAssertion_whenRequiredToolsAbsent` — replays the captured llama record shape; asserts TP>0 / precision>0.
- `…recoveredExpectedTool_stillScoresWrongToolAsFalsePositive` — wrong tool still FP, required tool still FN.
- `…explicitRequiredToolsTakesPrecedenceOverAssertionRecovery` — Ollama path / no-tool row unaffected.
- `test_expectedToolsFromAssertion_ignoresProseAndExtractsBacktickedTools` — extractor ignores prose.

All 8 `ConformanceScorer` tests green locally (`swift test --filter ScenarioRunnerTests/test_conformanceScorer`). Full `--profile local` deferred to CI.

Refs #2005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pi5goJ5FtB2xPWQMvRaER