### PR TITLE
feat(eval): render MATRIX.md from ConformanceRecords + wire local-integration-sweep

### DIFF
--- a/Sources/ManifoldTools/MatrixRenderer.swift
+++ b/Sources/ManifoldTools/MatrixRenderer.swift
@@ -1,0 +1,390 @@
+import Foundation
+
+/// Renders a cross-backend tool-calling conformance matrix as Markdown from a
+/// flat `[ConformanceRecord]` corpus — the rendered-query replacement for the
+/// hand-assembled `MATRIX.md` files under `docs/plans/runs/`.
+///
+/// Pure and deterministic: it does no I/O, takes no model/backend dependency,
+/// and the same records always render byte-identical (every grouping is
+/// stable-sorted). That is what lets it run in hosted CI as a unit test against
+/// hand-authored record fixtures — no Apple Silicon, no GGUF, no live server.
+///
+/// **The whole point is honesty about holes.** A ``CellStatus/notMeasured(_:)``
+/// or ``CellStatus/loadFail(_:)`` cell renders as a *distinct* row (🚫 / 💥)
+/// carrying its reason — never as a `0.000` measured row. A *measured* failure
+/// (e.g. the model called no tool, ``FailureClass/noCall``) does render its real
+/// `0.000` metrics, because that zero was actually measured. Conflating the two
+/// — "absence reads as a measured zero" — is exactly the defect the
+/// ``ConformanceRecord`` schema was added to kill.
+public enum MatrixRenderer {
+
+    /// Renders the full Markdown document for a record corpus.
+    ///
+    /// - Parameters:
+    ///   - records: the flat record corpus (any mix of backends, models,
+    ///     scenarios, decoy levels, and cell statuses).
+    ///   - title: the H1 heading. Defaults to the canonical matrix title.
+    /// - Returns: a Markdown string. Deterministic for a given `records` value.
+    public static func render(
+        _ records: [ConformanceRecord],
+        title: String = "Cross-Backend Tool-Calling Conformance Matrix"
+    ) -> String {
+        var sections: [String] = []
+        sections.append("# \(title)")
+        sections.append(provenanceLine(records))
+        sections.append(mainMatrixSection(records))
+        if let ladder = decoyLadderSection(records) {
+            sections.append(ladder)
+        }
+        if let cross = crossRuntimeSection(records) {
+            sections.append(cross)
+        }
+        return sections.joined(separator: "\n\n") + "\n"
+    }
+
+    // MARK: - Cell identity
+
+    /// The `(backend × model × quant × renderer)` tuple a row aggregates over.
+    /// `repeatIndex` is deliberately NOT part of the key: repeats are separate
+    /// transcripts that each emit a record, so "runs" for a cell is the *count*
+    /// of its records, not a keyed dimension (the scorer fixes `repeatIndex` at 0).
+    struct CellKey: Hashable, Comparable {
+        let backend: String
+        let model: String
+        let quant: String
+        let renderer: String
+
+        static func < (lhs: CellKey, rhs: CellKey) -> Bool {
+            (lhs.backend, lhs.model, lhs.quant, lhs.renderer)
+                < (rhs.backend, rhs.model, rhs.quant, rhs.renderer)
+        }
+
+        init(_ record: ConformanceRecord) {
+            self.backend = record.backend
+            self.model = record.model
+            self.quant = record.quant
+            self.renderer = record.renderer
+        }
+    }
+
+    // MARK: - Provenance
+
+    private static func provenanceLine(_ records: [ConformanceRecord]) -> String {
+        let cells = Set(records.map { CellKey($0) }).count
+        let backends = Set(records.map { $0.backend }).sorted()
+        let commits = Set(records.map { $0.coreCommit }).sorted()
+        let commitText = commits.isEmpty ? "—" : commits.joined(separator: ", ")
+        return "Rendered from \(records.count) `ConformanceRecord`(s) across "
+            + "\(cells) cell(s) · backends: \(backends.isEmpty ? "—" : backends.joined(separator: ", ")) "
+            + "· core: \(commitText)."
+    }
+
+    // MARK: - Main matrix (d0)
+
+    private static func mainMatrixSection(_ records: [ConformanceRecord]) -> String {
+        let d0 = records.filter { $0.decoyLevel == 0 }
+        var lines: [String] = []
+        lines.append("## Main matrix (d0 — no decoys)")
+        lines.append(
+            "Means of tool-selection precision/recall/F1 over the cell's *measured* "
+            + "records; `Runs` is the record count. Holes render as their own rows "
+            + "(🚫 not measured · 💥 load-fail · 🛑 render-fail) — never as a measured `0.000`. "
+            + "Verdicts: ✅ pass · ⚠️ partial / renders-no-call / low-precision · ❌ fail · 💥 errored."
+        )
+        lines.append("")
+        lines.append("| Backend | Model | Quant | Renderer | Runs | Prec | Recall | F1 | Verdict |")
+        lines.append("|---------|-------|-------|----------|------|------|--------|----|---------|")
+
+        // Stable cell order: every record contributes its cell key; sort the keys.
+        let byCell = Dictionary(grouping: d0) { CellKey($0) }
+        for key in byCell.keys.sorted() {
+            guard let cellRecords = byCell[key] else { continue }
+            lines.append(contentsOf: rows(for: key, records: cellRecords))
+        }
+        if byCell.isEmpty {
+            lines.append("| _(no d0 records)_ | | | | | | | | |")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// The row(s) one cell contributes to the main table. A cell with measured
+    /// records emits one aggregated measured row; its non-measured records emit
+    /// one honest hole row per distinct status (collapsed + counted).
+    private static func rows(for key: CellKey, records: [ConformanceRecord]) -> [String] {
+        var out: [String] = []
+        let measured = records.filter { $0.status == .measured }
+        let holes = records.filter { $0.status != .measured }
+
+        if !measured.isEmpty {
+            out.append(measuredRow(key, measured: measured))
+        }
+        for (label, count) in holeGroups(holes) {
+            out.append(holeRow(key, label: label, count: count))
+        }
+        return out
+    }
+
+    private static func measuredRow(_ key: CellKey, measured: [ConformanceRecord]) -> String {
+        let scored = measured.compactMap { $0.toolSelection }
+        let precision = scored.isEmpty ? "—" : fixed(mean(scored.map { $0.precision }))
+        let recall = scored.isEmpty ? "—" : fixed(mean(scored.map { $0.recall }))
+        let f1 = scored.isEmpty ? "—" : fixed(mean(scored.map { $0.f1 }))
+        let verdict = dominantVerdictLabel(measured)
+        return "| \(esc(key.backend)) | \(esc(key.model)) | \(esc(key.quant)) | "
+            + "\(esc(key.renderer)) | \(measured.count) | \(precision) | \(recall) | "
+            + "\(f1) | \(verdict) |"
+    }
+
+    /// A hole row: numeric columns are `—` (NOT `0.000`) and the verdict column
+    /// carries the status symbol + reason. This is the load-bearing honesty.
+    private static func holeRow(_ key: CellKey, label: String, count: Int) -> String {
+        let runs = count > 1 ? "\(count)×" : "0"
+        return "| \(esc(key.backend)) | \(esc(key.model)) | \(esc(key.quant)) | "
+            + "\(esc(key.renderer)) | \(runs) | — | — | — | \(label) |"
+    }
+
+    /// Collapses a cell's non-measured records into `(label, count)` pairs,
+    /// deterministically ordered by label.
+    private static func holeGroups(_ holes: [ConformanceRecord]) -> [(String, Int)] {
+        var counts: [String: Int] = [:]
+        for hole in holes {
+            counts[statusLabel(hole.status), default: 0] += 1
+        }
+        return counts.sorted { $0.key < $1.key }.map { ($0.key, $0.value) }
+    }
+
+    // MARK: - Decoy ladder
+
+    private static func decoyLadderSection(_ records: [ConformanceRecord]) -> String? {
+        let ladder = records.filter { $0.decoyLevel > 0 }
+        guard !ladder.isEmpty else { return nil }
+
+        // Cells appearing anywhere in the ladder; show their full level spread,
+        // baseline (d0) included where present so decay is readable.
+        let ladderKeys = Set(ladder.map { CellKey($0) })
+        let relevant = records.filter { ladderKeys.contains(CellKey($0)) && $0.status == .measured }
+        let levels = Set(relevant.map { $0.decoyLevel }).sorted()
+        guard !levels.isEmpty else { return nil }
+
+        // f1[cell][level] = mean F1 of measured, tool-bearing records at that level.
+        var byCellLevel: [CellKey: [Int: [Double]]] = [:]
+        for record in relevant {
+            guard let scores = record.toolSelection else { continue }
+            byCellLevel[CellKey(record), default: [:]][record.decoyLevel, default: []].append(scores.f1)
+        }
+
+        var lines: [String] = []
+        lines.append("## Decoy ladder (mean F1 per decoy level)")
+        lines.append(
+            "F1 under distractor pressure. `+N` = N decoy tools advertised alongside "
+            + "the real set. Blank cells weren't measured at that level."
+        )
+        lines.append("")
+        let header = (["Backend", "Model", "Quant", "Renderer"] + levels.map { levelHeader($0) })
+            .joined(separator: " | ")
+        lines.append("| \(header) |")
+        lines.append("|\(String(repeating: "---|", count: 4 + levels.count))")
+
+        for key in byCellLevel.keys.sorted() {
+            guard let perLevel = byCellLevel[key] else { continue }
+            var cells = [esc(key.backend), esc(key.model), esc(key.quant), esc(key.renderer)]
+            for level in levels {
+                if let values = perLevel[level], !values.isEmpty {
+                    cells.append(fixed(mean(values)))
+                } else {
+                    cells.append("—")
+                }
+            }
+            lines.append("| \(cells.joined(separator: " | ")) |")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func levelHeader(_ level: Int) -> String {
+        level == 0 ? "d0" : "+\(level)"
+    }
+
+    // MARK: - Cross-runtime view
+
+    private static func crossRuntimeSection(_ records: [ConformanceRecord]) -> String? {
+        // Group d0 cells by a normalized (logical) model key so the same model on
+        // different backends/quants sits adjacently for human inspection.
+        let d0 = records.filter { $0.decoyLevel == 0 }
+        let byCell = Dictionary(grouping: d0) { CellKey($0) }
+        guard !byCell.isEmpty else { return nil }
+
+        var groups: [String: [CellKey]] = [:]
+        for key in byCell.keys {
+            groups[normalizedModelKey(key.model), default: []].append(key)
+        }
+        // Only groups spanning more than one cell are worth a side-by-side.
+        let multi = groups.filter { $0.value.count > 1 }
+        guard !multi.isEmpty else { return nil }
+
+        var lines: [String] = []
+        lines.append("## Cross-runtime view (same logical model, side by side)")
+        lines.append(
+            "> **Read this as a prompt for inspection, not a verdict.** Cells in a "
+            + "group are matched only on a *normalized model name* — they may differ "
+            + "in quant, checkpoint, or renderer. A verdict difference here is therefore "
+            + "**not, on its own, evidence of a backend bug**: without a same-bytes "
+            + "control a divergence is confounded. Use it to decide what to spot-check, "
+            + "then read the transcripts."
+        )
+        lines.append("")
+        lines.append("| Logical model | Backend | Quant | Renderer | Runs | F1 | Verdict |")
+        lines.append("|---------------|---------|-------|----------|------|----|---------|")
+
+        for normalized in multi.keys.sorted() {
+            guard let keys = multi[normalized] else { continue }
+            for key in keys.sorted() {
+                guard let cellRecords = byCell[key] else { continue }
+                let measured = cellRecords.filter { $0.status == .measured }
+                let runs: String
+                let f1: String
+                let verdict: String
+                if measured.isEmpty {
+                    let groupsForCell = holeGroups(cellRecords.filter { $0.status != .measured })
+                    let label = groupsForCell.first?.0 ?? statusLabel(.notMeasured("unknown"))
+                    runs = "0"
+                    f1 = "—"
+                    verdict = label
+                } else {
+                    let scored = measured.compactMap { $0.toolSelection }
+                    runs = "\(measured.count)"
+                    f1 = scored.isEmpty ? "—" : fixed(mean(scored.map { $0.f1 }))
+                    verdict = dominantVerdictLabel(measured)
+                }
+                lines.append(
+                    "| \(esc(normalized)) | \(esc(key.backend)) | \(esc(key.quant)) | "
+                    + "\(esc(key.renderer)) | \(runs) | \(f1) | \(verdict) |"
+                )
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Best-effort logical-model key: lowercase, split on non-alphanumerics, and
+    /// drop quant markers and a few well-known role/format suffixes. Deliberately
+    /// conservative — it groups for *adjacency*, and the section labels the match
+    /// as approximate, so over- or under-merging never asserts a backend bug.
+    static func normalizedModelKey(_ model: String) -> String {
+        let lower = model.lowercased()
+        let tokens = lower.split(whereSeparator: { !($0.isLetter || $0.isNumber) }).map(String.init)
+        let dropped: Set<String> = ["tools", "tool", "instruct", "it", "chat", "gguf", "mlx", "tooltmpl"]
+        let kept = tokens.filter { !$0.isEmpty && !dropped.contains($0) && !isQuantToken($0) }
+        return kept.isEmpty ? lower : kept.joined(separator: "-")
+    }
+
+    /// Conservative quant-token detector: `q4_K_M`-style (after the split, `q4`,
+    /// `k`, `m` arrive separately so we match the `q<digit>` head), bit-width
+    /// labels, and the common float markers. Anything ambiguous is kept.
+    private static func isQuantToken(_ token: String) -> Bool {
+        if token.hasPrefix("q"), let second = token.dropFirst().first, second.isNumber { return true }
+        if ["fp16", "fp32", "bf16", "f16", "f32", "4bit", "8bit"].contains(token) { return true }
+        if token.hasPrefix("int"), token.count > 3, token.dropFirst(3).allSatisfy(\.isNumber) { return true }
+        return false
+    }
+
+    // MARK: - Verdict + status labels
+
+    /// Picks the most common verdict across a cell's measured records and renders
+    /// its symbol. For a dominant `.fail`, the dominant failure class refines the
+    /// label (no-call vs low-precision) so the matrix triages at a glance.
+    static func dominantVerdictLabel(_ measured: [ConformanceRecord]) -> String {
+        let verdicts = measured.compactMap { $0.verdict }
+        guard let topVerdict = dominant(verdicts, priority: verdictPriority) else { return "—" }
+        switch topVerdict {
+        case .pass:
+            return "✅ pass"
+        case .partial:
+            return "⚠️ partial"
+        case .errored:
+            return "💥 errored"
+        case .fail:
+            let failClasses = measured
+                .filter { $0.verdict == .fail }
+                .compactMap { $0.failureClass }
+            switch dominant(failClasses, priority: failureClassPriority) {
+            case .noCall:
+                return "⚠️ renders-no-call"
+            case .lowPrecision:
+                return "⚠️ low-precision"
+            case .truncation:
+                return "⚠️ truncation"
+            case .loadFail:
+                return "💥 load-fail"
+            case .renderFail:
+                return "🛑 render-fail"
+            case .none:
+                return "❌ fail"
+            }
+        }
+    }
+
+    private static func statusLabel(_ status: CellStatus) -> String {
+        switch status {
+        case .measured:
+            return "✅ measured"
+        case .notMeasured(let reason):
+            return "🚫 not measured (\(reason))"
+        case .loadFail(let reason):
+            return "💥 load-fail (\(reason))"
+        case .renderFail:
+            return "🛑 render-fail"
+        }
+    }
+
+    /// Tie-break priority for the dominant verdict (lower wins on a count tie),
+    /// so output stays deterministic regardless of record order.
+    private static func verdictPriority(_ verdict: ConformanceScorer.Verdict) -> Int {
+        switch verdict {
+        case .fail: return 0
+        case .partial: return 1
+        case .errored: return 2
+        case .pass: return 3
+        }
+    }
+
+    private static func failureClassPriority(_ failure: FailureClass) -> Int {
+        switch failure {
+        case .noCall: return 0
+        case .lowPrecision: return 1
+        case .truncation: return 2
+        case .renderFail: return 3
+        case .loadFail: return 4
+        }
+    }
+
+    /// Most frequent element; ties broken by ascending `priority` then stable.
+    private static func dominant<T: Hashable>(_ items: [T], priority: (T) -> Int) -> T? {
+        guard !items.isEmpty else { return nil }
+        var counts: [T: Int] = [:]
+        for item in items { counts[item, default: 0] += 1 }
+        return counts.max { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value < rhs.value }
+            // Equal counts: the lower priority value wins, so flip the comparison.
+            return priority(lhs.key) > priority(rhs.key)
+        }?.key
+    }
+
+    // MARK: - Formatting
+
+    /// Mean of a non-empty `[Double]`; `0` for an empty input (callers guard the
+    /// empty case before deciding to print `—`).
+    private static func mean(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    /// Three-decimal fixed format. `String(format:)` without a locale uses the C
+    /// locale (always `.`), so output is byte-stable across machines.
+    private static func fixed(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    /// Escapes a Markdown table cell value (the pipe would break the column).
+    private static func esc(_ value: String) -> String {
+        value.replacingOccurrences(of: "|", with: "\\|")
+    }
+}

--- a/Sources/manifold-tools/main.swift
+++ b/Sources/manifold-tools/main.swift
@@ -157,6 +157,8 @@ struct CLI {
 
         SUBCOMMANDS
           score <file.jsonl>    Score a transcript into a per-(model × scenario) matrix.
+          matrix <records.json> Render a [ConformanceRecord] JSON (from score --emit-records)
+                                into a cross-backend Markdown conformance matrix.
           test-uplift           Inspect or control ~/.claude/state/bck-test-uplift/.
 
         EXIT
@@ -445,6 +447,82 @@ enum ScoreCLI {
     }
 }
 
+/// `manifold-tools matrix <records.json> [--out <path>] [--title <title>]` —
+/// decodes a `[ConformanceRecord]` payload (the `score --emit-records` output)
+/// and renders the cross-backend conformance matrix as Markdown. Writes to
+/// `--out` when given, otherwise stdout. Additive — the matrix is a pure
+/// rendered query over the records, so the same records always render identically.
+enum MatrixCLI {
+    static func run(_ argv: [String]) -> Int32 {
+        if argv.first == "--help" || argv.first == "-h" || argv.isEmpty {
+            print("""
+            manifold-tools matrix — render a [ConformanceRecord] JSON into a Markdown matrix
+
+            USAGE
+              manifold-tools matrix <records.json> [--out <path>] [--title <title>]
+
+            FLAGS
+              --out <path>     Write the rendered Markdown to <path>. Default: stdout.
+              --title <title>  Override the document H1 heading.
+
+            INPUT
+              <records.json> is the [ConformanceRecord] array written by
+              `manifold-tools score --emit-records <path>`.
+            """)
+            return argv.isEmpty ? 2 : 0
+        }
+        var path: String?
+        var outPath: String?
+        var title: String?
+        var i = 0
+        while i < argv.count {
+            let arg = argv[i]
+            switch arg {
+            case "--out":
+                i += 1
+                guard i < argv.count else {
+                    FileHandle.standardError.write(Data("manifold-tools matrix: --out requires a path\n".utf8))
+                    return 2
+                }
+                outPath = argv[i]
+            case "--title":
+                i += 1
+                guard i < argv.count else {
+                    FileHandle.standardError.write(Data("manifold-tools matrix: --title requires a value\n".utf8))
+                    return 2
+                }
+                title = argv[i]
+            default:
+                if path == nil { path = arg } else {
+                    FileHandle.standardError.write(Data("manifold-tools matrix: unexpected argument '\(arg)'\n".utf8))
+                    return 2
+                }
+            }
+            i += 1
+        }
+        guard let path else {
+            FileHandle.standardError.write(Data("manifold-tools matrix: missing <records.json>\n".utf8))
+            return 2
+        }
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            let records = try JSONDecoder().decode([ConformanceRecord].self, from: data)
+            let markdown = title.map { MatrixRenderer.render(records, title: $0) }
+                ?? MatrixRenderer.render(records)
+            if let outPath {
+                try markdown.write(to: URL(fileURLWithPath: outPath), atomically: true, encoding: .utf8)
+                FileHandle.standardError.write(Data("Wrote matrix (\(records.count) record(s)) to \(outPath)\n".utf8))
+            } else {
+                print(markdown, terminator: "")
+            }
+            return 0
+        } catch {
+            FileHandle.standardError.write(Data("manifold-tools matrix: \(error)\n".utf8))
+            return 1
+        }
+    }
+}
+
 @MainActor
 func runCLI() async -> Int32 {
     let argv = Array(CommandLine.arguments.dropFirst())
@@ -453,6 +531,9 @@ func runCLI() async -> Int32 {
     }
     if argv.first == "score" {
         return ScoreCLI.run(Array(argv.dropFirst()))
+    }
+    if argv.first == "matrix" {
+        return MatrixCLI.run(Array(argv.dropFirst()))
     }
     let cli = CLI.parse(argv)
 

--- a/Tests/ManifoldToolsTests/MatrixRendererTests.swift
+++ b/Tests/ManifoldToolsTests/MatrixRendererTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import ManifoldTools
+
+/// Verifies ``MatrixRenderer`` is a pure, deterministic rendered query over
+/// `[ConformanceRecord]` — and, load-bearingly, that a `.notMeasured` /
+/// `.loadFail` hole renders as a *distinct* row carrying its reason, never as a
+/// measured `0.000`, while a genuinely measured failure (`.noCall`) does show its
+/// real `0.000`. Hermetic: every record is hand-authored, no models.
+final class MatrixRendererTests: XCTestCase {
+
+    // MARK: Builders
+
+    private func record(
+        backend: String = "ollama",
+        model: String = "mistral-7b-tools",
+        quant: String = "Q4_K_M",
+        renderer: String = "ollama-server",
+        scenario: String = "01-now",
+        decoyLevel: Int = 0,
+        status: CellStatus = .measured,
+        verdict: ConformanceScorer.Verdict? = .pass,
+        toolSelection: Scores? = Scores(precision: 1, recall: 1, f1: 1),
+        failureClass: FailureClass? = nil
+    ) -> ConformanceRecord {
+        ConformanceRecord(
+            backend: backend,
+            model: model,
+            quant: quant,
+            renderer: renderer,
+            scenario: scenario,
+            decoyLevel: decoyLevel,
+            repeatIndex: 0,
+            status: status,
+            verdict: verdict,
+            toolSelection: toolSelection,
+            failureClass: failureClass,
+            transcriptRef: "fixture.jsonl",
+            coreCommit: "deadbeef",
+            toolingVersions: [:]
+        )
+    }
+
+    /// Returns the single rendered table line containing `needle`, or fails.
+    private func line(_ markdown: String, containing needle: String) throws -> String {
+        let matches = markdown.split(separator: "\n").map(String.init).filter { $0.contains(needle) }
+        return try XCTUnwrap(matches.first, "no rendered line contains '\(needle)'")
+    }
+
+    // MARK: (a) main table means + Runs count from a multi-record cell
+
+    func testMainTableMeansAndRunsCount() throws {
+        // One cell, two measured records (separate transcripts → "runs" = 2).
+        // F1 1.0 and 0.5 → mean 0.750; precision 1.0 and 0.0 → 0.500.
+        let records = [
+            record(scenario: "01-now", toolSelection: Scores(precision: 1, recall: 1, f1: 1)),
+            record(scenario: "02-calc", toolSelection: Scores(precision: 0, recall: 1, f1: 0.5))
+        ]
+        let markdown = MatrixRenderer.render(records)
+        let row = try line(markdown, containing: "mistral-7b-tools")
+
+        // Runs is the record count, NOT a keyed repeat dimension.
+        XCTAssertTrue(row.contains("| 2 |"), "Runs must be the cell's record count (2): \(row)")
+        XCTAssertTrue(row.contains("0.750"), "mean F1 = (1.0 + 0.5)/2 = 0.750: \(row)")
+        XCTAssertTrue(row.contains("0.500"), "mean precision = (1.0 + 0.0)/2 = 0.500: \(row)")
+        XCTAssertTrue(row.contains("✅ pass"), "both records pass → dominant verdict pass: \(row)")
+
+        // Sabotage guard: a single-record reading would mis-count Runs as 1.
+        XCTAssertFalse(row.contains("| 1 |"), "two records must not collapse to Runs=1")
+    }
+
+    // MARK: (b) notMeasured + loadFail render as distinct, non-measured rows
+
+    func testHolesRenderAsDistinctRowsNotMeasuredZeros() throws {
+        let records = [
+            record(
+                backend: "llama.cpp", model: "llama3.1-8b", quant: "Q4_K_M", renderer: "jinja-prompt",
+                status: .notMeasured("GGUF absent"), verdict: nil, toolSelection: nil
+            ),
+            record(
+                backend: "llama.cpp", model: "gemma-4-E4B", quant: "Q4_K_M", renderer: "jinja-prompt",
+                status: .loadFail("Unsupported model architecture: gemma4"),
+                verdict: nil, toolSelection: nil, failureClass: .loadFail
+            )
+        ]
+        let markdown = MatrixRenderer.render(records)
+
+        let notMeasured = try line(markdown, containing: "llama3.1-8b")
+        XCTAssertTrue(notMeasured.contains("🚫 not measured (GGUF absent)"), notMeasured)
+        XCTAssertTrue(notMeasured.contains("| — | — | — |"), "metrics must be em-dashes, not zeros: \(notMeasured)")
+
+        let loadFail = try line(markdown, containing: "gemma-4-E4B")
+        XCTAssertTrue(loadFail.contains("💥 load-fail (Unsupported model architecture: gemma4)"), loadFail)
+        XCTAssertTrue(loadFail.contains("| — | — | — |"), loadFail)
+
+        // The whole point: absence is NEVER a measured zero.
+        XCTAssertFalse(notMeasured.contains("0.000"), "a hole must not read as 0.000: \(notMeasured)")
+        XCTAssertFalse(loadFail.contains("0.000"), "a load-fail must not read as 0.000: \(loadFail)")
+    }
+
+    // MARK: (c) measured + noCall is a measured failure, NOT a hole
+
+    func testMeasuredNoCallRendersAsMeasuredFailure() throws {
+        // The model called no tool where one was required: tp=fp=0, fn>0 → real
+        // measured 0.000. This DID get measured, so 0.000 is honest here.
+        let records = [
+            record(
+                backend: "ollama", model: "gemma3-4b-tools", quant: "Q4_K_M", renderer: "ollama-server",
+                status: .measured, verdict: .fail,
+                toolSelection: Scores(precision: 0, recall: 0, f1: 0), failureClass: .noCall
+            )
+        ]
+        let markdown = MatrixRenderer.render(records)
+        let row = try line(markdown, containing: "gemma3-4b-tools")
+
+        XCTAssertTrue(row.contains("0.000"), "a measured no-call shows its real 0.000: \(row)")
+        XCTAssertTrue(row.contains("⚠️ renders-no-call"), row)
+        XCTAssertTrue(row.contains("| 1 |"), "one measured record → Runs=1: \(row)")
+        // It must NOT be mistaken for an un-measured hole.
+        XCTAssertFalse(row.contains("🚫 not measured"), row)
+        XCTAssertFalse(row.contains("| — | — | — |"), "a measured row carries numbers, not em-dashes: \(row)")
+    }
+
+    // MARK: (d) decoy ladder renders when decoyLevel > 0
+
+    func testDecoyLadderRendersWhenDecoyLevelsPresent() throws {
+        let records = [
+            record(scenario: "01-now", decoyLevel: 0, toolSelection: Scores(precision: 1, recall: 1, f1: 1)),
+            record(scenario: "01-now", decoyLevel: 1, toolSelection: Scores(precision: 1, recall: 0.8, f1: 0.9)),
+            record(scenario: "01-now", decoyLevel: 5, toolSelection: Scores(precision: 0.5, recall: 0.5, f1: 0.5))
+        ]
+        let markdown = MatrixRenderer.render(records)
+
+        XCTAssertTrue(markdown.contains("## Decoy ladder"), "ladder section must render")
+        // The ladder header is the only one carrying decoy-level columns.
+        let header = try line(markdown, containing: "| +1 |")
+        // Headers cover every present level (baseline d0 included), in order.
+        XCTAssertTrue(header.contains("d0"), header)
+        XCTAssertTrue(header.contains("+5"), header)
+        let ladderRow = try line(markdown, containing: "| ollama | mistral-7b-tools | Q4_K_M | ollama-server | 1.000")
+        XCTAssertTrue(ladderRow.contains("0.900"), "F1 at +1: \(ladderRow)")
+        XCTAssertTrue(ladderRow.contains("0.500"), "F1 at +5: \(ladderRow)")
+
+        // Sabotage guard: with no decoy records the section must be absent.
+        let baselineOnly = MatrixRenderer.render([record(decoyLevel: 0)])
+        XCTAssertFalse(baselineOnly.contains("## Decoy ladder"), "no ladder when all decoyLevel==0")
+    }
+
+    // MARK: (e) deterministic — same records render byte-identical
+
+    func testDeterministicAcrossInputOrder() throws {
+        let records = [
+            record(backend: "ollama", model: "qwen3.5-9b", scenario: "01-now", toolSelection: Scores(precision: 1, recall: 1, f1: 1)),
+            record(backend: "mlx", model: "Mistral-v0.3", quant: "4bit", renderer: "swift-transformers",
+                   scenario: "02-calc", status: .measured, verdict: .fail,
+                   toolSelection: Scores(precision: 0, recall: 0, f1: 0), failureClass: .noCall),
+            record(backend: "llama.cpp", model: "gemma-4-E4B", renderer: "jinja-prompt",
+                   status: .loadFail("arch gemma4"), verdict: nil, toolSelection: nil, failureClass: .loadFail),
+            record(backend: "ollama", model: "qwen3.5-9b", scenario: "03-list", decoyLevel: 3,
+                   toolSelection: Scores(precision: 0.9, recall: 0.9, f1: 0.9))
+        ]
+        let first = MatrixRenderer.render(records)
+        let second = MatrixRenderer.render(records)
+        XCTAssertEqual(first, second, "same input renders identically")
+        // Input order must not change output (grouping is stable-sorted).
+        let reversed = MatrixRenderer.render(records.reversed())
+        XCTAssertEqual(first, reversed, "input order must not affect rendered output")
+    }
+
+    // MARK: Cross-runtime view honest labeling
+
+    func testCrossRuntimeViewIsHonestlyLabeledAndGroupsByLogicalModel() throws {
+        // Same logical model name, two backends/quants/renderers — must sit
+        // adjacently AND carry the "not necessarily a backend bug" caveat.
+        let records = [
+            record(backend: "ollama", model: "mistral-7b-tools", quant: "Q4_K_M", renderer: "ollama-server",
+                   toolSelection: Scores(precision: 0.8, recall: 0.8, f1: 0.8)),
+            record(backend: "mlx", model: "mistral-7b-instruct", quant: "4bit", renderer: "swift-transformers",
+                   status: .measured, verdict: .fail,
+                   toolSelection: Scores(precision: 0, recall: 0, f1: 0), failureClass: .noCall)
+        ]
+        let markdown = MatrixRenderer.render(records)
+        XCTAssertTrue(markdown.contains("## Cross-runtime view"), "cross-runtime section must render for a multi-cell logical group")
+        XCTAssertTrue(
+            markdown.contains("not, on its own, evidence of a backend bug"),
+            "the divergence-is-confounded caveat must be present — no authoritative 'divergence = bug' claim"
+        )
+        // Both cells appear under one normalized logical key.
+        XCTAssertEqual(MatrixRenderer.normalizedModelKey("mistral-7b-tools"),
+                       MatrixRenderer.normalizedModelKey("mistral-7b-instruct"),
+                       "role/format suffixes are stripped so the twin groups together")
+    }
+}

--- a/scripts/local-integration-sweep.sh
+++ b/scripts/local-integration-sweep.sh
@@ -172,8 +172,67 @@ elif have_lane mlx; then
   SUMMARY_LANES="${SUMMARY_LANES}mlx: skip (repo absent at $MLX_DIR)\n"
 fi
 
-# ----- 4. perf extraction ----------------------------------------------------
+# ----- 4. conformance matrix (rendered from ConformanceRecords) --------------
+# Run the reference tool-calling scenarios through the manifold-tools harness,
+# then SCORE -> emit [ConformanceRecord] JSON -> RENDER MATRIX.md. The matrix is
+# a PURE rendered query over the records (MatrixRenderer): the same records
+# always render byte-identical, and absence (model/GGUF/backend missing) reads as
+# a 🚫/💥 hole row, never a measured 0.000. This covers the Ollama leg; the
+# companion llama/mlx legs emit the same record shape from their own repos, so a
+# cross-leg collation can later concatenate the JSON arrays before `matrix`.
+# Bash 3.2 safe — no associative arrays.
+if have_lane core; then
+  MATRIX_DIR="$OUT/matrix"
+  mkdir -p "$MATRIX_DIR"
+  TRANSCRIPT="$MATRIX_DIR/transcript.jsonl"
+  RECORDS="$MATRIX_DIR/records.json"
+  MATRIX_MD="$OUT/MATRIX.md"
+  CORE_COMMIT="$(git -C "$CORE_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  log "=== [matrix] $(date +%H:%M:%S) building manifold-tools ==="
+  if ( cd "$CORE_DIR" && swift build --product manifold-tools ) >"$MATRIX_DIR/build.log" 2>&1; then
+    TOOL_BIN="$(cd "$CORE_DIR" && swift build --product manifold-tools --show-bin-path 2>/dev/null)/manifold-tools"
+    if curl -s --max-time 3 localhost:11434/api/tags >/dev/null 2>&1; then
+      # Optional model override: MATRIX_MODELS="m1,m2". Unset -> scenario defaults.
+      MATRIX_MODEL_ARGS=""
+      if [ -n "${MATRIX_MODELS:-}" ]; then MATRIX_MODEL_ARGS="--model ${MATRIX_MODELS}"; fi
+      # A non-zero exit means some scenarios failed — that is data, not a script
+      # error; score the transcript regardless (word-split MODEL_ARGS on purpose).
+      ( cd "$CORE_DIR" && "$TOOL_BIN" --backend ollama --scenario all --output "$TRANSCRIPT" ${MATRIX_MODEL_ARGS} ) \
+        >"$MATRIX_DIR/run.log" 2>&1 || true
+      if [ -s "$TRANSCRIPT" ]; then
+        "$TOOL_BIN" score "$TRANSCRIPT" --emit-records "$RECORDS" \
+          --renderer ollama-server --core-commit "$CORE_COMMIT" \
+          >/dev/null 2>"$MATRIX_DIR/score.log" || true
+        if [ -s "$RECORDS" ]; then
+          if "$TOOL_BIN" matrix "$RECORDS" --out "$MATRIX_MD" 2>>"$MATRIX_DIR/score.log"; then
+            SUMMARY_LANES="${SUMMARY_LANES}matrix: rendered -> $(basename "$MATRIX_MD")\n"
+            log "=== [matrix] $(date +%H:%M:%S) rendered $MATRIX_MD ==="
+          else
+            SUMMARY_LANES="${SUMMARY_LANES}matrix: render failed -> matrix/score.log\n"
+          fi
+        else
+          SUMMARY_LANES="${SUMMARY_LANES}matrix: skip (no records emitted -> matrix/score.log)\n"
+        fi
+      else
+        SUMMARY_LANES="${SUMMARY_LANES}matrix: skip (empty transcript — Ollama models absent?)\n"
+      fi
+    else
+      SUMMARY_LANES="${SUMMARY_LANES}matrix: skip (Ollama down at localhost:11434)\n"
+    fi
+  else
+    SUMMARY_LANES="${SUMMARY_LANES}matrix: skip (manifold-tools build failed -> matrix/build.log)\n"
+  fi
+fi
+
+# ----- 5. perf extraction ----------------------------------------------------
 {
+  echo "## Conformance matrix"
+  if [ -s "$OUT/MATRIX.md" ]; then
+    echo "- rendered from \`ConformanceRecord\`s: \`$OUT/MATRIX.md\` (records: \`matrix/records.json\`)"
+  else
+    echo "- not rendered this run (see Lane summary for why)"
+  fi
+  echo
   echo "## Performance signals"
   echo '```'
   echo "MLX benchmark (TTFT/TPS sentinels):"


### PR DESCRIPTION
## What

PR E (final) of the in-place eval-consolidation effort: make the cross-backend matrix a **rendered query over `ConformanceRecord`s** instead of hand-assembled Markdown.

### `MatrixRenderer` (pure, hosted-CI testable)
`Sources/ManifoldTools/MatrixRenderer.swift` — `public enum MatrixRenderer { static func render(_:[ConformanceRecord], title:String) -> String }`. No I/O, no model/backend deps, deterministic (stable-sorted → byte-identical for the same records).

- **Cells** keyed by `(backend × model × quant × renderer)`. `repeatIndex` is *not* keyed — repeats are separate transcripts each emitting a record, so **"Runs" = record count for the cell**.
- **Main table (d0):** Backend · Model · Quant · Renderer · Runs · Prec · Recall · F1 · Verdict. Metrics are means over the cell's *measured* records; verdict from the dominant verdict/failureClass.
- **Honesty about holes:** `.notMeasured` / `.loadFail` / `.renderFail` cells render as distinct 🚫 / 💥 / 🛑 rows carrying their reason, with `—` in the numeric columns — **never a measured `0.000`**. A *measured* `.noCall` failure does render its real `0.000` (it was measured).
- **Decoy ladder:** F1 per decoy level per cell, when any record has `decoyLevel > 0`.
- **Cross-runtime view:** same normalized logical model side-by-side across backends — **explicitly labeled** that cells may differ in quant/checkpoint/renderer, so a verdict difference is *not, on its own, a backend bug* (a divergence is confounded without a same-bytes control). No authoritative "divergence = bug" claim.

### CLI
Additive `matrix <records.json> [--out <path>] [--title <title>]` subcommand: decodes `[ConformanceRecord]` (the `score --emit-records` output) and renders the Markdown matrix.

### Sweep wiring
`scripts/local-integration-sweep.sh`: after the lanes, run the reference scenarios → `score --emit-records` → `matrix` to render `MATRIX.md` (Ollama leg; companion legs emit the same record shape for later collation). Resilient to missing models / down backend. **Bash 3.2-safe** (no associative arrays; `bash -n` clean under `/bin/bash` 3.2.57).

## Constraints
- Additive public API only (no existing `ManifoldTools` signatures changed). No `try?`/force-unwraps/`try!`/`as!`. `Package.swift` unchanged.

## Verification (bounded)
- `swift build --build-tests` — Build complete.
- `swift test --filter ManifoldToolsTests` — **84 passed, 0 failures** (incl. **6 new** `MatrixRendererTests`).
- End-to-end CLI smoke against a hand-crafted `records.json` confirms holes render as `—` rows, measured no-call shows `0.000`, and ladder + cross-runtime sections render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)