### PR TITLE
fix(example): repair Advanced demo build and harden DemoNowTool

### DIFF
--- a/Example/Advanced.xcodeproj/project.pbxproj
+++ b/Example/Advanced.xcodeproj/project.pbxproj
@@ -911,11 +911,6 @@
 		F20001000000000000000000 /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ..;
-			traits = (
-				MLX,
-				Llama,
-				HuggingFace,
-			);
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Example/Advanced/DemoContentView.swift
+++ b/Example/Advanced/DemoContentView.swift
@@ -30,9 +30,7 @@ struct DemoContentView: View {
     // on iOS Simulator launch (no audio input device). Mount the controller
     // and the composer accessory only on real hardware.
     #if !targetEnvironment(simulator)
-    @State private var voiceController = VoiceConversationController(
-        wakeWordDetector: AppleWakeWordDetector(wakeWords: ["hey base chat", "base chat"])
-    )
+    @State private var voiceController = VoiceConversationController()
     #endif
 
     /// Tool registry shared with the app's inference service. Held here so the

--- a/Example/Advanced/DemoNowTool.swift
+++ b/Example/Advanced/DemoNowTool.swift
@@ -18,6 +18,77 @@ enum DemoNowTool {
         let localTime: String
     }
 
+    /// Raised when the caller passes a `timezone` we can't resolve to a real
+    /// zone. We surface it instead of silently falling back to the device's
+    /// local zone — a small on-device model routinely passes a bare city name
+    /// like `"Tokyo"` (which `TimeZone(identifier:)` rejects), and a silent
+    /// fallback would answer with *local* time mislabelled as the requested
+    /// place. Throwing feeds the hint back to the model so it can retry with a
+    /// proper IANA identifier. See `ToolExecutor` — a thrown error becomes a
+    /// tool-error result the model sees.
+    struct UnknownTimeZoneError: LocalizedError {
+        let requested: String
+        var errorDescription: String? {
+            "Unknown timezone '\(requested)'. Pass an IANA identifier such as 'Asia/Tokyo', 'Europe/London', or 'America/New_York'."
+        }
+    }
+
+    /// Best-effort map from a bare city/region name to its IANA identifier, for
+    /// the common case where the model passes `"Tokyo"` rather than
+    /// `"Asia/Tokyo"`. Not exhaustive — unknown names throw rather than guess.
+    static let cityToIANA: [String: String] = [
+        "tokyo": "Asia/Tokyo",
+        "london": "Europe/London",
+        "paris": "Europe/Paris",
+        "berlin": "Europe/Berlin",
+        "madrid": "Europe/Madrid",
+        "rome": "Europe/Rome",
+        "moscow": "Europe/Moscow",
+        "dubai": "Asia/Dubai",
+        "mumbai": "Asia/Kolkata",
+        "delhi": "Asia/Kolkata",
+        "new delhi": "Asia/Kolkata",
+        "singapore": "Asia/Singapore",
+        "hong kong": "Asia/Hong_Kong",
+        "shanghai": "Asia/Shanghai",
+        "beijing": "Asia/Shanghai",
+        "seoul": "Asia/Seoul",
+        "sydney": "Australia/Sydney",
+        "melbourne": "Australia/Melbourne",
+        "auckland": "Pacific/Auckland",
+        "new york": "America/New_York",
+        "nyc": "America/New_York",
+        "chicago": "America/Chicago",
+        "denver": "America/Denver",
+        "los angeles": "America/Los_Angeles",
+        "la": "America/Los_Angeles",
+        "san francisco": "America/Los_Angeles",
+        "sf": "America/Los_Angeles",
+        "toronto": "America/Toronto",
+        "sao paulo": "America/Sao_Paulo",
+        "são paulo": "America/Sao_Paulo",
+        "utc": "UTC",
+        "gmt": "GMT"
+    ]
+
+    /// Resolve a caller-supplied string to a real `TimeZone`, trying in order:
+    /// IANA identifier (`Asia/Tokyo`, `GMT+9`), abbreviation (`JST`, `PST`),
+    /// then the common-city map. Throws ``UnknownTimeZoneError`` if all fail —
+    /// never silently substitutes the local zone.
+    static func resolveTimeZone(_ raw: String) throws -> TimeZone {
+        if let zone = TimeZone(identifier: raw) {
+            return zone
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let zone = TimeZone(abbreviation: trimmed.uppercased()) {
+            return zone
+        }
+        if let iana = cityToIANA[trimmed.lowercased()], let zone = TimeZone(identifier: iana) {
+            return zone
+        }
+        throw UnknownTimeZoneError(requested: raw)
+    }
+
     static func makeExecutor() -> TypedToolExecutor<Args, Result> {
         let definition = ToolDefinition(
             name: "now",
@@ -35,7 +106,15 @@ enum DemoNowTool {
         )
 
         return TypedToolExecutor(definition: definition) { args in
-            let timeZone = args.timezone.flatMap(TimeZone.init(identifier:)) ?? .current
+            // No timezone asked for → device-local. A supplied timezone must
+            // resolve to a real zone; an unrecognized one throws rather than
+            // silently answering with local time mislabelled as the request.
+            let timeZone: TimeZone
+            if let requested = args.timezone, !requested.isEmpty {
+                timeZone = try resolveTimeZone(requested)
+            } else {
+                timeZone = .current
+            }
             let clock = ISO8601DateFormatter()
             clock.timeZone = timeZone
 


### PR DESCRIPTION
## Why

Smoke-testing the **Advanced** demo app surfaced that it no longer built against current ManifoldKit, and that its `now` tool could silently answer with the wrong timezone.

## Changes

### 1. Repair the build (`dbb5fc62`)
- **`Advanced.xcodeproj`** pinned the `MLX`, `Llama`, and `HuggingFace` package traits — all retired in v0.48 (MLX/Llama moved to companion packages; HuggingFace compiles unconditionally). SwiftPM failed to resolve the package graph before any source compiled. The demo only registers Ollama/CloudSaaS/Foundation backends and imports `ManifoldHuggingFace` unconditionally, so the trait list was dead — removed it.
- **`DemoContentView`** constructed `VoiceConversationController(wakeWordDetector: AppleWakeWordDetector(...))`, but the wake-word detector was removed from `ManifoldVoice`; the initializer now takes only `transcriber:`/`synthesizer:`. Dropped the argument.

### 2. Harden `DemoNowTool` (`61cdfad9`)
The `now` tool resolved a caller-supplied timezone with `TimeZone(identifier:) ?? .current`. A small on-device model routinely passes a bare city name like `"Tokyo"` (which `TimeZone(identifier:)` rejects), so the tool **silently fell back to the device-local zone** and answered with local time mislabelled as the requested place — with no signal back to the model. (Observed live: at 09:16 Sydney, "What time is it in Tokyo?" returned a wrong time.)

Now resolves in order — IANA identifier → abbreviation (`JST`/`PST`) → common-city map (`"Tokyo"` → `"Asia/Tokyo"`) — and **throws `UnknownTimeZoneError`** on an unrecognized zone, which `ToolRegistry.dispatch` feeds back to the model as a tool error so it can retry with a proper IANA id. The no-timezone case still answers device-local.

## Verification
- `xcodebuild -scheme Advanced -destination 'platform=macOS'` → **BUILD SUCCEEDED** (was failing at package resolution before).
- App launches and completes a full chat turn (verified via screenshot smoke test).
- Resolution logic checked standalone: `Tokyo`/`tokyo` → `Asia/Tokyo` (correct JST), `JST`/`London`/`new york`/`SF` resolve, `Atlantis`/`Mordor` throw.

> Note: the demo tools live in the Xcode app target (only XCUITests, no unit-test target), so no unit test was added for `resolveTimeZone` — it is a pure, side-effect-free function that would be trivially testable if a host target existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)