### PR TITLE
test(catalog): pin Gemma-3 vs Gemma-4 tool-call close-delimiter family split

### DIFF
--- a/Tests/ManifoldModelCatalogTests/CrossTaxonomyDialectParityTests.swift
+++ b/Tests/ManifoldModelCatalogTests/CrossTaxonomyDialectParityTests.swift
@@ -34,9 +34,15 @@ import ManifoldHardware
 ///   `<|end_of_turn>`") and `PromptTemplate.gemma4`'s special-token set (which
 ///   carries `<|tool_call>` and `<|end_of_turn>` but neither `<tool_call|>` nor
 ///   `<|/tool_call>`).
-/// - The two descriptors each invented a *different, never-parsed* close spelling
-///   (`<tool_call|>` and `<|/tool_call>`). Both are wrong; `<|end_of_turn>` is the
-///   adjudicated truth.
+/// - Correction to the #2039 record: of the two pre-fix close spellings, only
+///   `<|/tool_call>` was genuinely invented (it appears in no template). `<tool_call|>`
+///   is NOT invented — it is the literal close the Ollama `gemma3-4b-tools` community
+///   model's baked template emits (`<|tool_call>call:NAME{…}<tool_call|>`, verified
+///   2026-06 via `ollama show gemma3-4b-tools --template`). But that model is
+///   **Gemma-3**, a different family from the repo's Gemma-4 `.gemma` dialect, so its
+///   close legitimately differs. `<|end_of_turn>` remains the adjudicated truth for the
+///   Gemma-4 `.gemma` dialect; the Gemma-3 vs Gemma-4 close split is pinned by
+///   `testGemma3CommunityCloseIsADistinctFamilyNotTheGemma4Close` below.
 final class CrossTaxonomyDialectParityTests: XCTestCase {
 
     /// One adjudicated dialect both descriptor taxonomies are expected to model
@@ -215,6 +221,56 @@ final class CrossTaxonomyDialectParityTests: XCTestCase {
             claim.declaredDialect?.openDelimiter,
             ManifoldHardware.ToolCallDialect.llamaPythonTag.openDelimiter,
             "Llama python-tag vs bare-JSON split changed shape — re-adjudicate before unifying"
+        )
+    }
+
+    /// The Ollama `gemma3-4b-tools` community model bakes a tool-call template whose
+    /// close delimiter is `<tool_call|>` — NOT the `<|end_of_turn>` the repo's Gemma-4
+    /// `.gemma` dialect uses. Verified 2026-06 against the live template, which emits:
+    ///
+    ///     {{- '<|tool_call>call:' + function['name'] + '{' -}} … {{- '}<tool_call|>' -}}
+    ///
+    /// i.e. `<|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>`.
+    ///
+    /// This corrects the #2039 record: `<tool_call|>` is not an "invented" spelling —
+    /// it is a real Gemma-3 emission. But Gemma-3 is a *different family* from the repo's
+    /// Gemma-4 `.gemma` dialect (`PromptTemplate.gemma4`, `ThinkingMarkers.gemma4`,
+    /// companion `LlamaToolMarkers.gemma4EndTurn`), so the two closes genuinely differ.
+    /// Pin the split so a future reader — or a stale overnight brief pointing at the
+    /// gemma3 Ollama model as "ground truth" — does not "fix" the Gemma-4 `.gemma` close
+    /// back to `<tool_call|>` and break the whole-repo Gemma-4 consensus. NB: Ollama
+    /// returns structured `tool_calls` JSON, so the marker parser never scans this
+    /// template's raw close at runtime — the divergence is a catalog/descriptor concern,
+    /// not a live parse bug.
+    func testGemma3CommunityCloseIsADistinctFamilyNotTheGemma4Close() {
+        // Ground truth: the literal close the Gemma-3 community template emits.
+        let gemma3CommunityClose = "<tool_call|>"
+        // The repo's `.gemma` dialect models Gemma-4, closing at the turn terminator.
+        let gemma4DialectClose = ManifoldHardware.ToolCallDialect.gemma.closeDelimiter
+
+        XCTAssertEqual(
+            gemma4DialectClose, "<|end_of_turn>",
+            "Gemma-4 `.gemma` dialect close changed — re-confirm against PromptTemplate.gemma4 / LlamaToolMarkers"
+        )
+        XCTAssertNotEqual(
+            gemma3CommunityClose, gemma4DialectClose,
+            "Gemma-3 community close and Gemma-4 dialect close collapsed to one value — re-adjudicate the family split before unifying"
+        )
+
+        // The catalog descriptor's heuristic maps any `<|tool_call>` template to the
+        // Gemma-4 close `<|end_of_turn>` — correct for the modelled family, and notably
+        // independent of the (Gemma-3) `<tool_call|>` literal present in the same input.
+        let claim = ChatTemplateToolDescriptor(parsingChatTemplate: """
+        {%- if tools %}You may call tools.{%- endif %}
+        <|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>
+        """)
+        XCTAssertEqual(
+            claim.declaredDialect?.closeDelimiter, "<|end_of_turn>",
+            "ChatTemplateToolDescriptor Gemma close drifted from the Gemma-4 dialect"
+        )
+        XCTAssertNotEqual(
+            claim.declaredDialect?.closeDelimiter, gemma3CommunityClose,
+            "Descriptor now reports the Gemma-3 community close — family split lost"
         )
     }
 }


### PR DESCRIPTION
## Summary

Phase 1a (adjudicate the Gemma tool-call close-delimiter contradiction) was **already implemented and merged in #2039** before this overnight run started: `ManifoldHardware.ToolCallDialect.gemma` and `ChatTemplateToolDescriptor` both already agree the Gemma `.gemma` close is `<|end_of_turn>`, and `CrossTaxonomyDialectParityTests` already exists and is green. There was no remaining contradiction to fix.

This PR is the **ground-truth validation + record correction** that the overnight brief asked for, shipped without changing any constant.

## Ground truth established (do-not-guess)

Per `ollama show gemma3-4b-tools --template` (Ollama running locally at :11434), that model's baked Jinja template emits:

```
{{- '<|tool_call>call:' + function['name'] + '{' -}}  …  {{- '}<tool_call|>' -}}
```

i.e. a full call is `<|tool_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>`. Literal counts in that template: `<|tool_call>` ×1, `<tool_call|>` ×1, `<|end_of_turn>` ×**0**.

## Finding

- The merged value (`<|end_of_turn>`) is **correct for the repo's `.gemma` dialect**, which consistently models **Gemma-4** (the `<|turn>` / `<|end_of_turn>` pipe-token family) across ~8 sites: `PromptTemplate.gemma4`, `ThinkingMarkers.gemma4`, `PromptTemplateDetector`, `ToolCallTransform`/`LocalInferenceAdapter` docs, and companion `manifold-llama` `LlamaToolMarkers.gemma4EndTurn = "<|end_of_turn>"`. No constant changed.
- **Correction to the #2039 docstring:** it called `<tool_call|>` an "invented / never-parsed" spelling. That is inaccurate — `<tool_call|>` is the *real* close emitted by the Ollama `gemma3-4b-tools` community model. It differs from the Gemma-4 close only because **gemma3-4b-tools is Gemma-3, a different family**. (`<|/tool_call>`, the other pre-#2039 spelling, *was* genuinely invented — it appears in no template.)

## Change

- Adds `testGemma3CommunityCloseIsADistinctFamilyNotTheGemma4Close` (mirrors the existing intentional-`testLlamaPythonTagVersusBareJSONIsAnIntentionalSplit` pattern) pinning the Gemma-3 (`<tool_call|>`) vs Gemma-4 (`<|end_of_turn>`) close split, so a future reader — or a stale brief pointing at the gemma3 Ollama model as authority — cannot "fix" the Gemma-4 `.gemma` close back to `<tool_call|>` and break the whole-repo Gemma-4 consensus.
- Corrects the inaccurate "invented / never-parsed" claim in the suite docstring.
- Single test file; no `Sources/` change, no force-unwraps.

## HOLD / for human review

No code-level uncertainty remains for the *Gemma-4* `.gemma` dialect — `<|end_of_turn>` is correct and unchanged. The one judgment call surfaced for the maintainer: the single `.gemma` dialect bucket cannot represent both Gemma-3 (`<tool_call|>`) and Gemma-4 (`<|end_of_turn>`) closes. If the conformance evals run tool-calling against the Ollama `gemma3-4b-tools` model and ever rely on the *text* close delimiter (rather than Ollama's structured `tool_calls` JSON), a `.gemma3` vs `.gemma4` dialect split may be warranted. Today Ollama returns structured `tool_calls`, so the marker parser never scans that raw close — no live parse bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMMNumZtU5ior9NaewGbts