### PR TITLE
feat(inference): add render-consistency regression gate for tool-call dialects

### DIFF
--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -306,6 +306,23 @@ final class ModelLifecycleCoordinator {
         // through `runLoad` directly and leave this nil (cloud backends do not
         // use prompt templates).
         selectedChatTemplateRaw = modelInfo.chatTemplateRaw
+
+        // Layer-2 render-consistency diagnostic (#2005). When a template is
+        // present, check whether the tool dialect it *declares* actually
+        // survives MK's render path. An `.inconsistent` verdict is the #1909
+        // class (template promises a dialect the renderer drops); surface it as
+        // a load-time warning so tool calls failing on this model is diagnosable.
+        // This is a render-health signal, not a capability verdict — it never
+        // blocks the load, and a toolless template stays silent (notApplicable).
+        if let chatTemplate = modelInfo.chatTemplateRaw {
+            let consistency = RenderConsistencyChecker.check(chatTemplateRaw: chatTemplate)
+            if consistency.status == .inconsistent {
+                Log.inference.warning(
+                    "Render-consistency (#2005): model '\(modelInfo.name)' declares a tool-call dialect its chat template does not render — \(consistency.detail). Tool calls may not work; this is an MK render issue, not a weights limitation."
+                )
+            }
+        }
+
         try await runLoad(
             source: "local",
             target: modelTypeLogLabel(modelInfo.modelType),

--- a/Sources/ManifoldRuntime/Services/ToolCallConformance.swift
+++ b/Sources/ManifoldRuntime/Services/ToolCallConformance.swift
@@ -36,15 +36,31 @@ public struct ToolCallConformanceKey: Hashable, Sendable, Codable {
 /// The tool-calling capability verdict for a cache cell.
 ///
 /// `unknown` is the lazy default for any cell that has not been measured — it is
-/// never a cold-start tax, and hosts treat it as "recommend = no; allow with a
-/// warning = host's call" (see the plan's Acceptance section).
+/// never a cold-start tax.
+///
+/// ## Host policy for `unknown` (#2005)
+///
+/// A host treats `unknown` tool-call conformance as **"recommend = no;
+/// allow-with-warning = host's call"**: don't surface the model as a
+/// tool-calling recommendation, but the host may still let the user select it
+/// and drive tools behind a warning. Crucially, a **toolless** static template
+/// resolves to `unknown`, *not* `unsupported`: MK's own prompt-injection
+/// (`ToolSystemPromptBuilder`) can drive tool calls on models whose template
+/// declares no tools block (e.g. Mistral-v0.3), so a static `unsupported` would
+/// mis-grey a usable model. `unsupported` is reserved for a **measured**
+/// near-zero emission verdict.
 public enum ToolCallCapability: String, Codable, Sendable {
-    /// Measured (or statically proven) able to drive tool calls.
+    /// Measured able to drive tool calls. A positive verdict is measurement-only
+    /// — the static layer never writes `supported`.
     case supported
-    /// Proven unable — e.g. a template with no tools block, or a soak that
-    /// produced ~0% parseable calls.
+    /// Proven unable — reserved for a **measured** soak that produced ~0%
+    /// parseable calls. NOT inferred statically: a toolless template is
+    /// `unknown` (see the type doc), because MK prompt-injection can still drive
+    /// tools on it.
     case unsupported
-    /// Not yet measured. The default for an unpopulated cell.
+    /// Not yet measured, or statically expressible-but-unproven. The default for
+    /// an unpopulated cell, and the verdict for every static template (toolless
+    /// or tool-bearing) until a soak measures it.
     case unknown
 }
 

--- a/Tests/ManifoldInferenceTests/RenderConsistencyCheckerTests.swift
+++ b/Tests/ManifoldInferenceTests/RenderConsistencyCheckerTests.swift
@@ -16,28 +16,149 @@ import XCTest
 /// which are not swift-jinja-evaluable.
 final class RenderConsistencyCheckerTests: XCTestCase {
 
+    // MARK: - Committed family-template corpus (single source of truth)
+    //
+    // The gate test (`testKnownGoodFamilyTemplatesNeverRenderInconsistent`) and
+    // the per-family round-trip tests both fold over these constants, so the
+    // CI invariant and the documented behaviour can never drift. The corpus is
+    // deliberately committed (not runtime-discovered) so CI stays deterministic.
+
+    /// Qwen / Hermes `<tool_call>…</tool_call>` JSON dialect behind `{% if tools %}`.
+    static let qwenStyleTemplate = """
+    {%- if tools %}
+    <tools>
+    {%- for tool in tools %}{{ tool.name }}
+    {%- endfor %}
+    </tools>
+    {%- endif %}
+    {%- for message in messages %}
+    <|{{ message.role }}|>{{ message.content }}
+    {%- if message.tool_calls %}
+        {%- for tc in message.tool_calls %}<tool_call>
+    {"name": "{{ tc.function.name }}"}
+    </tool_call>
+        {%- endfor %}
+    {%- endif %}
+    {%- endfor %}
+    """
+
+    /// Gemma-style `<|tool_call>` key/value dialect behind `{% if tools %}`.
+    static let gemmaStyleTemplate = """
+    {%- if tools %}
+    Tools:
+    {%- for tool in tools %}{{ tool.name }}
+    {%- endfor %}
+    {%- endif %}
+    {%- for message in messages %}
+    {{ message.role }}: {{ message.content }}
+    {%- if message.tool_calls %}
+        {%- for tc in message.tool_calls %}<|tool_call>
+    name: {{ tc.function.name }}
+    <|end_of_turn>
+        {%- endfor %}
+    {%- endif %}
+    {%- endfor %}
+    """
+
+    /// Mistral-v0.3 `[TOOL_CALLS]` dialect behind a `tools is not none` guard.
+    static let mistralStyleTemplate = """
+    {%- if tools is not none %}
+    [AVAILABLE_TOOLS]
+    {%- for tool in tools %}{{ tool.name }}
+    {%- endfor %}
+    [/AVAILABLE_TOOLS]
+    {%- endif %}
+    {%- for message in messages %}
+    {{ message.role }}: {{ message.content }}
+    {%- if message.tool_calls %}
+        {%- for tc in message.tool_calls %}[TOOL_CALLS] {{ tc.function.name }}
+        {%- endfor %}
+    {%- endif %}
+    {%- endfor %}
+    """
+
+    /// Hermes-style `<tool_call>` dialect behind a bare `{% for tool in tools %}`
+    /// guard (no `if`).
+    static let hermesStyleTemplate = """
+    {%- for tool in tools %}{{ tool.name }}
+    {%- endfor %}
+    {%- for message in messages %}
+    {{ message.role }}: {{ message.content }}
+    {%- if message.tool_calls %}
+        {%- for tc in message.tool_calls %}<tool_call>
+    {"name": "{{ tc.function.name }}"}
+    </tool_call>
+        {%- endfor %}
+    {%- endif %}
+    {%- endfor %}
+    """
+
+    /// Llama-3.1 `Environment: ipython` guard, bare-JSON dialect — declares NO
+    /// open delimiter, so consistency hinges on the tool name alone.
+    static let llamaStyleTemplate = """
+    {%- if tools %}
+    Environment: ipython
+    {%- for tool in tools %}{{ tool.name }}
+    {%- endfor %}
+    {%- endif %}
+    {%- for message in messages %}
+    {{ message.role }}: {{ message.content }}
+    {%- if message.tool_calls %}
+        {%- for tc in message.tool_calls %}{"name": "{{ tc.function.name }}"}
+        {%- endfor %}
+    {%- endif %}
+    {%- endfor %}
+    """
+
+    /// Phi-4-style: no tools guard at all → trustworthy negative claim
+    /// (`notApplicable`, not `inconsistent` — there is nothing to round-trip).
+    static let phiToollessTemplate = """
+    {%- for message in messages %}
+    <|im_start|>{{ message.role }}<|im_sep|>{{ message.content }}<|im_end|>
+    {%- endfor %}
+    <|im_start|>assistant<|im_sep|>
+    """
+
+    /// The known-good family corpus the CI gate folds over. Includes both
+    /// tool-bearing families (which must render `.consistent`) and the toolless
+    /// Phi-4 case (which must render `.notApplicable`) — the gate's invariant is
+    /// "no known-good family template ever renders `.inconsistent`".
+    static let familyCorpus: [(name: String, template: String)] = [
+        ("Qwen/Hermes", qwenStyleTemplate),
+        ("Gemma", gemmaStyleTemplate),
+        ("Mistral-v0.3", mistralStyleTemplate),
+        ("Hermes (for-guard)", hermesStyleTemplate),
+        ("Llama-3.1", llamaStyleTemplate),
+        ("Phi-4 (toolless)", phiToollessTemplate),
+    ]
+
+    // MARK: - CI gate (the regression spine)
+
+    /// Folds ``RenderConsistencyChecker/check(chatTemplateRaw:)`` over the whole
+    /// committed family corpus and **fails on any `.inconsistent`** verdict.
+    ///
+    /// This encodes the #2005 acceptance invariant: these known-good family
+    /// templates declare tool dialects MK's renderer actually emits, so the
+    /// render path can never silently drop their tool grammar (the #1909 class)
+    /// without this gate going red. `.consistent` and `.notApplicable` both pass
+    /// — only `.inconsistent` is the regression we guard against.
+    func testKnownGoodFamilyTemplatesNeverRenderInconsistent() {
+        for entry in Self.familyCorpus {
+            let result = RenderConsistencyChecker.check(chatTemplateRaw: entry.template)
+            XCTAssertNotEqual(
+                result.status,
+                .inconsistent,
+                "Family template '\(entry.name)' regressed to .inconsistent — "
+                + "its declared tool dialect no longer survives MK's render path "
+                + "(the #1909 class). Detail: \(result.detail)"
+            )
+        }
+    }
+
     // MARK: - Recognised families render consistently
 
     func testQwenStyleRendersConsistently() {
-        // {% if tools %} guard + <tool_call>…</tool_call> JSON dialect.
-        let template = """
-        {%- if tools %}
-        <tools>
-        {%- for tool in tools %}{{ tool.name }}
-        {%- endfor %}
-        </tools>
-        {%- endif %}
-        {%- for message in messages %}
-        <|{{ message.role }}|>{{ message.content }}
-        {%- if message.tool_calls %}
-            {%- for tc in message.tool_calls %}<tool_call>
-        {"name": "{{ tc.function.name }}"}
-        </tool_call>
-            {%- endfor %}
-        {%- endif %}
-        {%- endfor %}
-        """
-        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: Self.qwenStyleTemplate)
 
         XCTAssertEqual(result.status, .consistent, result.detail)
         XCTAssertTrue(result.toolDefinitionRendered)
@@ -47,24 +168,7 @@ final class RenderConsistencyCheckerTests: XCTestCase {
     }
 
     func testGemmaStyleRendersConsistently() {
-        // {% if tools %} guard + <|tool_call> key/value dialect.
-        let template = """
-        {%- if tools %}
-        Tools:
-        {%- for tool in tools %}{{ tool.name }}
-        {%- endfor %}
-        {%- endif %}
-        {%- for message in messages %}
-        {{ message.role }}: {{ message.content }}
-        {%- if message.tool_calls %}
-            {%- for tc in message.tool_calls %}<|tool_call>
-        name: {{ tc.function.name }}
-        <|end_of_turn>
-            {%- endfor %}
-        {%- endif %}
-        {%- endfor %}
-        """
-        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: Self.gemmaStyleTemplate)
 
         XCTAssertEqual(result.status, .consistent, result.detail)
         XCTAssertTrue(result.toolDefinitionRendered)
@@ -73,23 +177,7 @@ final class RenderConsistencyCheckerTests: XCTestCase {
     }
 
     func testMistralStyleRendersConsistently() {
-        // tools-is-not-none guard + [TOOL_CALLS] dialect.
-        let template = """
-        {%- if tools is not none %}
-        [AVAILABLE_TOOLS]
-        {%- for tool in tools %}{{ tool.name }}
-        {%- endfor %}
-        [/AVAILABLE_TOOLS]
-        {%- endif %}
-        {%- for message in messages %}
-        {{ message.role }}: {{ message.content }}
-        {%- if message.tool_calls %}
-            {%- for tc in message.tool_calls %}[TOOL_CALLS] {{ tc.function.name }}
-            {%- endfor %}
-        {%- endif %}
-        {%- endfor %}
-        """
-        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: Self.mistralStyleTemplate)
 
         XCTAssertEqual(result.status, .consistent, result.detail)
         XCTAssertTrue(result.toolDefinitionRendered)
@@ -98,21 +186,7 @@ final class RenderConsistencyCheckerTests: XCTestCase {
     }
 
     func testHermesStyleRendersConsistently() {
-        // {% for tool in tools %} guard (no `if`) + <tool_call> dialect.
-        let template = """
-        {%- for tool in tools %}{{ tool.name }}
-        {%- endfor %}
-        {%- for message in messages %}
-        {{ message.role }}: {{ message.content }}
-        {%- if message.tool_calls %}
-            {%- for tc in message.tool_calls %}<tool_call>
-        {"name": "{{ tc.function.name }}"}
-        </tool_call>
-            {%- endfor %}
-        {%- endif %}
-        {%- endfor %}
-        """
-        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: Self.hermesStyleTemplate)
 
         XCTAssertEqual(result.status, .consistent, result.detail)
         XCTAssertTrue(result.toolDefinitionRendered)
@@ -120,24 +194,10 @@ final class RenderConsistencyCheckerTests: XCTestCase {
     }
 
     func testLlamaStyleNoDelimiterRendersConsistently() {
-        // Llama-3.1: Environment: ipython guard, bare-JSON dialect — the claim
-        // declares NO open delimiter, so declaredDelimiterRendered must be nil
-        // and consistency must hinge on the tool name alone.
-        let template = """
-        {%- if tools %}
-        Environment: ipython
-        {%- for tool in tools %}{{ tool.name }}
-        {%- endfor %}
-        {%- endif %}
-        {%- for message in messages %}
-        {{ message.role }}: {{ message.content }}
-        {%- if message.tool_calls %}
-            {%- for tc in message.tool_calls %}{"name": "{{ tc.function.name }}"}
-            {%- endfor %}
-        {%- endif %}
-        {%- endfor %}
-        """
-        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+        // Llama-3.1: the claim declares NO open delimiter, so
+        // declaredDelimiterRendered must be nil and consistency must hinge on
+        // the tool name alone.
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: Self.llamaStyleTemplate)
 
         XCTAssertEqual(result.status, .consistent, result.detail)
         XCTAssertTrue(result.toolDefinitionRendered)
@@ -149,13 +209,7 @@ final class RenderConsistencyCheckerTests: XCTestCase {
 
     func testToollessTemplateIsNotApplicable() {
         // Phi-style: no tools guard at all → trustworthy negative claim.
-        let template = """
-        {%- for message in messages %}
-        <|im_start|>{{ message.role }}<|im_sep|>{{ message.content }}<|im_end|>
-        {%- endfor %}
-        <|im_start|>assistant<|im_sep|>
-        """
-        let result = RenderConsistencyChecker.check(chatTemplateRaw: template)
+        let result = RenderConsistencyChecker.check(chatTemplateRaw: Self.phiToollessTemplate)
 
         XCTAssertEqual(result.status, .notApplicable)
         XCTAssertFalse(result.claim.toolsExpressible)


### PR DESCRIPTION
First slice of the #2005 tool-call-conformance design — a narrow, honest **render-consistency regression gate**. Not an importer, resolver, cache write, or capability verdict. After two adversarial review rounds the agreed first PR is this gate alone.

## What this adds

1. **CI gate (the spine).** `RenderConsistencyCheckerTests.testKnownGoodFamilyTemplatesNeverRenderInconsistent` folds `RenderConsistencyChecker.check` over a committed family-template corpus (Qwen/Hermes, Gemma, Mistral-v0.3, Llama-3.1, Phi-4) and **fails on any `.inconsistent`**. This catches the #1909 class — a template that declares a tool dialect MK's renderer silently drops — deterministically at CI time, with no soak and no companion. The corpus is the single source of truth shared by the gate and the per-family round-trip tests, so the invariant and the documented behaviour can't drift. All family templates are currently `.consistent` (or `.notApplicable` for toolless Phi-4) — no existing render bug surfaced.

2. **Load-time `Log.warning`** in `ModelLifecycleCoordinator.performLoad` when a loaded model's template renders `.inconsistent`. Render-health signal only: it never blocks the load, runs one `check` call guarded on a present template, and stays silent for toolless templates.

3. **Doc note** on `ToolCallCapability` (`Sources/ManifoldRuntime/Services/ToolCallConformance.swift`) encoding the locked #2005 decision: a toolless static template resolves to `unknown`, **not** `unsupported` (MK prompt-injection can drive tools on toolless models), and the host policy for `unknown` is "recommend = no; allow-with-warning = host's call". This also corrects a now-contradictory `unsupported` doc example ("a template with no tools block").

## Deferred (explicitly out of scope)

`ToolCallConformanceResolver` query API, any cache write, `observedDialect` family-naming, and a static capability verdict — all deferred until a real reader (UI greying) or writer (importer, once a corpus exists) lands. The static layer emits no capability verdict, so this PR writes nothing to any cache.

## Gate results
- `swift build --build-tests` ✅
- `RenderConsistencyCheckerTests` ✅ 10/10 (gate + per-family + notApplicable + inconsistent-detection)
- Sabotage-verified: injecting a known-inconsistent template into the corpus turns the gate red, then reverted.

Refs #2005 (one slice of a multi-PR issue — no closing keyword).

🤖 Generated with [Claude Code](https://claude.com/claude-code)