### PR TITLE
chore(lint): fix force-unwrap lint :// blind spot

### DIFF
--- a/scripts/lint-no-new-force-unwraps.sh
+++ b/scripts/lint-no-new-force-unwraps.sh
@@ -131,6 +131,15 @@ ALLOWLIST_PATHS=(
     # SDK product.  (Otherwise hidden from the detector only by the `://`
     # comment-regex false-match — allowlist it explicitly so the review is real.)
     "manifold-tools/BFCLCLI.swift"
+
+    # URL(string: "https://…")! compile-time-constant API endpoints — the same
+    # reviewed-safe pattern as the HuggingFace/AnyLanguageModel entries above
+    # (HuggingFaceProbe.defaultURL; CloudReranker cohere/jina rerank presets,
+    # which already carry an inline "safe: constant literal URL" comment). These
+    # were only invisible to the detector before the `://` comment-regex
+    # false-match was fixed in this PR; allowlist them now that they are visible.
+    "ManifoldInference/Services/HuggingFaceProbe.swift"
+    "ManifoldCloudSaaS/CloudReranker.swift"
 )
 
 # Build find-exclusion args from the allowlist paths
@@ -141,14 +150,18 @@ done
 
 # Detect force-unwraps:
 #   - word char or ) followed by !
-#   - exclude: comment-only lines (both // and /// forms — grep output is
-#     "file:line:content" so we match ": *//"), != operators, string/char
-#     literals containing !
+#   - exclude: comment-only lines (both // and /// forms), != operators,
+#     string/char literals containing !
+# Comment exclusion is anchored to grep's "file:LINE:content" separator
+# (`:[0-9]+:[[:space:]]*//`) so it only drops lines whose *content* starts with
+# //.  The earlier unanchored `:[[:space:]]*//` false-matched the `://` inside
+# any URL literal (e.g. URL(string: "https://…")!), silently hiding force-unwraps
+# on URL constants repo-wide — see the URL-constant allowlist entries above.
 # Note: find -print0 | xargs -0 is used throughout for bash 3.2 compatibility
 # (macOS ships bash 3.2; mapfile requires bash 4+).
 VIOLATIONS=$(find "$SOURCES_DIR" -name "*.swift" "${FIND_EXCLUDES[@]}" -print0 \
     | xargs -0 grep -n '[a-zA-Z0-9_)]!' \
-    | grep -v ':[[:space:]]*//' \
+    | grep -vE ':[0-9]+:[[:space:]]*//' \
     | grep -v ' != ' \
     | grep -v '"[^"]*!"' \
     | grep -v "'\!'" \


### PR DESCRIPTION
## What

`scripts/lint-no-new-force-unwraps.sh` had a repo-wide false-negative: its comment-exclusion filter `grep -v ':[[:space:]]*//'` matched the `://` inside **any URL literal**, so every line containing `http(s)://...` was treated as a comment and dropped. Force-unwraps on URL constants (`URL(string: "https://…")!`) were therefore **invisible to the gate everywhere**.

Surfaced during the review of #2057 — its default-Ollama-URL force-unwrap was only passing CI by this accident.

## Fix

Anchor the comment match to grep's `file:LINE:content` separator — `grep -vE ':[0-9]+:[[:space:]]*//'` — so it only drops lines whose **content** starts with `//`, not any line containing `://`.

## Revealed force-unwraps (allowlisted)

The fix makes 3 pre-existing force-unwraps visible. All are compile-time-constant literal URLs (the same reviewed-safe pattern as the existing HuggingFace/AnyLanguageModel allowlist entries), so they're allowlisted with justification — no code change:
- `ManifoldInference/Services/HuggingFaceProbe.swift:18` — `defaultURL`
- `ManifoldCloudSaaS/CloudReranker.swift:81,96` — cohere/jina rerank presets (already carry an inline "safe: constant literal URL" comment)

## Verified (under `/bin/bash`, matching CI's bash 3.2)

- Lint passes clean after the fix.
- **Sabotage check:** a planted `let x = URL(string: "https://example.com")!` is now **caught** by the lint — it was invisible before, proving the blind spot is actually closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)