### PR TITLE
fix(eval): derive matrix cell verdict from F1, not dominant failure subtype

### DIFF
--- a/Sources/ManifoldTools/MatrixRenderer.swift
+++ b/Sources/ManifoldTools/MatrixRenderer.swift
@@ -288,38 +288,74 @@ public enum MatrixRenderer {
 
     // MARK: - Verdict + status labels
 
-    /// Picks the most common verdict across a cell's measured records and renders
-    /// its symbol. For a dominant `.fail`, the dominant failure class refines the
-    /// label (no-call vs low-precision) so the matrix triages at a glance.
+    /// F1-band ceiling below which a cell counts as "doesn't really call the right
+    /// tool" — only then may a no-call-dominated failure label as `renders-no-call`.
+    /// Set just above 0 so a genuine all-no-call cell (mean F1 0.000) still trips it
+    /// while any cell that lands real calls (e.g. F1 0.750) never does.
+    static let noCallF1Ceiling = 0.05
+
+    /// F1-band floor at/above which a cell reads as `pass` regardless of its most
+    /// common failure subtype — a cell selecting the right tool ~90%+ of the time
+    /// is passing in aggregate even if a minority of records failed.
+    static let passF1Floor = 0.9
+
+    /// Derives a cell's single verdict label from its measured records.
+    ///
+    /// why F1-first, not failure-subtype-first: a cell's *aggregate* tool-selection
+    /// F1 is the honest summary of how often it picks the right tool; the dominant
+    /// `failureClass` is only the shape of its *minority* misses. Refining off the
+    /// failure subtype alone mislabels a 0.750-F1 cell whose most common miss is
+    /// `noCall` as "renders-no-call" — a cell that in fact calls correctly ~75% of
+    /// the time. So we band on F1 first, then use verdict/failureClass only to
+    /// refine *within* a band. Deterministic: `mean` and `dominant` are order-free.
     static func dominantVerdictLabel(_ measured: [ConformanceRecord]) -> String {
         let verdicts = measured.compactMap { $0.verdict }
         guard let topVerdict = dominant(verdicts, priority: verdictPriority) else { return "—" }
-        switch topVerdict {
-        case .pass:
-            return "✅ pass"
-        case .partial:
-            return "⚠️ partial"
-        case .errored:
-            return "💥 errored"
-        case .fail:
-            let failClasses = measured
-                .filter { $0.verdict == .fail }
-                .compactMap { $0.failureClass }
-            switch dominant(failClasses, priority: failureClassPriority) {
-            case .noCall:
-                return "⚠️ renders-no-call"
-            case .lowPrecision:
-                return "⚠️ low-precision"
-            case .truncation:
-                return "⚠️ truncation"
-            case .loadFail:
-                return "💥 load-fail"
-            case .renderFail:
-                return "🛑 render-fail"
-            case .none:
-                return "❌ fail"
-            }
+
+        // A harness/tool error is an infra signal independent of any F1.
+        if topVerdict == .errored { return "💥 errored" }
+
+        let f1s = measured.compactMap { $0.toolSelection?.f1 }
+        let meanF1 = f1s.isEmpty ? nil : mean(f1s)
+
+        // High aggregate F1 — or an unambiguous pass-dominant cell — reads as pass.
+        if topVerdict == .pass || (meanF1 ?? 0) >= passF1Floor { return "✅ pass" }
+
+        // Dominant failure shape among the cell's *failing* records — used only to
+        // refine the label once F1 has placed the cell in a band.
+        let failClasses = measured
+            .filter { $0.verdict == .fail }
+            .compactMap { $0.failureClass }
+        let topFail = dominant(failClasses, priority: failureClassPriority)
+
+        // renders-no-call is reserved for cells that (almost) never call when
+        // required: F1 must be ≈ 0 AND no-call the dominant failure. A cell with no
+        // measured F1 at all but no-call-dominated failures also qualifies (nothing
+        // contradicts the no-call reading). Above the ceiling the cell DOES call, so
+        // the label would be a lie — fall through to the mid-band labels instead.
+        if topFail == .noCall {
+            let f1NearZero = meanF1.map { $0 <= noCallF1Ceiling } ?? true
+            if f1NearZero { return "⚠️ renders-no-call" }
         }
+
+        // Infra-flavoured failure classes keep their distinct symbol regardless of band.
+        switch topFail {
+        case .truncation:
+            return "⚠️ truncation"
+        case .loadFail:
+            return "💥 load-fail"
+        case .renderFail:
+            return "🛑 render-fail"
+        case .lowPrecision:
+            return "⚠️ low-precision"
+        case .noCall, .none:
+            break
+        }
+
+        // Mid band: the cell calls tools but imperfectly. A fail-dominant cell with
+        // no measured F1 to soften the verdict stays a hard fail; otherwise partial.
+        if topVerdict == .fail, meanF1 == nil { return "❌ fail" }
+        return "⚠️ partial"
     }
 
     private static func statusLabel(_ status: CellStatus) -> String {

--- a/Tests/ManifoldToolsTests/MatrixRendererTests.swift
+++ b/Tests/ManifoldToolsTests/MatrixRendererTests.swift
@@ -189,4 +189,87 @@ final class MatrixRendererTests: XCTestCase {
                        MatrixRenderer.normalizedModelKey("mistral-7b-instruct"),
                        "role/format suffixes are stripped so the twin groups together")
     }
+
+    // MARK: Verdict label is F1-aware, not failure-subtype-dominant
+
+    /// Reproduces the live-soak shape that mislabeled `llama3.1-8b` d0: 27 records,
+    /// verdicts {pass:6, partial:9, fail:12}, failureClass {noCall:6, lowPrecision:3,
+    /// nil:18}, mean tool-selection F1 0.750. `noCall` is the *dominant failure
+    /// subtype*, so the OLD subtype-first logic stamped "⚠️ renders-no-call" on a
+    /// cell that in fact calls the right tool ~75% of the time. The F1-aware logic
+    /// must NOT — a 0.750-F1 cell does call.
+    func testHighF1NoCallDominantCellIsNotRendersNoCall() throws {
+        var records: [ConformanceRecord] = []
+        // 6 pass + 9 partial: perfect tool selection, no failure class.
+        records += Array(repeating: record(model: "llama3.1-8b", verdict: .pass,
+                                            toolSelection: Scores(precision: 1, recall: 1, f1: 1)), count: 6)
+        records += Array(repeating: record(model: "llama3.1-8b", verdict: .partial,
+                                            toolSelection: Scores(precision: 1, recall: 1, f1: 1)), count: 9)
+        // 6 noCall fails (real 0.000) — the dominant failure subtype.
+        records += Array(repeating: record(model: "llama3.1-8b", verdict: .fail,
+                                            toolSelection: Scores(precision: 0, recall: 0, f1: 0),
+                                            failureClass: .noCall), count: 6)
+        // 3 low-precision fails.
+        records += Array(repeating: record(model: "llama3.1-8b", verdict: .fail,
+                                            toolSelection: Scores(precision: 0.6, recall: 1, f1: 0.75),
+                                            failureClass: .lowPrecision), count: 3)
+        // 3 fails with perfect tool selection but a non-tool (argument) assertion
+        // miss → verdict fail, failureClass nil. Keeps the F1 mean at 0.750.
+        records += Array(repeating: record(model: "llama3.1-8b", verdict: .fail,
+                                            toolSelection: Scores(precision: 1, recall: 1, f1: 1),
+                                            failureClass: nil), count: 3)
+
+        let markdown = MatrixRenderer.render(records)
+        let row = try line(markdown, containing: "llama3.1-8b")
+
+        XCTAssertTrue(row.contains("0.750"), "mean tool-selection F1 must read 0.750: \(row)")
+        // The fix: a 0.750-F1 cell calls the right tool most of the time — it is
+        // NOT a renders-no-call cell. (Fails under the OLD subtype-dominant logic.)
+        XCTAssertFalse(row.contains("renders-no-call"),
+                       "a 0.750-F1 cell must never be labeled renders-no-call: \(row)")
+        XCTAssertTrue(row.contains("⚠️ partial"),
+                      "a mid-band F1 cell reads as partial: \(row)")
+    }
+
+    /// The genuine no-call cell: every record is a `noCall` fail, mean F1 0.000.
+    /// This SHOULD keep "renders-no-call" — the model truly never calls.
+    func testAllNoCallZeroF1CellStaysRendersNoCall() throws {
+        let records = Array(repeating: record(
+            model: "gemma3-4b-tools", verdict: .fail,
+            toolSelection: Scores(precision: 0, recall: 0, f1: 0), failureClass: .noCall
+        ), count: 27)
+
+        let markdown = MatrixRenderer.render(records)
+        let row = try line(markdown, containing: "gemma3-4b-tools")
+
+        XCTAssertTrue(row.contains("0.000"), "an all-no-call cell shows its real 0.000: \(row)")
+        XCTAssertTrue(row.contains("⚠️ renders-no-call"),
+                      "F1 ≈ 0 with no-call dominant is a genuine renders-no-call: \(row)")
+    }
+
+    /// A perfect cell (mean F1 1.000) reads as pass.
+    func testPerfectF1CellIsPass() throws {
+        let records = Array(repeating: record(
+            model: "qwen3.5-9b", verdict: .pass,
+            toolSelection: Scores(precision: 1, recall: 1, f1: 1)
+        ), count: 5)
+
+        let markdown = MatrixRenderer.render(records)
+        let row = try line(markdown, containing: "qwen3.5-9b")
+        XCTAssertTrue(row.contains("1.000"), row)
+        XCTAssertTrue(row.contains("✅ pass"), row)
+    }
+
+    /// High aggregate F1 (≥ 0.9) bands to pass even when a minority of records fail
+    /// — the F1-floor short-circuit, exercised directly on `dominantVerdictLabel`.
+    func testHighF1WithMinorityFailuresBandsToPass() {
+        var records = Array(repeating: record(
+            verdict: .pass, toolSelection: Scores(precision: 1, recall: 1, f1: 1)
+        ), count: 9)
+        records.append(record(verdict: .fail,
+                              toolSelection: Scores(precision: 0, recall: 0, f1: 0),
+                              failureClass: .noCall))
+        // Mean F1 = 9/10 = 0.900 → at the pass floor.
+        XCTAssertEqual(MatrixRenderer.dominantVerdictLabel(records), "✅ pass")
+    }
 }


### PR DESCRIPTION
## Bug

`MatrixRenderer.dominantVerdictLabel` refined a fail-dominant cell's label from its **dominant `failureClass` subtype**. A live soak produced `llama3.1-8b` d0 at **mean F1 0.750** (verdicts {pass:6, partial:9, fail:12}, failureClass {noCall:6, lowPrecision:3, nil:18}) — but because `noCall` was the most common *failure subtype*, the cell rendered as **"⚠️ renders-no-call"**. That cell calls the correct tool ~75% of the time; the label is wrong and erodes trust in the matrix. Meanwhile `mistral-7b-tools` at F1 0.875 got the more reasonable "⚠️ partial".

## Fix

The label is now **F1/verdict-aware**, banding on aggregate tool-selection F1 first and using `verdict`/`failureClass` only to refine *within* a band:

- `topVerdict == .errored` → 💥 errored (infra signal, F1-independent)
- dominant verdict `pass` **or** mean F1 ≥ `passF1Floor` (0.9) → ✅ pass
- `noCall` dominant among fails **and** mean F1 ≤ `noCallF1Ceiling` (0.05, or no measured F1) → ⚠️ renders-no-call (reserved for cells that genuinely (almost) never call)
- `lowPrecision`/`truncation`/`loadFail`/`renderFail` dominant → their distinct symbol
- otherwise mid-band → ⚠️ partial (hard ❌ fail only when fail-dominant with no measured F1)

Deterministic — `mean` and `dominant` are order-free.

### Before / after for the soak case

| Cell | Mean F1 | Before | After |
|------|---------|--------|-------|
| `llama3.1-8b` d0 | 0.750 | ⚠️ renders-no-call | **⚠️ partial** |
| `gemma3-4b-tools` d0 (all noCall) | 0.000 | ⚠️ renders-no-call | ⚠️ renders-no-call (unchanged — genuine) |
| `qwen3.5-9b` | 1.000 | ✅ pass | ✅ pass (unchanged) |

## Tests

`Tests/ManifoldToolsTests/MatrixRendererTests.swift` — 4 new hand-authored-record cases (no models): the 0.750-F1 noCall-dominant cell is **not** renders-no-call (fails under the old logic), the all-noCall 0.000 cell still is, a perfect cell is pass, and an F1≥0.9-with-minority-failures cell bands to pass.

Additive/internal change to `MatrixRenderer`; no public signature change. No `try?`/force-unwraps/`try!`/`as!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)