### PR TITLE
fix(skills): gate SkillLoader default paths to macOS so the iOS umbrella builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,8 @@ Use **Prisma-style Highlights format** (adopted v0.11.2, PR #649): `### Highligh
 
 Workflow: check out the release branch via its worktree, rewrite CHANGELOG.md, amend + force-push, then merge via `gh api -X PUT repos/roryford/ManifoldKit/pulls/<N>/merge -f merge_method=squash`.
 
+**Pre-bump demo-app gate (mandatory before merging the release PR):** run `scripts/demo-apps-build.sh` — it builds both example apps (Advanced iOS, Minimal iOS + macOS) and must be green. The demos consume ManifoldKit by local path, so package drift (retired traits, renamed modules, iOS-unavailable symbols pulled in via the `ManifoldKit` umbrella) breaks them while `swift test` stays green — `swift test` builds for macOS only, so iOS-only API unavailability is invisible to it. This gate is **release-time, not per-PR**: demo breakage is rare and the xcodebuild runs are slow/10×-billed, so paying for them once per release (not per PR) is the right trade. Do not bump the version if it fails.
+
 `README.md` install-pin examples (`from: "x.y.z"`) are bumped automatically by Release Please via the `extra-files` entry in `release-please-config.json` — do not update them manually between releases.
 
 `changelog-lint` accepts: `^### ` (Prisma subheading) or `^\*\*[^*]+\*\* — ` (legacy bold+em-dash). Rejects any unrewritten `* lowercase` Release Please bullet.

--- a/Sources/ManifoldSkills/SkillLoader.swift
+++ b/Sources/ManifoldSkills/SkillLoader.swift
@@ -13,10 +13,15 @@ public struct SkillLoader: Sendable {
     /// Default Claude-Code-compatible search paths in priority order
     /// (last wins on duplicate skill names).
     ///
-    /// Resolved lazily — iOS sandboxed builds with no `$HOME` would otherwise
-    /// crash at module init. The actual filesystem probe is gated by
-    /// `#if os(macOS)` inside `discover()`.
+    /// macOS-only: the home-relative paths use `homeDirectoryForCurrentUser`,
+    /// which is `API_UNAVAILABLE(ios)` — referencing it at all fails to *compile*
+    /// on iOS, so the body must be gated, not merely the runtime probe. On iOS
+    /// this returns `[]` to match `discover()`, which is itself `#if os(macOS)`
+    /// (iOS skill discovery requires an entitlement / app-group design that
+    /// hasn't shipped). Without this gate the `ManifoldKit` umbrella — which
+    /// re-exports `ManifoldSkills` — won't build for iOS at all.
     public static var defaultClaudeCodePaths: [URL] {
+        #if os(macOS)
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser
         let pwd = URL(fileURLWithPath: fm.currentDirectoryPath, isDirectory: true)
@@ -27,6 +32,9 @@ public struct SkillLoader: Sendable {
             pwd.appendingPathComponent(".agents/skills", isDirectory: true),
             pwd.appendingPathComponent(".claude/skills", isDirectory: true),
         ]
+        #else
+        return []
+        #endif
     }
 
     public init(searchPaths: [URL] = SkillLoader.defaultClaudeCodePaths) {

--- a/scripts/demo-apps-build.sh
+++ b/scripts/demo-apps-build.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Pre-release demo-app build gate.
+#
+# Builds BOTH example apps across the platforms they ship for and prints an
+# honest pass/fail summary. Exits non-zero if any configuration fails.
+#
+#   - Advanced  (iOS Simulator)  — full reference app
+#   - Minimal   (iOS Simulator)  — umbrella-import smoke (catches `import
+#                                   ManifoldKit` breakage on iOS)
+#   - Minimal   (macOS)          — umbrella-import smoke on macOS
+#
+# WHY THIS EXISTS, AND WHY IT IS NOT PER-PR:
+# The demos consume ManifoldKit by local path, so package-level drift (retired
+# traits, renamed modules, changed `quickStart` signatures, iOS-unavailable
+# symbols pulled in via the umbrella) breaks them while plain `swift test` —
+# which builds for macOS only — stays green. iOS-only API unavailability is
+# invisible to the core gate; only an actual iOS build surfaces it. Demo
+# breakage is rare and these builds are slow, so this runs at RELEASE TIME,
+# not on every PR. Run it before bumping the version (see CLAUDE.md § Release
+# workflow); it must be green.
+#
+# Usage:
+#   scripts/demo-apps-build.sh
+#   scripts/demo-apps-build.sh --destination 'platform=iOS Simulator,id=<ID>'
+
+set -uo pipefail   # NOT -e: we want to run all configs and report every failure
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ADVANCED_DIR="$REPO_ROOT/Example"
+MINIMAL_DIR="$REPO_ROOT/Example/Examples"
+DERIVED_DATA_PATH="$REPO_ROOT/DerivedData/DemoAppsGate"
+
+IOS_DESTINATION="${1:-}"
+if [[ "$IOS_DESTINATION" == "--destination" ]]; then
+    IOS_DESTINATION="${2:-}"
+fi
+
+pick_simulator_line() {
+    xcrun simctl list devices available | grep -E "$1" | head -n 1 || true
+}
+
+resolve_ios_destination() {
+    local line=""
+    line="$(pick_simulator_line '^[[:space:]]+iPhone .*\([0-9A-F-]{36}\) \(Booted\)[[:space:]]*$')"
+    if [[ -z "$line" ]]; then
+        line="$(pick_simulator_line '^[[:space:]]+iPhone .*\([0-9A-F-]{36}\) \((Shutdown|Creating|Booting)\)[[:space:]]*$')"
+    fi
+    if [[ -z "$line" ]]; then
+        line="$(pick_simulator_line '^[[:space:]]+iPad .*\([0-9A-F-]{36}\) \((Booted|Shutdown|Creating|Booting)\)[[:space:]]*$')"
+    fi
+    if [[ -z "$line" ]]; then
+        echo "No available iOS Simulator destination found." >&2
+        echo "Run 'xcrun simctl list devices available' and pass --destination manually." >&2
+        exit 1
+    fi
+    local sim_id sim_name
+    sim_id="$(printf '%s\n' "$line" | sed -E 's/.*\(([0-9A-F-]{36})\) \((Booted|Shutdown|Creating|Booting)\)[[:space:]]*$/\1/')"
+    sim_name="$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]+(.+) \([0-9A-F-]{36}\) \((Booted|Shutdown|Creating|Booting)\)[[:space:]]*$/\1/')"
+    IOS_DESTINATION="platform=iOS Simulator,id=$sim_id"
+    echo "Using iOS simulator: $sim_name ($sim_id)" >&2
+}
+
+if [[ -z "$IOS_DESTINATION" ]]; then
+    resolve_ios_destination
+fi
+
+# Bash 3.2 on macOS has no associative arrays — track results in parallel arrays.
+NAMES=()
+STATUSES=()
+
+# xcodebuild intermittently crashes during the package-graph resolution phase
+# with an NSInvalidArgumentException ("insertObjects:atIndexes: count of array
+# ... differs from count of index set ...") — a tooling bug that aborts before
+# a single file compiles, unrelated to the demo's own code. Retry once on that
+# signature so the release gate doesn't emit a false "DO NOT RELEASE". A real
+# compile error (no signature match) fails immediately without a retry.
+XCODEBUILD_FLAKE_SIGNATURE="NSInvalidArgumentException"
+
+attempt_build() {
+    local project_dir="$1" project="$2" scheme="$3" destination="$4" out_log="$5"
+    ( cd "$project_dir" && xcodebuild \
+            -project "$project" \
+            -scheme "$scheme" \
+            -destination "$destination" \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            build ) 2>&1 | tee "$out_log"
+    return "${PIPESTATUS[0]}"
+}
+
+run_build() {
+    local name="$1" project_dir="$2" project="$3" scheme="$4" destination="$5"
+    echo
+    echo "=================================================================="
+    echo ">> $name"
+    echo "   project:     $project"
+    echo "   scheme:      $scheme"
+    echo "   destination: $destination"
+    echo "=================================================================="
+    local out_log
+    out_log="$(mktemp -t demo-apps-build)"
+
+    if attempt_build "$project_dir" "$project" "$scheme" "$destination" "$out_log"; then
+        NAMES+=("$name"); STATUSES+=("PASS"); rm -f "$out_log"; return
+    fi
+
+    if grep -q "$XCODEBUILD_FLAKE_SIGNATURE" "$out_log"; then
+        echo ">> $name: xcodebuild crashed during package resolution (flaky) — retrying once..." >&2
+        if attempt_build "$project_dir" "$project" "$scheme" "$destination" "$out_log"; then
+            NAMES+=("$name"); STATUSES+=("PASS (retry)"); rm -f "$out_log"; return
+        fi
+    fi
+
+    NAMES+=("$name"); STATUSES+=("FAIL"); rm -f "$out_log"
+}
+
+run_build "Advanced (iOS)"   "$ADVANCED_DIR" "Advanced.xcodeproj"        "Advanced"            "$IOS_DESTINATION"
+run_build "Minimal  (iOS)"   "$MINIMAL_DIR"  "ManifoldExamples.xcodeproj" "MinimalExample_iOS"   "$IOS_DESTINATION"
+run_build "Minimal  (macOS)" "$MINIMAL_DIR"  "ManifoldExamples.xcodeproj" "MinimalExample_macOS" "platform=macOS"
+
+echo
+echo "=================================================================="
+echo "Demo apps build summary"
+echo "=================================================================="
+exit_code=0
+for i in "${!NAMES[@]}"; do
+    printf '  %-18s %s\n' "${NAMES[$i]}" "${STATUSES[$i]}"
+    if [[ "${STATUSES[$i]}" == "FAIL" ]]; then
+        exit_code=1
+    fi
+done
+echo "=================================================================="
+if [[ "$exit_code" -eq 0 ]]; then
+    echo "All demo apps built. Safe to bump the release."
+else
+    echo "One or more demo apps FAILED to build. Do NOT bump the release."
+fi
+exit "$exit_code"


### PR DESCRIPTION
## Problem

`SkillLoader.defaultClaudeCodePaths` references `FileManager.homeDirectoryForCurrentUser`, which is `API_UNAVAILABLE(ios)` — a **compile-time** error on iOS, not just a runtime one. Since `SkillLoader.init` defaults to that property, its body must compile on every platform. The consequence: **`ManifoldSkills` doesn't build for iOS, which takes down the entire `ManifoldKit` umbrella** (it re-exports `ManifoldSkills`).

This is live on `main` today. Core CI stays green because `swift test` builds for **macOS only**, where the symbol exists — iOS-only API unavailability is invisible to it. The bug surfaces the moment an app does `import ManifoldKit` on iOS (e.g. the Minimal example).

```
error: 'homeDirectoryForCurrentUser' is unavailable in iOS
    let home = fm.homeDirectoryForCurrentUser
```

## Fix

Gate the property body with `#if os(macOS)`, returning `[]` on iOS to match `discover()` (already macOS-only — iOS skill discovery needs an entitlement / app-group design that hasn't shipped). Behaviour on macOS is unchanged.

## Prevent recurrence: release-time demo-app build gate

The demo apps consume ManifoldKit by local path, so they're the canary for package drift (retired traits, renamed modules, iOS-unavailable symbols pulled via the umbrella) that `swift test` can't catch. Added:

- **`scripts/demo-apps-build.sh`** — builds both example apps across the platforms they ship for (Advanced iOS, Minimal iOS + macOS), prints an honest pass/fail summary, exits non-zero on failure. Auto-retries once on the flaky xcodebuild package-resolution crash (`NSInvalidArgumentException`) so it doesn't emit a false "DO NOT RELEASE". Bash 3.2-safe.
- **CLAUDE.md** — documented as a **mandatory pre-bump step**. Deliberately release-time, not per-PR: demo breakage is rare and these xcodebuild runs are slow / 10×-billed, so paying once per release is the right trade.

## Verification (local, Apple Silicon)

- `scripts/demo-apps-build.sh` → **all 3 PASS** (Minimal iOS flips FAIL→PASS with the fix).
- `ManifoldSkills` tests on macOS → **42/42 pass** (macOS path resolution unchanged).
- Full `scripts/test.sh --profile local` → only 2 failures, both **pre-existing and environmental**, unrelated to this change (verified by re-running on `origin/main` via stash):
  - `QuickStartTests.test_quickStart_seededEndpoint_canLoadViaSelectedEndpoint` — live-Ollama test, model `llama3.1:8b` not pulled locally (404).
  - `ModelManagementSheetLogicTests.test_discoverModelsOffMain_matchesSyncDiscovery` — GGUF-parsing assertion in `ManifoldUIModelManagement`; fails identically without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)