### PR TITLE
fix(example,ui): add store-reset recovery, export Escape, upgrade-hint timing

### DIFF
--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -43,7 +43,12 @@ struct MinimalExampleApp: App {
 
     @MainActor
     private func resetAndRestart() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            // No Application Support directory to clean — clear the error and let
+            // start() resurface any genuine failure on retry.
+            self.error = nil
+            return
+        }
         let storeDir = appSupport.appendingPathComponent("com.manifoldkit.minimal-example")
         for name in ["store.sqlite", "store.sqlite-shm", "store.sqlite-wal"] {
             do {

--- a/Example/Examples/MinimalExample/MinimalExampleApp.swift
+++ b/Example/Examples/MinimalExample/MinimalExampleApp.swift
@@ -26,16 +26,35 @@ struct MinimalExampleApp: App {
                 .environment(result.viewModel)
                 .modelContainer(result.bootstrap.modelContainer)
             } else if let error {
-                ContentUnavailableView(
-                    "Failed to start",
-                    systemImage: "exclamationmark.triangle",
-                    description: Text(error.errorDescription ?? "Unknown error")
-                )
+                ContentUnavailableView {
+                    Label("Failed to start", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error.errorDescription ?? "Unknown error")
+                } actions: {
+                    Button("Reset app data") { resetAndRestart() }
+                        .buttonStyle(.borderedProminent)
+                }
             } else {
                 ProgressView("Starting…")
                     .task { await start() }
             }
         }
+    }
+
+    @MainActor
+    private func resetAndRestart() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let storeDir = appSupport.appendingPathComponent("com.manifoldkit.minimal-example")
+        for name in ["store.sqlite", "store.sqlite-shm", "store.sqlite-wal"] {
+            do {
+                try FileManager.default.removeItem(at: storeDir.appendingPathComponent(name))
+            } catch CocoaError.fileNoSuchFile {
+                // already absent — fine
+            } catch {
+                // best-effort; start() will surface any real failure
+            }
+        }
+        self.error = nil
     }
 
     @MainActor

--- a/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
+++ b/Sources/ManifoldUI/ViewModels/ChatGenerationCoordinator.swift
@@ -461,7 +461,7 @@ final class ChatGenerationCoordinator {
                 onSetLastTurnState(.idle)
             }
 
-            if reason == .stop,
+            if reason == .length,
                ManifoldConfiguration.shared.features.showUpgradeHint,
                let completed = currentMessages().first(where: { $0.id == messageID }),
                completed.hasVisibleContent {
@@ -651,7 +651,7 @@ final class ChatGenerationCoordinator {
             onSetLastTurnState(.idle)
         }
 
-        if outcome.reason == .stop,
+        if outcome.reason == .length,
            ManifoldConfiguration.shared.features.showUpgradeHint,
            let completed = outcome.assistantMessageID.flatMap({ id in
                currentMessages().first(where: { $0.id == id })

--- a/Sources/ManifoldUI/Views/Chat/ChatExportSheet.swift
+++ b/Sources/ManifoldUI/Views/Chat/ChatExportSheet.swift
@@ -40,6 +40,7 @@ public struct ChatExportSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
                 }
 
                 ToolbarItem(placement: .confirmationAction) {

--- a/Tests/ManifoldUITests/ChatGenerationCoordinatorTests.swift
+++ b/Tests/ManifoldUITests/ChatGenerationCoordinatorTests.swift
@@ -334,7 +334,62 @@ final class ChatGenerationCoordinatorTests: XCTestCase {
         XCTAssertNil(coord.activeConversationStreamHandle)
     }
 
-    // MARK: - 12. coordinator does not retain ChatViewModel
+    // MARK: - 12. streamFinished(.length) triggers upgrade hint
+
+    func test_handleStreamFinished_length_triggersUpgradeHint() async {
+        let coord = makeSilentCoordinator()
+        let sessionID = UUID()
+        let msgID = UUID()
+
+        ManifoldConfiguration.shared.features = ManifoldConfiguration.Features(showUpgradeHint: true)
+        defer { ManifoldConfiguration.shared.features = ManifoldConfiguration.Features() }
+
+        var hintFired = false
+        coord.setShowUpgradeHint = { if $0 { hintFired = true } }
+        coord.onTransitionPhase = { _ in true }
+        coord.currentActiveSessionID = { sessionID }
+
+        var msg = ChatMessage(id: msgID, role: .assistant, content: "Truncated", sessionID: sessionID)
+        msg.contentParts = [.text("Truncated")]
+        coord.currentMessages = { [msg] }
+        coord.currentActiveSession = { ChatSession(id: sessionID, title: "Test") }
+
+        coord.activeConversationMessageID = msgID
+        coord.activeConversationStreamHandle = ConversationStreamHandle(id: UUID())
+
+        await coord.handle(runtimeEvent: .streamFinished(messageID: msgID, reason: .length))
+
+        XCTAssertTrue(hintFired, "upgrade hint must fire when the backend hits its length cap")
+    }
+
+    func test_handleStreamFinished_stop_doesNotTriggerUpgradeHint() async {
+        let coord = makeSilentCoordinator()
+        let sessionID = UUID()
+        let msgID = UUID()
+
+        ManifoldConfiguration.shared.features = ManifoldConfiguration.Features(showUpgradeHint: true)
+        defer { ManifoldConfiguration.shared.features = ManifoldConfiguration.Features() }
+
+        var hintFired = false
+        coord.setShowUpgradeHint = { if $0 { hintFired = true } }
+        coord.onTransitionPhase = { _ in true }
+        coord.currentActiveSessionID = { sessionID }
+
+        var msg = ChatMessage(id: msgID, role: .assistant, content: "Done", sessionID: sessionID)
+        msg.contentParts = [.text("Done")]
+        coord.currentMessages = { [msg] }
+        coord.currentActiveSession = { ChatSession(id: sessionID, title: "Test") }
+        coord.currentPostGenerationTasks = { [] }
+
+        coord.activeConversationMessageID = msgID
+        coord.activeConversationStreamHandle = ConversationStreamHandle(id: UUID())
+
+        await coord.handle(runtimeEvent: .streamFinished(messageID: msgID, reason: .stop))
+
+        XCTAssertFalse(hintFired, "upgrade hint must NOT fire on a normal .stop completion")
+    }
+
+    // MARK: - 13. coordinator does not retain ChatViewModel
 
     func test_coordinatorDoesNotRetainChatViewModel() {
         // Construct a full VM and immediately release it — the coordinator's

--- a/Tests/ManifoldUITests/GenerationExtensionTests.swift
+++ b/Tests/ManifoldUITests/GenerationExtensionTests.swift
@@ -120,8 +120,9 @@ final class GenerationExtensionTests: XCTestCase {
 
     // MARK: - 2. Upgrade Hint Logic
 
-    func test_upgradeHint_triggersWhenAllConditionsMet() async {
-        // Save and restore the shared configuration to avoid leaking between tests.
+    func test_upgradeHint_doesNotTriggerOnNormalStop() async {
+        // A normal (.stop) generation must NOT show the hint — only context exhaustion
+        // (.length) should, so the banner doesn't fire on every successful reply.
         let originalConfig = ManifoldConfiguration.shared
         defer { ManifoldConfiguration.shared = originalConfig }
 
@@ -129,17 +130,12 @@ final class GenerationExtensionTests: XCTestCase {
 
         let mock = MockInferenceBackend()
         mock.tokensToYield = ["Hello"]
-        // Backend name must be the Foundation canonical to trigger the hint.
         let vm = await makeVM(backend: mock, name: BackendName.foundation.rawValue)
-
-        var hintCallbackCalled = false
-        vm.onUpgradeHintTriggered = { hintCallbackCalled = true }
 
         vm.inputText = "Hi"
         await vm.sendMessage()
 
-        XCTAssertTrue(vm.showUpgradeHint, "showUpgradeHint should be true after first assistant response with Apple backend")
-        XCTAssertTrue(hintCallbackCalled, "onUpgradeHintTriggered callback should fire")
+        XCTAssertFalse(vm.showUpgradeHint, "showUpgradeHint must stay false after a normal .stop reply")
     }
 
     func test_upgradeHint_doesNotTriggerWhenFeatureFlagDisabled() async {
@@ -174,7 +170,9 @@ final class GenerationExtensionTests: XCTestCase {
         XCTAssertFalse(vm.showUpgradeHint, "showUpgradeHint should remain false for non-Apple backends")
     }
 
-    func test_upgradeHint_doesNotTriggerOnSecondAssistantResponse() async {
+    func test_upgradeHint_doesNotTriggerAgainOnceFired() async {
+        // Once showUpgradeHint is true the guard `!showUpgradeHint` prevents
+        // onUpgradeHintTriggered from firing a second time, even after another turn.
         let originalConfig = ManifoldConfiguration.shared
         defer { ManifoldConfiguration.shared = originalConfig }
 
@@ -184,14 +182,9 @@ final class GenerationExtensionTests: XCTestCase {
         mock.tokensToYield = ["First"]
         let vm = await makeVM(backend: mock, name: BackendName.foundation.rawValue)
 
-        // First message triggers the hint.
-        vm.inputText = "Hi"
-        await vm.sendMessage()
-        XCTAssertTrue(vm.showUpgradeHint)
+        // Simulate the hint having already fired (e.g. via a prior .length turn).
+        vm.showUpgradeHint = true
 
-        // Reset the hint flag to simulate checking second-time behavior.
-        // The code checks `!showUpgradeHint`, so once set it won't trigger again.
-        // Send a second message: hint should already be true, callback should not re-fire.
         var secondCallback = false
         vm.onUpgradeHintTriggered = { secondCallback = true }
 
@@ -199,8 +192,6 @@ final class GenerationExtensionTests: XCTestCase {
         vm.inputText = "Another"
         await vm.sendMessage()
 
-        // showUpgradeHint is still true (never reset), and the second send should NOT
-        // re-trigger because the guard `!showUpgradeHint` prevents it.
         XCTAssertFalse(secondCallback, "onUpgradeHintTriggered should not fire again once hint is already shown")
     }
 

--- a/docs/MODEL-MANAGEMENT.md
+++ b/docs/MODEL-MANAGEMENT.md
@@ -99,8 +99,8 @@ recommender that filters before displaying.
 
 | Strategy | When to use |
 |----------|-------------|
-| `.mappable` | Default. mmap-backed — weights paged in on demand. Lower peak RSS, higher per-token latency variance on cold access. |
-| `.preloaded` | Force full weight load up front. Higher peak RSS, lower variance. Only worthwhile on devices with comfortable headroom. |
+| `.mappable` | Default for GGUF. mmap-backed — only active pages + KV cache need RAM. Lower peak RSS, higher per-token latency variance on cold access. |
+| `.resident` | Required for MLX (unified-memory backends). Weights must be fully resident in RAM before generation starts. Auto-selected by `compute(for:requestedContextSize:)` for `.mlx` model types — only pass explicitly if overriding the strategy for a custom backend. |
 
 ---
 

--- a/docs/MODEL-MANAGEMENT.md
+++ b/docs/MODEL-MANAGEMENT.md
@@ -1,0 +1,170 @@
+# Model Management
+
+A consolidated reference for quantization discovery, device-fit gating, and
+residency policy. For first-run model discovery and the `ModelSelection` list
+API, start at [`QUICKSTART-MODEL-SELECTION.md`](QUICKSTART-MODEL-SELECTION.md);
+for GGUF file locations and load-error diagnostics, see [`LOCAL-GGUF.md`](LOCAL-GGUF.md).
+This page covers the runtime policy surface — reading quant metadata, when the
+engine refuses a load, and how long a loaded model stays resident.
+
+---
+
+## 1. Quantization: discovery, not selection
+
+ManifoldKit reads quantization tags from GGUF metadata at discovery time and
+surfaces them on `ModelInfo.quantization` (a raw string — `"Q4_K_M"`, `"Q8_0"`,
+etc.). There is **no runtime chooser API** — quantization is a property of the
+file on disk. What you can do is read it and let it inform recommendations or UI:
+
+```swift,no-build
+import ManifoldKit
+
+@MainActor
+func describeModel(_ model: ModelInfo) {
+    let quant = model.quantization ?? "unknown"
+    let size  = ByteCountFormatter.string(fromByteCount: Int64(model.sizeBytes),
+                                          countStyle: .file)
+    print("\(model.name) — \(quant) — \(size)")
+}
+```
+
+The `rankedModels(useCase:)` scorer uses a composite `qualityScore` that weighs
+model-size tier first and quantization width second — a Q4_K_M 7B still
+outscores a Q8_0 1B on capability. Use the ranked list rather than rolling your
+own quant filter.
+
+**Quant tier quick-reference** (Apple Silicon, rough guidance):
+
+| Quant | Bits/weight | Typical tradeoff |
+|-------|-------------|------------------|
+| `Q2_K` | ~2.6 | Fits the largest models; quality noticeably degraded |
+| `Q4_K_M` | ~4.8 | Best quality-per-GB for most devices — default pick |
+| `Q5_K_M` | ~5.8 | Marginal quality lift over Q4; worth it for reasoning tasks |
+| `Q8_0` | ~8.5 | Near float16 quality; only practical on 32GB+ or sub-3B models |
+
+> `Q4_K_M` is the practical default for 7B–13B models on a 16 GB device. Step
+> up to `Q5_K_M` for reasoning or code when the model fits comfortably; reserve
+> `Q8_0` for high-RAM devices or small parameter counts.
+
+> **RAG note.** Chunk embeddings are produced by the *embedding* model, not the
+> chat model. Switching the chat model's quant tier does not invalidate the index;
+> switching the embedding backend does — re-ingest if you change embedders.
+
+---
+
+## 2. Device-fit: the load-plan gate
+
+Before loading any model, ManifoldKit runs
+`ModelLoadPlan.compute(for:requestedContextSize:strategy:)` as an admission
+check. A load is refused (`.deny`) when the model's weights plus the KV cache
+for the requested context window would exceed the device's resident memory
+budget.
+
+```swift,no-build
+import ManifoldKit
+
+@MainActor
+func canLoad(_ model: ModelInfo, contextSize: Int = 8_192) -> Bool {
+    let plan = ModelLoadPlan.compute(
+        for: model,
+        requestedContextSize: contextSize,
+        strategy: .mappable
+    )
+    switch plan.verdict {
+    case .allow:
+        return true
+    case .warn:
+        // Tight fit — the model will load but memory pressure is likely.
+        // Surface plan.reasons to the user:
+        // e.g. .insufficientResident, .insufficientKVCache
+        return true
+    case .deny:
+        // Refused. Inspect plan.reasons for the blocking constraint.
+        return false
+    }
+}
+```
+
+The context window cap defaults to the model's declared `contextLength` (from
+GGUF metadata), floored to `ManifoldConfiguration.shared.minimumContextSize`
+(512 on the simulator). Passing a smaller `requestedContextSize` can flip a
+`.deny` to `.warn` or `.allow` — useful when your use case only needs 4K context.
+
+`ModelSelection.loadSelected()` runs this check internally and surfaces
+`ModelLoadError.loadPlanDenied(plan:)` if the verdict is `.deny` — you only need
+to call `ModelLoadPlan.compute` directly when building a pre-flight UI or a model
+recommender that filters before displaying.
+
+**Memory strategies:**
+
+| Strategy | When to use |
+|----------|-------------|
+| `.mappable` | Default. mmap-backed — weights paged in on demand. Lower peak RSS, higher per-token latency variance on cold access. |
+| `.preloaded` | Force full weight load up front. Higher peak RSS, lower variance. Only worthwhile on devices with comfortable headroom. |
+
+---
+
+## 3. Residency and keep-alive
+
+Once loaded, a model stays resident until explicitly unloaded, memory pressure
+forces eviction, or an idle-timeout policy fires. Configure this on
+`InferenceService.keepAlivePolicy`:
+
+```swift,no-build
+import ManifoldKit
+
+// Unload after 5 minutes of idle time:
+inferenceService.keepAlivePolicy = KeepAlivePolicy(idleTimeout: 5 * 60)
+
+// Evict proactively on OS memory-pressure warning if idle > 10 s:
+inferenceService.keepAlivePolicy = KeepAlivePolicy(
+    idleTimeout: 5 * 60,
+    evictOnMemoryWarning: true,
+    memoryWarningGrace: 10
+)
+
+// Disable auto-unload (the default — model stays until you call unloadModel()):
+inferenceService.keepAlivePolicy = .never
+```
+
+| Property | Default | Meaning |
+|----------|---------|---------|
+| `idleTimeout` | `nil` (disabled) | Seconds of no generation before auto-unload. Generation resets the clock; a busy model is never evicted mid-turn. |
+| `evictOnMemoryWarning` | `false` | When `true`, an idle model may be evicted at OS `.warning` pressure (before `.critical`), freeing RAM earlier. Advisory: never interrupts generation. |
+| `memoryWarningGrace` | 10 s | How long the model must have been idle before a `.warning` event can trigger eviction. Prevents eviction immediately after a turn completes. |
+
+### Ollama advisory residency
+
+For Ollama backends, ManifoldKit mirrors the `KeepAlivePolicy` idle timeout into
+Ollama's server-side `keep_alive` field so the two timers agree. The default
+`OllamaBackend.keepAlive` is `"30m"` (Ollama's own default is `"5m"`). When a
+`KeepAlivePolicy.idleTimeout` is set, ManifoldKit overwrites `keepAlive`
+automatically with the same duration — you don't need to set both.
+
+To change the Ollama advisory residency independently (for example on a shared
+server where you want to release GPU VRAM sooner), access the backend directly:
+
+```swift,no-build
+import ManifoldOllama
+
+let backend = OllamaBackend()
+backend.keepAlive = "5m"   // free server VRAM sooner on a shared machine
+```
+
+---
+
+## 4. The Manifoldfile bundle (coming in #1932)
+
+> **Not yet shipped.** The `Manifoldfile` — a declarative bundle format for
+> packaging a GGUF model, a system prompt, default `GenerationConfig`, and tool
+> definitions into a single distributable artifact — is tracked in
+> [#1932](https://github.com/roryford/ManifoldKit/issues/1932). This section
+> will be filled in when it lands.
+
+---
+
+## See also
+
+- [`QUICKSTART-MODEL-SELECTION.md`](QUICKSTART-MODEL-SELECTION.md) — `ModelSelection`, the ranked-models API, and per-family load paths.
+- [`LOCAL-GGUF.md`](LOCAL-GGUF.md) — where ManifoldKit looks for GGUF files and how to diagnose load errors.
+- [`FeatureMatrix.md`](FeatureMatrix.md) — per-backend capability table.

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -164,6 +164,16 @@ ManifoldKit's distinct position is the diagonal across this table: not best at
 any single layer's niche, but the only thing that assembles all of them into a
 product you `import` instead of `git clone`.
 
+**Adjacent end-user apps (not Swift packages).** Developers evaluating
+ManifoldKit sometimes compare it against **Ollamac** (macOS Ollama client, Swift
+app), **LM Studio** (cross-platform Electron GUI for local model management),
+and **AnythingLLM** (Node.js / web RAG assistant). These are *end-user apps*,
+not Swift packages or frameworks — they solve "I want to run AI locally" for
+end users, while ManifoldKit solves "I want to build and ship an AI feature in
+my iOS/macOS app." They serve different jobs. The correct comparison for
+ManifoldKit is the table above; the correct comparison for those tools is the
+market of chat clients and local-model GUIs.
+
 ---
 
 ## 6. What's already in the box

--- a/docs/QUICKSTART-VOICE.md
+++ b/docs/QUICKSTART-VOICE.md
@@ -183,3 +183,15 @@ isn't a chat surface.
 | `.failed("Speech recognition permission…")` | `NSSpeechRecognitionUsageDescription` missing. |
 | `VoiceError.unsupportedLocale` | `SFSpeechRecognizer(locale:)` returned nil — pass a supported locale or `.current`. |
 | `liveTranscript` stuck empty | Authorization denied silently — check ``VoiceConversationController/errorMessage``. |
+
+---
+
+## Realtime voice: full-duplex, SpeechAnalyzer, VAD, and barge-in
+
+> **Not yet shipped.** Full-duplex conversation with voice activity detection
+> (VAD), barge-in interruption, Apple's `SpeechAnalyzer` framework, and
+> WhisperKit integration are tracked in
+> [#1928](https://github.com/roryford/ManifoldKit/issues/1928). The current
+> `ManifoldVoice` surface is half-duplex only — STT and TTS run in mutually
+> exclusive states, not simultaneously. See `docs/design/voice-surface-scoping.md`
+> for the design notes.

--- a/docs/QUICKSTART-VOICE.md
+++ b/docs/QUICKSTART-VOICE.md
@@ -193,5 +193,5 @@ isn't a chat surface.
 > WhisperKit integration are tracked in
 > [#1928](https://github.com/roryford/ManifoldKit/issues/1928). The current
 > `ManifoldVoice` surface is half-duplex only — STT and TTS run in mutually
-> exclusive states, not simultaneously. See `docs/design/voice-surface-scoping.md`
+> exclusive states, not simultaneously. See [design/voice-surface-scoping.md](design/voice-surface-scoping.md)
 > for the design notes.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -1,0 +1,254 @@
+# ManifoldKit Recipes
+
+Short, runnable patterns for the most common ManifoldKit tasks. Each recipe is
+the minimum viable code — check the linked quickstart for the full walkthrough
+including error handling, multi-turn state, and UI wiring.
+
+> **Snippet-gate note.** All recipes use `import ManifoldKit` (the umbrella) —
+> they compile against the standard ManifoldKit + ManifoldUI +
+> ManifoldUIModelManagement scaffold. Any recipe that needs a module outside the
+> umbrella is tagged `swift,no-build` with an explanation.
+
+---
+
+## 1. Tool loop
+
+Register a tool, wire it into the inference service, and run a turn. The turn
+loop calls the tool automatically and feeds the result back before the next
+token — you observe both through the event stream.
+
+Full walkthrough: [`QUICKSTART-TOOLS.md`](QUICKSTART-TOOLS.md).
+
+```swift,no-build
+import ManifoldKit
+
+// 1. Define argument + result types.
+struct EchoArgs:   Decodable, Sendable { let text: String }
+struct EchoResult: Encodable, Sendable { let echoed: String }
+
+// 2. Build an executor — handler decodes args, returns a result.
+let echoTool = TypedToolExecutor<EchoArgs, EchoResult>(
+    definition: ToolDefinition(
+        name: "echo",
+        description: "Returns the input text unchanged.",
+        parameters: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "text": .object([
+                    "type": .string("string"),
+                    "description": .string("Text to echo")
+                ])
+            ]),
+            "required": .array([.string("text")])
+        ])
+    )
+) { args in
+    EchoResult(echoed: args.text)
+}
+
+// 3. Register and wire into an InferenceService.
+let registry = ToolRegistry()
+registry.register(echoTool)
+
+let inference = InferenceService(toolRegistry: registry)
+OllamaBackends.register(with: inference)
+
+// 4. Run a turn — the dispatch loop fires tools automatically.
+var config = GenerationConfig()
+config.tools = registry.definitions
+config.toolChoice = .auto
+
+let (_, stream) = try inference.enqueue(
+    messages: [.user("Echo the phrase 'hello world' for me.")],
+    config: config
+)
+for try await event in stream.events {
+    switch event {
+    case .token(let t):      print(t, terminator: "")
+    case .toolCall(let c):   print("\n[calling \(c.name)]")
+    case .toolResult(let r): print("[result: \(r.content)]")
+    default: break
+    }
+}
+```
+
+> **Local-model ceiling.** Small instruct models (3B–8B) degrade when given more
+> than ~5 tool definitions per request. Keep the registered set minimal for
+> on-device use; cloud backends (OpenAI, Anthropic) handle 20+ without issue.
+
+---
+
+## 2. RAG (retrieval-augmented generation)
+
+Ingest documents and let the turn loop retrieve relevant passages automatically
+before each reply. Once configured, your existing `ChatView` surfaces citations
+with no per-turn code.
+
+Full walkthrough: [`QUICKSTART-RAG.md`](QUICKSTART-RAG.md).
+Tuning knobs: [`RAG-TUNING.md`](RAG-TUNING.md).
+
+```swift,no-build
+import ManifoldKit
+
+// RAG requires the manual bootstrap path (quickStart() has no RAG parameter).
+let ragConfig = RAGConfiguration(
+    embeddingBackend: nil,   // nil → keyword fallback; pass a LlamaEmbeddingBackend
+                             // for semantic search (requires manifold-llama)
+    chunkSize: 1800,
+    chunkOverlap: 200,
+    topK: 5
+)
+
+let bootstrap = try await ManifoldBootstrap.build(
+    ragConfiguration: ragConfig
+)
+
+// Ingest documents — parsing, chunking, and embedding happen here.
+let docURL = Bundle.main.url(forResource: "guide", withExtension: "txt")!
+try await bootstrap.ragService?.ingest(url: docURL)
+
+// The turn loop calls retrieve() automatically before each turn.
+// Citations arrive on the assistant ChatMessage:
+//   message.citations   → [Citation] with documentTitle, snippet, score
+// ChatView renders a "Sources" disclosure group automatically.
+```
+
+> **Re-ingest after switching the embedding backend.** Documents ingested while
+> no embedder was loaded store no vector. Load the embedder, then re-ingest for
+> semantic search to take effect.
+
+---
+
+## 3. On-device model pick
+
+Score and select the best model for a use case, gate on the load-plan verdict,
+then load it — without standing up a `ChatViewModel`.
+
+Full walkthrough: [`QUICKSTART-MODEL-SELECTION.md`](QUICKSTART-MODEL-SELECTION.md).
+
+```swift,no-build
+import ManifoldKit
+
+@MainActor
+func pickAndLoad(service: InferenceService) async throws {
+    let selection = ModelSelection(inferenceService: service)
+    try selection.refresh()   // scan the models directory
+
+    // Score every discovered model against a use case, best-first.
+    let ranked = selection.rankedModels(useCase: .reasoning)
+    guard let best = ranked.first else {
+        print("No models found — download one via ModelManagementSheet.")
+        return
+    }
+
+    // Pre-flight check: will this model fit on this device?
+    let plan = ModelLoadPlan.compute(
+        for: best.model,
+        requestedContextSize: 8_192,
+        strategy: .mappable
+    )
+    if case .deny = plan.verdict {
+        print("Won't fit: \(plan.reasons)")
+        return
+    }
+
+    // Select and load — admission check runs again inside loadSelected().
+    selection.select(best.model)
+    selection.loadSelected()
+
+    // Observe progress:
+    for await status in selection.loadStatusUpdates() {
+        switch status {
+        case .loading(let p): print("Loading… \(Int((p ?? 0) * 100))%")
+        case .loaded:         print("Ready: \(best.model.name)")
+        case .failed(let e):  print("Failed: \(e)"); return
+        default: break
+        }
+    }
+}
+```
+
+> **`supportsReasoning` honest-false footgun.** Single-file GGUFs ship no
+> `config.json`, so the reasoning-capability flag is `false` for most local
+> models — this means "unknown," not "cannot reason." Don't exclude local models
+> from a reasoning picker on that flag alone; use it as a hint and prefer curated
+> or cloud reasoners when you need certainty.
+
+---
+
+## 4. Structured output (raw strategy)
+
+Constrain generation to a JSON Schema or GBNF grammar. `StructuredOutputRouter`
+picks the strongest mechanism each backend supports; you decode the returned
+string yourself.
+
+> **No `@Generable` equivalent yet.** ManifoldKit constrains the *generation*
+> but does not hand back a decoded Swift instance. Decode with `JSONDecoder` after
+> the turn. The typed-instance ergonomics are tracked in
+> [#1915](https://github.com/roryford/ManifoldKit/issues/1915).
+
+```swift,no-build
+import ManifoldKit
+
+struct Sentiment: Decodable {
+    enum Label: String, Decodable { case positive, negative, neutral }
+    let label: Label
+    let confidence: Double
+}
+
+// Constrain with a JSON Schema document — routed to grammar-constrained decoding
+// where available, falling back to .jsonPrompting on cloud backends.
+var config = GenerationConfig()
+config.structuredOutput = .jsonSchema(#"""
+{
+  "type": "object",
+  "properties": {
+    "label":      { "enum": ["positive", "negative", "neutral"] },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+  },
+  "required": ["label", "confidence"]
+}
+"""#)
+
+let messages: [ChatMessage] = [
+    .system("Classify the sentiment of the user's message. Respond in JSON only."),
+    .user("I love this library!")
+]
+let (_, stream) = try inference.enqueue(messages: messages, config: config)
+
+var raw = ""
+for try await event in stream.events {
+    if case .token(let t) = event { raw += t }
+}
+
+// Decode yourself — ManifoldKit guarantees the JSON shape, not a Swift instance.
+let result = try JSONDecoder().decode(Sentiment.self, from: Data(raw.utf8))
+print(result.label, result.confidence)
+```
+
+**Other strategies:**
+
+```swift,no-build
+// GBNF grammar (llama.cpp-class backends):
+config.structuredOutput = .gbnf(#"root ::= "yes" | "no""#)
+
+// Foundation guided-generation target type (iOS/macOS 26+, Foundation backend):
+config.structuredOutput = .guided(MyGuidedType.self)
+
+// JSON-prompting fallback (any backend, no grammar support needed):
+config.structuredOutput = .jsonPrompting
+```
+
+`StructuredOutputRouter` selects the best strategy automatically — you only need
+to override if you want a specific mechanism regardless of what the backend
+supports.
+
+---
+
+## See also
+
+- [`QUICKSTART-TOOLS.md`](QUICKSTART-TOOLS.md) — full tool-calling guide with `TypedToolExecutor`, approval gates, and streaming results.
+- [`QUICKSTART-RAG.md`](QUICKSTART-RAG.md) — end-to-end RAG setup with semantic search and reranking.
+- [`RAG-TUNING.md`](RAG-TUNING.md) — chunk size, reranker tradeoffs, and the citation surface.
+- [`QUICKSTART-MODEL-SELECTION.md`](QUICKSTART-MODEL-SELECTION.md) — `ModelSelection` and `ModelLoadPlan` details.
+- [`MIGRATING-FROM-FOUNDATION-MODELS.md`](MIGRATING-FROM-FOUNDATION-MODELS.md) — mapping `@Generable` / `LanguageModelSession` onto ManifoldKit.

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -99,9 +99,12 @@ let ragConfig = RAGConfiguration(
     topK: 5
 )
 
-let bootstrap = try await ManifoldBootstrap.build(
+// build() returns (progress stream, task) — await the task for the bootstrap.
+let (_, task) = ManifoldBootstrap.build(
+    configuration: ManifoldConfiguration.shared,
     ragConfiguration: ragConfig
 )
+let bootstrap = try await task.value
 
 // Ingest documents — parsing, chunking, and embedding happen here.
 let docURL = Bundle.main.url(forResource: "guide", withExtension: "txt")!


### PR DESCRIPTION
## Summary

Three bugs found during MinimalExample smoke testing, fixed in one PR:

- **Store-reset recovery** (`MinimalExampleApp.swift`): The error view after a failed `quickStart()` was a dead end with no recovery action. Now shows a "Reset app data" button that wipes the three SQLite files (`store.sqlite`, `-shm`, `-wal`) and retries. Recovers from V8→V9 SwiftData migration failures without requiring users to dig into `~/Library/Application Support`.

- **Export sheet Escape** (`ChatExportSheet.swift`): The Cancel button in the export sheet toolbar didn't respond to Escape on macOS. Added `.keyboardShortcut(.cancelAction)`.

- **Upgrade-hint timing** (`ChatGenerationCoordinator.swift`): The "Want longer responses? Download a model" banner was firing after every successful Foundation Model reply instead of only when the context window was actually exhausted. Changed both `streamFinished` sites from `reason == .stop` → `reason == .length`.

## Test plan

- [x] `swift build --build-tests` passes in worktree
- [x] `swift test --filter ManifoldUITests` — 703 tests, 0 failures
- Coordinator tests: added `test_handleStreamFinished_length_triggersUpgradeHint` and `test_handleStreamFinished_stop_doesNotTriggerUpgradeHint`
- Extension tests: renamed and flipped the `.stop` trigger test; updated the "no second fire" test to pre-set the flag directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)