### PR TITLE
feat(model-management): chat-template integrity hash (#1932)

### DIFF
--- a/Sources/ManifoldHardware/ChatTemplateIntegritySidecar.swift
+++ b/Sources/ManifoldHardware/ChatTemplateIntegritySidecar.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Per-file, warn-only sidecar recording the SHA-256 of a single-file model's
+/// embedded chat template, captured on first observation for drift detection
+/// (#1932).
+///
+/// **Deliberately distinct from `GGUFSignedManifest` / `<file>.manifest.json`.**
+/// That manifest hashes the model's *weight bytes* and its verifier *throws* on
+/// mismatch — a digest mismatch there means tampering and must fail closed.
+/// Chat-template drift is a softer signal: a template that changed underneath a
+/// cached selection should only *warn* and let the load proceed. Keeping a
+/// separate record (and a separate filename) ensures the two semantics can never
+/// be conflated into one verifier.
+///
+/// The record is keyed to the model's own filename (see ``sidecarURL(forModelAt:)``),
+/// not the shared models directory, so several `.gguf` files living in one
+/// directory cannot collide on a single sidecar.
+public struct ChatTemplateIntegritySidecar: Codable, Hashable, Sendable {
+    /// Filename suffix appended to a model's path to locate its sidecar
+    /// (`foo.gguf` → `foo.gguf.template.json`).
+    public static let fileNameSuffix = ".template.json"
+
+    /// SHA-256 (lowercase hex) of the model's embedded chat template, captured
+    /// the first time the model was loaded. Compared against the freshly-loaded
+    /// template's digest on every subsequent load.
+    public let chatTemplateSHA256: String
+
+    public init(chatTemplateSHA256: String) {
+        self.chatTemplateSHA256 = chatTemplateSHA256
+    }
+
+    /// The sidecar location for a single-file model at `modelURL`: the model's
+    /// own filename with ``fileNameSuffix`` appended, in the same directory.
+    public static func sidecarURL(forModelAt modelURL: URL) -> URL {
+        modelURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(modelURL.lastPathComponent + fileNameSuffix)
+    }
+}

--- a/Sources/ManifoldHardware/DownloadedModelPackageManifest.swift
+++ b/Sources/ManifoldHardware/DownloadedModelPackageManifest.swift
@@ -20,11 +20,17 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
     /// treat as full-precision.
     public let variant: PrecisionVariant?
 
-    /// SHA-256 (lowercase hex) of the GGUF-embedded chat template captured when
-    /// this package was written. Optional so manifests produced before #1932 —
-    /// and packages with no chat template — still decode. The load path compares
-    /// this against the freshly-loaded template's digest to detect a template
-    /// that changed underneath a cached selection; a mismatch warns, never gates.
+    /// SHA-256 (lowercase hex) of the package's embedded chat template, for
+    /// chat-template drift detection (#1932). Optional so manifests produced
+    /// before #1932 — and packages with no chat template — still decode.
+    ///
+    /// This is the **multi-file/package** recording home. Single-file GGUFs
+    /// instead use the per-file `ChatTemplateIntegritySidecar` (they have no
+    /// package directory). The load path reads the per-file sidecar first and
+    /// falls back to this field; a mismatch warns and proceeds, never gates.
+    /// Currently unwritten in core — multi-file/MLX coverage is a documented
+    /// follow-up (those types carry no load-time `chatTemplateRaw` without
+    /// altering rendering); kept so that coverage is an additive write.
     public let chatTemplateSHA256: String?
 
     public init(

--- a/Sources/ManifoldHardware/DownloadedModelPackageManifest.swift
+++ b/Sources/ManifoldHardware/DownloadedModelPackageManifest.swift
@@ -20,6 +20,13 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
     /// treat as full-precision.
     public let variant: PrecisionVariant?
 
+    /// SHA-256 (lowercase hex) of the GGUF-embedded chat template captured when
+    /// this package was written. Optional so manifests produced before #1932 —
+    /// and packages with no chat template — still decode. The load path compares
+    /// this against the freshly-loaded template's digest to detect a template
+    /// that changed underneath a cached selection; a mismatch warns, never gates.
+    public let chatTemplateSHA256: String?
+
     public init(
         packageKind: ModelPackageKind,
         id: String,
@@ -27,7 +34,8 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
         format: ImageModelFormat? = nil,
         huggingFaceRepoID: String? = nil,
         files: [String],
-        variant: PrecisionVariant? = nil
+        variant: PrecisionVariant? = nil,
+        chatTemplateSHA256: String? = nil
     ) {
         self.packageKind = packageKind
         self.id = id
@@ -36,6 +44,7 @@ public struct DownloadedModelPackageManifest: Codable, Hashable, Sendable {
         self.huggingFaceRepoID = huggingFaceRepoID
         self.files = files
         self.variant = variant
+        self.chatTemplateSHA256 = chatTemplateSHA256
     }
 }
 

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -324,27 +324,26 @@ final class ModelLifecycleCoordinator {
         }
 
         // Chat-template integrity (#1932): warn loudly if the model's embedded
-        // template changed since the hash recorded in its on-disk package
-        // manifest — a cached selection or preset may be pinned to the old
-        // template. This is an observability signal only: it never gates the
-        // load and never feeds the renderer (which reads `chatTemplateRaw`
-        // directly), so it cannot reintroduce the #1909 template→render coupling.
+        // template changed since the hash recorded on first observation — a
+        // cached selection or preset may be pinned to the old template. This is
+        // an observability signal only: it never gates the load and never feeds
+        // the renderer (which reads `chatTemplateRaw` directly), so it cannot
+        // reintroduce the #1909 template→render coupling.
         //
-        // ACTIVATION (Piece 1 reads; the writer is deferred): no production path
-        // yet records `chatTemplateSHA256` for a template-bearing package, so this
-        // mismatch branch is currently inert in the field. The only sidecar writers
-        // emit `.diffusion` packages (no chat template); text packages
-        // (`.mlxSnapshot` / single-file GGUF) carry templates but are written
-        // without a `.manifoldkit-package.json`. Detection goes live once the
-        // download path records the template digest for text packages (#1932
-        // Piece 2). The read path, tests, and warning ship now so the writer is a
-        // one-line populate when it lands. End-to-end coverage drives this branch
-        // via a hand-written sidecar (see ChatTemplateIntegrityTests).
+        // Live for single-file GGUF: its `chatTemplateRaw` comes from
+        // `GGUFMetadataReader` at BOTH record-time and load-time, so the recorded
+        // and compared digests hash byte-identical input — no false positives.
+        // The recorded hash lives in a per-file sidecar (see the writer below);
+        // the first load records it, every later load compares against it.
         if case let .mismatch(recorded, current) = chatTemplateIntegrityStatus(for: modelInfo) {
             Log.inference.warning(
-                "Chat template changed since the recorded manifest hash for model '\(modelInfo.name)' (recorded \(recorded, privacy: .public), now \(current, privacy: .public)). A cached selection or preset may target the old template; rendering proceeds with the current embedded template (#1932)."
+                "Chat template changed since the recorded hash for model '\(modelInfo.name)' (recorded \(recorded, privacy: .public), now \(current, privacy: .public)). A cached selection or preset may target the old template; rendering proceeds with the current embedded template (#1932)."
             )
         }
+        // Record-on-first-observation. Runs AFTER the comparison above so the very
+        // first load (no sidecar yet) stays silent and then establishes the
+        // baseline that subsequent loads check.
+        recordChatTemplateSHA256IfNeeded(for: modelInfo)
 
         try await runLoad(
             source: "local",
@@ -437,23 +436,71 @@ final class ModelLifecycleCoordinator {
             : .mismatch(recorded: recordedHash, current: currentHash)
     }
 
-    /// Reads the recorded chat-template SHA-256 from the `.manifoldkit-package.json`
-    /// sidecar next to `modelURL`, or `nil` when there is no sidecar, it cannot be
-    /// decoded, or it carries no recorded hash.
+    /// Reads the recorded chat-template SHA-256 for the model at `modelURL`, or
+    /// `nil` when no recorded hash exists.
     ///
-    /// A missing or legacy sidecar is the common case (single-file GGUFs have no
-    /// sidecar at all), so a read/decode failure is treated as "nothing to compare"
-    /// rather than an error — this is a trust-boundary read, kept deliberately quiet.
+    /// Checks the per-file ``ChatTemplateIntegritySidecar`` first (the live path
+    /// for single-file GGUF, keyed to the model filename so co-located models
+    /// never collide), then falls back to the multi-file package manifest
+    /// (`.manifoldkit-package.json`) for package models that record there.
+    ///
+    /// A missing sidecar is the common case, so a read/decode failure is treated
+    /// as "nothing to compare" — a trust-boundary read kept deliberately quiet.
     private func recordedChatTemplateSHA256(forModelAt modelURL: URL) -> String? {
+        if let hash = perFileChatTemplateSHA256(forModelAt: modelURL) { return hash }
+        return packageManifestChatTemplateSHA256(forModelAt: modelURL)
+    }
+
+    private func perFileChatTemplateSHA256(forModelAt modelURL: URL) -> String? {
+        let sidecarURL = ChatTemplateIntegritySidecar.sidecarURL(forModelAt: modelURL)
+        do {
+            let data = try Data(contentsOf: sidecarURL)
+            return try JSONDecoder().decode(ChatTemplateIntegritySidecar.self, from: data).chatTemplateSHA256
+        } catch {
+            return nil
+        }
+    }
+
+    private func packageManifestChatTemplateSHA256(forModelAt modelURL: URL) -> String? {
         let manifestURL = modelURL
             .deletingLastPathComponent()
             .appendingPathComponent(DownloadedModelPackageManifest.fileName)
         do {
             let data = try Data(contentsOf: manifestURL)
-            let manifest = try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data)
-            return manifest.chatTemplateSHA256
+            return try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data).chatTemplateSHA256
         } catch {
             return nil
+        }
+    }
+
+    /// Records the loaded model's chat-template digest into a per-file sidecar the
+    /// first time the model is observed, so a later load can detect a template
+    /// that changed underneath a cached selection (#1932).
+    ///
+    /// **Same-source-by-construction:** the recorded hash is captured from the
+    /// exact `GGUFMetadataReader`-sourced `chatTemplateRaw` the load path reads,
+    /// so write and compare hash byte-identical input — no spurious "changed"
+    /// warnings. **Idempotent:** only writes when no sidecar exists, so a real
+    /// drift keeps warning rather than being silently re-baselined. **Best-effort:**
+    /// a write failure (read-only models dir, sandboxing) is logged and the load
+    /// proceeds — integrity recording must never block bringing a model up.
+    ///
+    /// Scoped to single-file GGUF: only that type carries a load-time
+    /// `chatTemplateRaw` without routing a template through the renderer. MLX /
+    /// diffusion packages carry no load-time template here, so they are left
+    /// uncovered (the `chatTemplateSHA256 == nil` guard short-circuits them too).
+    private func recordChatTemplateSHA256IfNeeded(for modelInfo: ModelInfo) {
+        guard modelInfo.modelType == .gguf,
+              let hash = modelInfo.chatTemplateSHA256 else { return }
+        let sidecarURL = ChatTemplateIntegritySidecar.sidecarURL(forModelAt: modelInfo.url)
+        guard !FileManager.default.fileExists(atPath: sidecarURL.path) else { return }
+        do {
+            let data = try JSONEncoder().encode(ChatTemplateIntegritySidecar(chatTemplateSHA256: hash))
+            try data.write(to: sidecarURL, options: .atomic)
+        } catch {
+            Log.inference.warning(
+                "Chat-template integrity (#1932): could not record sidecar for model '\(modelInfo.name)' at \(sidecarURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public). Drift detection re-attempts on the next load."
+            )
         }
     }
 

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -323,6 +323,18 @@ final class ModelLifecycleCoordinator {
             }
         }
 
+        // Chat-template integrity (#1932): warn loudly if the model's embedded
+        // template changed since the hash recorded in its on-disk package
+        // manifest — a cached selection or preset may be pinned to the old
+        // template. This is an observability signal only: it never gates the
+        // load and never feeds the renderer (which reads `chatTemplateRaw`
+        // directly), so it cannot reintroduce the #1909 template→render coupling.
+        if case let .mismatch(recorded, current) = chatTemplateIntegrityStatus(for: modelInfo) {
+            Log.inference.warning(
+                "Chat template changed since the recorded manifest hash for model '\(modelInfo.name)' (recorded \(recorded, privacy: .public), now \(current, privacy: .public)). A cached selection or preset may target the old template; rendering proceeds with the current embedded template (#1932)."
+            )
+        }
+
         try await runLoad(
             source: "local",
             target: modelTypeLogLabel(modelInfo.modelType),
@@ -383,6 +395,54 @@ final class ModelLifecycleCoordinator {
             newBackend.unloadModel()
             logLoadEvent("load.suppress", request: request, reason: "stale-success", clearMetadata: true)
             return
+        }
+    }
+
+    // MARK: - Chat-Template Integrity (#1932)
+
+    /// Outcome of comparing a freshly-loaded model's chat-template hash against
+    /// the hash recorded in its on-disk package-manifest sidecar.
+    enum ChatTemplateIntegrityStatus: Equatable {
+        /// No loaded template, no sidecar, or the sidecar carries no recorded
+        /// hash — nothing to compare, so the load is silent.
+        case noRecordedHash
+        /// The recorded hash matches the freshly-loaded template.
+        case match
+        /// The recorded hash differs from the loaded template: the embedded
+        /// template changed underneath whatever cached the recorded hash.
+        case mismatch(recorded: String, current: String)
+    }
+
+    /// Compares the loaded model's chat-template digest against the one recorded
+    /// in its on-disk package manifest, if any. Pure read — never throws, never
+    /// mutates state, never touches the renderer.
+    func chatTemplateIntegrityStatus(for modelInfo: ModelInfo) -> ChatTemplateIntegrityStatus {
+        guard let currentHash = modelInfo.chatTemplateSHA256,
+              let recordedHash = recordedChatTemplateSHA256(forModelAt: modelInfo.url) else {
+            return .noRecordedHash
+        }
+        return recordedHash == currentHash
+            ? .match
+            : .mismatch(recorded: recordedHash, current: currentHash)
+    }
+
+    /// Reads the recorded chat-template SHA-256 from the `.manifoldkit-package.json`
+    /// sidecar next to `modelURL`, or `nil` when there is no sidecar, it cannot be
+    /// decoded, or it carries no recorded hash.
+    ///
+    /// A missing or legacy sidecar is the common case (single-file GGUFs have no
+    /// sidecar at all), so a read/decode failure is treated as "nothing to compare"
+    /// rather than an error — this is a trust-boundary read, kept deliberately quiet.
+    private func recordedChatTemplateSHA256(forModelAt modelURL: URL) -> String? {
+        let manifestURL = modelURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(DownloadedModelPackageManifest.fileName)
+        do {
+            let data = try Data(contentsOf: manifestURL)
+            let manifest = try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data)
+            return manifest.chatTemplateSHA256
+        } catch {
+            return nil
         }
     }
 

--- a/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
+++ b/Sources/ManifoldInference/Services/ModelLifecycleCoordinator.swift
@@ -329,6 +329,17 @@ final class ModelLifecycleCoordinator {
         // template. This is an observability signal only: it never gates the
         // load and never feeds the renderer (which reads `chatTemplateRaw`
         // directly), so it cannot reintroduce the #1909 template→render coupling.
+        //
+        // ACTIVATION (Piece 1 reads; the writer is deferred): no production path
+        // yet records `chatTemplateSHA256` for a template-bearing package, so this
+        // mismatch branch is currently inert in the field. The only sidecar writers
+        // emit `.diffusion` packages (no chat template); text packages
+        // (`.mlxSnapshot` / single-file GGUF) carry templates but are written
+        // without a `.manifoldkit-package.json`. Detection goes live once the
+        // download path records the template digest for text packages (#1932
+        // Piece 2). The read path, tests, and warning ship now so the writer is a
+        // one-line populate when it lands. End-to-end coverage drives this branch
+        // via a hand-written sidecar (see ChatTemplateIntegrityTests).
         if case let .mismatch(recorded, current) = chatTemplateIntegrityStatus(for: modelInfo) {
             Log.inference.warning(
                 "Chat template changed since the recorded manifest hash for model '\(modelInfo.name)' (recorded \(recorded, privacy: .public), now \(current, privacy: .public)). A cached selection or preset may target the old template; rendering proceeds with the current embedded template (#1932)."

--- a/Sources/ManifoldModelCatalog/ModelInfo.swift
+++ b/Sources/ManifoldModelCatalog/ModelInfo.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 // @_spi(BackendInternals): GGUFKVCacheEstimator was promoted from `package`
 // to SPI-public in v0.48 (PR C2) for the manifold-llama companion package.
@@ -39,6 +40,21 @@ public struct ModelInfo: Identifiable, Hashable, Sendable {
     public var modelArchitecture: String?
     /// The raw Jinja chat template string from `tokenizer.chat_template`, if present.
     public var chatTemplateRaw: String?
+
+    /// SHA-256 (lowercase hex) of ``chatTemplateRaw``'s UTF-8 bytes, or `nil`
+    /// when no template is present.
+    ///
+    /// Computed — never stored — so it can never desync from the template it
+    /// describes. Recorded in the on-disk package manifest at download time; the
+    /// load path compares the recorded value against this digest to detect a
+    /// GGUF-embedded template that changed underneath a cached selection and
+    /// warn (it never alters rendering, which reads ``chatTemplateRaw`` directly).
+    /// See #1932.
+    public var chatTemplateSHA256: String? {
+        guard let chatTemplateRaw else { return nil }
+        let digest = SHA256.hash(data: Data(chatTemplateRaw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
     /// Best-effort KV-cache bytes-per-token estimate derived from GGUF metadata.
     public var estimatedKVBytesPerToken: UInt64?
 

--- a/Tests/ManifoldHardwareTests/DownloadedModelPackageManifestTests.swift
+++ b/Tests/ManifoldHardwareTests/DownloadedModelPackageManifestTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import ManifoldHardware
+
+/// Codable round-trip and backward-compatibility coverage for
+/// ``DownloadedModelPackageManifest``, focused on the optional
+/// `chatTemplateSHA256` field added for chat-template integrity (#1932).
+final class DownloadedModelPackageManifestTests: XCTestCase {
+
+    private func roundTrip(_ manifest: DownloadedModelPackageManifest) throws -> DownloadedModelPackageManifest {
+        let data = try JSONEncoder().encode(manifest)
+        return try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data)
+    }
+
+    /// A manifest carrying a hash survives an encode/decode round-trip intact.
+    func test_roundTrip_withChatTemplateHash() throws {
+        let manifest = DownloadedModelPackageManifest(
+            packageKind: .mlxSnapshot,
+            id: "org/model",
+            displayName: "Model",
+            files: ["config.json", "model.safetensors"],
+            chatTemplateSHA256: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+
+        let decoded = try roundTrip(manifest)
+
+        XCTAssertEqual(decoded, manifest)
+        XCTAssertEqual(
+            decoded.chatTemplateSHA256,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+    }
+
+    /// A manifest with no hash round-trips with the field nil.
+    func test_roundTrip_withoutChatTemplateHash() throws {
+        let manifest = DownloadedModelPackageManifest(
+            packageKind: .diffusion,
+            id: "org/diffusion",
+            displayName: "Diffusion",
+            files: ["model_index.json"]
+        )
+
+        let decoded = try roundTrip(manifest)
+
+        XCTAssertEqual(decoded, manifest)
+        XCTAssertNil(decoded.chatTemplateSHA256)
+    }
+
+    /// **Backward compat:** a pre-#1932 sidecar payload that predates the
+    /// `chatTemplateSHA256` key must still decode, leaving the field nil.
+    func test_legacyPayloadWithoutField_stillDecodes() throws {
+        let legacyJSON = """
+        {
+          "packageKind": "mlxSnapshot",
+          "id": "org/legacy",
+          "displayName": "Legacy",
+          "files": ["config.json", "model.safetensors"]
+        }
+        """
+
+        let data = Data(legacyJSON.utf8)
+        let decoded = try JSONDecoder().decode(DownloadedModelPackageManifest.self, from: data)
+
+        XCTAssertEqual(decoded.id, "org/legacy")
+        XCTAssertEqual(decoded.files, ["config.json", "model.safetensors"])
+        XCTAssertNil(decoded.chatTemplateSHA256, "Legacy payloads must decode with a nil hash, not fail")
+    }
+}

--- a/Tests/ManifoldInferenceTests/ChatTemplateIntegrityTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateIntegrityTests.swift
@@ -3,57 +3,68 @@ import XCTest
 import ManifoldHardware
 import ManifoldTestSupport
 
-/// Load-time chat-template integrity coverage (Piece 1 of #1932).
+/// Load-time chat-template integrity coverage (#1932), **live for single-file GGUF**
+/// via record-on-first-observation into a per-file `ChatTemplateIntegritySidecar`.
 ///
-/// A mismatch between a model's freshly-loaded chat template and the digest
-/// recorded in its `.manifoldkit-package.json` sidecar must **warn and proceed**
-/// — never throw, never gate, never alter which template drives rendering.
+/// The first load records the template digest; later loads compare against it.
+/// A mismatch must **warn and proceed** — never throw, never gate, never alter
+/// which template drives rendering. Tests drive through the coordinator with a
+/// real sidecar file on disk to prove the mechanism is no longer inert.
 @MainActor
 final class ChatTemplateIntegrityTests: XCTestCase {
 
     // MARK: - Fixtures
 
-    private var packageDir: URL!
+    private var modelsDir: URL!
 
     override func setUp() async throws {
         try await super.setUp()
-        packageDir = FileManager.default.temporaryDirectory
+        modelsDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("ChatTemplateIntegrityTests-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
     }
 
     override func tearDown() async throws {
-        if let packageDir { try? FileManager.default.removeItem(at: packageDir) }
-        packageDir = nil
+        if let modelsDir {
+            // Restore writability first so a read-only-dir test can still be cleaned up.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: modelsDir.path)
+            try? FileManager.default.removeItem(at: modelsDir)
+        }
+        modelsDir = nil
         try await super.tearDown()
     }
 
-    private let template = "{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}"
+    private let templateA = "{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}"
+    private let templateB = "{{ bos }}{% for m in messages %}<|{{ m.role }}|>{{ m.content }}{% endfor %}"
 
-    /// Builds a `ModelInfo` whose `url` lives inside `packageDir`, carrying the
-    /// shared chat template.
-    private func makeModelInfo() -> ModelInfo {
+    private func modelURL(_ fileName: String = "model.gguf") -> URL {
+        modelsDir.appendingPathComponent(fileName)
+    }
+
+    /// A single-file GGUF `ModelInfo` carrying `template`, located in `modelsDir`.
+    private func makeModelInfo(template: String?, fileName: String = "model.gguf") -> ModelInfo {
         ModelInfo(
             name: "Test",
-            fileName: "model.gguf",
-            url: packageDir.appendingPathComponent("model.gguf"),
+            fileName: fileName,
+            url: modelURL(fileName),
             fileSize: 0,
             modelType: .gguf,
             chatTemplateRaw: template
         )
     }
 
-    /// Writes a sidecar manifest next to the model recording `hash`.
-    private func writeSidecar(recording hash: String?) throws {
-        let manifest = DownloadedModelPackageManifest(
-            packageKind: .mlxSnapshot,
-            id: "org/model",
-            displayName: "Test",
-            files: ["model.gguf"],
-            chatTemplateSHA256: hash
-        )
-        let data = try JSONEncoder().encode(manifest)
-        try data.write(to: packageDir.appendingPathComponent(DownloadedModelPackageManifest.fileName))
+    /// Writes a per-file integrity sidecar recording `hash` next to the model.
+    private func writePerFileSidecar(recording hash: String, fileName: String = "model.gguf") throws {
+        let url = ChatTemplateIntegritySidecar.sidecarURL(forModelAt: modelURL(fileName))
+        let data = try JSONEncoder().encode(ChatTemplateIntegritySidecar(chatTemplateSHA256: hash))
+        try data.write(to: url)
+    }
+
+    /// Decodes the recorded hash from the on-disk sidecar, or `nil` if absent.
+    private func recordedSidecarHash(fileName: String = "model.gguf") -> String? {
+        let url = ChatTemplateIntegritySidecar.sidecarURL(forModelAt: modelURL(fileName))
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(ChatTemplateIntegritySidecar.self, from: data).chatTemplateSHA256
     }
 
     private func makeCoordinator() -> ModelLifecycleCoordinator {
@@ -64,81 +75,149 @@ final class ChatTemplateIntegrityTests: XCTestCase {
         return coordinator
     }
 
+    private func load(_ coordinator: ModelLifecycleCoordinator, _ model: ModelInfo) async throws {
+        try await coordinator.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+    }
+
     // MARK: - Integrity status (pure comparison)
 
     func test_integrityStatus_noSidecar_isNoRecordedHash() {
-        let coordinator = makeCoordinator()
-
-        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: makeModelInfo()), .noRecordedHash)
+        XCTAssertEqual(makeCoordinator().chatTemplateIntegrityStatus(for: makeModelInfo(template: templateA)), .noRecordedHash)
     }
 
     func test_integrityStatus_matchingHash_isMatch() throws {
-        let model = makeModelInfo()
-        try writeSidecar(recording: model.chatTemplateSHA256)
-        let coordinator = makeCoordinator()
+        let model = makeModelInfo(template: templateA)
+        try writePerFileSidecar(recording: try XCTUnwrap(model.chatTemplateSHA256))
 
-        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: model), .match)
+        XCTAssertEqual(makeCoordinator().chatTemplateIntegrityStatus(for: model), .match)
     }
 
     func test_integrityStatus_changedTemplate_isMismatch() throws {
-        let model = makeModelInfo()
-        let recorded = String(repeating: "0", count: 64) // a hash that cannot equal the live digest
-        try writeSidecar(recording: recorded)
+        let model = makeModelInfo(template: templateA)
+        let recorded = String(repeating: "0", count: 64) // cannot equal the live digest
+        try writePerFileSidecar(recording: recorded)
         let coordinator = makeCoordinator()
 
         let current = try XCTUnwrap(model.chatTemplateSHA256)
-        XCTAssertEqual(
-            coordinator.chatTemplateIntegrityStatus(for: model),
-            .mismatch(recorded: recorded, current: current)
-        )
-        // Sabotage check (verifies the assertion above is load-bearing): a sidecar
-        // recording the *live* digest must NOT report a mismatch.
-        try writeSidecar(recording: current)
+        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: model), .mismatch(recorded: recorded, current: current))
+
+        // Inline negative guard: a sidecar recording the *live* digest must NOT mismatch.
+        try writePerFileSidecar(recording: current)
         if case .mismatch = coordinator.chatTemplateIntegrityStatus(for: model) {
             XCTFail("A matching recorded hash must not report a mismatch")
         }
     }
 
-    // MARK: - Load path
+    // MARK: - Liveness (record-on-first-observation, through the coordinator)
 
-    /// A recorded-hash mismatch warns but the load still proceeds (no throw),
-    /// and the embedded template still reaches the renderer unchanged.
-    func test_load_withMismatchedHash_proceedsAndKeepsTemplate() async throws {
-        try writeSidecar(recording: String(repeating: "a", count: 64))
+    /// **First load, no sidecar:** the coordinator records a sidecar with the
+    /// template's correct digest, and the pre-write status is silent (no warning).
+    func test_firstLoad_writesSidecarWithCorrectHash_andIsSilent() async throws {
+        let model = makeModelInfo(template: templateA)
         let coordinator = makeCoordinator()
 
-        try await coordinator.loadModel(
-            from: makeModelInfo(),
-            plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048)
-        )
+        // No sidecar yet → nothing to compare → no warning.
+        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: model), .noRecordedHash)
+        XCTAssertNil(recordedSidecarHash(), "Precondition: no sidecar before first load")
 
-        XCTAssertTrue(coordinator.isModelLoaded, "A template mismatch must warn, not block the load")
-        XCTAssertEqual(coordinator.selectedChatTemplateRaw, template,
-                       "The loaded model's embedded template must still drive rendering after a mismatch")
+        try await load(coordinator, model)
+
+        XCTAssertTrue(coordinator.isModelLoaded)
+        XCTAssertEqual(recordedSidecarHash(), model.chatTemplateSHA256,
+                       "First load must record the live template digest into the sidecar")
     }
 
-    /// **Anti-regression guard (#1909):** the integrity check must not perturb
-    /// what drives rendering. `selectedChatTemplateRaw` must be byte-identical
-    /// whether the recorded hash matches, mismatches, or is absent entirely.
+    /// **Second load, unchanged template (false-positive / consistency guard):**
+    /// after the first load records the hash, loading the identical template again
+    /// reports `.match` — the write and load digests hash the same source string,
+    /// so an unchanged template must never warn.
+    func test_secondLoad_unchangedTemplate_matchesNoFalsePositive() async throws {
+        let model = makeModelInfo(template: templateA)
+
+        try await load(makeCoordinator(), model) // records baseline
+
+        let recorded = try XCTUnwrap(recordedSidecarHash())
+        XCTAssertEqual(recorded, model.chatTemplateSHA256)
+
+        let second = makeCoordinator()
+        XCTAssertEqual(second.chatTemplateIntegrityStatus(for: model), .match,
+                       "An unchanged template must report .match, not a spurious mismatch")
+        try await load(second, model)
+        XCTAssertTrue(second.isModelLoaded)
+        XCTAssertEqual(recordedSidecarHash(), recorded, "Idempotent: a matching reload must not rewrite the sidecar")
+    }
+
+    /// **Second load, mutated template (the liveness proof):** after a baseline is
+    /// recorded for templateA, loading templateB at the same path reports a
+    /// `.mismatch` carrying both digests, the load still completes, and the
+    /// recorded baseline is NOT silently re-written (drift keeps warning).
+    func test_secondLoad_mutatedTemplate_warnsAndProceeds() async throws {
+        let original = makeModelInfo(template: templateA)
+        try await load(makeCoordinator(), original) // records hash(templateA)
+        let hashA = try XCTUnwrap(recordedSidecarHash())
+
+        // The GGUF on disk is swapped: same path, different embedded template.
+        let mutated = makeModelInfo(template: templateB)
+        let hashB = try XCTUnwrap(mutated.chatTemplateSHA256)
+        XCTAssertNotEqual(hashA, hashB, "Fixture sanity: the two templates must hash differently")
+
+        let coordinator = makeCoordinator()
+
+        // The exact liveness assertion: the recorded baseline (hashA) is compared
+        // against the freshly-loaded template (hashB) and reported as a mismatch.
+        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: mutated),
+                       .mismatch(recorded: hashA, current: hashB),
+                       "A swapped template must surface as a mismatch carrying both digests")
+
+        try await load(coordinator, mutated)
+
+        XCTAssertTrue(coordinator.isModelLoaded, "A template mismatch must warn, not block the load")
+        XCTAssertEqual(coordinator.selectedChatTemplateRaw, templateB,
+                       "The freshly-loaded template must still drive rendering after a mismatch")
+        XCTAssertEqual(recordedSidecarHash(), hashA,
+                       "Idempotent: a mismatch must not re-baseline the sidecar (drift keeps warning)")
+    }
+
+    /// **Best-effort write:** if the sidecar cannot be written (read-only models
+    /// directory), the load still completes without crashing or throwing.
+    func test_firstLoad_readOnlyDir_proceedsWithoutCrash() async throws {
+        let model = makeModelInfo(template: templateA)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: modelsDir.path)
+
+        let coordinator = makeCoordinator()
+        try await load(coordinator, model)
+
+        XCTAssertTrue(coordinator.isModelLoaded, "A sidecar write failure must not block the load")
+        // Restore writability so the assertion and teardown can read/clean the dir.
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: modelsDir.path)
+        XCTAssertNil(recordedSidecarHash(), "No sidecar should exist when the write failed")
+    }
+
+    // MARK: - #1909 anti-regression
+
+    /// The integrity check must not perturb what drives rendering:
+    /// `selectedChatTemplateRaw` must be byte-identical whether the recorded hash
+    /// matches, mismatches, or is absent.
     func test_load_integrityCheck_doesNotAlterRenderedTemplate() async throws {
-        let model = makeModelInfo()
+        let model = makeModelInfo(template: templateA)
+        let liveHash = try XCTUnwrap(model.chatTemplateSHA256)
 
-        // 1. Matching sidecar.
-        try writeSidecar(recording: model.chatTemplateSHA256)
+        // 1. Matching baseline already on disk.
+        try writePerFileSidecar(recording: liveHash)
         let matching = makeCoordinator()
-        try await matching.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+        try await load(matching, model)
 
-        // 2. Mismatching sidecar.
-        try writeSidecar(recording: String(repeating: "f", count: 64))
+        // 2. Mismatching baseline.
+        try writePerFileSidecar(recording: String(repeating: "f", count: 64))
         let mismatching = makeCoordinator()
-        try await mismatching.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+        try await load(mismatching, model)
 
-        // 3. No sidecar at all.
-        try FileManager.default.removeItem(at: packageDir.appendingPathComponent(DownloadedModelPackageManifest.fileName))
+        // 3. No baseline at all.
+        try FileManager.default.removeItem(at: ChatTemplateIntegritySidecar.sidecarURL(forModelAt: modelURL()))
         let absent = makeCoordinator()
-        try await absent.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+        try await load(absent, model)
 
-        XCTAssertEqual(matching.selectedChatTemplateRaw, template)
+        XCTAssertEqual(matching.selectedChatTemplateRaw, templateA)
         XCTAssertEqual(mismatching.selectedChatTemplateRaw, matching.selectedChatTemplateRaw,
                        "A hash mismatch must leave the render-driving template identical to the match case")
         XCTAssertEqual(absent.selectedChatTemplateRaw, matching.selectedChatTemplateRaw,

--- a/Tests/ManifoldInferenceTests/ChatTemplateIntegrityTests.swift
+++ b/Tests/ManifoldInferenceTests/ChatTemplateIntegrityTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import ManifoldInference
+import ManifoldHardware
+import ManifoldTestSupport
+
+/// Load-time chat-template integrity coverage (Piece 1 of #1932).
+///
+/// A mismatch between a model's freshly-loaded chat template and the digest
+/// recorded in its `.manifoldkit-package.json` sidecar must **warn and proceed**
+/// — never throw, never gate, never alter which template drives rendering.
+@MainActor
+final class ChatTemplateIntegrityTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var packageDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        packageDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChatTemplateIntegrityTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        if let packageDir { try? FileManager.default.removeItem(at: packageDir) }
+        packageDir = nil
+        try await super.tearDown()
+    }
+
+    private let template = "{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}"
+
+    /// Builds a `ModelInfo` whose `url` lives inside `packageDir`, carrying the
+    /// shared chat template.
+    private func makeModelInfo() -> ModelInfo {
+        ModelInfo(
+            name: "Test",
+            fileName: "model.gguf",
+            url: packageDir.appendingPathComponent("model.gguf"),
+            fileSize: 0,
+            modelType: .gguf,
+            chatTemplateRaw: template
+        )
+    }
+
+    /// Writes a sidecar manifest next to the model recording `hash`.
+    private func writeSidecar(recording hash: String?) throws {
+        let manifest = DownloadedModelPackageManifest(
+            packageKind: .mlxSnapshot,
+            id: "org/model",
+            displayName: "Test",
+            files: ["model.gguf"],
+            chatTemplateSHA256: hash
+        )
+        let data = try JSONEncoder().encode(manifest)
+        try data.write(to: packageDir.appendingPathComponent(DownloadedModelPackageManifest.fileName))
+    }
+
+    private func makeCoordinator() -> ModelLifecycleCoordinator {
+        let coordinator = ModelLifecycleCoordinator()
+        coordinator.registerBackendFactory { type in
+            type == .gguf ? MockInferenceBackend() : nil
+        }
+        return coordinator
+    }
+
+    // MARK: - Integrity status (pure comparison)
+
+    func test_integrityStatus_noSidecar_isNoRecordedHash() {
+        let coordinator = makeCoordinator()
+
+        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: makeModelInfo()), .noRecordedHash)
+    }
+
+    func test_integrityStatus_matchingHash_isMatch() throws {
+        let model = makeModelInfo()
+        try writeSidecar(recording: model.chatTemplateSHA256)
+        let coordinator = makeCoordinator()
+
+        XCTAssertEqual(coordinator.chatTemplateIntegrityStatus(for: model), .match)
+    }
+
+    func test_integrityStatus_changedTemplate_isMismatch() throws {
+        let model = makeModelInfo()
+        let recorded = String(repeating: "0", count: 64) // a hash that cannot equal the live digest
+        try writeSidecar(recording: recorded)
+        let coordinator = makeCoordinator()
+
+        let current = try XCTUnwrap(model.chatTemplateSHA256)
+        XCTAssertEqual(
+            coordinator.chatTemplateIntegrityStatus(for: model),
+            .mismatch(recorded: recorded, current: current)
+        )
+        // Sabotage check (verifies the assertion above is load-bearing): a sidecar
+        // recording the *live* digest must NOT report a mismatch.
+        try writeSidecar(recording: current)
+        if case .mismatch = coordinator.chatTemplateIntegrityStatus(for: model) {
+            XCTFail("A matching recorded hash must not report a mismatch")
+        }
+    }
+
+    // MARK: - Load path
+
+    /// A recorded-hash mismatch warns but the load still proceeds (no throw),
+    /// and the embedded template still reaches the renderer unchanged.
+    func test_load_withMismatchedHash_proceedsAndKeepsTemplate() async throws {
+        try writeSidecar(recording: String(repeating: "a", count: 64))
+        let coordinator = makeCoordinator()
+
+        try await coordinator.loadModel(
+            from: makeModelInfo(),
+            plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048)
+        )
+
+        XCTAssertTrue(coordinator.isModelLoaded, "A template mismatch must warn, not block the load")
+        XCTAssertEqual(coordinator.selectedChatTemplateRaw, template,
+                       "The loaded model's embedded template must still drive rendering after a mismatch")
+    }
+
+    /// **Anti-regression guard (#1909):** the integrity check must not perturb
+    /// what drives rendering. `selectedChatTemplateRaw` must be byte-identical
+    /// whether the recorded hash matches, mismatches, or is absent entirely.
+    func test_load_integrityCheck_doesNotAlterRenderedTemplate() async throws {
+        let model = makeModelInfo()
+
+        // 1. Matching sidecar.
+        try writeSidecar(recording: model.chatTemplateSHA256)
+        let matching = makeCoordinator()
+        try await matching.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+
+        // 2. Mismatching sidecar.
+        try writeSidecar(recording: String(repeating: "f", count: 64))
+        let mismatching = makeCoordinator()
+        try await mismatching.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+
+        // 3. No sidecar at all.
+        try FileManager.default.removeItem(at: packageDir.appendingPathComponent(DownloadedModelPackageManifest.fileName))
+        let absent = makeCoordinator()
+        try await absent.loadModel(from: model, plan: ModelLoadPlan.systemManaged(requestedContextSize: 2048))
+
+        XCTAssertEqual(matching.selectedChatTemplateRaw, template)
+        XCTAssertEqual(mismatching.selectedChatTemplateRaw, matching.selectedChatTemplateRaw,
+                       "A hash mismatch must leave the render-driving template identical to the match case")
+        XCTAssertEqual(absent.selectedChatTemplateRaw, matching.selectedChatTemplateRaw,
+                       "Absence of a recorded hash must leave the render-driving template identical")
+    }
+}

--- a/Tests/ManifoldModelCatalogTests/ModelInfoChatTemplateHashTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ModelInfoChatTemplateHashTests.swift
@@ -30,18 +30,18 @@ final class ModelInfoChatTemplateHashTests: XCTestCase {
     }
 
     /// A digest is 64 lowercase hex characters and stable across reads.
-    func test_chatTemplateSHA256_isStableLowercaseHex() {
+    func test_chatTemplateSHA256_isStableLowercaseHex() throws {
         let template = "{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}"
         let model = makeModel(chatTemplateRaw: template)
 
         let first = model.chatTemplateSHA256
         let second = model.chatTemplateSHA256
 
-        let digest = try? XCTUnwrap(first)
+        let digest = try XCTUnwrap(first)
         XCTAssertEqual(first, second, "Digest must be deterministic for the same template")
-        XCTAssertEqual(digest?.count, 64)
-        XCTAssertEqual(digest, digest?.lowercased(), "Digest must be lowercase hex")
-        XCTAssertTrue(digest?.allSatisfy(\.isHexDigit) ?? false)
+        XCTAssertEqual(digest.count, 64)
+        XCTAssertEqual(digest, digest.lowercased(), "Digest must be lowercase hex")
+        XCTAssertTrue(digest.allSatisfy(\.isHexDigit))
     }
 
     /// Distinct templates produce distinct digests (collision sanity).

--- a/Tests/ManifoldModelCatalogTests/ModelInfoChatTemplateHashTests.swift
+++ b/Tests/ManifoldModelCatalogTests/ModelInfoChatTemplateHashTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import ManifoldModelCatalog
+
+/// Verifies ``ModelInfo/chatTemplateSHA256`` — the chat-template integrity digest
+/// (Piece 1 of #1932). The hash is a verification signal only; it must never
+/// influence which template drives rendering.
+final class ModelInfoChatTemplateHashTests: XCTestCase {
+
+    private func makeModel(chatTemplateRaw: String?) -> ModelInfo {
+        ModelInfo(
+            name: "Test",
+            fileName: "test.gguf",
+            url: URL(fileURLWithPath: "/virtual/test.gguf"),
+            fileSize: 0,
+            modelType: .gguf,
+            chatTemplateRaw: chatTemplateRaw
+        )
+    }
+
+    /// The digest is the lowercase-hex SHA-256 of the template's UTF-8 bytes.
+    /// `2cf24dba…` is the canonical SHA-256 of the ASCII string "hello",
+    /// independently verifiable via `printf 'hello' | shasum -a 256`.
+    func test_chatTemplateSHA256_matchesKnownVector() {
+        let model = makeModel(chatTemplateRaw: "hello")
+
+        XCTAssertEqual(
+            model.chatTemplateSHA256,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+    }
+
+    /// A digest is 64 lowercase hex characters and stable across reads.
+    func test_chatTemplateSHA256_isStableLowercaseHex() {
+        let template = "{% for m in messages %}{{ m.role }}: {{ m.content }}{% endfor %}"
+        let model = makeModel(chatTemplateRaw: template)
+
+        let first = model.chatTemplateSHA256
+        let second = model.chatTemplateSHA256
+
+        let digest = try? XCTUnwrap(first)
+        XCTAssertEqual(first, second, "Digest must be deterministic for the same template")
+        XCTAssertEqual(digest?.count, 64)
+        XCTAssertEqual(digest, digest?.lowercased(), "Digest must be lowercase hex")
+        XCTAssertTrue(digest?.allSatisfy(\.isHexDigit) ?? false)
+    }
+
+    /// Distinct templates produce distinct digests (collision sanity).
+    func test_chatTemplateSHA256_differsForDifferentTemplates() {
+        let a = makeModel(chatTemplateRaw: "template-A")
+        let b = makeModel(chatTemplateRaw: "template-B")
+
+        XCTAssertNotNil(a.chatTemplateSHA256)
+        XCTAssertNotEqual(a.chatTemplateSHA256, b.chatTemplateSHA256)
+    }
+
+    /// No template → no digest.
+    func test_chatTemplateSHA256_nilWhenNoTemplate() {
+        let model = makeModel(chatTemplateRaw: nil)
+
+        XCTAssertNil(model.chatTemplateSHA256)
+    }
+}


### PR DESCRIPTION
Detect when a single-file GGUF's embedded chat template changes underneath a cached selection and **fail loud (warn), not silent**. This is a verification/observability feature — it does **not** change rendering behavior.

### What ships (Piece 1 of #1932) — now **live for single-file GGUF**
- **`ModelInfo.chatTemplateSHA256`** — computed SHA-256 (lowercase hex) of `chatTemplateRaw`'s UTF-8 bytes, `nil` when no template. Computed (not stored) so it can never desync from the template.
- **`ChatTemplateIntegritySidecar`** (new, in `ManifoldHardware`) — a tiny per-file, warn-only `{ chatTemplateSHA256 }` record stored at `<model>.gguf.template.json`. **Deliberately separate from `GGUFSignedManifest` / `<file>.manifest.json`**, which hashes *weight bytes* and *throws* on mismatch (tampering = fail closed); template drift must only warn and proceed, so the two semantics never conflate. Keyed to the model filename so co-located GGUFs can't collide.
- **`ModelLifecycleCoordinator`** — **record-on-first-observation**: at load, once `chatTemplateRaw` is established for a single-file GGUF, if no sidecar exists it writes one (best-effort `do/catch` → `Log.warning`, never blocks the load). Every later load reads the sidecar and, on a digest mismatch, emits `Log.inference.warning` and **proceeds**. Idempotent (only writes when absent → real drift keeps warning, never silently re-baselined). Never feeds the renderer.
- **`DownloadedModelPackageManifest.chatTemplateSHA256`** — retained as the *future* multi-file/package recording home (the reader falls back to it); see gap below.

### Why this is consistency-safe (no false positives)
GGUF's `chatTemplateRaw` comes from `GGUFMetadataReader` at **both** record-time and load-time, so the recorded and compared digests hash byte-identical input. An unchanged template can never produce a spurious "template changed" warning (covered by a dedicated test).

### Residual gap (honest scope)
**Single-file GGUF only.** MLX-snapshot and diffusion packages are **not** covered: in this codebase an MLX `ModelInfo` carries **no** load-time `chatTemplateRaw` (only the GGUF initializers populate it), and routing one through `ModelInfo.chatTemplateRaw` would change MLX rendering/stop-sequences because `GenerationQueue` consumes `selectedChatTemplateRaw` un-gated — out of bounds for a "must not change rendering" feature. Multi-file/MLX coverage (recording into the package manifest field, or a rendering-neutral `tokenizer_config.json` reader) is a documented follow-up. No `ModelProfileRecord`/preset store (deferred Piece 2).

### Tests
- `chatTemplateSHA256`: stable/correct hex digest for a known vector (`printf 'hello' | shasum -a 256` → `2cf24dba…`); `nil` when `chatTemplateRaw` is nil.
- `DownloadedModelPackageManifest` round-trips with/without the field; a legacy JSON payload lacking it still decodes.
- **Liveness (through the coordinator, real sidecar on disk):** first load writes the sidecar with the correct hash and stays silent; second load with an unchanged template reports `.match` (false-positive guard); second load with a **mutated** template reports `.mismatch` carrying both digests, the load **proceeds**, and the baseline is not re-written; a read-only models dir makes the write fail gracefully and the load still completes.
- Anti-regression (#1909): match vs mismatch vs no-sidecar leave `selectedChatTemplateRaw` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)