### PR TITLE
feat(contract): add CancellableModelLoading seam for observable/cancellable model loads

### DIFF
--- a/Sources/ManifoldContract/BackendOptInProtocols.swift
+++ b/Sources/ManifoldContract/BackendOptInProtocols.swift
@@ -209,6 +209,105 @@ public protocol TokenCountingBackend: AnyObject {
     func countTokens(_ text: String) throws -> Int
 }
 
+/// Adopted by backends whose model load is a long-running, externally-driven
+/// operation that a host may need to observe or cancel — primarily the local
+/// llama.cpp/ggml family, whose load is a **blocking C call that ignores Swift
+/// `Task` cancellation** and keeps mutating the backend on a background thread
+/// even after the awaiting Swift call site has thrown or been cancelled.
+///
+/// ## The hazard this addresses
+///
+/// `InferenceBackend/loadModel(from:plan:)` is `async`, so a host can wrap it
+/// in a deadline (`Task` timeout / `withDeadline`). When that deadline fires,
+/// the Swift continuation resumes with a `CancellationError`, **but the native
+/// load underneath does not stop** — for the llama.cpp/ggml backend it is a
+/// synchronous C call that builds and swaps graph/backend state on a worker
+/// thread with no cooperative cancellation point. The Swift side believes the
+/// load is over; the native side is still writing into the backend.
+///
+/// If a *second* operation then touches the backend while that orphaned native
+/// load is still in flight — a retry `loadModel`, or an autonomous
+/// `generate()` / `llama_decode` — the process **SIGSEGVs inside
+/// `ggml_backend_graph_compute_async`**, because two threads are mutating the
+/// same backend graph. (Seen downstream: Idlewick #315 / PR #347.)
+///
+/// Without this protocol a host's only mitigation is a *coarse latch*: set a
+/// flag for the entire opaque duration of `loadModel` and refuse every other
+/// load/decode until it returns — defensively serialising around a thread it
+/// can neither observe nor cancel, and over-blocking whenever the Swift await
+/// returns early.
+///
+/// ## What adopting this protocol buys the host
+///
+/// - ``isModelLoadInFlight`` lets the host **observe** whether a native load is
+///   still mutating the backend, rather than inferring it from the (possibly
+///   already-resumed) `loadModel` await.
+/// - ``cancelModelLoad()`` lets the host **request** that an in-flight load
+///   unwind — best-effort and cooperative (see below).
+/// - ``awaitModelLoadSettled()`` lets the host **latch precisely**: await the
+///   true completion of any in-flight native load before it tears the backend
+///   down or issues the next load/decode, instead of guessing with a timer.
+///
+/// Backends that do not adopt this protocol leave hosts on the coarse-latch
+/// fallback — correct, just conservative.
+///
+/// ## Best-effort cancellation
+///
+/// ``cancelModelLoad()`` is a **request**, not a guarantee. The underlying
+/// runtime may have no interruption point mid-graph-build, in which case the
+/// load runs to completion regardless and `cancelModelLoad()` only shortens the
+/// window where one exists (e.g. between sub-steps the backend polls a flag).
+/// Hosts must therefore still pair a cancel with ``awaitModelLoadSettled()``
+/// before reusing or freeing the backend — cancel asks it to stop *sooner*,
+/// settle tells you it has *actually* stopped. Never touch the backend (retry
+/// load / decode / unload) while ``isModelLoadInFlight`` is `true`.
+///
+/// ## Thread safety
+///
+/// All three members may be called from any thread (the same `Task.detached`
+/// load-dispatch contract as ``InferenceBackend``). Conformers with mutable
+/// in-flight state must synchronise it (lock or actor) — the flag is read from
+/// the host's actor while the native load writes it from a worker thread.
+///
+/// - Note: This is the core API *seam* only. Wiring it into the concrete
+///   `LlamaBackend` native unwind (a cancel flag the load loop polls, plus the
+///   settled signal fired from the C completion point) is a follow-up in the
+///   `manifold-llama` companion repo.
+public protocol CancellableModelLoading: AnyObject {
+    /// Whether a native model load is currently in flight — i.e. still
+    /// potentially mutating the backend on a background thread.
+    ///
+    /// This is **independent** of the `async` `loadModel` await: it stays
+    /// `true` from the moment the native load begins mutating state until that
+    /// native work has truly finished, which may be *after* the Swift
+    /// `loadModel` continuation has already resumed (e.g. via a fired deadline).
+    /// A host must treat any backend access as unsafe while this is `true`.
+    ///
+    /// Read from the host's actor while the load thread writes it; conformers
+    /// must publish it under their own synchronisation.
+    var isModelLoadInFlight: Bool { get }
+
+    /// Requests that an in-flight model load unwind as soon as possible.
+    ///
+    /// **Best-effort and cooperative.** The native load may not be interruptible
+    /// mid-graph-build; in that case this call sets the intent and the load
+    /// still runs to completion. It is a no-op when no load is in flight.
+    /// Always follow with ``awaitModelLoadSettled()`` before reusing or freeing
+    /// the backend — cancel does not by itself mean the native work has stopped.
+    func cancelModelLoad()
+
+    /// Suspends until any in-flight native load has **truly finished** — whether
+    /// it completed normally, failed, or unwound in response to
+    /// ``cancelModelLoad()``.
+    ///
+    /// Returns immediately when no load is in flight. This is the precise latch
+    /// a host awaits before tearing the backend down or issuing the next
+    /// load/decode, replacing the coarse "refuse everything for the opaque
+    /// duration" mitigation. After it returns, ``isModelLoadInFlight`` is
+    /// `false` and the backend is safe to touch.
+    func awaitModelLoadSettled() async
+}
+
 /// Adopted by local backends that support a multimodal projector (mmproj) companion file.
 ///
 /// `ModelLifecycleCoordinator` calls ``setMmprojURL(_:)`` with the URL from

--- a/Sources/ManifoldTestSupport/MockCancellableLoadBackend.swift
+++ b/Sources/ManifoldTestSupport/MockCancellableLoadBackend.swift
@@ -1,0 +1,177 @@
+import Foundation
+import ManifoldInference
+
+/// A minimal ``InferenceBackend`` + ``CancellableModelLoading`` stub for
+/// contract tests.
+///
+/// Simulates the hazard the protocol addresses: a native load that keeps
+/// "mutating the backend" after the awaiting `loadModel` call site may have
+/// already returned. The load body parks at a test-driven gate so a test can
+/// observe ``isModelLoadInFlight`` while the load is mid-flight, then drive it
+/// to completion (or cancellation) deterministically — no `Task.sleep`, no
+/// wall-clock races.
+///
+/// Does not perform real inference — use `MockInferenceBackend` when generation
+/// is needed.
+public final class MockCancellableLoadBackend: InferenceBackend, CancellableModelLoading, @unchecked Sendable {
+
+    // MARK: - InferenceBackend
+
+    public var isModelLoaded: Bool = false
+    public var isGenerating: Bool = false
+    public var capabilities: BackendCapabilities = BackendCapabilities(
+        supportedParameters: [.temperature, .topP, .repeatPenalty],
+        maxContextTokens: 4096,
+        requiresPromptTemplate: false,
+        supportsSystemPrompt: true
+    )
+
+    // MARK: - State (guarded by `lock`)
+
+    private let lock = NSLock()
+    private var _isModelLoadInFlight = false
+    private var _cancelRequested = false
+
+    /// Synchronous gate the simulated native load parks at while "in flight".
+    /// `completeInFlightLoad()` / `cancelModelLoad()` are synchronous (matching
+    /// the real protocol), so the gate is a lock-guarded continuation rather
+    /// than an actor: a release before the load parks is latched, otherwise it
+    /// resumes the parked load.
+    private var _gateReleased = false
+    private var _gateWaiter: CheckedContinuation<Void, Never>?
+
+    /// Resumed once the in-flight load has truly settled, so
+    /// ``awaitModelLoadSettled()`` returns precisely on completion. A single
+    /// load at a time is assumed (matches the engine's serialised load path).
+    private var settledWaiters: [CheckedContinuation<Void, Never>] = []
+
+    // MARK: - Tracking
+
+    public private(set) var cancelModelLoadCallCount = 0
+
+    public init() {}
+
+    // MARK: - CancellableModelLoading
+
+    public var isModelLoadInFlight: Bool {
+        lock.withLock { _isModelLoadInFlight }
+    }
+
+    public func cancelModelLoad() {
+        lock.lock()
+        cancelModelLoadCallCount += 1
+        // Best-effort: only meaningful while a load is actually in flight.
+        // Real backends may have no interruption point — here we record the
+        // request and let the load body honor it at the gate.
+        if _isModelLoadInFlight {
+            _cancelRequested = true
+        }
+        lock.unlock()
+        // Releasing the gate lets a parked load proceed to settle — modelling
+        // a backend whose load polls a cancel flag at a sub-step boundary.
+        releaseGate()
+    }
+
+    public func awaitModelLoadSettled() async {
+        // Fast path: nothing in flight → return immediately, no suspension.
+        let inFlight = lock.withLock { _isModelLoadInFlight }
+        guard inFlight else { return }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if _isModelLoadInFlight {
+                settledWaiters.append(cont)
+                lock.unlock()
+            } else {
+                // Settled between the guard and acquiring the lock.
+                lock.unlock()
+                cont.resume()
+            }
+        }
+    }
+
+    /// Releases the load gate so an in-flight ``loadModel`` proceeds to settle.
+    /// Test affordance for the "normal completion" path (no cancel involved).
+    public func completeInFlightLoad() {
+        releaseGate()
+    }
+
+    /// Synchronous gate release: resumes a parked load body, or latches the
+    /// release for a load body that has not yet reached the gate.
+    private func releaseGate() {
+        lock.lock()
+        if let waiter = _gateWaiter {
+            _gateWaiter = nil
+            lock.unlock()
+            waiter.resume()
+        } else {
+            _gateReleased = true
+            lock.unlock()
+        }
+    }
+
+    /// Suspends the simulated load until the gate is released.
+    private func parkAtGate() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if _gateReleased {
+                _gateReleased = false
+                lock.unlock()
+                cont.resume()
+            } else {
+                _gateWaiter = cont
+                lock.unlock()
+            }
+        }
+    }
+
+    // MARK: - InferenceBackend methods
+
+    public func loadModel(from url: URL, plan: ModelLoadPlan) async throws {
+        lock.withLock {
+            _isModelLoadInFlight = true
+            _cancelRequested = false
+        }
+
+        // Park at the gate to model the native load still mutating the backend
+        // after the Swift await may have been abandoned. The test releases it
+        // via `completeInFlightLoad()` or `cancelModelLoad()`.
+        await parkAtGate()
+
+        let cancelled = lock.withLock { _cancelRequested }
+
+        // Drain settled-waiters and flip the flag atomically so a host that
+        // awaited `awaitModelLoadSettled()` observes `isModelLoadInFlight ==
+        // false` the instant it resumes.
+        let waiters: [CheckedContinuation<Void, Never>] = lock.withLock {
+            _isModelLoadInFlight = false
+            isModelLoaded = !cancelled
+            let pending = settledWaiters
+            settledWaiters.removeAll()
+            return pending
+        }
+        for w in waiters { w.resume() }
+
+        if cancelled {
+            throw CancellationError()
+        }
+    }
+
+    public func generate(
+        prompt: String,
+        systemPrompt: String?,
+        config: GenerationConfig
+    ) throws -> GenerationStream {
+        guard isModelLoaded else { throw InferenceError.inferenceFailure("No model loaded") }
+        let stream = AsyncThrowingStream<GenerationEvent, Error> { continuation in
+            continuation.finish()
+        }
+        return GenerationStream(stream)
+    }
+
+    public func stopGeneration() { isGenerating = false }
+
+    public func unloadModel() {
+        isModelLoaded = false
+        isGenerating = false
+    }
+}

--- a/Tests/ManifoldBackendsTests/CancellableModelLoadingContractTests.swift
+++ b/Tests/ManifoldBackendsTests/CancellableModelLoadingContractTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+import ManifoldInference
+import ManifoldTestSupport
+
+/// Verifies the ``CancellableModelLoading`` protocol contract using
+/// ``MockCancellableLoadBackend``.
+///
+/// These tests confirm the seam is self-consistent: a host can observe an
+/// in-flight native load, request its cancellation, and await its true
+/// completion. They do **not** verify that `LlamaBackend` implements the
+/// protocol correctly — that native cancel/settle wiring is a follow-up in the
+/// `manifold-llama` companion repo, and real-backend coverage requires
+/// hardware (`ManifoldE2ETests`).
+@MainActor
+final class CancellableModelLoadingContractTests: XCTestCase {
+
+    private static let modelURL = URL(fileURLWithPath: "/tmp/fake-model")
+
+    /// Polls `condition` until it holds or a tight deadline elapses. Used to
+    /// bridge the gap between launching a detached `loadModel` and the moment
+    /// its body actually reaches the in-flight gate — real `async/await`
+    /// scheduling, no fixed sleep.
+    private func waitUntil(
+        _ condition: @escaping () -> Bool,
+        timeout: TimeInterval = 2.0,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000) // 1 ms
+        }
+        XCTFail(message, file: file, line: line)
+    }
+
+    // MARK: - 1. Fast path: nothing in flight
+
+    func test_noLoad_isNotInFlight_andSettleReturnsImmediately() async {
+        let backend = MockCancellableLoadBackend()
+
+        XCTAssertFalse(backend.isModelLoadInFlight, "No load started → not in flight")
+
+        // Must return promptly without suspending on a non-existent load.
+        await backend.awaitModelLoadSettled()
+
+        XCTAssertFalse(backend.isModelLoadInFlight)
+    }
+
+    // MARK: - 2. In-flight is observable while the native load is mid-flight
+
+    func test_loadInFlight_isObservable_thenSettlesOnCompletion() async throws {
+        let backend = MockCancellableLoadBackend()
+
+        let loadTask = Task { try await backend.loadModel(from: Self.modelURL, plan: .testStub(effectiveContextSize: 512)) }
+
+        await waitUntil({ backend.isModelLoadInFlight }, "load should report in-flight while parked")
+        XCTAssertFalse(backend.isModelLoaded, "model must not be marked loaded while still in flight")
+
+        // Drive the simulated native load to normal completion.
+        backend.completeInFlightLoad()
+        try await loadTask.value
+
+        XCTAssertFalse(backend.isModelLoadInFlight, "settled load is no longer in flight")
+        XCTAssertTrue(backend.isModelLoaded, "normal completion marks the model loaded")
+    }
+
+    // MARK: - 3. awaitModelLoadSettled suspends until the load truly finishes
+
+    func test_awaitSettled_suspendsUntilLoadFinishes() async throws {
+        let backend = MockCancellableLoadBackend()
+
+        let loadTask = Task { try await backend.loadModel(from: Self.modelURL, plan: .testStub(effectiveContextSize: 512)) }
+        await waitUntil({ backend.isModelLoadInFlight }, "load should be in flight before awaiting settle")
+
+        // Latch: this must NOT return until the in-flight load settles.
+        let settledObserved = SettleProbe()
+        let settleTask = Task {
+            await backend.awaitModelLoadSettled()
+            await settledObserved.markSettled(inFlightAtReturn: backend.isModelLoadInFlight)
+        }
+
+        // While the load is still parked, the settle latch must still be pending.
+        await Task.yield()
+        let returnedEarly = await settledObserved.didSettle
+        XCTAssertFalse(returnedEarly, "awaitModelLoadSettled must not return while the load is in flight")
+
+        // Now let the load finish; the latch must release.
+        backend.completeInFlightLoad()
+        try await loadTask.value
+        await settleTask.value
+
+        let didSettle = await settledObserved.didSettle
+        let inFlightAtReturn = await settledObserved.inFlightAtReturn
+        XCTAssertTrue(didSettle, "awaitModelLoadSettled must return once the load settles")
+        XCTAssertEqual(inFlightAtReturn, false, "isModelLoadInFlight must be false the instant settle returns")
+    }
+
+    // MARK: - 4. cancelModelLoad requests an unwind; the load settles cancelled
+
+    func test_cancelModelLoad_unwindsInFlightLoad() async {
+        let backend = MockCancellableLoadBackend()
+
+        let loadTask = Task { try await backend.loadModel(from: Self.modelURL, plan: .testStub(effectiveContextSize: 512)) }
+        await waitUntil({ backend.isModelLoadInFlight }, "load should be in flight before cancel")
+
+        backend.cancelModelLoad()
+
+        // The load should unwind (cooperatively, here) rather than complete.
+        var threwCancellation = false
+        do {
+            try await loadTask.value
+            XCTFail("cancelled load should not complete normally")
+        } catch is CancellationError {
+            threwCancellation = true
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+
+        XCTAssertTrue(threwCancellation)
+        XCTAssertEqual(backend.cancelModelLoadCallCount, 1)
+        XCTAssertFalse(backend.isModelLoadInFlight, "cancelled load is no longer in flight")
+        XCTAssertFalse(backend.isModelLoaded, "a cancelled load must not mark the model loaded")
+
+        // A host that latches with settle after cancel observes a settled backend.
+        await backend.awaitModelLoadSettled()
+        XCTAssertFalse(backend.isModelLoadInFlight)
+    }
+
+    // MARK: - 5. cancel with no load in flight is a no-op
+
+    func test_cancel_withNoLoad_isNoOp() {
+        let backend = MockCancellableLoadBackend()
+        backend.cancelModelLoad()
+        XCTAssertFalse(backend.isModelLoadInFlight)
+        XCTAssertEqual(backend.cancelModelLoadCallCount, 1, "the call is counted but has no in-flight effect")
+    }
+}
+
+/// Thread-safe probe recording whether ``CancellableModelLoading/awaitModelLoadSettled()``
+/// has returned, and what it observed at return.
+private actor SettleProbe {
+    private(set) var didSettle = false
+    private(set) var inFlightAtReturn: Bool?
+
+    func markSettled(inFlightAtReturn: Bool) {
+        didSettle = true
+        self.inFlightAtReturn = inFlightAtReturn
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **core API seam** for #2037 — a way for a host to *observe* and *cancel* an in-flight native model load. This is the ManifoldKit-core half only; the concrete `LlamaBackend` native unwind lands in the `manifold-llama` companion repo (see follow-up below), so this PR intentionally does **not** close #2037.

### The problem (#2037)
The local llama.cpp/ggml `loadModel` is a blocking C call that ignores Swift `Task` cancellation. When a host wraps it in a deadline and the deadline fires, the Swift await resumes/cancels but the native load keeps mutating the backend on a worker thread. With no cancel hook and no completion signal, a host can't know the load is still in flight nor tear it down — and touching the backend mid-load (retry load / decode) SIGSEGVs in `ggml_backend_graph_compute_async`. (Downstream: roryford/idlewick#315, PR #347.) The only mitigation today is a coarse latch for the whole opaque duration.

### What this adds
A new **opt-in** protocol in `Sources/ManifoldContract/BackendOptInProtocols.swift`, following the existing opt-in pattern (`LoadProgressReporting`, `MultimodalProjectorConfigurable`, …):

```swift
public protocol CancellableModelLoading: AnyObject {
    var isModelLoadInFlight: Bool { get }   // observe: native load still mutating the backend?
    func cancelModelLoad()                  // best-effort cooperative cancel request
    func awaitModelLoadSettled() async      // await true completion → latch precisely
}
```

- Backends that adopt it let a host observe in-flight state, request a cancel, and await the precise settle point before reuse/teardown.
- Backends that don't adopt it keep today's coarse-latch fallback — correct, just conservative.
- Cancellation is documented as **best-effort**: the native load may have no interruption point mid-graph-build, so hosts must still pair `cancelModelLoad()` with `awaitModelLoadSettled()`.

### Purely additive / non-breaking
- `InferenceBackend`'s required members are unchanged.
- No `BackendCapabilities`-shaped switched enum touched.
- Source-only stability: additions + an opt-in protocol only.

### Tests
- `MockCancellableLoadBackend` (in `ManifoldTestSupport`) simulates a native load parked mid-flight via a synchronous lock-guarded gate.
- `CancellableModelLoadingContractTests` (in `ManifoldBackendsTests`) proves: fast-path settle when nothing in flight; in-flight is observable and not marked loaded until settled; `awaitModelLoadSettled()` truly suspends until completion; `cancelModelLoad()` unwinds an in-flight load and a post-cancel settle observes a quiesced backend; cancel-with-no-load is a counted no-op. Real `async/await` timing, no `try?` in production paths.

## Backend adoption checklist
- [ ] `LlamaBackend` (manifold-llama): poll a cancel flag at load sub-step boundaries; fire the settled signal from the native completion point; publish `isModelLoadInFlight` under its existing lock. **(the actual #2037 fix — follow-up in manifold-llama)**
- [ ] `MLXBackend` (manifold-mlx): adopt if its container load exhibits the same orphaned-mutation hazard (likely lower-risk via actor isolation).
- [ ] Cloud / Ollama / Foundation: no native graph build → no adoption needed (coarse-latch fallback is fine).

## Note
#2037 stays **open** until the `manifold-llama` `LlamaBackend` wiring lands — this PR only ships the contract surface hosts code against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)