### PR TITLE
feat(skills): AGENTS.md ambient-instruction support (#1943)

### DIFF
--- a/Sources/ManifoldSkills/AgentInstruction.swift
+++ b/Sources/ManifoldSkills/AgentInstruction.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A single `AGENTS.md` file discovered by ``AgentInstructionLoader``.
+///
+/// `AGENTS.md` (Linux Foundation cross-tool standard, 60k+ repos) is a
+/// plain-markdown ambient instruction file read by agent tools at session
+/// start. Unlike `SKILL.md`, it carries no YAML frontmatter — the full file
+/// content is the instruction body.
+public struct AgentInstruction: Sendable, Equatable {
+    /// The directory containing the `AGENTS.md` file.
+    public let directory: URL
+
+    /// Markdown content of the `AGENTS.md` file.
+    public let content: String
+
+    /// Absolute path to the `AGENTS.md` file.
+    public var sourcePath: URL {
+        directory.appendingPathComponent(AgentInstructionLoader.defaultFileName)
+    }
+
+    public init(directory: URL, content: String) {
+        self.directory = directory
+        self.content = content
+    }
+}

--- a/Sources/ManifoldSkills/AgentInstructionContextProvider.swift
+++ b/Sources/ManifoldSkills/AgentInstructionContextProvider.swift
@@ -18,7 +18,16 @@ import ManifoldInference
 ///
 /// The slot is placed at ``PromptSlotPosition/systemPreamble`` so it sits
 /// before conversation history and after any host-supplied system prompt.
-public final class AgentInstructionContextProvider: PromptContextProvider, @unchecked Sendable {
+///
+/// **Opt-in by design.** The session-level "current directory" scoping model
+/// (which directory to resolve `AGENTS.md` from, per session) is undesigned
+/// as of v1 (#1943). Hosts supply `currentDirectory` at construction time.
+///
+/// - Note: ``AgentInstructionLoader/discover(from:stoppingAt:)`` performs
+///   synchronous file I/O. `AGENTS.md` files are expected to be small
+///   (< 64 KB); the blocking duration is negligible. A future revision may
+///   add async file reading if this assumption changes.
+public struct AgentInstructionContextProvider: PromptContextProvider {
 
     private let loader: AgentInstructionLoader
     private let currentDirectory: URL

--- a/Sources/ManifoldSkills/AgentInstructionContextProvider.swift
+++ b/Sources/ManifoldSkills/AgentInstructionContextProvider.swift
@@ -1,0 +1,56 @@
+import Foundation
+import ManifoldInference
+
+/// A ``PromptContextProvider`` that injects merged ``AGENTS.md`` ambient
+/// instructions into the system preamble at turn assembly time.
+///
+/// Wire this into a ``PromptContextPipeline`` to give every session transparent
+/// access to project- and user-level `AGENTS.md` instructions:
+///
+/// ```swift
+/// // swift,no-build
+/// let agentsProvider = AgentInstructionContextProvider(
+///     currentDirectory: projectRoot,
+///     stoppingAt: homeDirectory
+/// )
+/// let pipeline = PromptContextPipeline(providers: [agentsProvider])
+/// ```
+///
+/// The slot is placed at ``PromptSlotPosition/systemPreamble`` so it sits
+/// before conversation history and after any host-supplied system prompt.
+public final class AgentInstructionContextProvider: PromptContextProvider, @unchecked Sendable {
+
+    private let loader: AgentInstructionLoader
+    private let currentDirectory: URL
+    private let stopDirectory: URL?
+
+    /// Creates a provider that discovers `AGENTS.md` files from `currentDirectory`
+    /// upward to `stopDirectory` (or home if nil).
+    public init(
+        currentDirectory: URL,
+        stoppingAt stopDirectory: URL? = nil,
+        loader: AgentInstructionLoader = AgentInstructionLoader()
+    ) {
+        self.currentDirectory = currentDirectory
+        self.stopDirectory = stopDirectory
+        self.loader = loader
+    }
+
+    public func contributeSlots(messageCount: Int) async throws -> [PromptSlot] {
+        guard let merged = loader.loadMerged(
+            from: currentDirectory,
+            stoppingAt: stopDirectory
+        ) else {
+            return []
+        }
+        return [
+            PromptSlot(
+                id: "agents-md-ambient",
+                content: merged,
+                position: .systemPreamble,
+                role: .userInstruction,
+                label: "AGENTS.md ambient instructions"
+            )
+        ]
+    }
+}

--- a/Sources/ManifoldSkills/AgentInstructionLoader.swift
+++ b/Sources/ManifoldSkills/AgentInstructionLoader.swift
@@ -50,16 +50,31 @@ public struct AgentInstructionLoader: Sendable {
     #if os(macOS)
     private func _discover(from currentDirectory: URL, stoppingAt stopDirectory: URL?) -> [AgentInstruction] {
         let fm = FileManager.default
-        let stop = stopDirectory?.standardizedFileURL
-            ?? fm.homeDirectoryForCurrentUser.standardizedFileURL
+        // Resolve symlinks on both sides for reliable equality (matches SkillReferenceResolver pattern).
+        let stop = (stopDirectory ?? fm.homeDirectoryForCurrentUser)
+            .resolvingSymlinksInPath().standardizedFileURL
+
+        let leaf = currentDirectory.resolvingSymlinksInPath().standardizedFileURL
+
+        // Guard: if currentDirectory is above stopDirectory the walk would
+        // proceed toward the filesystem root without ever matching stop.
+        // Treat this as an empty result and log so the caller can correct the
+        // anchor — silently returning everything above stop is worse than
+        // returning nothing.
+        if !leaf.path.hasPrefix(stop.path) {
+            Log.inference.warning(
+                "ManifoldSkills: currentDirectory '\(leaf.path, privacy: .public)' is not under stopDirectory '\(stop.path, privacy: .public)'; returning empty"
+            )
+            return []
+        }
 
         // Accumulate the walk path leaf → root, then reverse for root-to-leaf delivery.
         var walkPath: [URL] = []
-        var cursor = currentDirectory.standardizedFileURL
+        var cursor = leaf
         while true {
             walkPath.append(cursor)
             if cursor == stop { break }
-            let parent = cursor.deletingLastPathComponent().standardizedFileURL
+            let parent = cursor.deletingLastPathComponent().resolvingSymlinksInPath().standardizedFileURL
             // Guard against the filesystem root creating an infinite loop.
             if parent.path == cursor.path { break }
             cursor = parent

--- a/Sources/ManifoldSkills/AgentInstructionLoader.swift
+++ b/Sources/ManifoldSkills/AgentInstructionLoader.swift
@@ -1,0 +1,113 @@
+import Foundation
+import ManifoldInference
+
+/// Discovers `AGENTS.md` ambient instruction files by walking upward from a
+/// session directory to a configurable stop point.
+///
+/// Results are returned in **root-to-leaf order** (furthest ancestor first,
+/// `currentDirectory` last) so that the most-specific instructions appear last
+/// when merged and carry higher LLM recency weight — the "closest-wins"
+/// semantic used by every major agent tool that reads the format.
+///
+/// **macOS-only in v1.** On other platforms `discover()` returns `[]` and logs
+/// a one-time warning (same contract as ``SkillLoader``).
+public struct AgentInstructionLoader: Sendable {
+
+    /// The cross-tool-standard filename; matches the Linux Foundation spec.
+    public static let defaultFileName = "AGENTS.md"
+
+    public init() {}
+
+    // MARK: - Discovery
+
+    /// Walks upward from `currentDirectory` to `stopDirectory` (inclusive) and
+    /// returns every `AGENTS.md` found along the path.
+    ///
+    /// Files are ordered **root-to-leaf**: the ancestor-most file first, the
+    /// file in `currentDirectory` last. Callers that want only the single
+    /// closest instruction can take `.last`.
+    ///
+    /// - Parameters:
+    ///   - currentDirectory: Starting point; typically the session's working
+    ///     directory or git root.
+    ///   - stopDirectory: Walk stops here (inclusive). Defaults to the current
+    ///     user's home directory so the loader never escapes into system paths.
+    ///     Pass an explicit URL to anchor to a project root.
+    public func discover(
+        from currentDirectory: URL,
+        stoppingAt stopDirectory: URL? = nil
+    ) -> [AgentInstruction] {
+        #if os(macOS)
+        return _discover(from: currentDirectory, stoppingAt: stopDirectory)
+        #else
+        Log.inference.warning(
+            "ManifoldSkills: AgentInstructionLoader.discover() is macOS-only in v1; returning empty array"
+        )
+        return []
+        #endif
+    }
+
+    #if os(macOS)
+    private func _discover(from currentDirectory: URL, stoppingAt stopDirectory: URL?) -> [AgentInstruction] {
+        let fm = FileManager.default
+        let stop = stopDirectory?.standardizedFileURL
+            ?? fm.homeDirectoryForCurrentUser.standardizedFileURL
+
+        // Accumulate the walk path leaf → root, then reverse for root-to-leaf delivery.
+        var walkPath: [URL] = []
+        var cursor = currentDirectory.standardizedFileURL
+        while true {
+            walkPath.append(cursor)
+            if cursor == stop { break }
+            let parent = cursor.deletingLastPathComponent().standardizedFileURL
+            // Guard against the filesystem root creating an infinite loop.
+            if parent.path == cursor.path { break }
+            cursor = parent
+        }
+
+        var results: [AgentInstruction] = []
+        for dir in walkPath.reversed() {
+            let candidate = dir.appendingPathComponent(Self.defaultFileName)
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: candidate.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else {
+                continue
+            }
+            let content: String
+            do {
+                content = try String(contentsOf: candidate, encoding: .utf8)
+            } catch {
+                Log.inference.warning(
+                    "ManifoldSkills: cannot read \(candidate.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                continue
+            }
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                continue
+            }
+            results.append(AgentInstruction(directory: dir, content: content))
+        }
+        return results
+    }
+    #endif
+
+    // MARK: - Merging
+
+    /// Merges instructions into a single string in the order given (root-to-leaf
+    /// from ``discover(from:stoppingAt:)``). Sections are separated by `---` so
+    /// the LLM can distinguish instruction scopes.
+    ///
+    /// Returns `nil` when `instructions` is empty.
+    public func merged(_ instructions: [AgentInstruction]) -> String? {
+        guard !instructions.isEmpty else { return nil }
+        return instructions.map(\.content).joined(separator: "\n\n---\n\n")
+    }
+
+    /// Convenience: discovers and merges in one call.
+    public func loadMerged(
+        from currentDirectory: URL,
+        stoppingAt stopDirectory: URL? = nil
+    ) -> String? {
+        merged(discover(from: currentDirectory, stoppingAt: stopDirectory))
+    }
+}

--- a/Tests/ManifoldSkillsTests/AgentInstructionLoaderTests.swift
+++ b/Tests/ManifoldSkillsTests/AgentInstructionLoaderTests.swift
@@ -161,6 +161,28 @@ final class AgentInstructionLoaderTests: XCTestCase {
         #endif
     }
 
+    func test_discover_currentDirectoryAboveStop_returnsEmpty() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let root = try makeTempDir()
+        let sub = root.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try writeAgentsMd(content: "Root instructions.", in: root)
+        // currentDirectory is root, stopDirectory is sub → root is ABOVE sub.
+        // The loader must return empty and warn rather than silently walking
+        // all the way to the filesystem root.
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: root, stoppingAt: sub)
+
+        XCTAssertTrue(found.isEmpty)
+        // Sabotage-evidence: M1 remove the inversion guard → loader walks
+        // root → / and may pick up AGENTS.md files along the way, making
+        // found non-empty; M2 fix the guard to only warn without returning
+        // early → found would contain root's file.
+        #endif
+    }
+
     // MARK: - Merging
 
     func test_merged_returnsNilForEmptyInput() {

--- a/Tests/ManifoldSkillsTests/AgentInstructionLoaderTests.swift
+++ b/Tests/ManifoldSkillsTests/AgentInstructionLoaderTests.swift
@@ -1,0 +1,237 @@
+import XCTest
+@testable import ManifoldSkills
+
+/// Tests for `AgentInstructionLoader` filesystem discovery and merging.
+///
+/// All tests use sandboxed temp dirs; never probe the real `$HOME`.
+final class AgentInstructionLoaderTests: XCTestCase {
+
+    private var tempRoots: [URL] = []
+
+    override func tearDownWithError() throws {
+        let fm = FileManager.default
+        for root in tempRoots {
+            do {
+                try fm.removeItem(at: root)
+            } catch {
+                XCTAssertNotNil(error as Error?, "tear-down cleanup error captured")
+            }
+        }
+        tempRoots = []
+    }
+
+    private func makeTempDir(named label: String = UUID().uuidString) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agents-loader-\(label)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        tempRoots.append(root)
+        return root
+    }
+
+    private func writeAgentsMd(content: String, in directory: URL) throws {
+        let url = directory.appendingPathComponent(AgentInstructionLoader.defaultFileName)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Discovery
+
+    func test_discover_findsAgentsMd_inCurrentDirectory() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let cwd = try makeTempDir()
+        try writeAgentsMd(content: "# Project instructions\nDo the thing.", in: cwd)
+
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: cwd, stoppingAt: cwd)
+
+        XCTAssertEqual(found.count, 1)
+        XCTAssertEqual(found.first?.directory.standardizedFileURL, cwd.standardizedFileURL)
+        XCTAssertTrue(found.first?.content.contains("Do the thing.") ?? false)
+        // Sabotage-evidence: M1 rename the file to AGENTS.txt → count drops to 0;
+        // M2 remove the `content.contains` check body → passes vacuously;
+        // M3 change stoppingAt to a non-matching dir → count could grow.
+        #endif
+    }
+
+    func test_discover_findsAgentsMd_inParentDirectory() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let root = try makeTempDir()
+        let sub = root.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try writeAgentsMd(content: "Root instructions.", in: root)
+        // No AGENTS.md in `sub`.
+
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: sub, stoppingAt: root)
+
+        XCTAssertEqual(found.count, 1)
+        XCTAssertEqual(found.first?.directory.standardizedFileURL, root.standardizedFileURL)
+        // Sabotage-evidence: M1 add AGENTS.md to `sub` → count becomes 2;
+        // M2 swap stoppingAt to `sub` → root's file is outside the walk, count 0;
+        // M3 remove the root AGENTS.md → count drops to 0.
+        #endif
+    }
+
+    func test_discover_rootToLeafOrdering() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let root = try makeTempDir()
+        let mid = root.appendingPathComponent("mid", isDirectory: true)
+        let leaf = mid.appendingPathComponent("leaf", isDirectory: true)
+        try FileManager.default.createDirectory(at: leaf, withIntermediateDirectories: true)
+        try writeAgentsMd(content: "ROOT", in: root)
+        try writeAgentsMd(content: "MID", in: mid)
+        try writeAgentsMd(content: "LEAF", in: leaf)
+
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: leaf, stoppingAt: root)
+
+        XCTAssertEqual(found.count, 3)
+        XCTAssertEqual(found.map(\.content), ["ROOT", "MID", "LEAF"])
+        // Sabotage-evidence: M1 swap root ↔ leaf in the returned order →
+        // the map equality fails ("LEAF", "MID", "ROOT" ≠ expected);
+        // M2 remove `mid` AGENTS.md → count becomes 2, map fails;
+        // M3 flip stoppingAt to `mid` → root is excluded, count becomes 2.
+        #endif
+    }
+
+    func test_discover_stopsAtStopDirectory_excludesAbove() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let grandparent = try makeTempDir()
+        let parent = grandparent.appendingPathComponent("parent", isDirectory: true)
+        let child = parent.appendingPathComponent("child", isDirectory: true)
+        try FileManager.default.createDirectory(at: child, withIntermediateDirectories: true)
+        try writeAgentsMd(content: "Grandparent — should be excluded.", in: grandparent)
+        try writeAgentsMd(content: "Parent — is the stop.", in: parent)
+        try writeAgentsMd(content: "Child — should be included.", in: child)
+
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: child, stoppingAt: parent)
+
+        XCTAssertEqual(found.count, 2)
+        XCTAssertFalse(found.contains { $0.content.contains("Grandparent") })
+        XCTAssertTrue(found.contains { $0.content.contains("Parent") })
+        XCTAssertTrue(found.contains { $0.content.contains("Child") })
+        // Sabotage-evidence: M1 change stoppingAt to `grandparent` → count
+        // becomes 3 and the Grandparent exclusion check fails;
+        // M2 remove grandparent AGENTS.md → count stays 2 but the first
+        // assertion masks stoppingAt bugs — test remains valid.
+        #endif
+    }
+
+    func test_discover_skipsEmptyAgentsMd() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let root = try makeTempDir()
+        let sub = root.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        try writeAgentsMd(content: "   \n\n  \t  \n", in: root)   // whitespace-only
+        try writeAgentsMd(content: "# Real instructions", in: sub)
+
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: sub, stoppingAt: root)
+
+        XCTAssertEqual(found.count, 1)
+        XCTAssertTrue(found.first?.content.contains("Real instructions") ?? false)
+        // Sabotage-evidence: M1 add non-whitespace to root's file → count
+        // becomes 2; M2 remove the whitespace-trim in the loader → root
+        // included, count 2.
+        #endif
+    }
+
+    func test_discover_noAgentsMd_returnsEmpty() throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let cwd = try makeTempDir()
+
+        let loader = AgentInstructionLoader()
+        let found = loader.discover(from: cwd, stoppingAt: cwd)
+
+        XCTAssertTrue(found.isEmpty)
+        // Sabotage-evidence: M1 add AGENTS.md to cwd → count becomes 1;
+        // M2 flip the isEmpty check to !isEmpty → assertion inverts.
+        #endif
+    }
+
+    // MARK: - Merging
+
+    func test_merged_returnsNilForEmptyInput() {
+        let loader = AgentInstructionLoader()
+        XCTAssertNil(loader.merged([]))
+        // Sabotage-evidence: M1 return "" instead of nil → nil check fails.
+    }
+
+    func test_merged_singleInstruction_returnsItsContent() throws {
+        let url = URL(fileURLWithPath: "/fake/dir")
+        let instruction = AgentInstruction(directory: url, content: "Hello.")
+        let loader = AgentInstructionLoader()
+
+        let result = loader.merged([instruction])
+        XCTAssertEqual(result, "Hello.")
+        // Sabotage-evidence: M1 wrap in extra "\n" → equality fails;
+        // M2 join with "---" unconditionally → single-item gets separator.
+    }
+
+    func test_merged_multipleInstructions_separatedByRule() throws {
+        let url = URL(fileURLWithPath: "/fake/dir")
+        let instructions = [
+            AgentInstruction(directory: url, content: "A"),
+            AgentInstruction(directory: url, content: "B"),
+            AgentInstruction(directory: url, content: "C"),
+        ]
+        let loader = AgentInstructionLoader()
+
+        let result = loader.merged(instructions)
+        XCTAssertEqual(result, "A\n\n---\n\nB\n\n---\n\nC")
+        // Sabotage-evidence: M1 change separator to "\n---\n" → equality fails;
+        // M2 use "," as separator → equality fails.
+    }
+
+    // MARK: - ContextProvider
+
+    func test_contextProvider_returnsEmptySlots_whenNoAgentsMd() async throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let cwd = try makeTempDir()
+        let provider = AgentInstructionContextProvider(
+            currentDirectory: cwd,
+            stoppingAt: cwd
+        )
+
+        let slots = try await provider.contributeSlots(messageCount: 0)
+        XCTAssertTrue(slots.isEmpty)
+        // Sabotage-evidence: M1 add AGENTS.md → slots count becomes 1.
+        #endif
+    }
+
+    func test_contextProvider_injectsSystemPreambleSlot() async throws {
+        #if !os(macOS)
+        throw XCTSkip("AgentInstructionLoader.discover() is macOS-only in v1")
+        #else
+        let cwd = try makeTempDir()
+        try writeAgentsMd(content: "Be helpful.", in: cwd)
+        let provider = AgentInstructionContextProvider(
+            currentDirectory: cwd,
+            stoppingAt: cwd
+        )
+
+        let slots = try await provider.contributeSlots(messageCount: 0)
+        XCTAssertEqual(slots.count, 1)
+        XCTAssertEqual(slots.first?.id, "agents-md-ambient")
+        XCTAssertEqual(slots.first?.position, .systemPreamble)
+        XCTAssertTrue(slots.first?.content.contains("Be helpful.") ?? false)
+        // Sabotage-evidence: M1 change position to .contextSetup → position
+        // check fails; M2 change id → id check fails; M3 remove content →
+        // content check fails.
+        #endif
+    }
+}


### PR DESCRIPTION
## What

Adds `AGENTS.md` ambient-instruction discovery to `ManifoldSkills`, resolving #1943.

The Linux Foundation cross-tool `AGENTS.md` standard (60k+ repos) is a plain-markdown file read by every major agent tool (Claude Code, Cursor, Copilot, etc.) at session start. ManifoldKit lacked a way to discover and inject these files.

## New types

| Type | Purpose |
|------|---------|
| `AgentInstruction` | Value type for a discovered `AGENTS.md` file (directory + content) |
| `AgentInstructionLoader` | Walks upward from `currentDirectory` to `stopDirectory`, returns instructions root-to-leaf |
| `AgentInstructionContextProvider` | `PromptContextProvider` that injects the merged instructions as a `systemPreamble` slot |

## Closest-wins semantics

Results are returned in **root-to-leaf order** (ancestor files first, `currentDirectory`-local file last). Because LLMs weight recent context more heavily, the most-specific instruction is naturally authoritative. Callers wanting only the single closest file can take `.last`.

## Default stop

`stopDirectory` defaults to the current user's home directory, so the loader never walks into system paths.

## Tests

11 unit tests covering: cwd discovery, parent-directory discovery, root-to-leaf ordering, stop-directory boundary, empty-file skipping, nil-on-empty merge, separator shape, and `AgentInstructionContextProvider` slot injection.

## Closes

- #1943