### PR TITLE
docs(eval): post-#2049 conformance re-measure (Ollama + cloud)

### DIFF
--- a/docs/plans/runs/soak-20260626-212345/MATRIX.md
+++ b/docs/plans/runs/soak-20260626-212345/MATRIX.md
@@ -1,0 +1,23 @@
+# Ollama+cloud tool-call conformance — soak-20260626-212345 (post-#2049)
+
+Rendered from 234 `ConformanceRecord`(s) across 6 cell(s) · backends: ollama, openai-compat · core: b05c55e7.
+
+## Main matrix (d0 — no decoys)
+Means of tool-selection precision/recall/F1 over the cell's *measured* records; `Runs` is the record count. Holes render as their own rows (🚫 not measured · 💥 load-fail · 🛑 render-fail) — never as a measured `0.000`. Verdicts: ✅ pass · ⚠️ partial / renders-no-call / low-precision · ❌ fail · 💥 errored.
+
+| Backend | Model | Quant | Renderer | Runs | Prec | Recall | F1 | Verdict |
+|---------|-------|-------|----------|------|------|--------|----|---------|
+| ollama | gemma3-4b-tools | unknown | ollama-server | 27 | 0.000 | 0.000 | 0.000 | ⚠️ renders-no-call |
+| ollama | gemma4-e4b | unknown | ollama-server | 27 | 1.000 | 1.000 | 1.000 | ✅ pass |
+| ollama | llama3.1-8b | unknown | ollama-server | 27 | 0.750 | 0.750 | 0.750 | ⚠️ partial |
+| ollama | mistral-7b-tools | unknown | ollama-server | 27 | 0.875 | 0.875 | 0.875 | ⚠️ partial |
+| ollama | qwen3.5-9b | unknown | ollama-server | 27 | 1.000 | 1.000 | 1.000 | ✅ pass |
+| openai-compat | openai/gpt-oss-120b | unknown | openrouter | 9 | 1.000 | 0.938 | 0.958 | ✅ pass |
+
+## Decoy ladder (mean F1 per decoy level)
+F1 under distractor pressure. `+N` = N decoy tools advertised alongside the real set. Blank cells weren't measured at that level.
+
+| Backend | Model | Quant | Renderer | d0 | +1 | +3 | +5 | +10 | +20 |
+|---|---|---|---|---|---|---|---|---|---|
+| ollama | mistral-7b-tools | unknown | ollama-server | 0.875 | 0.208 | 0.225 | 0.250 | 0.208 | 0.000 |
+| ollama | qwen3.5-9b | unknown | ollama-server | 1.000 | 0.917 | 0.958 | 0.958 | 0.917 | 0.958 |

--- a/docs/plans/runs/soak-20260626-212345/all_records.json
+++ b/docs/plans/runs/soak-20260626-212345/all_records.json
@@ -1,0 +1,4857 @@
+[
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "lowPrecision",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "lowPrecision",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r2.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "noCall",
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma3-4b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "gemma4-e4b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "failureClass": "lowPrecision",
+    "model": "llama3.1-8b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d0_r3.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "lowPrecision",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 0.5,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 1,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d1_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "lowPrecision",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.8,
+      "precision": 0.6666666666666666,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 3,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d3_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 5,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d5_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "lowPrecision",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 0.5,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 10,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d10_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "failureClass": "noCall",
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0,
+      "precision": 0,
+      "recall": 0
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "mistral-7b-tools",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "fail"
+  },
+  {
+    "backend": "ollama",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 20,
+    "model": "qwen3.5-9b",
+    "quant": "unknown",
+    "renderer": "ollama-server",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/d20_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "01-now",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "02-calc",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "03-read",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "04-list",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "meeting-notes-summary",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "shopping-list-budget",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 0.6666666666666666,
+      "precision": 1,
+      "recall": 0.5
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "parallel-readme-comparison",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "partial"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "oversize-tool-output",
+    "status": {
+      "kind": "measured"
+    },
+    "toolSelection": {
+      "f1": 1,
+      "precision": 1,
+      "recall": 1
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  },
+  {
+    "backend": "openai-compat",
+    "coreCommit": "b05c55e7",
+    "decoyLevel": 0,
+    "model": "openai/gpt-oss-120b",
+    "quant": "unknown",
+    "renderer": "openrouter",
+    "repeatIndex": 0,
+    "scenario": "structured-json-extraction",
+    "status": {
+      "kind": "measured"
+    },
+    "toolingVersions": {},
+    "transcriptRef": "/Users/roryford/Repos/ManifoldKit/docs/plans/runs/soak-20260626-212345/cloud_d0_r1.jsonl",
+    "verdict": "pass"
+  }
+]


### PR DESCRIPTION
## What
Clean re-measure on core `b05c55e7` (post-#2049), committed as the matrix + aggregate records only (raw JSONL/logs pruned per the trim convention).

## Headline — #2049 validated on real models
`oversize-tool-output` behavioural verdict (d0):

| Model | Pre (#100115) | Post (#2049) |
|-------|------|------|
| qwen3.5-9b | partial | **pass** |
| gemma4-e4b | partial | **pass** |
| gpt-oss-120b (cloud) | — | **pass** |
| gemma3-4b-tools | fail | partial |
| mistral-7b-tools / llama3.1-8b | partial / fail | unchanged (real model behavior) |

Tool-selection F1 is unchanged — the fix targets the behavioural assertion, not selection.

## Decoy ladder
- mistral-7b-tools collapses: 0.875 → 0.208 (+1) → 0.000 (+20)
- qwen3.5-9b robust: holds ~0.92–0.96 through +20
- gpt-oss-120b cloud anchor: F1 0.958 at d0

## Scope
Ollama + OpenRouter legs only this session. llama.cpp + MLX legs not run here (MLX folds into the F3 re-measure lane; llama.cpp needs the companion binary). Data only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)