### PR TITLE
fix(tools): remove two conformance-harness false-negatives

### DIFF
--- a/Sources/ManifoldTools/ConformanceScorer.swift
+++ b/Sources/ManifoldTools/ConformanceScorer.swift
@@ -352,6 +352,17 @@ public enum ConformanceScorer {
     /// safe (it never manufactures a false positive *or* a false true-positive),
     /// whereas loose prose matching could. A genuinely wrong tool therefore still
     /// scores as FP.
+    ///
+    /// Because this matcher is deliberately strict, it only recovers a tool whose
+    /// dispatch-requirement assertion *names it in the recognized form* (backtick or
+    /// the bare `… to actually be dispatched` frame). A built-in scenario that words
+    /// its requirement as free prose hides the tool here, so a companion transcript
+    /// (which omits `requiredTools`) mis-scores the correct call as an FP — keep the
+    /// `toolInvoked` messages naming the tool in backticks (a `ScenarioRecoveryTests`
+    /// case guards this for all built-ins). The durable fix is to log the
+    /// `toolInvoked` assertion's structured tool `value` in the transcript and prefer
+    /// it over message parsing; it is deferred because it changes the transcript
+    /// schema and the companions would have to re-vendor + re-run to benefit.
     static func expectedToolsFromAssertion(_ message: String) -> [String] {
         guard message.hasPrefix("Scenario requires") else { return [] }
         var tools: [String] = []

--- a/Sources/ManifoldTools/README.md
+++ b/Sources/ManifoldTools/README.md
@@ -53,6 +53,7 @@ Supported assertion kinds:
 | `containsLiteral` | `"value": String` | `finalAnswer.contains(value)` |
 | `equalsLiteral` | `"value": String` | `finalAnswer == value` |
 | `containsAll` | `"values": [String]` | Every entry in `values` is present |
+| `containsAny` | `"values": [String]` | At least one entry in `values` is present (use for contracts a correct model can paraphrase) |
 | `toolInvoked` | `"value": String` | Tool `value` was dispatched at least once |
 | `toolResultContains` | `"value": String`, `"values": [String]` | At least one result for tool `value` contains every entry in `values` |
 | `toolResultErrorKind` | `"value": String`, `"values": [String]` | At least one result for tool `value` has `errorKind` equal to the first entry in `values` |

--- a/Sources/ManifoldTools/Scenarios/Scenario.swift
+++ b/Sources/ManifoldTools/Scenarios/Scenario.swift
@@ -32,6 +32,10 @@ public struct Scenario: Codable, Sendable, Equatable {
         /// - `"containsLiteral"` — final-answer text must contain `value` as a substring.
         /// - `"equalsLiteral"` — final-answer text must equal `value` exactly.
         /// - `"containsAll"` — final-answer text must contain every string in `values` as substrings.
+        /// - `"containsAny"` — final-answer text must contain at least one string in `values` as a
+        ///   substring. Use this for behavioural contracts a correct model can phrase many ways
+        ///   (e.g. "acknowledge the size policy") so paraphrase isn't scored as failure — a literal
+        ///   `containsAll` over one canonical wording mis-fails every model that paraphrases.
         /// - `"toolInvoked"` — the scenario must have dispatched the tool named `value` at least once.
         ///   This is the honesty gate: a scenario that only asserts `containsLiteral` can silently
         ///   pass when a model hallucinates the expected answer without actually calling the tool.
@@ -107,6 +111,15 @@ public enum AssertionEvaluator {
             let passed = values.allSatisfy { finalAnswer.contains($0) }
             let label = assertion.message ?? "contains all of \(values)"
             return AssertionOutcome(passed: passed, message: label)
+
+        case "containsAny":
+            guard let values = assertion.values, !values.isEmpty else {
+                return AssertionOutcome(passed: false, message: "containsAny missing 'values'")
+            }
+            let passed = values.contains { finalAnswer.contains($0) }
+            let detail = passed ? "found" : "none present"
+            let label = assertion.message ?? "contains any of \(values)"
+            return AssertionOutcome(passed: passed, message: "\(label) — \(detail)")
 
         case "toolInvoked":
             guard let name = assertion.value else {

--- a/Sources/ManifoldTools/Scenarios/built-in/06-shopping-list-budget.json
+++ b/Sources/ManifoldTools/Scenarios/built-in/06-shopping-list-budget.json
@@ -8,7 +8,7 @@
     {
       "kind": "toolInvoked",
       "value": "read_file",
-      "message": "Scenario requires the shopping list to be read from the fixture"
+      "message": "Scenario requires `read_file` to load the shopping list from the fixture"
     },
     {
       "kind": "toolInvoked",

--- a/Sources/ManifoldTools/Scenarios/built-in/07-parallel-readme-comparison.json
+++ b/Sources/ManifoldTools/Scenarios/built-in/07-parallel-readme-comparison.json
@@ -8,7 +8,7 @@
     {
       "kind": "toolInvoked",
       "value": "read_file",
-      "message": "Scenario requires file reads rather than hallucinated README contents"
+      "message": "Scenario requires `read_file` rather than hallucinated README contents"
     },
     {
       "kind": "toolResultContains",

--- a/Sources/ManifoldTools/Scenarios/built-in/08-oversize-tool-output.json
+++ b/Sources/ManifoldTools/Scenarios/built-in/08-oversize-tool-output.json
@@ -17,9 +17,14 @@
       "message": "Oversize output should be rejected before it floods context"
     },
     {
-      "kind": "containsAll",
-      "values": ["exceeds maxBytes", "narrower"],
-      "message": "Final answer should surface the bounded-output contract without hallucinating file contents"
+      "kind": "containsAny",
+      "values": ["exceeds", "exceed", "too large", "too big", "maximum", "limit", "maxBytes", "size"],
+      "message": "Final answer should acknowledge the output-size policy was hit"
+    },
+    {
+      "kind": "containsAny",
+      "values": ["narrower", "smaller", "specific", "portion", "range", "section", "subset", "chunk", "slice", "part"],
+      "message": "Final answer should offer to read a narrower slice rather than the whole file"
     }
   ],
   "backend": {

--- a/Tests/ManifoldToolsTests/ScenarioRecoveryTests.swift
+++ b/Tests/ManifoldToolsTests/ScenarioRecoveryTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import ManifoldTools
+
+/// Guards two conformance-harness false-negatives that understated real scores:
+///
+/// 1. **Bug B — a built-in scenario's required tool was hidden from scoring.**
+///    The scorer's expected-set recovery (used for companion transcripts that omit
+///    the `requiredTools` prompt field) only extracts a tool named in the
+///    recognized backtick / bare-dispatch form. Two scenarios worded their
+///    `read_file` requirement as free prose, so a *correct* `read_file` call was
+///    mis-scored as a false positive on llama.cpp / MLX. This suite asserts every
+///    built-in `toolInvoked` assertion names its tool in a recoverable form, so the
+///    regression can't reappear when a scenario is added or reworded.
+///
+/// 2. **Bug A — `oversize-tool-output` demanded a literal phrasing.** Its
+///    final-answer assertion was `containsAll: ["exceeds maxBytes", "narrower"]`,
+///    which fails every model that paraphrases the (correct) size-policy response.
+///    The fix introduces a `containsAny` assertion kind; these tests cover the new
+///    kind and prove a canonical correct answer now passes while a hallucinated one
+///    still fails.
+final class ScenarioRecoveryTests: XCTestCase {
+
+    // MARK: - Bug B: every built-in's required tool is recoverable
+
+    /// For every built-in scenario, each `toolInvoked` dispatch-requirement
+    /// assertion must name its tool in a form the scorer's expected-set recovery
+    /// can extract — using the *exact message the runner logs* (label + outcome
+    /// suffix), not the raw authored label. Otherwise a companion transcript
+    /// (no `requiredTools`) scores the correct call as a false positive.
+    func testEveryBuiltInToolInvokedAssertionExposesItsToolForRecovery() throws {
+        let scenarios = try ScenarioLoader.loadBuiltIn()
+        XCTAssertFalse(scenarios.isEmpty, "no built-in scenarios loaded")
+
+        for scenario in scenarios {
+            for assertion in scenario.assertions where assertion.kind == "toolInvoked" {
+                let tool = try XCTUnwrap(assertion.value, "\(scenario.id): toolInvoked missing 'value'")
+
+                // Reproduce the message the runner actually appends to the transcript
+                // for a dispatched tool — that string is what the scorer parses.
+                let logged = AssertionEvaluator.evaluate(
+                    assertion,
+                    finalAnswer: "",
+                    toolsInvoked: [tool]
+                ).message
+
+                let recovered = ConformanceScorer.expectedToolsFromAssertion(logged)
+                XCTAssertTrue(
+                    recovered.contains(tool),
+                    "\(scenario.id): required tool '\(tool)' is not recoverable from its logged "
+                        + "assertion message — name it in backticks. Logged: \(logged)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Bug A: containsAny assertion kind
+
+    func testContainsAnyPassesWhenAnyValuePresent() {
+        let assertion = Scenario.Assertion(
+            kind: "containsAny",
+            value: nil,
+            values: ["narrower", "smaller", "portion"],
+            message: "offer a narrower slice"
+        )
+        let outcome = AssertionEvaluator.evaluate(
+            assertion,
+            finalAnswer: "I can read a smaller portion if you tell me which lines."
+        )
+        XCTAssertTrue(outcome.passed)
+    }
+
+    func testContainsAnyFailsWhenNoValuePresent() {
+        let assertion = Scenario.Assertion(
+            kind: "containsAny",
+            value: nil,
+            values: ["narrower", "smaller", "portion"],
+            message: "offer a narrower slice"
+        )
+        let outcome = AssertionEvaluator.evaluate(
+            assertion,
+            finalAnswer: "Here is the full contents of the file: lorem ipsum …"
+        )
+        XCTAssertFalse(outcome.passed)
+    }
+
+    func testContainsAnyFailsWithoutValues() {
+        let assertion = Scenario.Assertion(kind: "containsAny", value: nil, values: nil, message: nil)
+        let outcome = AssertionEvaluator.evaluate(assertion, finalAnswer: "anything")
+        XCTAssertFalse(outcome.passed)
+    }
+
+    // MARK: - Bug A: oversize scenario accepts a correct paraphrase
+
+    /// A real, behaviourally-perfect answer (qwen3.5-9b, soak 20260626) — it hit the
+    /// size policy, didn't hallucinate, and offered narrower reads. Under the old
+    /// literal `containsAll` it failed; under `containsAny` it must pass.
+    private static let canonicalCorrectOversizeAnswer = """
+    The file `oversize-output.txt` is too large for me to read in one go. The system \
+    returned an error indicating that the output size (41,203 bytes) exceeds the maximum \
+    allowed limit of 32,768 bytes. To help you with this oversized file, I can read \
+    specific line ranges if you provide them, break it into smaller chunks for sequential \
+    reading, or focus on particular sections most relevant to your needs.
+    """
+
+    /// An answer that ignored the policy and fabricated content — it must still fail.
+    private static let hallucinatedOversizeAnswer = """
+    The file is a quarterly business report. Q3 revenue was $4.2M, up 12% year over year, \
+    driven by strong enterprise demand and a new product line.
+    """
+
+    private func oversizeFinalAnswerAssertions() throws -> [Scenario.Assertion] {
+        let scenario = try XCTUnwrap(
+            try ScenarioLoader.loadBuiltIn().first { $0.id == "oversize-tool-output" },
+            "oversize-tool-output scenario missing"
+        )
+        // The final-answer behavioural checks are the containsAny pair; the tool /
+        // tool-result asserts are exercised live by the runner, not here.
+        return scenario.assertions.filter { $0.kind == "containsAny" }
+    }
+
+    func testOversizeScenarioPassesCorrectParaphrase() throws {
+        let asserts = try oversizeFinalAnswerAssertions()
+        XCTAssertEqual(asserts.count, 2, "expected size-ack + narrowing containsAny assertions")
+        for assertion in asserts {
+            let outcome = AssertionEvaluator.evaluate(
+                assertion,
+                finalAnswer: Self.canonicalCorrectOversizeAnswer
+            )
+            XCTAssertTrue(outcome.passed, "correct paraphrase failed assertion: \(outcome.message)")
+        }
+    }
+
+    func testOversizeScenarioRejectsHallucinatedAnswer() throws {
+        let asserts = try oversizeFinalAnswerAssertions()
+        // A hallucinated answer acknowledges no size policy, so at least one
+        // behavioural assertion must fail — the honesty gate stays intact.
+        let anyFailed = asserts.contains { assertion in
+            !AssertionEvaluator.evaluate(
+                assertion,
+                finalAnswer: Self.hallucinatedOversizeAnswer
+            ).passed
+        }
+        XCTAssertTrue(anyFailed, "hallucinated answer should fail the bounded-output contract")
+    }
+}


### PR DESCRIPTION
## What

Two scoring artifacts in the tool-calling conformance harness were **understating real scores** — neither is a model defect. Found while auditing the `soak-20260626-100115` results.

### Bug A — `oversize-tool-output` demanded a literal phrasing (affects every backend)
The final-answer assertion was `containsAll: ["exceeds maxBytes", "narrower"]`. A behaviourally-perfect answer (e.g. qwen3.5-9b: calls `read_file`, hits the policy, *"…output size (41,203 bytes) exceeds the maximum allowed limit of 32,768 bytes… read a smaller portion"*, no hallucination) **fails** because it paraphrases instead of echoing those exact substrings — **0 passes across all 5 soak models** despite F1=1.0 tool selection.

Fix: add a `containsAny` assertion kind and re-express the oversize final-answer check as a size-acknowledgement OR-set **and** a narrowing OR-set. The `toolResultErrorKind` honesty gate is unchanged, so a hallucinated answer still fails.

### Bug B — a built-in's required tool was hidden from companion scoring (affects llama.cpp / MLX)
The scorer's expected-set recovery — the fallback for transcripts that omit the `requiredTools` prompt field (companion soaks) — only extracts a tool named in the backtick or bare-dispatch form. Scenarios **06** and **07** worded their `read_file` requirement as free prose, so a *correct* `read_file` call was mis-scored as a false positive. Verified against a real llama-Mistral transcript: those cells read F1≈0.81 with `parallel-readme-comparison` wrongly at 0.0.

Fix: name the tool in backticks in both `toolInvoked` messages (Ollama, which writes authoritative `requiredTools`, was unaffected). A new `ScenarioRecoveryTests` case asserts **every** built-in `toolInvoked` assertion exposes its tool to recovery, so this can't reappear when a scenario is added or reworded.

## Not in scope (already fixed, verified during the audit)
- No-tool F1 drag — already handled (`toolSelection: nil`, excluded from the mean).
- llama.cpp TP attribution (F1=0.000) — already fixed by #2043; current scorer scores that transcript F1≈0.81.

## Tests
- `containsAny` pass / fail / missing-values
- oversize accepts the canonical correct paraphrase, still rejects a hallucinated answer
- built-in recovery coverage for all scenarios

## Backend checklist
- [x] Ollama (unaffected by B; A flips `oversize` to pass for competent models)
- [x] llama.cpp / MLX (B fixes understated `read_file` cells — confirmed on a retained transcript; re-measured by the next cross-backend soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)