### PR TITLE
docs(eval): consolidation plan, cross-repo model coverage, and soak results

### DIFF
--- a/docs/plans/manifold-eval-repo.md
+++ b/docs/plans/manifold-eval-repo.md
@@ -1,0 +1,78 @@
+# Plan: Consolidate cross-backend model evaluation (in-place, no new repo)
+
+**Status:** Revised after adversarial review (2026-06-26) — **a dedicated `manifold-eval` repo was proposed and REJECTED.** This doc now tracks the in-place path.
+**Related:** `docs/plans/tested-models-cross-repo.md`, `docs/plans/tool-calling-architecture.md`, `scripts/local-integration-sweep.sh`, `ToolCallConformance` port (#2030), SwiftData adapter (#2034)
+
+## 1. Problem
+
+Behavioral model evaluation — "does *this model × quant × backend × renderer* actually tool-call" — is smeared across three repos with real correctness defects in the eval itself:
+
+- **Scorer attribution bug.** The llama.cpp Mistral cell dispatched the correct tool on every scenario (`passed:true` on both assertions) yet scored `toolTP=0, toolFP=1, f1=0`. The matrix verdict was **hand-corrected by a human reading JSONL** — the automated path was wrong.
+- **Scorer "divergence" is a CLI `print`, not an engine fork.** MLX's `manifold-tools-mlx` hand-rolls a `SUMMARY` line on top of the *shared* `ScenarioRunner`; its `passed`/`clean` gate reads 0/9 for every model and never fires. `ConformanceScorer.swift` already documents it was built "to be promotable to a shared `.library` product."
+- **Absence is not a state.** A missing GGUF → empty CSV → reads as measured.
+- **No normalized result record.** Matrices are hand-assembled markdown.
+- **`ScenarioLoader.loadBuiltIn()` is CWD-relative** → companions vendor copies of the corpus → drift.
+
+## 2. Adversarial review verdict (why the repo was rejected)
+
+Three independent reviewers (architecture / methodology / pragmatism) converged: **the consolidation is worth doing; a 4th repo is the wrong unit and the headline justifications are false.**
+
+**Factual code corrections (architecture reviewer, verified against `Package.swift`):**
+1. Both companions **already** depend on the published `ManifoldTools` library product (`manifold-llama/Package.swift:94`, `manifold-mlx/Package.swift:138`). The corpus + scorer are already shared. "Lifting them into `manifold-eval`" would invert that edge → **package cycle**.
+2. `ConformanceScorer` is already meant to be promoted to a `.library`; unifying scoring is a **one-line product change**, not a repo.
+3. **"One process" is unbuildable:** `llama_backend_init` is once-per-process, MLX needs serialized in-process Metal, #982 is the dual-engine hazard. Collation must be over records from *separate processes* — which the existing sweep script already does.
+
+**Methodology reviewer (do not trust verdicts until these are fixed):**
+- **Twin-divergence is confounded** — Ollama tag vs Q4_K_M GGUF vs 4bit MLX differ in quant **and** checkpoint **and** renderer at once; a divergence can't be attributed to the renderer without a **same-bytes control**.
+- **Auto-rendering the matrix removes the human transcript-read that caught the last scorer bug**; golden tests only protect already-seen transcript shapes, not the novel cells the eval exists to run.
+- **No determinism pinning.** Two *identical-code* runs show 0.10–0.12 F1 swings; a verdict-class regression detector would cry wolf.
+- Macro-F1 over 9 scenarios (one a no-tool scenario scored as F1=0) is a toolset canary, not a capability measure. The cloud "anchor" is noisy and is **not** a ground-truth oracle.
+
+**Pragmatism reviewer:** the value is all code that lives in existing repos; a repo with no owner rots (the documented fuzz cadence collapse — per-PR → nightly → weekly → hand-run — is the precedent); P0–P4 is the banned phased-multi-PR anti-pattern.
+
+## 3. Revised approach — five in-place PRs, no new repo
+
+| PR | Title | Repo / area | Wave | Depends on |
+|----|-------|-------------|------|------------|
+| **A** | `fix(tools): correct tool-call TP attribution in ConformanceScorer + golden-transcript test` | core / `ManifoldTools` | 1 | — |
+| **B** | `fix(tools): load built-in scenarios from Bundle.module, not CWD` | core / `ManifoldTools` | 1 | — |
+| **C** | `feat(tools): add ConformanceRecord + CellStatus normalized result schema` | core / `ManifoldTools` | 1 | — |
+| **D** | `feat(tools): promote ConformanceScorer to a shared library surface; retire MLX self-scoring` | core product decl (+ companion follow-ups) | 2 | A |
+| **E** | `feat(eval): local-integration-sweep emits ConformanceRecords + renders MATRIX from a query` | core / `scripts/` | 2 | C, (A) |
+
+**Wave 1 (A, B, C)** — independent, core-only, additive/low-risk; run in parallel worktrees. **Wave 2 (D, E)** — held until Wave 1 merges (D promotes the *fixed* scorer; E emits the *new* record schema). The companion-side wiring for D (pointing `manifold-tools-mlx`/`-llama` at the shared scorer) is a separate follow-up PR per companion repo, not part of D's core change.
+
+**Execution loop per wave:** implement in isolated worktrees → draft PRs (compile-then-commit-then-push to protect work) → **review-and-fix worker pass on each diff** → mark ready → CI → auto-merge on green. Orchestrator owns CI-watch, merge ordering, and rebases.
+
+## 4. Measurement caveats to fix before any verdict is load-bearing
+
+(These are *not* code PRs above — they gate trusting the output, tracked here so they aren't lost.)
+- Pin sampling temperature + seed; report variance / repeats, not means-only.
+- Type divergence by *what changed*; require a **same-bytes control** before calling a divergence a renderer bug.
+- Drop or separately-score the no-tool scenario (`structured-json-extraction`) out of macro-F1.
+- Keep a human transcript spot-check in the loop; demote the cloud anchor from "oracle" to "scenario-design sanity check."
+- Guard regression-vs-last-run against environment drift (artifact-hash + same-cell-set baseline) so a missing GGUF doesn't read as a regression.
+
+## 5. When to revisit a dedicated repo
+
+Only if the script-based eval is **actually run on a cadence by an owner for 2–3 months** (clears the fuzz-rot bar) *and* in-process all-three collation proves necessary (it currently isn't — separate-process records suffice). Until both hold, a repo is speculative infrastructure.
+
+## 6. Shipped (2026-06-26)
+
+All six PRs landed on `main` (each reviewed by an adversarial worker before merge):
+
+| PR | Change |
+|----|--------|
+| #2041 | `ConformanceRecord` + `CellStatus` normalized schema (`notMeasured` first-class) |
+| #2042 | `ScenarioLoader` loads the corpus from `Bundle.module`, not CWD (kills vendoring drift) |
+| #2043 | Scorer tool-call TP-attribution fix (bare-vs-backtick assertion recovery) + golden test |
+| #2045 | `ConformanceScorer.records(...)` public API + `score --emit-records` (absence → `notMeasured`/`loadFail`) |
+| #2046 | `MatrixRenderer` (records → `MATRIX.md`) + `matrix` CLI + `local-integration-sweep.sh` wiring |
+| #2047 | Matrix cell verdict derived from F1, not dominant failure subtype |
+
+**Validation (`docs/plans/runs/soak-20260626-100115/`):**
+- **Smoke + soak** through the full chain (run → `score --emit-records` → `matrix`): 21 cells, 189 normalized Ollama records, one queried `MATRIX.md`. Within-run repeats were bit-identical (greedy sampling) — the overnight 0.10–0.12 F1 swings were cross-environment drift, not per-call noise.
+- **#2043 proven on real companion data:** the new scorer re-scored the exact llama.cpp Mistral transcript the overnight run wrongly reported as **F1=0.000** → **F1=0.810**. The cell that previously needed a human reading JSONL to override now scores correctly through the pipeline.
+- **Cross-runtime matrix** (`XRUNTIME_MATRIX.md`, Ollama + llama.cpp from existing transcripts) surfaces the gap the hand-written matrices hid: gemma4-e4b ✅ on Ollama vs 💥 load-fail on llama.cpp; gemma3-4b 0.000 on both (model fact); mistral-7b ~0.81–0.88 on both — with the honest "not evidence of a backend bug without a same-bytes control" caveat.
+
+**Still open (tracked in §4, not yet built):** determinism pinning (temp/seed) for cross-run comparison; companion CLIs (`manifold-tools-mlx`/`-llama`) scoring via the shared core scorer rather than self-`SUMMARY` (the consolidation enables it — demonstrated here by scoring their transcripts centrally); MLX leg (no transcripts emitted locally yet).

--- a/docs/plans/runs/soak-20260626-100115/MATRIX.md
+++ b/docs/plans/runs/soak-20260626-100115/MATRIX.md
@@ -1,0 +1,22 @@
+# Ollama Tool-Calling Conformance — soak 20260626 (5 models × 3 repeats + decoy ladder)
+
+Rendered from 189 `ConformanceRecord`(s) across 5 cell(s) · backends: ollama · core: 5a0de5cd.
+
+## Main matrix (d0 — no decoys)
+Means of tool-selection precision/recall/F1 over the cell's *measured* records; `Runs` is the record count. Holes render as their own rows (🚫 not measured · 💥 load-fail · 🛑 render-fail) — never as a measured `0.000`. Verdicts: ✅ pass · ⚠️ partial / renders-no-call / low-precision · ❌ fail · 💥 errored.
+
+| Backend | Model | Quant | Renderer | Runs | Prec | Recall | F1 | Verdict |
+|---------|-------|-------|----------|------|------|--------|----|---------|
+| ollama | gemma3-4b-tools | unknown | ollama-server | 27 | 0.000 | 0.000 | 0.000 | ⚠️ renders-no-call |
+| ollama | gemma4-e4b | unknown | ollama-server | 27 | 1.000 | 1.000 | 1.000 | ✅ pass |
+| ollama | llama3.1-8b | unknown | ollama-server | 27 | 0.750 | 0.750 | 0.750 | ⚠️ partial |
+| ollama | mistral-7b-tools | unknown | ollama-server | 27 | 0.875 | 0.875 | 0.875 | ⚠️ partial |
+| ollama | qwen3.5-9b | unknown | ollama-server | 27 | 1.000 | 1.000 | 1.000 | ✅ pass |
+
+## Decoy ladder (mean F1 per decoy level)
+F1 under distractor pressure. `+N` = N decoy tools advertised alongside the real set. Blank cells weren't measured at that level.
+
+| Backend | Model | Quant | Renderer | d0 | +1 | +3 | +5 |
+|---|---|---|---|---|---|---|---|
+| ollama | mistral-7b-tools | unknown | ollama-server | 0.875 | 0.208 | 0.225 | 0.250 |
+| ollama | qwen3.5-9b | unknown | ollama-server | 1.000 | 0.917 | 0.958 | 0.917 |

--- a/docs/plans/runs/soak-20260626-100115/XRUNTIME_MATRIX.md
+++ b/docs/plans/runs/soak-20260626-100115/XRUNTIME_MATRIX.md
@@ -1,0 +1,37 @@
+# Cross-Runtime Tool-Calling Conformance (Ollama + llama.cpp)
+
+Rendered from 244 `ConformanceRecord`(s) across 8 cell(s) · backends: llama.cpp, ollama · core: 5a0de5cd.
+
+## Main matrix (d0 — no decoys)
+Means of tool-selection precision/recall/F1 over the cell's *measured* records; `Runs` is the record count. Holes render as their own rows (🚫 not measured · 💥 load-fail · 🛑 render-fail) — never as a measured `0.000`. Verdicts: ✅ pass · ⚠️ partial / renders-no-call / low-precision · ❌ fail · 💥 errored.
+
+| Backend | Model | Quant | Renderer | Runs | Prec | Recall | F1 | Verdict |
+|---------|-------|-------|----------|------|------|--------|----|---------|
+| llama.cpp | gemma3-4b-it | Q4_K_M | jinja-prompt | 27 | 0.000 | 0.000 | 0.000 | ⚠️ renders-no-call |
+| llama.cpp | gemma4-e4b | Q4_K_M | jinja-prompt | 0 | — | — | — | 💥 load-fail (Unsupported model architecture: gemma4) |
+| llama.cpp | mistral-7b-instruct | Q4_K_M | jinja-prompt | 27 | 0.857 | 0.786 | 0.810 | ✅ pass |
+| ollama | gemma3-4b-tools | unknown | ollama-server | 27 | 0.000 | 0.000 | 0.000 | ⚠️ renders-no-call |
+| ollama | gemma4-e4b | unknown | ollama-server | 27 | 1.000 | 1.000 | 1.000 | ✅ pass |
+| ollama | llama3.1-8b | unknown | ollama-server | 27 | 0.750 | 0.750 | 0.750 | ⚠️ partial |
+| ollama | mistral-7b-tools | unknown | ollama-server | 27 | 0.875 | 0.875 | 0.875 | ⚠️ partial |
+| ollama | qwen3.5-9b | unknown | ollama-server | 27 | 1.000 | 1.000 | 1.000 | ✅ pass |
+
+## Decoy ladder (mean F1 per decoy level)
+F1 under distractor pressure. `+N` = N decoy tools advertised alongside the real set. Blank cells weren't measured at that level.
+
+| Backend | Model | Quant | Renderer | d0 | +1 | +3 | +5 |
+|---|---|---|---|---|---|---|---|
+| ollama | mistral-7b-tools | unknown | ollama-server | 0.875 | 0.208 | 0.225 | 0.250 |
+| ollama | qwen3.5-9b | unknown | ollama-server | 1.000 | 0.917 | 0.958 | 0.917 |
+
+## Cross-runtime view (same logical model, side by side)
+> **Read this as a prompt for inspection, not a verdict.** Cells in a group are matched only on a *normalized model name* — they may differ in quant, checkpoint, or renderer. A verdict difference here is therefore **not, on its own, evidence of a backend bug**: without a same-bytes control a divergence is confounded. Use it to decide what to spot-check, then read the transcripts.
+
+| Logical model | Backend | Quant | Renderer | Runs | F1 | Verdict |
+|---------------|---------|-------|----------|------|----|---------|
+| gemma3-4b | llama.cpp | Q4_K_M | jinja-prompt | 27 | 0.000 | ⚠️ renders-no-call |
+| gemma3-4b | ollama | unknown | ollama-server | 27 | 0.000 | ⚠️ renders-no-call |
+| gemma4-e4b | llama.cpp | Q4_K_M | jinja-prompt | 0 | — | 💥 load-fail (Unsupported model architecture: gemma4) |
+| gemma4-e4b | ollama | unknown | ollama-server | 27 | 1.000 | ✅ pass |
+| mistral-7b | llama.cpp | Q4_K_M | jinja-prompt | 27 | 0.810 | ✅ pass |
+| mistral-7b | ollama | unknown | ollama-server | 27 | 0.875 | ⚠️ partial |

--- a/docs/plans/runs/soak-20260626-100115/all_records.json
+++ b/docs/plans/runs/soak-20260626-100115/all_records.json
@@ -1,0 +1,3922 @@
+[
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 0.5,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.8,
+   "precision": 0.6666666666666666,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ }
+]

--- a/docs/plans/runs/soak-20260626-100115/xruntime_records.json
+++ b/docs/plans/runs/soak-20260626-100115/xruntime_records.json
@@ -1,0 +1,5039 @@
+[
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_gemma4-e4b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_gemma4-e4b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r2_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma3-4b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma4-e4b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_gemma4-e4b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "llama3.1-8b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_llama3.1-8b.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d0_r3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 0.5,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 1,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d1_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.8,
+   "precision": 0.6666666666666666,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 3,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d3_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "failureClass": "noCall",
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "mistral-7b-tools",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_mistral-7b-tools.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "ollama",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 5,
+  "model": "qwen3.5-9b",
+  "quant": "unknown",
+  "renderer": "ollama-server",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/soak-20260626-100115/d5_qwen3.5-9b.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r1.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r2.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "noCall",
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "gemma3-4b-it",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_gemma-3-4b-it-Q4_K_M.tooltmpl_d0_r3.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r1.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r2.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "01-now",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "02-calc",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "03-read",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "04-list",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "meeting-notes-summary",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0.6666666666666666,
+   "precision": 1,
+   "recall": 0.5
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "shopping-list-budget",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 0,
+   "precision": 0,
+   "recall": 0
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "parallel-readme-comparison",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "pass"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "oversize-tool-output",
+  "status": {
+   "kind": "measured"
+  },
+  "toolSelection": {
+   "f1": 1,
+   "precision": 1,
+   "recall": 1
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "partial"
+ },
+ {
+  "backend": "llama.cpp",
+  "coreCommit": "5a0de5cd",
+  "decoyLevel": 0,
+  "failureClass": "lowPrecision",
+  "model": "mistral-7b-instruct",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "repeatIndex": 0,
+  "scenario": "structured-json-extraction",
+  "status": {
+   "kind": "measured"
+  },
+  "toolingVersions": {},
+  "transcriptRef": "docs/plans/runs/overnight-20260624-212539/llama_Mistral-7B-Instruct-v0.3-Q4_K_M_d0_r3.jsonl",
+  "verdict": "fail"
+ },
+ {
+  "backend": "llama.cpp",
+  "model": "gemma4-e4b",
+  "quant": "Q4_K_M",
+  "renderer": "jinja-prompt",
+  "scenario": "(load)",
+  "decoyLevel": 0,
+  "repeatIndex": 0,
+  "status": {
+   "kind": "loadFail",
+   "reason": "Unsupported model architecture: gemma4"
+  },
+  "transcriptRef": "(empty \u2014 load failed)",
+  "coreCommit": "5a0de5cd",
+  "toolingVersions": {}
+ }
+]

--- a/docs/plans/tested-models-cross-repo.md
+++ b/docs/plans/tested-models-cross-repo.md
@@ -1,0 +1,107 @@
+# Tested Local Models — Cross-Repo Consolidated View
+
+**Compiled:** 2026-06-26 · **Scope:** ManifoldKit (Ollama) + `manifold-llama` (llama.cpp/GGUF) + `manifold-mlx` (MLX) companion repos.
+
+This doc consolidates which **local models** have been exercised against each backend family, pulling together signal that is otherwise scattered across two `MATRIX.md` conformance runs in this repo and the native test suites of the two companion repos. It is a snapshot, not a live gate — re-derive from the sources below when in doubt.
+
+## Sources
+
+| Source | What it covers |
+|--------|----------------|
+| `docs/plans/runs/20260622-232839/MATRIX.md` (PR #2033) | Cross-backend tool-call conformance, **pre-#2032** (Mistral cells flagged re-measure-pending) |
+| `docs/plans/runs/overnight-20260624-212539/MATRIX.md` | **Re-measure** on post-#2035 core — authoritative for tool-calling cells |
+| `manifold-llama` `Tests/ManifoldLlamaTests/Conformance/` | 5-family GBNF + tool-call E2E, embeddings, tokenization |
+| `manifold-mlx` integration tests + `MLXModelProbe.swift` | Text, vision/VLM, image-gen/diffusion |
+
+> **The headline principle (from the matrices):** tool-calling capability is a property of the **(model × quant × backend × renderer)** cell, not of the model. The same weights can pass on one backend and emit nothing on another. The cross-backend matrix exists precisely to surface those divergences.
+
+---
+
+## 1. Cross-backend tool-calling matrix
+
+The only place the **same models** run head-to-head on all three local backends, against a shared 9-scenario reference toolset. Figures are from the latest re-measure (`overnight-20260624`); F1 = macro tool-selection.
+
+### Ollama (server-side templates — cleanest leg)
+
+| Model | F1 | Verdict |
+|-------|----|---------|
+| mistral-7b-tools | 0.778 | ✅ |
+| gemma4-e4b | 0.889 | ✅ |
+| qwen3.5-9b | 0.889 | ✅ |
+| llama3.1-8b | 0.667 | ✅ |
+| gemma3-4b-tools | 0.000 | ⚠️ renders-no-call (model fact — never tool-calls) |
+
+### llama.cpp / GGUF (all Q4_K_M)
+
+| Model | Verdict |
+|-------|---------|
+| Mistral-7B-Instruct-v0.3 | ✅ **recovered** post-#2032/#2035 (correct tool every scenario; reported F1=0 is a **scorer attribution bug**, not a model failure) |
+| gemma-3-4b-it `.tooltmpl` | ⚠️ renders-no-call (model fact) |
+| gemma-4-E4B | 💥 load-fail — `gemma4` arch unsupported by the prebuilt xcframework |
+| llama3.1-8b | 🚫 not measured this run (GGUF absent; last good = **0.622** on Jun 22) |
+| qwen3.5-4b | 🚫 not measured (GGUF absent) |
+
+### MLX (4-bit)
+
+| Model | F1 | Verdict |
+|-------|----|---------|
+| Llama-3.2-3B | 1.000 | ✅ |
+| Qwen3-8B | 0.917 | ✅ (most decoy-robust local cell — flat across +1…+20 distractors) |
+| Mistral-v0.3 | 0.000 | ⚠️ **no-call — F3 confirmed** (MLX injects tools as system-prompt prose, never calls `applyChatTemplate(messages:tools:)`) |
+
+### Cloud anchor / control (OpenRouter)
+
+`gpt-oss-120b` (0.864, latest run). The Jun 22 run also scored `owl-alpha`, `gemma4-31b`, `nemotron3-super`, `laguna`.
+
+### The Mistral 3-way split (the whole point)
+
+**Same Mistral-v0.3 weights, three outcomes:** ✅ Ollama (0.778, server template) · ✅ llama.cpp (recovered via the #2032 alternation-fold) · ⚠️ MLX (still emits nothing). The MLX case is failure mode **F3**, which gates Phase 0 of the tool-calling architecture plan (`docs/plans/tool-calling-architecture.md`).
+
+---
+
+## 2. manifold-llama — native suites (beyond the matrix)
+
+llama.cpp owns the **5-family GBNF + tool-call conformance** surface. Per-family dialect and grammar support:
+
+| Family | Models exercised | Tool dialect | GBNF grammar | 9-scenario pass |
+|--------|------------------|--------------|--------------|-----------------|
+| **Llama** | 3.1-8B | Hermes | ✅ | 1–4/9 |
+| **Qwen** | 2.5-7B, 3-0.6B, 3-4B-Q4_K_M | Qwen JSON | ✅ (+ thinking) | 4/9 |
+| **Mistral** | 7B-Instruct-v0.3 | `[TOOL_CALLS]` array | ✅ | 4/9 |
+| **Gemma** | 3 / 3n / 4 (+ 4-E4B) | native `<\|tool_call\|>` | ❌ **carve-out** | 3/9 (gemma3) |
+| **Phi** | 3 / 3.5 | generic JSON | ✅ | — |
+
+**Also exercised:** SmolLM2, TinyLlama (tokenization/template tests). **Embeddings:** `nomic-embed-text-v1.5` (Q8_0), plus bge/minilm/jina patterns; reranking via `bge-reranker-v2-m3`.
+
+---
+
+## 3. manifold-mlx — native suites (beyond the matrix)
+
+Much broader than tool-calling — MLX owns vision and image-gen, neither of which has a tool-calling story yet.
+
+**Text (real weights, 4-bit):** Qwen2.5-0.5B, Llama-3.2-3B, Mistral-7B-v0.3. Grammar-constrained sampling E2E on Qwen2.5.
+
+**Text — blocked / crashing (known upstream bugs):**
+- Qwen3.5-4B — gated-DeltaNet broadcast mismatch (mlx-swift-lm #157)
+- Gemma-4 (all variants) — sliding-window/KV-shared broadcast mismatch (#282/#802)
+
+**Vision / VLM (integration tests):** Qwen2-VL, Qwen2.5-VL, Qwen3-VL, PaliGemma, SmolVLM, LLaVA-Qwen2, Pixtral, FastVLM, IDEFICS3, Gemma-3 vision.
+
+> `MLXModelProbe.swift` declares 30+ LM and 15+ VLM architectures as *supported in code*, but only the handful above are run against real weights.
+
+**Image-gen / diffusion:** FLUX.1-schnell (4-bit), stable-diffusion-2-1-base, sdxl-turbo.
+
+---
+
+## 4. Net read
+
+- The **cross-backend matrix** (§1) is the only head-to-head surface; the companion repos test much wider surfaces individually (§2 grammar, §3 vision + image-gen).
+- **Recurring cast everywhere:** Llama-3.x, Qwen (2.5/3/3.5), Mistral-7B-v0.3, Gemma-3/4.
+- **Gemma is the consistent problem child:** no GBNF on llama.cpp (deliberate carve-out), `gemma4` arch won't load on llama.cpp at all, Gemma-4 crashes MLX, and gemma3-4b-tools renders-no-call on every backend that *can* load it. It only tool-calls cleanly on Ollama (gemma4-e4b, 0.889).
+- **Two MLX gaps trace to upstream mlx-swift-lm bugs**, not ManifoldKit — re-measure when those land.
+
+## 5. Caveats
+
+- §1 cells marked 🚫 reflect GGUFs absent from `~/Documents/Models/` at run time — re-download to re-measure; they are not regressions.
+- The llama.cpp Mistral **F1=0 is a scorer attribution bug** (`toolTP=0, toolFP=1` on correct calls); trust the `verdict=pass` (24/45), not the aggregate F1. A scorer fix is a follow-up, not a tool-calling defect.
+- Decoy-ladder F1s (§1 robustness claims) are 1 run each except d0 — directional, not tight.


### PR DESCRIPTION
Documentation + validation artifacts for the eval-consolidation effort (PRs #2041–#2047, all merged).

## What's here
- **`docs/plans/manifold-eval-repo.md`** — the proposal to build a dedicated `manifold-eval` repo, the adversarial-review verdict that **rejected** it (it would create a package cycle, the "one process" framing is unbuildable, and the value is all in-repo code), and the **6-PR in-place path** that shipped instead. Includes a shipped-log.
- **`docs/plans/tested-models-cross-repo.md`** — consolidated view of which local models have been tested across Ollama / llama.cpp / MLX.
- **`docs/plans/runs/soak-20260626-100115/`** — first real run through the consolidated pipeline:
  - `MATRIX.md` — Ollama soak (5 models × 3 repeats + decoy ladder), 189 normalized records, rendered from a query.
  - `XRUNTIME_MATRIX.md` — cross-runtime (Ollama + llama.cpp), surfaces gemma4 ✅-Ollama vs 💥-load-fail-llama.cpp with the honest "not a backend bug without a same-bytes control" caveat.
  - `all_records.json` / `xruntime_records.json` — the queryable `ConformanceRecord` sources. Raw transcripts/logs intentionally left untracked (trim convention).

## Highlights from the soak
- The #2043 scorer fix, proven on **real companion data**: the llama.cpp Mistral transcript the overnight run wrongly reported as **F1=0.000** now scores **F1=0.810** through the automated pipeline (no human JSONL-read needed).
- Within-run repeats were bit-identical → the overnight 0.10–0.12 F1 swings were cross-environment drift, not per-call noise.

Docs/data only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)