### PR TITLE
feat(eval): on-device Score/EvalScorer surface + BFCL AST-track adoption (#1997)

### DIFF
--- a/Sources/ManifoldInference/Eval/EvalScorer.swift
+++ b/Sources/ManifoldInference/Eval/EvalScorer.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A read-only projection of one run's output, handed to scorers.
+///
+/// Deliberately small and eval-native: visible text, reasoning text, the tool
+/// calls the model emitted, and the coarse stop reason. A scorer reads only the
+/// fields it needs (a similarity scorer reads `visibleText`; a tool-call matcher
+/// reads `toolCalls`) — empty fields are honest "this run had none", not stubs.
+public struct EvalRunOutput: Sendable {
+    /// User-visible assistant text (post-thinking).
+    public let visibleText: String
+    /// Reasoning/thinking text, if the model produced any.
+    public let thinkingText: String
+    /// Tool calls the model emitted during the run.
+    public let toolCalls: [ToolCall]
+    /// Coarse stop classification (`naturalStop` / `maxTokens` / `error` / …),
+    /// or empty when the producer did not classify it.
+    public let stopReason: String
+
+    public init(
+        visibleText: String,
+        thinkingText: String = "",
+        toolCalls: [ToolCall] = [],
+        stopReason: String = ""
+    ) {
+        self.visibleText = visibleText
+        self.thinkingText = thinkingText
+        self.toolCalls = toolCalls
+        self.stopReason = stopReason
+    }
+}
+
+/// Scores one run's output against an expectation.
+///
+/// Expected-vs-actual only — `Expected` is the ground truth the output is judged
+/// against (a reference string for similarity, a list of acceptable calls for a
+/// tool matcher). Run-level *annotations* that judge a run without an expectation
+/// (e.g. generation-hygiene signals) are a separate concern and do **not** belong
+/// here as an `Expected == Void` conformance.
+public protocol EvalScorer<Expected>: Sendable {
+    associatedtype Expected: Sendable
+    func score(output: EvalRunOutput, expected: Expected) async -> Score
+}

--- a/Sources/ManifoldInference/Eval/Score.swift
+++ b/Sources/ManifoldInference/Eval/Score.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// The value a scorer assigns to one sample.
+///
+/// A sum type rather than a bare `Double` because scorers disagree on shape: a
+/// similarity scorer yields a continuous number, a structural matcher yields a
+/// boolean, and a degenerate run yields *no* signal at all (which must never be
+/// confused with a numeric `0`). Future scorers (graded rubric, per-criterion
+/// breakdown) will add cases — `category(String)` / `dict([String: Double])` are
+/// the obvious next two and slot in additively.
+///
+/// `Score` is intentionally **not** `Codable` in this phase: nothing persists a
+/// `Score` yet, so growing this enum stays a pure source-level (non-breaking)
+/// change. Freeze the on-disk shape only when a real persistence consumer exists.
+public enum ScoreValue: Sendable, Equatable {
+    /// A continuous score (e.g. cosine similarity, a normalized grade).
+    case number(Double)
+    /// A pass/fail verdict (e.g. structural AST match).
+    case bool(Bool)
+    /// The scorer could produce no signal for this run — e.g. empty or
+    /// unembeddable input. Distinct from `number(0)`: "no signal" must never read
+    /// as "maximally wrong". Consumers should skip `unavailable` samples when
+    /// aggregating rather than treat them as zero.
+    case unavailable
+
+    /// Numeric projection for aggregation: the wrapped value for `number`, `1`/`0`
+    /// for `bool`, and `nil` for `unavailable` (and any future non-numeric case),
+    /// so a caller can `compactMap(\.value.doubleValue)` to drop no-signal samples.
+    public var doubleValue: Double? {
+        switch self {
+        case .number(let d): return d
+        case .bool(let b): return b ? 1 : 0
+        case .unavailable: return nil
+        }
+    }
+}
+
+/// One scorer's verdict on one run's output.
+///
+/// Mirrors the per-sample `Score` shape common to the eval field (Inspect AI et
+/// al.): a `value` plus the optional `explanation` that makes a judge/structural
+/// verdict debuggable, and free-form `metadata` for scorer-specific detail.
+public struct Score: Sendable, Equatable {
+    /// The verdict.
+    public let value: ScoreValue
+    /// The answer extracted from the run, if the scorer isolates one.
+    public let answer: String?
+    /// Why the scorer reached `value` — a failure reason, threshold note, etc.
+    public let explanation: String?
+    /// Scorer-specific detail (which scorer, threshold used, signal status …).
+    public let metadata: [String: String]
+
+    public init(
+        value: ScoreValue,
+        answer: String? = nil,
+        explanation: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.value = value
+        self.answer = answer
+        self.explanation = explanation
+        self.metadata = metadata
+    }
+}

--- a/Sources/ManifoldInference/Eval/SemanticSimilarityScorer.swift
+++ b/Sources/ManifoldInference/Eval/SemanticSimilarityScorer.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Scores free-form output by cosine similarity of on-device sentence embeddings.
+///
+/// ## What this measures — and what it does NOT
+///
+/// Uses whatever ``EmbeddingBackend`` is injected (e.g. Apple's general-purpose
+/// `NLEmbedding`), **not** an eval-tuned model. Cosine measures *topical
+/// relatedness*, not *correctness*: a wrong-but-on-topic answer (wrong city, a
+/// negated claim, a swapped entity) can score as high as the right one. Treat the
+/// result as a **screening signal for free-form prose**, not a graded verdict for
+/// factual or short-answer tasks — use exact / contains / rubric scorers for those.
+///
+/// `value` is the raw cosine over L2-normalized vectors. `threshold` is
+/// caller-supplied (there is no universal cutoff; promptfoo uses 0.75 as a
+/// *starting point*, not a guarantee); `metadata["passed"]` records the
+/// thresholded decision. Empty or unembeddable input, or an embedding failure,
+/// yields ``ScoreValue/unavailable`` — never `number(0)`, which would misread as
+/// "maximally wrong".
+public struct SemanticSimilarityScorer: EvalScorer {
+    public typealias Expected = String
+
+    private let embedder: any EmbeddingBackend
+    private let threshold: Double
+
+    /// - Parameters:
+    ///   - embedder: the on-device embedding backend to score with.
+    ///   - threshold: the cosine cutoff for the `metadata["passed"]` decision.
+    ///     Required by design — no default, because no cutoff is universally valid.
+    public init(embedder: any EmbeddingBackend, threshold: Double) {
+        self.embedder = embedder
+        self.threshold = threshold
+    }
+
+    public func score(output: EvalRunOutput, expected: String) async -> Score {
+        let candidate = output.visibleText
+        do {
+            let vectors = try await embedder.embed([candidate, expected])
+            // The EmbeddingBackend contract guarantees one vector per input on a
+            // non-throwing return, but verify rather than trust before indexing.
+            guard vectors.count == 2 else {
+                return Self.noSignal("embedder returned \(vectors.count) vectors, expected 2")
+            }
+            guard
+                let a = Self.l2normalized(vectors[0]),
+                let b = Self.l2normalized(vectors[1])
+            else {
+                // A zero-norm vector means empty / unembeddable text (e.g. Apple's
+                // NLEmbedding returns zeros for such input). No signal — not zero.
+                return Self.noSignal("zero-norm embedding (empty or unembeddable input)")
+            }
+            let cosine = Double(Self.dot(a, b))
+            let passed = cosine >= threshold
+            return Score(
+                value: .number(cosine),
+                explanation: passed
+                    ? "cosine \(cosine) ≥ threshold \(threshold)"
+                    : "cosine \(cosine) < threshold \(threshold)",
+                metadata: [
+                    "signal": "ok",
+                    "threshold": "\(threshold)",
+                    "passed": "\(passed)",
+                ]
+            )
+        } catch {
+            // Surface the failure (do not swallow) and return an explicit no-signal
+            // score so the caller can drop it rather than read it as a zero.
+            Log.inference.warning(
+                "SemanticSimilarityScorer: embedding failed: \(String(describing: error), privacy: .public)"
+            )
+            return Self.noSignal("embedding failed: \(error)")
+        }
+    }
+
+    private static func noSignal(_ reason: String) -> Score {
+        Score(value: .unavailable, explanation: reason, metadata: ["signal": "none"])
+    }
+
+    /// Returns the L2-normalized vector, or `nil` when the norm is zero (degenerate
+    /// input). We normalize here rather than assume the embedder already did —
+    /// `EmbeddingBackend` does not guarantee unit-length output.
+    private static func l2normalized(_ v: [Float]) -> [Float]? {
+        let norm = (v.reduce(Float(0)) { $0 + $1 * $1 }).squareRoot()
+        guard norm > 0 else { return nil }
+        return v.map { $0 / norm }
+    }
+
+    /// Dot product of two equal-length vectors — cosine similarity once both are
+    /// L2-normalized.
+    private static func dot(_ a: [Float], _ b: [Float]) -> Float {
+        zip(a, b).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+    }
+}

--- a/Sources/ManifoldInference/Eval/SemanticSimilarityScorer.swift
+++ b/Sources/ManifoldInference/Eval/SemanticSimilarityScorer.swift
@@ -49,6 +49,11 @@ public struct SemanticSimilarityScorer: EvalScorer {
                 // NLEmbedding returns zeros for such input). No signal — not zero.
                 return Self.noSignal("zero-norm embedding (empty or unembeddable input)")
             }
+            // The contract guarantees equal length, but `dot`'s `zip` would
+            // silently truncate (→ a wrong cosine) if a custom backend violated it.
+            guard a.count == b.count else {
+                return Self.noSignal("embedding length mismatch: \(a.count) vs \(b.count)")
+            }
             let cosine = Double(Self.dot(a, b))
             let passed = cosine >= threshold
             return Score(

--- a/Sources/ManifoldTools/BFCL/BFCLRunner.swift
+++ b/Sources/ManifoldTools/BFCL/BFCLRunner.swift
@@ -73,6 +73,11 @@ public struct BFCLRunner {
         var errored = 0
         var records: [BFCLRunRecord] = []
 
+        // The AST and name-only checks are real `EvalScorer`s over the emitted
+        // calls; the runner accounts for the run through their `Score` output.
+        let astScorer = BFCLASTScorer()
+        let nameScorer = BFCLNameOnlyScorer()
+
         for testCase in cases {
             let id = testCase.id.padding(toLength: 13, withPad: " ", startingAt: 0)
 
@@ -87,24 +92,27 @@ public struct BFCLRunner {
                 continue
             }
 
-            let score = ASTMatcher.scoreCase(emittedCalls: calls, groundTruth: testCase.groundTruth)
-            let nameOK = calls.contains { call in
-                testCase.groundTruth.contains { $0.functionName == call.toolName }
-            }
-            if score.matched { astMatched += 1 }
+            // A BFCL case is a tool-call eval: the projected output carries the
+            // emitted calls; visible/thinking text is legitimately empty here.
+            let output = EvalRunOutput(visibleText: "", toolCalls: calls)
+            let astScore = await astScorer.score(output: output, expected: testCase.groundTruth)
+            let nameScore = await nameScorer.score(output: output, expected: testCase.groundTruth)
+            let astOK = astScore.value == .bool(true)
+            let nameOK = nameScore.value == .bool(true)
+            if astOK { astMatched += 1 }
             if nameOK { nameMatched += 1 }
             records.append(BFCLRunRecord.make(
                 id: testCase.id,
                 model: modelLabel,
                 emittedCalls: calls,
-                astMatched: score.matched,
+                astMatched: astOK,
                 nameMatched: nameOK
             ))
 
-            let marker = score.matched ? "✓" : "✗"
+            let marker = astOK ? "✓" : "✗"
             let emitted = calls.first.map { "\($0.toolName) \($0.arguments)" } ?? "<no tool call>"
             var line = "  \(marker) \(id) \(emitted)"
-            if !score.matched, let reason = score.bestFailures.first {
+            if !astOK, let reason = astScore.explanation {
                 // Name matched but arguments wrong → exactly the gap the name-only
                 // scorer misses. Surface why.
                 line += "   ↳ \(reason)"

--- a/Sources/ManifoldTools/BFCL/BFCLScorers.swift
+++ b/Sources/ManifoldTools/BFCL/BFCLScorers.swift
@@ -1,0 +1,41 @@
+import Foundation
+import ManifoldInference
+
+/// Argument-level structural scorer for one BFCL case: does some emitted call
+/// match some ground-truth alternative on function name *and* arguments?
+///
+/// A genuine ``EvalScorer`` conformance, not a veneer — the AST-match logic
+/// (``ASTMatcher/scoreCase(emittedCalls:groundTruth:)``) is the score function,
+/// and ``BFCLRunner`` drives the run through this type's `Score` output rather
+/// than reading a bool out of band.
+public struct BFCLASTScorer: EvalScorer {
+    public typealias Expected = [BFCLExpectedCall]
+
+    public init() {}
+
+    public func score(output: EvalRunOutput, expected: [BFCLExpectedCall]) async -> Score {
+        let result = ASTMatcher.scoreCase(emittedCalls: output.toolCalls, groundTruth: expected)
+        return Score(
+            value: .bool(result.matched),
+            explanation: result.matched ? nil : result.bestFailures.first.map { "\($0)" },
+            metadata: ["scorer": "bfcl-ast"]
+        )
+    }
+}
+
+/// Name-only scorer: did the model call the right *function*, regardless of
+/// whether the arguments are correct? This is the weaker signal a name-only
+/// conformance scorer credits; contrasting it with ``BFCLASTScorer`` is the whole
+/// point of the BFCL AST track (the gap = right tool, wrong arguments).
+public struct BFCLNameOnlyScorer: EvalScorer {
+    public typealias Expected = [BFCLExpectedCall]
+
+    public init() {}
+
+    public func score(output: EvalRunOutput, expected: [BFCLExpectedCall]) async -> Score {
+        let nameMatched = output.toolCalls.contains { call in
+            expected.contains { $0.functionName == call.toolName }
+        }
+        return Score(value: .bool(nameMatched), metadata: ["scorer": "bfcl-name-only"])
+    }
+}

--- a/Tests/ManifoldInferenceTests/Eval/ScoreTests.swift
+++ b/Tests/ManifoldInferenceTests/Eval/ScoreTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import ManifoldInference
+
+final class ScoreTests: XCTestCase {
+
+    func testDoubleValueForNumber() {
+        XCTAssertEqual(ScoreValue.number(0.42).doubleValue, 0.42)
+    }
+
+    func testDoubleValueForBool() {
+        XCTAssertEqual(ScoreValue.bool(true).doubleValue, 1)
+        XCTAssertEqual(ScoreValue.bool(false).doubleValue, 0)
+    }
+
+    func testDoubleValueForUnavailableIsNil() {
+        // The whole point of `unavailable`: it must NOT read as a numeric zero.
+        XCTAssertNil(ScoreValue.unavailable.doubleValue)
+    }
+
+    func testCompactMapDropsUnavailable() {
+        let scores: [Score] = [
+            Score(value: .number(1.0)),
+            Score(value: .unavailable),
+            Score(value: .bool(true)),
+        ]
+        let numeric = scores.compactMap(\.value.doubleValue)
+        XCTAssertEqual(numeric, [1.0, 1.0])
+    }
+
+    func testEquatable() {
+        let a = Score(value: .bool(true), explanation: "matched", metadata: ["scorer": "x"])
+        let b = Score(value: .bool(true), explanation: "matched", metadata: ["scorer": "x"])
+        let c = Score(value: .bool(false), explanation: "matched", metadata: ["scorer": "x"])
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+}

--- a/Tests/ManifoldInferenceTests/Eval/SemanticSimilarityScorerTests.swift
+++ b/Tests/ManifoldInferenceTests/Eval/SemanticSimilarityScorerTests.swift
@@ -29,12 +29,15 @@ private final class StubEmbeddingBackend: EmbeddingBackend, @unchecked Sendable 
 
 final class SemanticSimilarityScorerTests: XCTestCase {
 
-    private func cosine(of score: Score, file: StaticString = #filePath, line: UInt = #line) -> Double? {
+    /// The numeric cosine, or `nil` if the score isn't a `number` (e.g. it came
+    /// back `unavailable`). Call sites `try XCTUnwrap` so a non-numeric regression
+    /// FAILS the test rather than passing silently.
+    private func cosine(of score: Score) -> Double? {
         guard case .number(let value) = score.value else { return nil }
         return value
     }
 
-    func testIdenticalEmbeddingsScoreOne() async {
+    func testIdenticalEmbeddingsScoreOne() async throws {
         let backend = StubEmbeddingBackend([
             "the cat sat": [1, 0, 0],
             "the cat sat on the mat": [1, 0, 0],
@@ -43,12 +46,12 @@ final class SemanticSimilarityScorerTests: XCTestCase {
         let out = EvalRunOutput(visibleText: "the cat sat")
         let score = await scorer.score(output: out, expected: "the cat sat on the mat")
 
-        XCTAssertEqual(cosine(of: score), 1.0, accuracy: 1e-6)
+        XCTAssertEqual(try XCTUnwrap(cosine(of: score)), 1.0, accuracy: 1e-6)
         XCTAssertEqual(score.metadata["signal"], "ok")
         XCTAssertEqual(score.metadata["passed"], "true")
     }
 
-    func testOrthogonalEmbeddingsScoreZeroButHaveSignal() async {
+    func testOrthogonalEmbeddingsScoreZeroButHaveSignal() async throws {
         // cosine 0.0 is a real "dissimilar" verdict — distinct from `unavailable`.
         let backend = StubEmbeddingBackend([
             "apples": [1, 0, 0],
@@ -59,12 +62,12 @@ final class SemanticSimilarityScorerTests: XCTestCase {
             output: EvalRunOutput(visibleText: "apples"),
             expected: "quantum chromodynamics"
         )
-        XCTAssertEqual(cosine(of: score), 0.0, accuracy: 1e-6)
+        XCTAssertEqual(try XCTUnwrap(cosine(of: score)), 0.0, accuracy: 1e-6)
         XCTAssertEqual(score.metadata["signal"], "ok")
         XCTAssertEqual(score.metadata["passed"], "false")
     }
 
-    func testThresholdBoundaryIsInclusive() async {
+    func testThresholdBoundaryIsInclusive() async throws {
         // a=[1,0,0], b normalizes to [0.5, .866, 0] → cosine exactly 0.5.
         let backend = StubEmbeddingBackend([
             "a": [1, 0, 0],
@@ -75,7 +78,7 @@ final class SemanticSimilarityScorerTests: XCTestCase {
             output: EvalRunOutput(visibleText: "a"),
             expected: "b"
         )
-        XCTAssertEqual(cosine(of: score) ?? .nan, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(try XCTUnwrap(cosine(of: score)), 0.5, accuracy: 1e-6)
         XCTAssertEqual(score.metadata["passed"], "true", "threshold compare is >=, so exactly-at-threshold passes")
     }
 

--- a/Tests/ManifoldInferenceTests/Eval/SemanticSimilarityScorerTests.swift
+++ b/Tests/ManifoldInferenceTests/Eval/SemanticSimilarityScorerTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import ManifoldInference
+
+/// Embedding backend that returns a caller-specified vector per input text, so a
+/// test can pin exact cosine outcomes (identical / orthogonal / zero / boundary)
+/// without a real model. Returns a zero vector for any text not in the map — which
+/// is also how the degenerate (empty/unembeddable) path is exercised.
+private final class StubEmbeddingBackend: EmbeddingBackend, @unchecked Sendable {
+    var isModelLoaded = true
+    var dimensions = 3
+    private let vectors: [String: [Float]]
+    private let throwOnEmbed: Bool
+
+    init(_ vectors: [String: [Float]], throwOnEmbed: Bool = false) {
+        self.vectors = vectors
+        self.throwOnEmbed = throwOnEmbed
+    }
+
+    func loadModel(from url: URL) async throws {}
+    func unloadModel() {}
+
+    func embed(_ texts: [String]) async throws -> [[Float]] {
+        if throwOnEmbed { throw EmbeddingError.encodingFailed(underlying: StubError.boom) }
+        return texts.map { vectors[$0] ?? [Float](repeating: 0, count: dimensions) }
+    }
+
+    enum StubError: Error { case boom }
+}
+
+final class SemanticSimilarityScorerTests: XCTestCase {
+
+    private func cosine(of score: Score, file: StaticString = #filePath, line: UInt = #line) -> Double? {
+        guard case .number(let value) = score.value else { return nil }
+        return value
+    }
+
+    func testIdenticalEmbeddingsScoreOne() async {
+        let backend = StubEmbeddingBackend([
+            "the cat sat": [1, 0, 0],
+            "the cat sat on the mat": [1, 0, 0],
+        ])
+        let scorer = SemanticSimilarityScorer(embedder: backend, threshold: 0.75)
+        let out = EvalRunOutput(visibleText: "the cat sat")
+        let score = await scorer.score(output: out, expected: "the cat sat on the mat")
+
+        XCTAssertEqual(cosine(of: score), 1.0, accuracy: 1e-6)
+        XCTAssertEqual(score.metadata["signal"], "ok")
+        XCTAssertEqual(score.metadata["passed"], "true")
+    }
+
+    func testOrthogonalEmbeddingsScoreZeroButHaveSignal() async {
+        // cosine 0.0 is a real "dissimilar" verdict — distinct from `unavailable`.
+        let backend = StubEmbeddingBackend([
+            "apples": [1, 0, 0],
+            "quantum chromodynamics": [0, 1, 0],
+        ])
+        let scorer = SemanticSimilarityScorer(embedder: backend, threshold: 0.75)
+        let score = await scorer.score(
+            output: EvalRunOutput(visibleText: "apples"),
+            expected: "quantum chromodynamics"
+        )
+        XCTAssertEqual(cosine(of: score), 0.0, accuracy: 1e-6)
+        XCTAssertEqual(score.metadata["signal"], "ok")
+        XCTAssertEqual(score.metadata["passed"], "false")
+    }
+
+    func testThresholdBoundaryIsInclusive() async {
+        // a=[1,0,0], b normalizes to [0.5, .866, 0] → cosine exactly 0.5.
+        let backend = StubEmbeddingBackend([
+            "a": [1, 0, 0],
+            "b": [1, Float(3).squareRoot(), 0],
+        ])
+        let scorer = SemanticSimilarityScorer(embedder: backend, threshold: 0.5)
+        let score = await scorer.score(
+            output: EvalRunOutput(visibleText: "a"),
+            expected: "b"
+        )
+        XCTAssertEqual(cosine(of: score) ?? .nan, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(score.metadata["passed"], "true", "threshold compare is >=, so exactly-at-threshold passes")
+    }
+
+    func testEmptyOutputYieldsUnavailableNotZero() async {
+        // Candidate text maps to the default zero vector → no signal, NOT number(0).
+        let backend = StubEmbeddingBackend(["reference": [1, 0, 0]])
+        let scorer = SemanticSimilarityScorer(embedder: backend, threshold: 0.75)
+        let score = await scorer.score(
+            output: EvalRunOutput(visibleText: ""),
+            expected: "reference"
+        )
+        XCTAssertEqual(score.value, .unavailable)
+        XCTAssertNil(score.value.doubleValue, "no-signal must never read as a numeric zero")
+        XCTAssertEqual(score.metadata["signal"], "none")
+    }
+
+    func testEmbeddingFailureYieldsUnavailable() async {
+        let backend = StubEmbeddingBackend(["x": [1, 0, 0]], throwOnEmbed: true)
+        let scorer = SemanticSimilarityScorer(embedder: backend, threshold: 0.75)
+        let score = await scorer.score(
+            output: EvalRunOutput(visibleText: "x"),
+            expected: "x"
+        )
+        XCTAssertEqual(score.value, .unavailable)
+        XCTAssertEqual(score.metadata["signal"], "none")
+    }
+}

--- a/docs/plans/1997-on-device-eval.md
+++ b/docs/plans/1997-on-device-eval.md
@@ -68,7 +68,7 @@ When it lands (separate effort, lockstep with a manifold-llama consumer):
 
 | # | Piece | Module | Notes |
 |---|---|---|---|
-| 1 | `ScoreValue` enum (`number`/`bool`/`category`) + `Score {value, answer, explanation, metadata}` | `ManifoldInference` | **Drop `dict`** — overlaps `metadata` until a consumer needs it. BFCL exercises `bool`+`category` on day one. `var doubleValue: Double?` convenience. |
+| 1 | `ScoreValue` enum (`number`/`bool`/`unavailable`) + `Score {value, answer, explanation, metadata}` | `ManifoldInference` | All three cases have a live consumer this PR: `number` (similarity cosine), `bool` (BFCL AST match), `unavailable` (similarity degenerate/no-signal — never `number(0)`). `category`/`dict` deferred (no consumer; additive when hygiene/ConformanceScorer migrates). `Score` intentionally not `Codable` yet. `var doubleValue: Double?` convenience. |
 | 2 | `EvalScorer { associatedtype Expected; func score(output:expected:) }` + `EvalRunOutput` projection | `ManifoldInference` | Expected-vs-actual only. Zero fuzz deps. |
 | 3 | `SemanticSimilarityScorer` (standalone, NOT tied to any gate) | `ManifoldInference` | Required `threshold`; internal L2-norm (don't assume `NLEmbedding` normalized); **detect zero-norm post-embed → explicit no-signal** (`NLEmbeddingBackend.embed` silently returns a zero vector for empty/unembeddable text, `NLEmbeddingBackend.swift:79` — cosine 0.0 must NOT read as "maximally wrong"). Ships the §6 caveat. |
 | 4 | **First real consumer:** BFCL **AST track** (`ASTMatcher`/`BFCLRunner`) emits `[Score]` | `ManifoldTools/BFCL` | Maps cleanly: per-case `Score{value: .bool(matched), explanation: bestFailures.first}`. Replaces inline `astMatched += 1` counters. Two scorers (AST + name-only) over the same output validate the heterogeneous-scorer design. **Leave `ConformanceScorer` on `ConfusionCounts`** — its set-valued confusion counts do NOT collapse to one `ScoreValue`; forcing it would be a fake conformance. |
@@ -115,7 +115,7 @@ separate, later, cross-repo-lockstep effort.
   (mock) / unverified (Ollama) + config-lossy re-drive. Moat moves cross-repo.
 - ✅ v2 placement split (scorers in Inference, gate in Fuzz) — holds; Fuzz→Inference edge exists
   (`Package.swift:920`). v3 keeps scorers in Inference and removes the in-core gate.
-- ✅ v2 `ScoreValue` enum — holds (BFCL exercises `bool`+`category`); trimmed `dict`.
+- ✅ v2 `ScoreValue` enum — holds, refined during impl to `number`/`bool`/`unavailable` (all three have a live consumer this PR; `unavailable` replaces a metadata flag for the similarity no-signal path). `category`/`dict` deferred until a real consumer exists.
 
 ## 9. Decision needed
 

--- a/docs/plans/1997-on-device-eval.md
+++ b/docs/plans/1997-on-device-eval.md
@@ -1,0 +1,124 @@
+# Plan: On-device LLM eval surface — Phase 1 (#1997)
+
+> **Status:** v3 — converged after TWO adversarial review rounds (3 reviewers on the v1
+> strawman, 2 on the v2 revision). Ground-truthed against MK source 2026-06-28. The
+> product-motivated successor that `docs/plans/1993-eval-surface.md` step 4 invited —
+> justified on on-device differentiation, NOT on deduping downstream apps (rejected at N=2).
+>
+> **Headline decision (v3):** Ship the **scorer surface + BFCL adoption** in-core now. **Move
+> the replay-regression "moat" OUT of Phase 1** to a manifold-llama lockstep follow-up — it
+> cannot be honestly demonstrated in this repo (see §3). This inverts v2's "lead with the moat."
+
+## 1. Thesis (unchanged) and what survives review
+
+MK should own **on-device, deterministic LLM eval**. The genuinely ownable card no HTTP-client
+framework can reproduce is **byte-deterministic re-drive of a captured local-model session +
+detect whether the score moved** ("did re-quantizing / upgrading the GGUF change correctness?").
+
+The two review rounds confirmed the *direction* and demolished the *in-core demonstration* of
+the moat. What survives as **Phase 1 (shippable, demonstrable in this repo)**:
+- A small, honest **scorer surface** in `ManifoldInference`.
+- A **real in-repo consumer** (BFCL's AST track) that adopts it — proving it's live, not scaffolding.
+
+What moves to a **cross-repo lockstep follow-up**: the replay-regression gate (§3).
+
+## 2. The decisive finding: why the moat can't ship in-core
+
+Both v2 reviewers, independently, killed "lead with the moat in Phase 1":
+
+1. **The in-core regression test is green by construction.** Deterministic replay ⇒ identical
+   output bytes ⇒ any pure scorer returns an identical value ⇒ "assert the score didn't move"
+   is *tautologically true*. It tests the replay machinery, not the scorer — an inert
+   #2064-shaped test. (A `MockInferenceBackend` emits scripted tokens regardless of config, so
+   re-drive-and-compare *cannot fail*.)
+2. **Byte-determinism and score-movement are in direct tension.** The scorer only earns its
+   keep when bytes *differ* (GGUF re-quant, model upgrade) — which only happens **cross-repo**
+   (real local-backend factories live in `manifold-llama` / `manifold-mlx`, not here).
+3. **In-core determinism witnesses are untrustworthy.** `OllamaFuzzFactory` inherits
+   `supportsDeterministicReplay == true` by default, but the protocol's own doc hedges "verify
+   first — Ollama seed plumbing varies" (`FuzzBackendFactory.swift:18-20`). Worse, the existing
+   re-drive path `runOnce` **never plumbs the recorded seed into generation** and **hardcodes
+   `repeatPenalty: 1.1`** (`Replayer.swift:331-336`) — so even the baseline re-drive is
+   config-lossy and not faithfully deterministic for *scoring*.
+4. **Cosine is the worst scorer for the gate anyway.** Where the scorer matters (bytes differ),
+   §6's own caveat applies: cosine is uncalibrated and measures topicality, not correctness — a
+   real regression (wrong city, negated claim) can read "stable." So similarity is *vacuous*
+   in-core and *untrustworthy* cross-repo. Decouple it from the gate entirely.
+
+**Conclusion:** shipping `reproduceOutput` + a regression gate in-core would freeze a public
+fuzz API for a use case no in-core backend can exercise, behind a test that can never go red.
+Don't. Ship the seam *with* its real consumer (manifold-llama), as a re-drive **primitive**.
+
+## 3. The replay-regression gate → cross-repo lockstep follow-up (NOT Phase 1)
+
+When it lands (separate effort, lockstep with a manifold-llama consumer):
+- **Extract, don't bolt on.** Pull `runOnce`'s body into a free
+  `RecordReDriver.reDrive(handle:record:) -> RunRecord` primitive. Do NOT add a hash-resolving
+  `Replayer.reproduceOutput` — that drags `findingsRoot`, drift refusal, and the
+  `findings/<detector>/<hash>/record.json` layout (whose only writer is fuzz's `FindingsSink`)
+  into the eval surface. Eval composes `makeHandle + reDrive + score`.
+- **Fix the config-lossy re-drive:** plumb the recorded seed (and `topK`/`repeatPenalty`) into
+  `GenerationConfig` so "the score moved" compares against a faithful baseline.
+- **Use a meaningful deterministic scorer** (exact-match / AST equality), not cosine.
+- **Non-tautological test:** drive *two different* backends; assert the score *moves* on
+  divergence and *holds* on identical re-drive. (A genuine red-capable assertion — what v2's
+  §7 liveness gate failed to require.)
+
+## 4. Phase 1 deliverables (the demonstrable, fuzz-decoupled core)
+
+| # | Piece | Module | Notes |
+|---|---|---|---|
+| 1 | `ScoreValue` enum (`number`/`bool`/`category`) + `Score {value, answer, explanation, metadata}` | `ManifoldInference` | **Drop `dict`** — overlaps `metadata` until a consumer needs it. BFCL exercises `bool`+`category` on day one. `var doubleValue: Double?` convenience. |
+| 2 | `EvalScorer { associatedtype Expected; func score(output:expected:) }` + `EvalRunOutput` projection | `ManifoldInference` | Expected-vs-actual only. Zero fuzz deps. |
+| 3 | `SemanticSimilarityScorer` (standalone, NOT tied to any gate) | `ManifoldInference` | Required `threshold`; internal L2-norm (don't assume `NLEmbedding` normalized); **detect zero-norm post-embed → explicit no-signal** (`NLEmbeddingBackend.embed` silently returns a zero vector for empty/unembeddable text, `NLEmbeddingBackend.swift:79` — cosine 0.0 must NOT read as "maximally wrong"). Ships the §6 caveat. |
+| 4 | **First real consumer:** BFCL **AST track** (`ASTMatcher`/`BFCLRunner`) emits `[Score]` | `ManifoldTools/BFCL` | Maps cleanly: per-case `Score{value: .bool(matched), explanation: bestFailures.first}`. Replaces inline `astMatched += 1` counters. Two scorers (AST + name-only) over the same output validate the heterogeneous-scorer design. **Leave `ConformanceScorer` on `ConfusionCounts`** — its set-valued confusion counts do NOT collapse to one `ScoreValue`; forcing it would be a fake conformance. |
+| 5 | `Metric` protocol + retrofit onto `MacroAveragedMetrics` **with `BFCLRunner` as the real caller** | `ManifoldInference` | **Only if** it cleanly abstracts the metric MK already ships. If it can't cover `MacroAveragedMetrics`/`ConfusionCounts`, it's the wrong abstraction — **defer to Phase 2**, don't ship a lone toy `MeanAccuracy` conformance (speculative generality). |
+
+**Cut from Phase 1** (agree across all reviewers): `HygieneScorer` (needs the detector-protocol
+`DetectorInput` narrowing first — only ~3 of 11 detectors fire on an eval capture; §ex-4),
+JSONL/`EvalFixture` loader, backend-matrix runner, `epochs`/pass@k, `LLMRubricScorer`, report
+formatter, and the replay-regression gate (§3, → cross-repo lockstep).
+
+## 5. Liveness (the #2064 gate, corrected)
+
+The anti-inert-scaffolding proof for Phase 1 is **BFCL adoption (#4) itself** — a real in-repo
+consumer with an actual ground truth, not a self-contained test the test itself writes. Scorer
+unit tests live in `ManifoldInferenceTests` (the scorers have no fuzz dep). There is no
+replay-gate test in Phase 1 because there is no replay gate in Phase 1.
+
+## 6. Must-ship caveat for `SemanticSimilarityScorer`
+
+> Uses Apple's general-purpose `NLEmbedding` (sentence vectors), NOT an eval-tuned model.
+> Cosine measures *topical relatedness*, not *correctness*: a wrong-but-on-topic answer can
+> score as high as the right one. It is a **screening signal for free-form prose**, not a
+> graded verdict for factual/short-answer tasks — use exact/contains/rubric scorers for those.
+> `value` is raw cosine over L2-normalized vectors; `threshold` is caller-supplied (promptfoo
+> uses 0.75 as a starting point, not a guarantee). Empty/unembeddable text yields an explicit
+> "no signal", never `0.0`.
+
+## 7. Scope / PR shape
+
+Phase 1 (#1–4, +#5 if it earns it) is one PR, comfortably under CLAUDE.md's ~800-LOC / ~40-file
+threshold — it's value types + one scorer + a BFCL refactor, no new target, no fuzz API change.
+This is the smallest **demonstrable-in-this-repo** shippable core. The replay seam (§3) is a
+separate, later, cross-repo-lockstep effort.
+
+## 8. Honest ledger — corrections accumulated across both rounds
+
+- ❌ v1 "the moat is a thin `Replayer` wrapper" — wrong; `Replayer` is finding-hash-repro-shaped
+  (`runOnce` private, `:323`), surfaces no output.
+- ❌ v1 "+4 public snapshot inits trips the api-break gate" — wrong; additive API doesn't trip
+  breakage-mode digester.
+- ❌ v1 "hygiene-as-a-scorer, for free" — wrong; ~3 of 11 detectors fire on a stubbed eval record.
+- ❌ v1/v2 "`NLEmbedding` is L2-normalized" — unverified; normalize defensively + handle zero-vector.
+- ❌ v2 "lead with the moat; in-core mock/Ollama proves the mechanism" — wrong; tautological
+  (mock) / unverified (Ollama) + config-lossy re-drive. Moat moves cross-repo.
+- ✅ v2 placement split (scorers in Inference, gate in Fuzz) — holds; Fuzz→Inference edge exists
+  (`Package.swift:920`). v3 keeps scorers in Inference and removes the in-core gate.
+- ✅ v2 `ScoreValue` enum — holds (BFCL exercises `bool`+`category`); trimmed `dict`.
+
+## 9. Decision needed
+
+Build Phase 1 (§4)? It's small, fully demonstrable in-repo via BFCL, freezes no fuzz API, and
+de-risks the eval `Score`/`Metric` shape against a real consumer before any cross-repo work. The
+moat is preserved as a *direction* with a concrete, honest landing path (§3) — just not in this PR.


### PR DESCRIPTION
## Summary

Phase 1 of the on-device LLM eval surface (#1997), per `docs/plans/1997-on-device-eval.md` (v3, converged after two adversarial review rounds). Ships a small, **fuzz-decoupled** scorer surface in `ManifoldInference` and wires the **BFCL AST track** as the first real in-repo consumer — the liveness proof that this isn't inert scaffolding.

This is the product-motivated successor the rejected dedup play (`1993-eval-surface.md` step 4) invited — justified on on-device differentiation, not on deduping downstream apps.

## What's here

- **`Score` + `ScoreValue {number, bool, unavailable}` + `EvalScorer`/`EvalRunOutput`** (`ManifoldInference/Eval/`). `ScoreValue` is a sum type (not bare `Double`) so future scorers add cases additively; it is **intentionally not `Codable`** in this phase (nothing persists a `Score` yet), so growing the enum stays a non-breaking source change. All three cases have a live consumer this PR: `number` (similarity cosine), `bool` (BFCL AST match), `unavailable` (similarity no-signal — never `number(0)`). `category`/`dict` deferred until a consumer exists.
- **`SemanticSimilarityScorer`** — required `threshold` (no default; no universal cutoff exists), internal L2-normalization (does **not** assume `NLEmbedding` is normalized), explicit `unavailable` on zero-vector / empty / ragged / locale-unavailable input, and a visible `do/catch` + `Log.inference.warning` on embed failure (no silent swallow). Ships the cosine≠correctness caveat in its doc-comment. **Standalone public library surface** — exercised in-repo by tests; its first production consumer is downstream (a declared API choice per the plan, not a dead read path).
- **BFCL adoption** — `BFCLRunner` now drives the AST and name-only checks through `BFCLASTScorer` / `BFCLNameOnlyScorer`, real `EvalScorer` conformances over `[BFCLExpectedCall]`. Scoring outcomes are **byte-identical** to before (guarded by the unchanged `BFCLRunnerTests`). `ConformanceScorer` is **deliberately left on `ConfusionCounts`** (set-valued confusion counts don't collapse to one `ScoreValue` — forcing it would be a fake conformance).

## Deliberate decisions / deferrals

- **`Metric` protocol deferred to Phase 2.** Per the plan's condition, it only ships if it cleanly retrofits the existing `MacroAveragedMetrics` — but that consumes `[ConfusionCounts]`, not `[Score]`, so the protocol doesn't fit. Shipping a lone toy `MeanAccuracy` conformance would be speculative generality, so it's dropped.
- **Out of scope** (cross-repo / future): `HygieneScorer` (needs a `DetectorInput` detector-protocol narrowing — only ~3 of 11 detectors fire on an eval capture), the **replay-regression gate** (cross-repo lockstep with manifold-llama — `Replayer` is finding-hash-shaped, and deterministic replay makes a scorer-stability gate tautological in-core; see plan §2–3), JSONL/`EvalFixture` loader, backend-matrix runner, `epochs`/pass@k, `LLMRubricScorer`, report formatter.

## Tests

- `ScoreTests` — `doubleValue` per case, `unavailable` is non-numeric, `compactMap` drops no-signal, equality.
- `SemanticSimilarityScorerTests` — identical→1.0/passed, orthogonal→0.0-with-signal (distinct from `unavailable`), threshold boundary inclusive, empty→`unavailable` (not zero), embed-failure→`unavailable`.
- Existing BFCL harness tests cover the new `[Score]` path; scoring outcomes unchanged.

## Local gate (`scripts/test.sh --profile local`)

All new + BFCL suites pass. The full run reported **2 failures, both pre-existing local-environment false-negatives unrelated to this diff** (neither touches `ManifoldInference/Eval` or `ManifoldTools/BFCL`; `main` is green on them in CI):
- `QuickStartTests.test_quickStart_seededEndpoint…` — live Ollama 404 (the test seeds tag `llama3.1:8b`; the dev box has `llama3.1-8b:latest`).
- `ModelManagementSheetLogicTests.test_discoverModelsOffMain…` — leaked GGUF artifacts in the dev box's `~/Documents/Models/`.

Adversarial review (skeptical subagent): **SHIP**, no blocking issues; verified BFCL behavior byte-identical, cosine math (incl. exact 0.5 boundary), zero force-unwraps, visible catch. Two nits applied (ragged-vector guard; plan-doc `ScoreValue` text synced to shipped code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)