### PR TITLE
ci: skip CI on draft PRs + add mandatory /ship draft-PR review loop

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 
 # /ship — draft-PR review-and-fix loop
 
-This repo gates CI to **skip draft PRs** (`ci.yml`/`readme-snippets.yml`/`cold-start-human.yml`
+This repo gates CI to **skip draft PRs** (`ci.yml`/`readme-snippets.yml`/`cold-start-human.yml`/`build-modes.yml`
 guard on `draft == false`, with `ready_for_review` in the trigger types). So a draft PR is a
 **zero-CI staging area**, and `gh pr ready` is the single, deliberate CI trigger. Use that window
 to catch green-but-wrong code *before* paying for a 10×-billed macOS run. See CLAUDE.md

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: ship
+description: >-
+  Ship a non-trivial change through the mandatory draft-PR review-and-fix loop
+  before CI. Use when asked to implement an issue/feature/fix as a PR, or to
+  "ship", "land", or "PR" a non-trivial change. Implements in an isolated
+  worktree, opens a DRAFT PR, runs a skeptical reviewer subagent, fixes findings,
+  gates on the full affected test targets (incl. audit suites), then marks ready
+  — which is the single trigger that starts CI (drafts run zero CI in this repo).
+---
+
+# /ship — draft-PR review-and-fix loop
+
+This repo gates CI to **skip draft PRs** (`ci.yml`/`readme-snippets.yml`/`cold-start-human.yml`
+guard on `draft == false`, with `ready_for_review` in the trigger types). So a draft PR is a
+**zero-CI staging area**, and `gh pr ready` is the single, deliberate CI trigger. Use that window
+to catch green-but-wrong code *before* paying for a 10×-billed macOS run. See CLAUDE.md
+§"Draft-PR review loop".
+
+## When this applies
+
+**Non-trivial** = touches **2+ files** OR adds/changes **behavior or logic**. Trivial single-file
+mechanical edits (typo, version bump, comment/doc-only, pure rename) skip this loop — make a normal
+PR. When in doubt, run the loop.
+
+## The loop
+
+### 1. Implement (isolated worktree off `origin/main`)
+- `git fetch origin` then create a worktree on a fresh branch off `origin/main` — **never** the
+  current working branch. Do all edits there.
+- Follow the change's conventions (CLAUDE.md): async/await + `@Observable`/`@MainActor`; no `try?`
+  in production paths (`do/catch` + `Log.*`); no `assertionFailure`/`fatalError` on recoverable
+  paths; inject `UserDefaults`; in-memory SwiftData (never mock persistence). Tests + docs ship in
+  the same PR.
+- **Open the DRAFT PR the moment it compiles** (`swift build`) — protect work before the long gate.
+  `gh pr create --draft --title "<conventional title>" --body "..."`. Never `--auto`/`--merge`.
+
+### 2. Review (skeptical subagent)
+Dispatch a reviewer subagent against the diff (`gh pr diff <N>` + read changed files in full).
+It must be **adversarial** — assume there are bugs — and check:
+- **Correctness** and the **premise/assumptions** (verify cited file:line anchors against `Sources/`).
+- **Is the feature actually live, or inert?** A read path with no writer is dead code — the #2064
+  lesson (a hash recorded nowhere never fires). Trace every consumer/producer.
+- **Scope discipline** — no unrelated changes; deferred work stays deferred.
+- **Conventions** — the CLAUDE.md list above; minimal `public` surface.
+- **Tests prove the behavior** (not vacuous asserts) and a sabotage check would fail if the code broke.
+
+### 3. Fix
+Apply findings; push to the **same** branch (still draft). Loop step 2 again if the fixes are
+substantial.
+
+### 4. Local gate — FULL affected targets, not `--filter <featureSuite>`
+> Cross-cutting audits live **outside** feature suites — `TestSuiteSilentSkipAuditTest`,
+> `SilentCatchAuditTest`, schema/codegen/snapshot guards — so a filtered run goes **green** while CI
+> goes **red**. This is exactly how #2064's `try? XCTUnwrap` reached CI.
+- Run the affected test **target(s) whole**, plus the audit suites by name:
+  `swift test --filter TestSuiteSilentSkipAuditTest` and `swift test --filter SilentCatchAuditTest`.
+- For broad or risky changes, run the full gate: `scripts/test.sh --profile local`.
+- `grep -rnE 'try\? (XCTUnwrap|XCTSkip)' Tests/` must be clean in added files.
+
+### 5. Mark ready (the CI trigger)
+Only when **review-clean AND the local gate is green**: `gh pr ready <N>`. That flip fires
+`ready_for_review` → CI starts. Do **not** merge; the maintainer reviews and merges. Report the PR
+URL and the review/gate summary.
+
+## Worker hygiene (when delegating to subagents)
+- Each worker brief must: sync the branch first (`git fetch && git reset --hard origin/<branch>`),
+  stage **explicit paths** (never `git add -A` — it sweeps `Package.resolved`/build artifacts), and
+  end commit messages with the `Co-Authored-By` trailer.
+- Reviewer and implementer can be the same resumed agent across rounds (it keeps context) or fresh
+  agents — but the reviewer must be told to be adversarial, not confirmatory.

--- a/.github/workflows/build-modes.yml
+++ b/.github/workflows/build-modes.yml
@@ -52,6 +52,10 @@ on:
     - cron: "30 5 * * *"
   workflow_dispatch:
   pull_request:
+    # `ready_for_review` required so a draft→ready transition triggers this
+    # heavy macos-15 build (see CLAUDE.md §"Draft-PR review loop"); the job's
+    # draft guard keeps drafts a zero-CI staging area.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       # Package.resolved only (not Package.swift): a dep-version bump can break
@@ -85,6 +89,10 @@ permissions:
 jobs:
   macos-build-and-audit:
     name: ${{ matrix.mode }} (macOS build + audit)
+    # Draft PRs skip this 10×-billed build — CI runs once the PR is marked
+    # ready. The `event_name != 'pull_request'` clause keeps the nightly
+    # `schedule` and `workflow_dispatch` runs unconditional.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: macos-15
     timeout-minutes: 35
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ on:
       # must re-trigger CI so the action change is validated under the gate.
       - ".github/actions/setup-swift-ci/**"
   pull_request:
+    # `ready_for_review` is REQUIRED here: the default pull_request activity
+    # types omit it, so without it a draft→ready transition would fire no event
+    # and CI would never start until the next push. With it, marking a draft
+    # ready is the single trigger that starts the heavy macOS run — drafts stay
+    # a zero-CI staging area for the review-and-fix loop (see CLAUDE.md §"Draft-PR
+    # review loop"). The `changes` job's draft guard below does the actual gating.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "Sources/**"
@@ -77,6 +84,12 @@ jobs:
   # downstream job that needs it. Avoids spinning up a macOS runner (10× billed)
   # per push just to detect that no relevant files changed.
   changes:
+    # Draft PRs do not run CI: the review-and-fix loop happens on the draft, and
+    # CI fires once when the PR is marked ready (see CLAUDE.md §"Draft-PR review
+    # loop"). Every heavy job `needs: [changes]`, so skipping this gate cascades
+    # the skip to the whole workflow. The `event_name != 'pull_request'` clause
+    # keeps push-to-main runs unconditional (no PR context there).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       server: ${{ steps.filter.outputs.server }}

--- a/.github/workflows/cold-start-human.yml
+++ b/.github/workflows/cold-start-human.yml
@@ -31,6 +31,10 @@ name: cold-start-human
 
 on:
   pull_request:
+    # `ready_for_review` required so a draft→ready transition triggers this
+    # gate (see CLAUDE.md §"Draft-PR review loop"); the job's draft guard keeps
+    # drafts a zero-CI staging area.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "README.md"
@@ -52,6 +56,8 @@ permissions:
 
 jobs:
   cold-start-human:
+    # Skip on draft PRs — CI runs once the PR is marked ready.
+    if: github.event.pull_request.draft == false
     # Match the macos-15 runner the tier-1/2/3 cold-start jobs use so SwiftPM
     # cache keys collide and we share the warm checkouts cache.
     runs-on: macos-15

--- a/.github/workflows/readme-snippets.yml
+++ b/.github/workflows/readme-snippets.yml
@@ -19,6 +19,10 @@ name: README Snippets
 
 on:
   pull_request:
+    # `ready_for_review` required so a draft→ready transition triggers this
+    # gate (see CLAUDE.md §"Draft-PR review loop"); the job's draft guard keeps
+    # drafts a zero-CI staging area.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       # Any of these can invalidate a snippet:
@@ -57,6 +61,8 @@ permissions:
 
 jobs:
   readme-snippets:
+    # Skip on draft PRs — CI runs once the PR is marked ready.
+    if: github.event.pull_request.draft == false
     runs-on: macos-15  # matches ci.yml — Apple Silicon arm64 standard runner
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ xcuserdata/
 .claude/*
 !.claude/README.md
 !.claude/settings.json
+# Shared project skills (e.g. /ship — the draft-PR review loop). Committed like
+# settings.json so the workflow tooling travels with the repo.
+!.claude/skills/
+!.claude/skills/**
 tmp/
 .worktrees/
 # DX walkthrough per-run artefacts — large + ephemeral. Keep only the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,18 @@ All changes go through PRs — direct pushes to `main` are blocked.
 
 CI must pass all suites before merge. `ManifoldBackendsTests` covers the cloud/Foundation/mock surface — the MLX/Llama backend suites run in the companion repos' CI.
 
+### Draft-PR review loop (mandatory for non-trivial PRs)
+
+Every **non-trivial** PR goes through an adversarial review-and-fix loop **on a draft PR, before CI runs**. CI is gated to skip draft PRs (`ci.yml`/`readme-snippets.yml`/`cold-start-human.yml` guard the run on `draft == false`, with `ready_for_review` in the trigger types), so the draft is a **zero-CI staging area** and marking ready is the single, deliberate CI trigger. This keeps green-but-wrong code — and the re-run tax at 10× macOS billing — off CI. Invoke it with the `/ship` skill, or run it by hand:
+
+1. **Implement** in an isolated worktree off `origin/main` (never the current branch). Open a **draft** PR the moment it compiles (protect work early).
+2. **Review** — dispatch a skeptical reviewer subagent against the diff: correctness, the premise/assumptions, scope discipline, conventions, and *is the feature actually live or inert* (the #2064 lesson — a read path with no writer is dead code).
+3. **Fix** — apply findings, push to the same branch (still draft).
+4. **Local gate — the FULL affected test targets, not `--filter <featureSuite>`.** Cross-cutting audits (`TestSuiteSilentSkipAuditTest`, `SilentCatchAuditTest`, schema/codegen/snapshot guards) live *outside* feature suites, so a filtered run goes green while CI goes red (exactly how #2064's `try? XCTUnwrap` reached CI). Run the affected target(s) whole, plus the audit suites by name.
+5. **Mark ready** (`gh pr ready`) **only when review-clean and the local gate is green** — that flip is what triggers CI.
+
+**Non-trivial** = touches **2+ files** OR adds/changes **behavior or logic**. Trivial single-file mechanical edits (typo, version bump, comment/doc-only, pure rename) skip the loop and go straight to a normal PR. When in doubt, run the loop.
+
 ## Issue & PR hygiene
 
 CI is macOS-only (10× billing). Cost scales with **run count**, and each run pays an ~8-min cold `swift build` floor before any test executes. Caching is two-tiered (see the `actions/cache@v5` step in `ci.yml`): compiled **own-module** artifacts (`.build/debug`) are deliberately *not* cached — SwiftPM embeds paths in module fingerprints, so restored objects go stale on miss; tried and reverted twice (#961/#1045 → #1036, ~13% worse). But SwiftPM **dependency** material *is* cached and live — `.build/artifacts` holds the prebuilt ~100 MB llama.cpp xcframework (the real win), plus `.build/checkouts`/`.build/repositories` for the clone phase. The residual floor is local-module + test compile and test execution, neither cacheable. The dominant cost lever is therefore **run count**, not per-run speed. Recent baseline: 183 PRs merged in 14 days across **384 CI runs** (a 2.1× re-run tax). (Note: GitHub's native merge queue is org-only and unavailable on this personal-account repo, so batching is a discipline, not something CI enforces.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ CI must pass all suites before merge. `ManifoldBackendsTests` covers the cloud/F
 
 ### Draft-PR review loop (mandatory for non-trivial PRs)
 
-Every **non-trivial** PR goes through an adversarial review-and-fix loop **on a draft PR, before CI runs**. CI is gated to skip draft PRs (`ci.yml`/`readme-snippets.yml`/`cold-start-human.yml` guard the run on `draft == false`, with `ready_for_review` in the trigger types), so the draft is a **zero-CI staging area** and marking ready is the single, deliberate CI trigger. This keeps green-but-wrong code — and the re-run tax at 10× macOS billing — off CI. Invoke it with the `/ship` skill, or run it by hand:
+Every **non-trivial** PR goes through an adversarial review-and-fix loop **on a draft PR, before CI runs**. CI is gated to skip draft PRs (`ci.yml`/`readme-snippets.yml`/`cold-start-human.yml`/`build-modes.yml` guard the run on `draft == false`, with `ready_for_review` in the trigger types), so the draft is a **zero-CI staging area** and marking ready is the single, deliberate CI trigger. This keeps green-but-wrong code — and the re-run tax at 10× macOS billing — off CI. Invoke it with the `/ship` skill, or run it by hand:
 
 1. **Implement** in an isolated worktree off `origin/main` (never the current branch). Open a **draft** PR the moment it compiles (protect work early).
 2. **Review** — dispatch a skeptical reviewer subagent against the diff: correctness, the premise/assumptions, scope discipline, conventions, and *is the feature actually live or inert* (the #2064 lesson — a read path with no writer is dead code).


### PR DESCRIPTION
## What

Builds in the review-and-fix loop that just caught a green-but-inert feature and a CI-only audit failure on #2064. Makes a **draft PR a zero-CI staging area**, so non-trivial changes get an adversarial review *before* paying for a 10×-billed macOS run, and **marking ready is the single CI trigger**.

## Changes

- **CI gating (3 heavy macOS workflows).** `ci.yml`, `readme-snippets.yml`, `cold-start-human.yml` now guard their run on `draft == false` and add `ready_for_review` to the `pull_request` trigger types.
  - `ci.yml` guards its root `changes` job — every heavy job `needs: [changes]`, so the skip cascades to the whole workflow. The `github.event_name != 'pull_request'` clause keeps **push-to-main runs unconditional**.
  - `ready_for_review` in `types:` is load-bearing: the default activity types omit it, so without it a draft→ready flip would fire **no event** and CI would never start.
  - Cheap ubuntu checks (lint, CodeQL/Analyze) are left unconditional by design — early title/lint feedback, negligible cost.
- **Convention (CLAUDE.md → PR workflow).** New "Draft-PR review loop" section: the mandatory 5-step loop, the **non-trivial threshold** (2+ files OR behavior/logic change; trivial mechanical edits skip), and the **full-target/audit-suite gate** lesson — filtered runs miss cross-cutting audits (`TestSuiteSilentSkipAuditTest` et al.), exactly how #2064's `try? XCTUnwrap` reached CI.
- **`/ship` skill** (`.claude/skills/ship/SKILL.md`) runs the loop end to end. Committed via a `.gitignore` exception (same precedent as `settings.json`) so the tooling travels with the repo.

## Behavior

| Event | Before | After |
|-------|--------|-------|
| Open/push **draft** PR | full CI runs | **no heavy CI** |
| Mark draft **ready** | (no event) | `ready_for_review` → CI runs once |
| Push to **ready** PR | CI runs | CI runs |
| Push to **main** | CI runs | CI runs (unchanged) |

## Why it's safe

Draft PRs can't be merged anyway, so skipping their checks blocks nothing; required checks all run once the PR is marked ready, before merge. Net CI-cost **reduction** (no runs burned on WIP drafts) — aligned with the repo's run-count frugality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)