### PR TITLE
feat(tools): ConformanceScorer emits ConformanceRecords + public scoring API

### DIFF
--- a/Sources/ManifoldTools/ConformanceScorer+Records.swift
+++ b/Sources/ManifoldTools/ConformanceScorer+Records.swift
@@ -1,0 +1,227 @@
+import Foundation
+import ManifoldInference
+
+/// Emits the normalized ``ConformanceRecord`` schema (the cross-leg eval row added
+/// in #2041) from a scored transcript.
+///
+/// This is the single source that turns a `TranscriptLogger` JSONL into
+/// `[ConformanceRecord]`, so the Ollama / llama.cpp / MLX / cloud legs — and the
+/// companion manifold-mlx / manifold-llama repos — all emit the *same* shape
+/// instead of hand-rolling a per-leg `SUMMARY`. It reuses the one parse pass in
+/// ``ConformanceScorer/resolve(jsonl:)`` (so the expected-set recovery #2005 and
+/// TP attribution #2043 apply identically) and maps each resolved row to a
+/// `.measured` record.
+///
+/// **Absence is not failure.** A transcript that is missing, unreadable, or empty
+/// (the model didn't load, the GGUF was absent, the backend was offline) must NOT
+/// be dropped silently and must NOT read as a measured zero. When the caller names
+/// the cell it expected via ``ExpectedCell``, the file-based emitter returns a
+/// single record carrying ``CellStatus/notMeasured(_:)`` / ``CellStatus/loadFail(_:)``
+/// instead — the load-bearing distinction ``ConformanceRecord`` exists to preserve.
+extension ConformanceScorer {
+
+    /// Caller-supplied provenance the transcript itself doesn't carry.
+    ///
+    /// - `renderer`: the prompt-rendering path exercised (e.g. `"ollama-server"`,
+    ///   `"jinja-prompt"`, `"swift-transformers"`). The transcript never records
+    ///   this, so it is a **caller-declared label**, not a measured value — pass
+    ///   the renderer the leg was configured with.
+    /// - `coreCommit`: the ManifoldKit core commit the eval binary was built from.
+    ///   Runs are only comparable across the same core binary. Resolve it from the
+    ///   build (git SHA) and pass it in; use a documented placeholder (e.g.
+    ///   `"unknown"`) when it can't be resolved.
+    public struct RecordContext: Sendable, Equatable {
+        public let renderer: String
+        public let coreCommit: String
+        public let toolingVersions: [String: String]
+        public let transcriptRef: String
+
+        public init(
+            renderer: String,
+            coreCommit: String,
+            toolingVersions: [String: String] = [:],
+            transcriptRef: String
+        ) {
+            self.renderer = renderer
+            self.coreCommit = coreCommit
+            self.toolingVersions = toolingVersions
+            self.transcriptRef = transcriptRef
+        }
+    }
+
+    /// The cell a transcript was *supposed* to measure, so an absent/empty/unreadable
+    /// transcript produces a `.notMeasured`/`.loadFail` record for the right
+    /// coordinates instead of a silently-dropped row.
+    public struct ExpectedCell: Sendable, Equatable {
+        public let backend: String
+        public let model: String
+        public let quant: String
+        public let scenario: String
+        public let decoyLevel: Int
+        public let repeatIndex: Int
+
+        public init(
+            backend: String,
+            model: String,
+            quant: String,
+            scenario: String,
+            decoyLevel: Int = 0,
+            repeatIndex: Int = 0
+        ) {
+            self.backend = backend
+            self.model = model
+            self.quant = quant
+            self.scenario = scenario
+            self.decoyLevel = decoyLevel
+            self.repeatIndex = repeatIndex
+        }
+    }
+
+    /// Maps a scored JSONL transcript to `.measured` ``ConformanceRecord`` rows —
+    /// one per (backend × model × quant × scenario) group the scorer produces.
+    ///
+    /// Returns `[]` for an empty transcript; callers that need the absence handled
+    /// as an explicit hole should use ``records(fileAt:context:expectedCell:)`` with
+    /// an ``ExpectedCell``.
+    public static func records(jsonl text: String, context: RecordContext) -> [ConformanceRecord] {
+        resolve(jsonl: text).map { record(from: $0, context: context) }
+    }
+
+    /// Scores a transcript file and emits ``ConformanceRecord`` rows, handling the
+    /// absence case so a hole in the matrix is never confused with a failure.
+    ///
+    /// - An unreadable file (e.g. the run never wrote a transcript because the
+    ///   weights failed to load) → one ``CellStatus/loadFail(_:)`` record for
+    ///   `expectedCell`.
+    /// - A non-UTF-8 / empty transcript (no scorable rows) → one
+    ///   ``CellStatus/notMeasured(_:)`` record for `expectedCell`.
+    /// - When `expectedCell` is `nil`, the absence cases return `[]` (the caller
+    ///   chose not to name a cell, so there is nothing to attribute the hole to).
+    ///
+    /// This method does not throw: an unreadable transcript is data about the cell,
+    /// not a programming error to propagate.
+    public static func records(
+        fileAt url: URL,
+        context: RecordContext,
+        expectedCell: ExpectedCell? = nil
+    ) -> [ConformanceRecord] {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            // The transcript could not be read — most often because the run never
+            // produced one (missing GGUF, backend offline). That is a load hole,
+            // not a measured failure.
+            if let cell = expectedCell {
+                return [notMeasuredRecord(cell, context: context, status: .loadFail("transcript unreadable: \(error)"))]
+            }
+            return []
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
+            if let cell = expectedCell {
+                return [notMeasuredRecord(cell, context: context, status: .notMeasured("transcript not valid UTF-8"))]
+            }
+            return []
+        }
+        let rows = resolve(jsonl: text)
+        guard !rows.isEmpty else {
+            if let cell = expectedCell {
+                return [notMeasuredRecord(cell, context: context, status: .notMeasured("transcript empty: no scorable rows"))]
+            }
+            return []
+        }
+        return rows.map { record(from: $0, context: context) }
+    }
+
+    /// Builds a single un-measured record for a named cell. `verdict` and
+    /// `toolSelection` are `nil` (there is no measurement); `failureClass` mirrors
+    /// the load/render holes so matrix triage can bucket them.
+    public static func notMeasuredRecord(
+        _ cell: ExpectedCell,
+        context: RecordContext,
+        status: CellStatus
+    ) -> ConformanceRecord {
+        let failure: FailureClass?
+        switch status {
+        case .loadFail:
+            failure = .loadFail
+        case .renderFail:
+            failure = .renderFail
+        case .notMeasured, .measured:
+            failure = nil
+        }
+        return ConformanceRecord(
+            backend: cell.backend,
+            model: cell.model,
+            quant: cell.quant,
+            renderer: context.renderer,
+            scenario: cell.scenario,
+            decoyLevel: cell.decoyLevel,
+            repeatIndex: cell.repeatIndex,
+            status: status,
+            verdict: nil,
+            toolSelection: nil,
+            failureClass: failure,
+            transcriptRef: context.transcriptRef,
+            coreCommit: context.coreCommit,
+            toolingVersions: context.toolingVersions
+        )
+    }
+
+    /// Pretty-printed, stable-key JSON for a record array (the `--emit-records`
+    /// payload). Overloads the ``ResultRow`` encoder of the same name.
+    public static func encodeJSON(_ records: [ConformanceRecord]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(records)
+    }
+
+    // MARK: - Internal mapping
+
+    /// Maps one measured ``ResolvedRow`` to a `.measured` ``ConformanceRecord``.
+    ///
+    /// `repeatIndex` is fixed at `0`: the scorer groups by
+    /// (backend × model × quant × scenario) and has no repeat dimension, so a
+    /// single transcript yields one row per cell. A caller running repeats writes
+    /// separate transcripts and stamps the index at collation time.
+    static func record(from row: ResolvedRow, context: RecordContext) -> ConformanceRecord {
+        let verdict = row.verdict
+        let toolSelection: Scores? = row.isToolBearing
+            ? Scores(
+                precision: row.confusion.precision,
+                recall: row.confusion.recall,
+                f1: row.confusion.f1
+            )
+            : nil
+        // Decoy pressure = the count of decoy distractors advertised this run. The
+        // harness names them `decoy_tool_<n>_<base>`; everything else in the
+        // advertised set is a real reference tool, so a prefix filter isolates them.
+        let decoyLevel = row.advertisedTools.filter { $0.hasPrefix("decoy_tool_") }.count
+        return ConformanceRecord(
+            backend: row.backend ?? "unknown",
+            model: row.model ?? "unknown",
+            quant: row.quant ?? "unknown",
+            renderer: context.renderer,
+            scenario: row.scenario,
+            decoyLevel: decoyLevel,
+            repeatIndex: 0,
+            status: .measured,
+            verdict: verdict,
+            toolSelection: toolSelection,
+            failureClass: failureClass(for: row, verdict: verdict),
+            transcriptRef: context.transcriptRef,
+            coreCommit: context.coreCommit,
+            toolingVersions: context.toolingVersions
+        )
+    }
+
+    /// Coarse failure bucket for a *measured* row. `nil` on a clean pass.
+    static func failureClass(for row: ResolvedRow, verdict: Verdict) -> FailureClass? {
+        guard verdict != .pass else { return nil }
+        // Required a tool but called none → the model under-called.
+        if row.isToolBearing && row.calledTools.isEmpty { return .noCall }
+        // Called wrong/extra tools (decoys or off-target) → low selection precision.
+        if row.confusion.fp > 0 { return .lowPrecision }
+        return nil
+    }
+}

--- a/Sources/ManifoldTools/ConformanceScorer.swift
+++ b/Sources/ManifoldTools/ConformanceScorer.swift
@@ -141,6 +141,59 @@ public enum ConformanceScorer {
     /// Scores a transcript supplied as a JSONL string. Rows are returned in a
     /// stable order (first-seen grouping key) so output diffs are deterministic.
     public static func score(jsonl text: String) -> [ResultRow] {
+        resolve(jsonl: text).map { r in
+            ResultRow(
+                backend: r.backend,
+                model: r.model,
+                quant: r.quant,
+                scenario: r.scenario,
+                assertionsPassed: r.assertionsPassed,
+                assertionsFailed: r.assertionsFailed,
+                errored: r.errored,
+                toolCallCount: r.toolCallCount,
+                verdict: r.verdict,
+                expectedTools: r.expectedTools,
+                calledTools: r.calledTools,
+                toolTP: r.confusion.tp,
+                toolFP: r.confusion.fp,
+                toolFN: r.confusion.fn
+            )
+        }
+    }
+
+    /// Internal richer row produced by the single parse pass. Carries everything
+    /// ``ResultRow`` exposes *plus* the advertised-tools set (decoy-pressure
+    /// signal), which the public `ResultRow` deliberately doesn't surface but the
+    /// ``ConformanceRecord`` mapping needs to derive `decoyLevel`.
+    struct ResolvedRow {
+        let backend: String?
+        let model: String?
+        let quant: String?
+        let scenario: String
+        let assertionsPassed: Int
+        let assertionsFailed: Int
+        let errored: Bool
+        let toolCallCount: Int
+        /// Resolved expected set (prompt `requiredTools`, else assertion recovery).
+        let expectedTools: [String]
+        /// Full tool set advertised to the model this run (real + decoys), used to
+        /// count decoy pressure. Empty when the transcript omits `advertisedTools`.
+        let advertisedTools: [String]
+        let calledTools: [String]
+        let confusion: ConfusionCounts
+
+        var verdict: Verdict {
+            ConformanceScorer.verdict(passed: assertionsPassed, failed: assertionsFailed, errored: errored)
+        }
+
+        var isToolBearing: Bool { !expectedTools.isEmpty }
+    }
+
+    /// Single parse pass over the JSONL transcript, grouping events into resolved
+    /// rows keyed by the attribution tuple + scenario. Both ``score(jsonl:)`` and
+    /// the ``ConformanceRecord`` emitters consume this so the grouping/expected-set
+    /// recovery logic lives in exactly one place.
+    static func resolve(jsonl text: String) -> [ResolvedRow] {
         // Accumulator keyed by the attribution tuple + scenario.
         struct Accumulator {
             var backend: String?
@@ -152,6 +205,8 @@ public enum ConformanceScorer {
             var errored = false
             var toolCallCount = 0
             var expectedTools: [String] = []
+            /// Full advertised tool set forwarded to the model (real + decoys).
+            var advertisedTools: [String] = []
             /// Whether a `prompt` record actually carried a `requiredTools` field.
             /// Distinguishes "no-tool scenario" (`requiredTools: []`) from "this
             /// transcript shape never emits the field" — only the latter triggers
@@ -205,6 +260,12 @@ public enum ConformanceScorer {
                     groups[key]?.expectedTools = required
                     groups[key]?.requiredToolsPresent = true
                 }
+                // The advertised set (real tools + decoy distractors) is what lets
+                // the record mapping derive `decoyLevel`. Absent on baseline /
+                // pre-decoy transcripts — left empty, scored as zero decoy pressure.
+                if let advertised = object["advertisedTools"] as? [String] {
+                    groups[key]?.advertisedTools = advertised
+                }
             case "assertion":
                 if (object["passed"] as? Bool) == true {
                     groups[key]?.assertionsPassed += 1
@@ -240,7 +301,7 @@ public enum ConformanceScorer {
             }
         }
 
-        return order.compactMap { key -> ResultRow? in
+        return order.compactMap { key -> ResolvedRow? in
             guard let acc = groups[key] else { return nil }
             // Expected set: the prompt's `requiredTools` when present, otherwise the
             // set recovered from dispatch-requirement assertions (older / companion
@@ -256,7 +317,7 @@ public enum ConformanceScorer {
                 actual: acc.calledTools,
                 expected: Set(expectedTools)
             )
-            return ResultRow(
+            return ResolvedRow(
                 backend: acc.backend,
                 model: acc.model,
                 quant: acc.quant,
@@ -265,16 +326,10 @@ public enum ConformanceScorer {
                 assertionsFailed: acc.assertionsFailed,
                 errored: acc.errored,
                 toolCallCount: acc.toolCallCount,
-                verdict: verdict(
-                    passed: acc.assertionsPassed,
-                    failed: acc.assertionsFailed,
-                    errored: acc.errored
-                ),
                 expectedTools: expectedTools,
+                advertisedTools: acc.advertisedTools,
                 calledTools: acc.calledTools.sorted(),
-                toolTP: confusion.tp,
-                toolFP: confusion.fp,
-                toolFN: confusion.fn
+                confusion: confusion
             )
         }
     }

--- a/Sources/manifold-tools/main.swift
+++ b/Sources/manifold-tools/main.swift
@@ -333,9 +333,11 @@ enum TestUpliftCLI {
     }
 }
 
-/// `manifold-tools score <file.jsonl> [--csv]` — parses a transcript and prints
-/// the per-(backend × model × quant × scenario) conformance matrix. Defaults to
-/// JSON; `--csv` emits CSV instead.
+/// `manifold-tools score <file.jsonl> [--csv] [--emit-records <path>]` — parses a
+/// transcript and prints the per-(backend × model × quant × scenario) conformance
+/// matrix. Defaults to JSON; `--csv` emits CSV instead. `--emit-records <path>`
+/// additionally writes the normalized `[ConformanceRecord]` schema (#2041) as JSON
+/// so cross-leg eval collation reads one shape across Ollama / llama / MLX / cloud.
 enum ScoreCLI {
     static func run(_ argv: [String]) -> Int32 {
         if argv.first == "--help" || argv.first == "-h" || argv.isEmpty {
@@ -344,20 +346,59 @@ enum ScoreCLI {
 
             USAGE
               manifold-tools score <file.jsonl> [--csv]
+                  [--emit-records <out.json>] [--renderer <label>] [--core-commit <sha>]
+
+            FLAGS
+              --csv                 Emit the matrix as CSV instead of JSON (stdout).
+              --emit-records <path> Also write the normalized [ConformanceRecord] JSON
+                                    (the cross-leg eval schema) to <path>. Additive —
+                                    stdout still carries the JSON/CSV matrix.
+              --renderer <label>    Renderer label stamped on emitted records (the
+                                    transcript doesn't capture it). Default: 'unknown'.
+              --core-commit <sha>   ManifoldKit core commit the run was built from.
+                                    Default: $MANIFOLD_CORE_COMMIT, else 'unknown'.
             """)
             return argv.isEmpty ? 2 : 0
         }
         var path: String?
         var csv = false
-        for arg in argv {
+        var emitRecordsPath: String?
+        var renderer = "unknown"
+        var coreCommit = ProcessInfo.processInfo.environment["MANIFOLD_CORE_COMMIT"] ?? "unknown"
+        var i = 0
+        while i < argv.count {
+            let arg = argv[i]
             switch arg {
-            case "--csv": csv = true
+            case "--csv":
+                csv = true
+            case "--emit-records":
+                i += 1
+                guard i < argv.count else {
+                    FileHandle.standardError.write(Data("manifold-tools score: --emit-records requires a path\n".utf8))
+                    return 2
+                }
+                emitRecordsPath = argv[i]
+            case "--renderer":
+                i += 1
+                guard i < argv.count else {
+                    FileHandle.standardError.write(Data("manifold-tools score: --renderer requires a value\n".utf8))
+                    return 2
+                }
+                renderer = argv[i]
+            case "--core-commit":
+                i += 1
+                guard i < argv.count else {
+                    FileHandle.standardError.write(Data("manifold-tools score: --core-commit requires a value\n".utf8))
+                    return 2
+                }
+                coreCommit = argv[i]
             default:
                 if path == nil { path = arg } else {
                     FileHandle.standardError.write(Data("manifold-tools score: unexpected argument '\(arg)'\n".utf8))
                     return 2
                 }
             }
+            i += 1
         }
         guard let path else {
             FileHandle.standardError.write(Data("manifold-tools score: missing <file.jsonl>\n".utf8))
@@ -371,6 +412,20 @@ enum ScoreCLI {
             } else {
                 let data = try ConformanceScorer.encodeJSON(rows)
                 print(String(data: data, encoding: .utf8) ?? "[]")
+            }
+            // Additive: write the normalized ConformanceRecord schema alongside the
+            // matrix when requested. The transcript path doubles as the record's
+            // `transcriptRef` so a verdict can always be traced back to its source.
+            if let emitRecordsPath {
+                let context = ConformanceScorer.RecordContext(
+                    renderer: renderer,
+                    coreCommit: coreCommit,
+                    transcriptRef: path
+                )
+                let records = ConformanceScorer.records(fileAt: url, context: context)
+                let data = try ConformanceScorer.encodeJSON(records)
+                try data.write(to: URL(fileURLWithPath: emitRecordsPath))
+                FileHandle.standardError.write(Data("Wrote \(records.count) ConformanceRecord(s) to \(emitRecordsPath)\n".utf8))
             }
             // Macro-averaged tool-selection metrics to stderr (stdout stays pure
             // JSON/CSV) — the cross-backend-comparable SUMMARY line, same shape

--- a/Tests/ManifoldToolsTests/ConformanceRecordEmitTests.swift
+++ b/Tests/ManifoldToolsTests/ConformanceRecordEmitTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import ManifoldTools
+
+/// Verifies ``ConformanceScorer`` emits the normalized ``ConformanceRecord``
+/// schema (#2041) from a scored transcript, and — load-bearingly — that an
+/// absent/empty transcript reads as a `.notMeasured` / `.loadFail` hole rather
+/// than a silently-dropped row or a measured zero ("absence is not failure").
+final class ConformanceRecordEmitTests: XCTestCase {
+
+    private func loadFixture(_ name: String) throws -> String {
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: name, withExtension: "jsonl", subdirectory: "Fixtures"),
+            "fixture \(name).jsonl not bundled"
+        )
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
+
+    private func context(transcriptRef: String = "fixture") -> ConformanceScorer.RecordContext {
+        ConformanceScorer.RecordContext(
+            renderer: "llama-cpp",
+            coreCommit: "deadbeef",
+            toolingVersions: ["llama.cpp": "b1234"],
+            transcriptRef: transcriptRef
+        )
+    }
+
+    private func record(_ records: [ConformanceRecord], scenario: String) throws -> ConformanceRecord {
+        try XCTUnwrap(records.first { $0.scenario == scenario }, "no record for \(scenario)")
+    }
+
+    // MARK: (a) measured records carry the correct verdict + non-empty Scores
+
+    /// The #2043 golden transcript dispatched the correct tool on every scenario.
+    /// The emitted record must be `.measured` with verdict `.pass` and a non-nil
+    /// `toolSelection` whose F1 == 1.0 — the correctly-dispatched tool is a TP.
+    func testMeasuredRecordCarriesVerdictAndScores() throws {
+        let records = ConformanceScorer.records(
+            jsonl: try loadFixture("llama-mistral-toolcall-attribution"),
+            context: context()
+        )
+
+        XCTAssertEqual(records.count, 2, "one record per scored (cell × scenario) group")
+
+        let list = try record(records, scenario: "04-list")
+        XCTAssertEqual(list.status, .measured)
+        XCTAssertEqual(list.verdict, .pass)
+        let listScores = try XCTUnwrap(list.toolSelection, "tool-bearing scenario must carry Scores")
+        XCTAssertEqual(listScores.f1, 1.0, accuracy: 1e-9, "correct dispatch is a TP → F1 == 1")
+        XCTAssertEqual(listScores.precision, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(listScores.recall, 1.0, accuracy: 1e-9)
+        XCTAssertNil(list.failureClass, "a clean pass has no failure bucket")
+        // Provenance/identity flows from the caller-supplied context.
+        XCTAssertEqual(list.renderer, "llama-cpp")
+        XCTAssertEqual(list.coreCommit, "deadbeef")
+        XCTAssertEqual(list.toolingVersions, ["llama.cpp": "b1234"])
+
+        // Control: the backtick-named scenario keeps working too.
+        let now = try record(records, scenario: "01-now")
+        XCTAssertEqual(now.verdict, .pass)
+        XCTAssertEqual(try XCTUnwrap(now.toolSelection).f1, 1.0, accuracy: 1e-9)
+    }
+
+    /// A wrong-tool transcript must surface as a measured failure with a non-nil
+    /// failure bucket and a non-empty (but imperfect) Scores — distinct from the
+    /// un-measured hole tested below.
+    func testWrongToolIsMeasuredFailureNotHole() throws {
+        let jsonl = """
+        {"kind":"prompt","scenario":"neg","user":"add it up","requiredTools":["calc"]}
+        {"kind":"tool_call","scenario":"neg","name":"read_file","arguments":"{}"}
+        {"kind":"assertion","scenario":"neg","passed":false,"message":"Scenario requires `calc` to actually be dispatched — never dispatched"}
+        """
+        let records = ConformanceScorer.records(jsonl: jsonl, context: context())
+        let neg = try record(records, scenario: "neg")
+
+        XCTAssertEqual(neg.status, .measured, "a wrong tool is measured, not a hole")
+        XCTAssertEqual(neg.verdict, .fail)
+        XCTAssertEqual(neg.failureClass, .lowPrecision, "wrong tool called → low selection precision")
+        let scores = try XCTUnwrap(neg.toolSelection)
+        XCTAssertEqual(scores.f1, 0.0, accuracy: 1e-9)
+    }
+
+    /// Decoy pressure is recovered from the advertised set (`decoy_tool_*`).
+    func testDecoyLevelDerivedFromAdvertisedTools() throws {
+        let jsonl = """
+        {"kind":"prompt","scenario":"dec","user":"x","requiredTools":["now"],"advertisedTools":["now","calc","decoy_tool_1_get_weather","decoy_tool_2_send_email"]}
+        {"kind":"tool_call","scenario":"dec","name":"now","arguments":"{}"}
+        {"kind":"assertion","scenario":"dec","passed":true,"message":"Scenario requires `now` to actually be dispatched — dispatched"}
+        """
+        let rec = try record(ConformanceScorer.records(jsonl: jsonl, context: context()), scenario: "dec")
+        XCTAssertEqual(rec.decoyLevel, 2, "two decoy_tool_* entries advertised")
+    }
+
+    // MARK: (b) absence is not failure
+
+    /// An empty transcript with a declared expected cell must produce a single
+    /// `.notMeasured` record — NOT an empty array (dropped row) and NOT a measured
+    /// zero with a `.fail` verdict.
+    func testEmptyTranscriptYieldsNotMeasuredNotZero() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("empty-\(UUID().uuidString).jsonl")
+        try Data().write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let cell = ConformanceScorer.ExpectedCell(
+            backend: "llama.cpp",
+            model: "mistral-7b-instruct-v0.3",
+            quant: "Q4_K_M",
+            scenario: "04-list"
+        )
+        let records = ConformanceScorer.records(fileAt: tmp, context: context(transcriptRef: tmp.path), expectedCell: cell)
+
+        XCTAssertEqual(records.count, 1, "the hole must be recorded, not dropped")
+        let rec = records[0]
+        guard case .notMeasured = rec.status else {
+            return XCTFail("empty transcript must read as .notMeasured, got \(rec.status)")
+        }
+        XCTAssertNil(rec.verdict, "an un-measured cell carries no verdict (never .fail)")
+        XCTAssertNil(rec.toolSelection, "an un-measured cell carries no Scores (never a zero)")
+        XCTAssertEqual(rec.backend, "llama.cpp")
+        XCTAssertEqual(rec.scenario, "04-list")
+    }
+
+    /// A missing transcript file (the run never wrote one — weights absent) must
+    /// read as `.loadFail`, again with no measured verdict/Scores.
+    func testMissingFileYieldsLoadFail() throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).jsonl")
+        let cell = ConformanceScorer.ExpectedCell(
+            backend: "llama.cpp", model: "m", quant: "Q4", scenario: "01-now"
+        )
+        let records = ConformanceScorer.records(fileAt: missing, context: context(), expectedCell: cell)
+
+        XCTAssertEqual(records.count, 1)
+        let rec = records[0]
+        guard case .loadFail = rec.status else {
+            return XCTFail("missing file must read as .loadFail, got \(rec.status)")
+        }
+        XCTAssertEqual(rec.failureClass, .loadFail)
+        XCTAssertNil(rec.verdict)
+        XCTAssertNil(rec.toolSelection)
+    }
+
+    /// Without a declared expected cell there is nothing to attribute the hole to,
+    /// so an empty transcript returns `[]` (the caller opted out of hole-tracking).
+    func testEmptyTranscriptWithoutCellReturnsEmpty() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("empty-\(UUID().uuidString).jsonl")
+        try Data().write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let records = ConformanceScorer.records(fileAt: tmp, context: context(), expectedCell: nil)
+        XCTAssertTrue(records.isEmpty)
+    }
+
+    /// The emitted record round-trips through JSON (the `--emit-records` payload).
+    func testRecordsRoundTripThroughJSON() throws {
+        let records = ConformanceScorer.records(
+            jsonl: try loadFixture("llama-mistral-toolcall-attribution"),
+            context: context()
+        )
+        let data = try ConformanceScorer.encodeJSON(records)
+        let decoded = try JSONDecoder().decode([ConformanceRecord].self, from: data)
+        XCTAssertEqual(decoded, records)
+    }
+}


### PR DESCRIPTION
## PR D — connect the ConformanceRecord schema (#2041) to the scorer

Makes `ConformanceScorer` the **single source** that emits the normalized `ConformanceRecord` schema, and exposes a clean **public** scoring entry point so companion repos (manifold-mlx / manifold-llama) can reuse it instead of hand-rolling their own `SUMMARY`. **Core-only — companion repos untouched.**

### What changed
- **Single parse pass.** Extracted `ConformanceScorer.resolve(jsonl:) -> [ResolvedRow]` (internal) shared by `score(jsonl:)` and the new record emitters. `ResolvedRow` carries the advertised-tool set so `decoyLevel` is derivable. `score(jsonl:)` / `ResultRow` public signatures are **unchanged** — purely additive public API (so the `api-breakage` gate stays green).
- **New public API:**
  - `RecordContext(renderer:coreCommit:toolingVersions:transcriptRef:)` — caller-supplied provenance the transcript doesn't carry.
  - `ExpectedCell(backend:model:quant:scenario:decoyLevel:repeatIndex:)`.
  - `records(jsonl:context:) -> [ConformanceRecord]` (measured rows).
  - `records(fileAt:context:expectedCell:) -> [ConformanceRecord]` (absence-aware, non-throwing).
  - `notMeasuredRecord(_:context:status:)` and an `encodeJSON([ConformanceRecord])` overload.
- **Absence ≠ failure.** Unreadable file → `.loadFail`; empty transcript → `.notMeasured` (verdict/Scores `nil`) for the declared cell — never a dropped row or a measured zero.
- **CLI (additive):** `score --emit-records <path> [--renderer <label>] [--core-commit <sha>]` writes the `[ConformanceRecord]` JSON alongside the existing `--csv`/JSON matrix. Neither is removed.

### Sourcing of non-transcript fields
- `renderer` — caller-declared label (the transcript never records the render path); CLI default `unknown`.
- `coreCommit` — CLI flag `--core-commit`, else `$MANIFOLD_CORE_COMMIT`, else placeholder `unknown`.
- `backend/model/quant` — from #2027 transcript attribution; `repeatIndex` fixed at 0 (scorer has no repeat dimension — repeats are written as separate transcripts and stamped at collation).

### Tests (`Tests/ManifoldToolsTests/ConformanceRecordEmitTests.swift`, XCTest)
- (a) scores the #2043 fixture → record carries verdict `.pass` + non-empty `Scores` (F1 == 1.0; correct dispatch is a TP).
- (b) empty transcript → `.notMeasured`; missing file → `.loadFail`; both with `nil` verdict/Scores — asserted as *not* a measured zero.
- Plus: wrong-tool measured failure (`.lowPrecision`), decoy-level derivation, JSON round-trip.

### Verification (bounded — orchestrator owns full gate + CI)
- `swift build --build-tests` → Build complete.
- `swift test --filter ManifoldToolsTests` → **78 passed, 0 failures** (7 new + existing).

`Package.swift` untouched. No force-unwraps / `try?` / `try!` / `as!` in new sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)