### PR TITLE
feat(tools): add ConformanceRecord normalized result schema

### DIFF
--- a/Sources/ManifoldTools/ConformanceRecord.swift
+++ b/Sources/ManifoldTools/ConformanceRecord.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+/// The single normalized result record every eval leg emits — one row per
+/// evaluated cell, the `(model × quant × backend × renderer)` tuple run against
+/// one scenario at one decoy level and repeat index.
+///
+/// It exists so the Ollama, llama.cpp, MLX, and cloud legs — which run in
+/// *separate processes* (see `docs/plans/manifold-eval-repo.md` §3: one process
+/// is unbuildable because `llama_backend_init` is once-per-process and MLX needs
+/// serialized in-process Metal) — can each emit the same shape, and a downstream
+/// collator can fold them into one matrix without re-deriving per-backend
+/// vocabulary. It mirrors the `ConformanceScorer.ResultRow` outputs (the
+/// assertion-derived ``ConformanceScorer/Verdict`` and the tool-selection
+/// precision/recall/F1) but adds the cell-identity coordinates and, crucially,
+/// a first-class ``CellStatus``.
+///
+/// `notMeasured` is a distinct ``CellStatus`` case — **absence is not failure.**
+/// A missing GGUF, an unavailable backend, or a skipped cell must read as
+/// `notMeasured`, never as a `fail` ``ConformanceScorer/Verdict``: scoring a hole
+/// in the matrix as a failure is exactly the "empty CSV reads as measured" defect
+/// this schema was added to kill (plan §1). When `status` is anything other than
+/// `.measured`, `verdict` and `toolSelection` are `nil` — there is no measurement
+/// to carry.
+public struct ConformanceRecord: Codable, Sendable, Equatable {
+
+    // MARK: Cell identity — the (model × quant × backend × renderer) tuple
+
+    /// Backend family that drove the run, e.g. `"ollama"`, `"llama.cpp"`,
+    /// `"mlx"`, `"openrouter"`. Matches `ConformanceScorer.ResultRow.backend`'s
+    /// vocabulary (non-optional here: a record always names the cell it measured).
+    public let backend: String
+
+    /// Logical model id, e.g. `"mistral-7b-instruct-v0.3"`.
+    public let model: String
+
+    /// Quantization / weight label, e.g. `"Q4_K_M"`, `"4bit"`, `"server"`,
+    /// `"cloud"`. Mirrors `ConformanceScorer.ResultRow.quant`.
+    public let quant: String
+
+    /// The prompt-rendering path exercised, e.g. `"ollama-server"`,
+    /// `"jinja-prompt"`, `"swift-transformers"`, `"native"`. Not present on the
+    /// scorer row — it is the dimension cross-backend twin-divergence is attributed
+    /// to (plan §4: a divergence needs a same-bytes control before it's a renderer
+    /// bug).
+    public let renderer: String
+
+    // MARK: Scenario coordinates
+
+    /// Scenario id, matching `TranscriptLogger.Event.prompt`'s `scenarioId`.
+    public let scenario: String
+
+    /// Number of decoy/distractor tools advertised alongside the required set
+    /// (the `--extra-tools N` knob surfaced as `advertisedTools` in the
+    /// transcript). `0` for a baseline run.
+    public let decoyLevel: Int
+
+    /// Which repetition of an otherwise-identical cell this is. Named
+    /// `repeatIndex` because `repeat` is a Swift keyword. Repeats exist so a
+    /// verdict-class regression detector can see the 0.10–0.12 F1 run-to-run swing
+    /// (plan §4) rather than trust a single sample.
+    public let repeatIndex: Int
+
+    // MARK: Outcome
+
+    /// Whether the cell was actually measured, and if not, why. First-class so a
+    /// hole in the matrix is never confused with a measured failure.
+    public let status: CellStatus
+
+    /// The assertion-derived scenario verdict — reusing the scorer's own
+    /// ``ConformanceScorer/Verdict`` (`pass` / `partial` / `fail` / `errored`)
+    /// rather than a competing two-case enum, so the record carries exactly what
+    /// `ConformanceScorer.ResultRow` produces. `nil` when `status != .measured`.
+    public let verdict: ConformanceScorer.Verdict?
+
+    /// Tool-selection precision/recall/F1 for this cell — the same metric the
+    /// MLX/llama soak CLIs and `ConfusionCounts` report. `nil` for a no-tool
+    /// scenario (an empty expected set is not a tool-selection class) or when the
+    /// cell was not measured.
+    public let toolSelection: Scores?
+
+    /// Coarse failure bucket when something went wrong, for at-a-glance matrix
+    /// triage. `nil` on a clean `pass`.
+    public let failureClass: FailureClass?
+
+    // MARK: Provenance
+
+    /// Path to (or content hash of) the raw `TranscriptLogger` JSONL this record
+    /// was reduced from, so a human can always re-read the transcript that
+    /// produced a verdict (plan §4: keep the human transcript spot-check in the
+    /// loop).
+    public let transcriptRef: String
+
+    /// The ManifoldKit core commit the run was built from — runs are only
+    /// comparable across the same core binary (eval drivers share the core
+    /// binary; never rebuild mid-eval).
+    public let coreCommit: String
+
+    /// Tooling/runtime versions that shaped the run (e.g. `"ollama": "0.5.4"`,
+    /// `"mlx": "0.18.0"`), so an environment drift doesn't read as a regression
+    /// (plan §4: guard regression-vs-last-run against environment drift).
+    public let toolingVersions: [String: String]
+
+    public init(
+        backend: String,
+        model: String,
+        quant: String,
+        renderer: String,
+        scenario: String,
+        decoyLevel: Int,
+        repeatIndex: Int,
+        status: CellStatus,
+        verdict: ConformanceScorer.Verdict?,
+        toolSelection: Scores?,
+        failureClass: FailureClass?,
+        transcriptRef: String,
+        coreCommit: String,
+        toolingVersions: [String: String]
+    ) {
+        self.backend = backend
+        self.model = model
+        self.quant = quant
+        self.renderer = renderer
+        self.scenario = scenario
+        self.decoyLevel = decoyLevel
+        self.repeatIndex = repeatIndex
+        self.status = status
+        self.verdict = verdict
+        self.toolSelection = toolSelection
+        self.failureClass = failureClass
+        self.transcriptRef = transcriptRef
+        self.coreCommit = coreCommit
+        self.toolingVersions = toolingVersions
+    }
+}
+
+/// Whether a cell was measured, and — when it wasn't — why. The non-`measured`
+/// cases are the whole reason this type exists: a hole in the matrix (missing
+/// weights, dead backend, a render that never produced a prompt) is a *state*,
+/// distinct from a measured `fail` ``ConformanceScorer/Verdict``.
+public enum CellStatus: Codable, Sendable, Equatable {
+    /// The cell ran end-to-end and produced a scorable transcript.
+    case measured
+    /// The cell was deliberately not run (e.g. weights absent, backend offline).
+    /// The associated string is a human-readable reason for the hole.
+    case notMeasured(String)
+    /// The model/weights failed to load. The associated string carries the
+    /// load error for triage.
+    case loadFail(String)
+    /// Prompt rendering produced no usable prompt, so no inference ran.
+    case renderFail
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case reason
+    }
+
+    private enum Kind: String, Codable {
+        case measured
+        case notMeasured
+        case loadFail
+        case renderFail
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .measured:
+            self = .measured
+        case .notMeasured:
+            let reason = try container.decode(String.self, forKey: .reason)
+            self = .notMeasured(reason)
+        case .loadFail:
+            let reason = try container.decode(String.self, forKey: .reason)
+            self = .loadFail(reason)
+        case .renderFail:
+            self = .renderFail
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .measured:
+            try container.encode(Kind.measured, forKey: .kind)
+        case .notMeasured(let reason):
+            try container.encode(Kind.notMeasured, forKey: .kind)
+            try container.encode(reason, forKey: .reason)
+        case .loadFail(let reason):
+            try container.encode(Kind.loadFail, forKey: .kind)
+            try container.encode(reason, forKey: .reason)
+        case .renderFail:
+            try container.encode(Kind.renderFail, forKey: .kind)
+        }
+    }
+}
+
+/// Coarse failure bucket for at-a-glance matrix triage. Orthogonal to
+/// ``CellStatus``: `loadFail`/`renderFail` mirror the un-measured states, while
+/// `noCall`/`lowPrecision`/`truncation` classify *measured* failures.
+public enum FailureClass: String, Codable, Sendable {
+    /// The model emitted no tool call where one was required.
+    case noCall
+    /// Prompt rendering failed (mirrors ``CellStatus/renderFail``).
+    case renderFail
+    /// Model/weights failed to load (mirrors ``CellStatus/loadFail``).
+    case loadFail
+    /// A tool call was made but selection precision was below threshold (decoys
+    /// or wrong tools called).
+    case lowPrecision
+    /// Generation was truncated before the call could complete.
+    case truncation
+}
+
+/// A Codable snapshot of tool-selection precision / recall / F1 for one cell.
+///
+/// Mirrors the `precision`/`recall`/`f1` carried by the core `ConfusionCounts` /
+/// `MacroAveragedMetrics`, but is a self-contained `Codable` value so the record
+/// round-trips without making those `ManifoldInference` metric types `Codable`
+/// (that surface belongs to another module).
+public struct Scores: Codable, Sendable, Equatable {
+    public let precision: Double
+    public let recall: Double
+    public let f1: Double
+
+    public init(precision: Double, recall: Double, f1: Double) {
+        self.precision = precision
+        self.recall = recall
+        self.f1 = f1
+    }
+}

--- a/Tests/ManifoldToolsTests/ConformanceRecordTests.swift
+++ b/Tests/ManifoldToolsTests/ConformanceRecordTests.swift
@@ -166,4 +166,35 @@ final class ConformanceRecordTests: XCTestCase {
         let renderFail = try encoder.encode(CellStatus.renderFail)
         XCTAssertEqual(String(decoding: renderFail, as: UTF8.self), #"{"kind":"renderFail"}"#)
     }
+
+    /// The load-bearing guard: a `CellStatus` whose `kind` discriminator is
+    /// unrecognized must fail to decode — *loudly* — never silently default to
+    /// `.measured`. Defaulting an unknown/garbage kind to `.measured` is exactly
+    /// the "absence reads as measured" defect this schema exists to kill, so the
+    /// throw is pinned here against future refactors.
+    func testUnknownCellStatusKindFailsToDecode() throws {
+        let json = Data(#"{"kind":"teleported"}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(CellStatus.self, from: json)) { error in
+            XCTAssertTrue(error is DecodingError, "expected a DecodingError, got \(error)")
+        }
+    }
+
+    /// A `CellStatus` with no `kind` discriminator at all must also fail loudly —
+    /// a missing key must never be read as `.measured`.
+    func testMissingCellStatusKindFailsToDecode() throws {
+        let json = Data(#"{"reason":"offline"}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(CellStatus.self, from: json)) { error in
+            XCTAssertTrue(error is DecodingError, "expected a DecodingError, got \(error)")
+        }
+    }
+
+    /// `notMeasured`/`loadFail` carry a required reason; a record that drops it
+    /// fails to decode rather than fabricating an empty reason — the reason is part
+    /// of the measured-hole's identity, not optional decoration.
+    func testNotMeasuredMissingReasonFailsToDecode() throws {
+        let json = Data(#"{"kind":"notMeasured"}"#.utf8)
+        XCTAssertThrowsError(try JSONDecoder().decode(CellStatus.self, from: json)) { error in
+            XCTAssertTrue(error is DecodingError, "expected a DecodingError, got \(error)")
+        }
+    }
 }

--- a/Tests/ManifoldToolsTests/ConformanceRecordTests.swift
+++ b/Tests/ManifoldToolsTests/ConformanceRecordTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import ManifoldTools
+
+final class ConformanceRecordTests: XCTestCase {
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private func roundTrip(_ record: ConformanceRecord) throws -> ConformanceRecord {
+        let data = try makeEncoder().encode(record)
+        return try JSONDecoder().decode(ConformanceRecord.self, from: data)
+    }
+
+    /// A fully-measured cell carrying a verdict + tool-selection scores must
+    /// survive encode → decode unchanged.
+    func testMeasuredRecordRoundTrips() throws {
+        let record = ConformanceRecord(
+            backend: "llama.cpp",
+            model: "mistral-7b-instruct-v0.3",
+            quant: "Q4_K_M",
+            renderer: "jinja-prompt",
+            scenario: "weather-lookup",
+            decoyLevel: 3,
+            repeatIndex: 1,
+            status: .measured,
+            verdict: .pass,
+            toolSelection: Scores(precision: 1.0, recall: 1.0, f1: 1.0),
+            failureClass: nil,
+            transcriptRef: "runs/llama-20260626.jsonl#weather-lookup",
+            coreCommit: "ba936494",
+            toolingVersions: ["llama.cpp": "b3901", "core": "0.54.0"]
+        )
+
+        let decoded = try roundTrip(record)
+        XCTAssertEqual(decoded, record)
+        XCTAssertEqual(decoded.status, .measured)
+        XCTAssertEqual(decoded.verdict, .pass)
+        XCTAssertEqual(decoded.toolSelection, Scores(precision: 1.0, recall: 1.0, f1: 1.0))
+    }
+
+    /// The whole point of the schema: a `notMeasured` hole is a *state*, not a
+    /// `fail` verdict. It must round-trip preserving its reason, and must never
+    /// read as a measured failure.
+    func testNotMeasuredRecordRoundTripsAndIsNotFailure() throws {
+        let record = ConformanceRecord(
+            backend: "mlx",
+            model: "qwen2.5-7b-instruct",
+            quant: "4bit",
+            renderer: "swift-transformers",
+            scenario: "weather-lookup",
+            decoyLevel: 0,
+            repeatIndex: 0,
+            status: .notMeasured("weights absent on this host"),
+            verdict: nil,
+            toolSelection: nil,
+            failureClass: nil,
+            transcriptRef: "",
+            coreCommit: "ba936494",
+            toolingVersions: [:]
+        )
+
+        let decoded = try roundTrip(record)
+        XCTAssertEqual(decoded, record)
+        XCTAssertEqual(decoded.status, .notMeasured("weights absent on this host"))
+
+        // Absence is not failure — a not-measured cell carries no verdict at all,
+        // and is distinct from a measured `.fail`.
+        XCTAssertNil(decoded.verdict)
+        XCTAssertNotEqual(decoded.status, .measured)
+        let measuredFail = CellStatus.measured
+        XCTAssertNotEqual(decoded.status, measuredFail)
+    }
+
+    /// `loadFail` carries its error reason through a round trip.
+    func testLoadFailRecordRoundTrips() throws {
+        let record = ConformanceRecord(
+            backend: "llama.cpp",
+            model: "gemma-2-9b",
+            quant: "Q4_K_M",
+            renderer: "jinja-prompt",
+            scenario: "structured-json-extraction",
+            decoyLevel: 0,
+            repeatIndex: 2,
+            status: .loadFail("gguf header parse error"),
+            verdict: nil,
+            toolSelection: nil,
+            failureClass: .loadFail,
+            transcriptRef: "runs/llama-20260626.jsonl",
+            coreCommit: "ba936494",
+            toolingVersions: ["llama.cpp": "b3901"]
+        )
+
+        let decoded = try roundTrip(record)
+        XCTAssertEqual(decoded, record)
+        XCTAssertEqual(decoded.status, .loadFail("gguf header parse error"))
+        XCTAssertEqual(decoded.failureClass, .loadFail)
+    }
+
+    /// `renderFail` (no associated value) round-trips and stays distinct from a
+    /// measured failure.
+    func testRenderFailRecordRoundTrips() throws {
+        let record = ConformanceRecord(
+            backend: "mlx",
+            model: "mistral-7b-instruct-v0.3",
+            quant: "4bit",
+            renderer: "swift-transformers",
+            scenario: "weather-lookup",
+            decoyLevel: 0,
+            repeatIndex: 0,
+            status: .renderFail,
+            verdict: nil,
+            toolSelection: nil,
+            failureClass: .renderFail,
+            transcriptRef: "",
+            coreCommit: "ba936494",
+            toolingVersions: [:]
+        )
+
+        let decoded = try roundTrip(record)
+        XCTAssertEqual(decoded, record)
+        XCTAssertEqual(decoded.status, .renderFail)
+        XCTAssertNil(decoded.verdict)
+    }
+
+    /// A measured `.fail` verdict must be distinguishable from every non-measured
+    /// status — the matrix must never collapse "ran and failed" into "didn't run".
+    func testMeasuredFailIsDistinctFromNotMeasured() throws {
+        let measuredFail = ConformanceRecord(
+            backend: "ollama",
+            model: "llama3.1-8b",
+            quant: "server",
+            renderer: "ollama-server",
+            scenario: "weather-lookup",
+            decoyLevel: 0,
+            repeatIndex: 0,
+            status: .measured,
+            verdict: .fail,
+            toolSelection: Scores(precision: 0.0, recall: 0.0, f1: 0.0),
+            failureClass: .noCall,
+            transcriptRef: "runs/ollama.jsonl",
+            coreCommit: "ba936494",
+            toolingVersions: ["ollama": "0.5.4"]
+        )
+
+        let decoded = try roundTrip(measuredFail)
+        XCTAssertEqual(decoded, measuredFail)
+        XCTAssertEqual(decoded.status, .measured)
+        XCTAssertEqual(decoded.verdict, .fail)
+        XCTAssertNotEqual(decoded.status, .notMeasured("did not run"))
+    }
+
+    /// Each `CellStatus` case encodes to a stable, self-describing shape so the
+    /// JSONL a human reads is unambiguous.
+    func testCellStatusEncodingShape() throws {
+        let encoder = makeEncoder()
+
+        let measured = try encoder.encode(CellStatus.measured)
+        XCTAssertEqual(String(decoding: measured, as: UTF8.self), #"{"kind":"measured"}"#)
+
+        let notMeasured = try encoder.encode(CellStatus.notMeasured("offline"))
+        XCTAssertEqual(String(decoding: notMeasured, as: UTF8.self), #"{"kind":"notMeasured","reason":"offline"}"#)
+
+        let renderFail = try encoder.encode(CellStatus.renderFail)
+        XCTAssertEqual(String(decoding: renderFail, as: UTF8.self), #"{"kind":"renderFail"}"#)
+    }
+}


### PR DESCRIPTION
## PR C of the in-place eval-consolidation effort

Plan: `docs/plans/manifold-eval-repo.md` §3 (Wave 1, PR **C** — independent, core-only, additive).

### What
Adds a **single normalized eval record** to the `ManifoldTools` library so every backend leg (Ollama / llama.cpp / MLX / cloud), which run in *separate processes*, can emit the same shape for downstream collation:

- `ConformanceRecord` — cell identity (`backend × model × quant × renderer`) + scenario coordinates (`scenario`, `decoyLevel`, `repeatIndex`) + outcome + provenance (`transcriptRef`, `coreCommit`, `toolingVersions`).
- `CellStatus` — `measured` / `notMeasured(String)` / `loadFail(String)` / `renderFail`, with hand-rolled `Codable` for the associated values.
- `FailureClass`, `Scores` — coarse triage bucket + a Codable P/R/F1 snapshot.

All `Codable, Sendable` value types. **`notMeasured` is first-class** — a missing GGUF / offline backend never reads as a measured `fail` verdict (the "empty CSV reads as measured" defect, plan §1).

### Scope discipline
- **Purely additive** — one new source file + one test file. **No `Package.swift` change** (file lives in the existing `ManifoldTools` target).
- Does **not** wire the scorer to emit the record — that is PR D/E. This only makes the type *capable* of representing the scorer's output.

### Naming reconciliation vs the sketch
- `verdict` reuses the existing **`ConformanceScorer.Verdict`** (`pass`/`partial`/`fail`/`errored`) instead of a new two-case `pass/fail` enum — matches what `ConformanceScorer.ResultRow` actually produces and avoids a competing vocabulary.
- `Scores` is a self-contained Codable triple mirroring core `ConfusionCounts`/`MacroAveragedMetrics` P/R/F1, kept local so the record round-trips without making those `ManifoldInference` metric types `Codable` (a different module's surface).

### Verification (bounded — orchestrator owns the full gate + CI)
- `swift build --build-tests` — Build complete.
- `swift test --filter ConformanceRecordTests` — **6/6 passed** (round-trip for measured / notMeasured / loadFail / renderFail; measured-`fail` proven distinct from `notMeasured`; `CellStatus` encoding shape).

No `try?`, no force-unwraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)